### PR TITLE
Dev Tools: Announce a fixed file, so a page that did not start the client can act on it

### DIFF
--- a/javascript/packages/dev-tools/src/dev-server/client.ts
+++ b/javascript/packages/dev-tools/src/dev-server/client.ts
@@ -5,6 +5,7 @@ import { MismatchAlert } from "./mismatch-alert"
 
 import { applyPatch } from "./patch"
 import { diagnosticsFromError } from "./diagnostics"
+import { DEV_SERVER_FIXED_EVENT } from "./types"
 
 import type {
   DiagnosticSink,
@@ -68,6 +69,10 @@ export class HerbClient {
 
   getPort(): number {
     return this.port
+  }
+
+  refreshConnection(): void {
+    this.connectionDot.apply()
   }
 
   applyConnectionDot(): void {
@@ -169,6 +174,8 @@ export class HerbClient {
   private handleFixed(message: FixedMessage): void {
     this.options.onFixed?.(message)
     this.getDiagnostics()?.clear()
+
+    document.dispatchEvent(new CustomEvent(DEV_SERVER_FIXED_EVENT, { detail: message }))
   }
 
   private updateState(state: ClientState): void {

--- a/javascript/packages/dev-tools/src/dev-server/connection-dot.ts
+++ b/javascript/packages/dev-tools/src/dev-server/connection-dot.ts
@@ -16,21 +16,19 @@ export class ConnectionDot {
     }
 
     const dot = document.getElementById("herbConnectionDot")
-    if (!dot) return
 
-    const panelDot = document.getElementById("herbDevServerDot")
-    const panelStatus = document.getElementById("herbDevServerStatus")
-    const panelRetry = document.getElementById("herbDevServerRetry") as HTMLButtonElement | null
+    const panelDot = this.all("[data-herb-dev-server-dot]")
+    const panelStatus = this.all("[data-herb-dev-server-status]")
+    const panelRetry = this.all("[data-herb-dev-server-retry]") as HTMLButtonElement[]
+
+    if (!dot && panelDot.length === 0 && panelStatus.length === 0) return
     const retryHandler = (e: MouseEvent) => { e.stopPropagation(); this.client.retry() }
 
     const state = this.client.getState()
 
     switch (state) {
       case "connected":
-        this.setDotStyle(dot, colors.green, true, true)
-        dot.style.cursor = "default"
-        dot.title = "Connected to herb dev server"
-        dot.onclick = null
+        this.applyBadge(dot, colors.green, "Connected to herb dev server", true, true, "default", null)
 
         this.updatePanel(panelDot, panelStatus, panelRetry, {
           dotColor: colors.green,
@@ -42,10 +40,7 @@ export class ConnectionDot {
         break
 
       case "disconnected":
-        this.setDotStyle(dot, colors.red, false, false)
-        dot.style.cursor = "default"
-        dot.title = "Disconnected from herb dev server"
-        dot.onclick = null
+        this.applyBadge(dot, colors.red, "Disconnected from herb dev server", false, false, "default", null)
 
         this.updatePanel(panelDot, panelStatus, panelRetry, {
           dotColor: colors.red,
@@ -58,10 +53,7 @@ export class ConnectionDot {
         break
 
       case "given-up":
-        this.setDotStyle(dot, colors.amber, false, false)
-        dot.style.cursor = "pointer"
-        dot.title = "Connection to herb dev server failed — click to retry"
-        dot.onclick = retryHandler
+        this.applyBadge(dot, colors.amber, "Connection to herb dev server failed — click to retry", false, false, "pointer", retryHandler)
 
         this.updatePanel(panelDot, panelStatus, panelRetry, {
           dotColor: colors.amber,
@@ -76,8 +68,8 @@ export class ConnectionDot {
   }
 
   updateReconnectCountdown(attempt: number, maxAttempts: number, delay: number): void {
-    const panelStatus = document.getElementById("herbDevServerStatus")
-    if (!panelStatus) return
+    const panelStatus = this.all("[data-herb-dev-server-status]")
+    if (panelStatus.length === 0) return
 
     if (this.reconnectCountdown) {
       clearInterval(this.reconnectCountdown)
@@ -85,8 +77,7 @@ export class ConnectionDot {
     }
 
     let remaining = Math.ceil(delay / 1000)
-    panelStatus.textContent = `Retry ${attempt}/${maxAttempts} in ${remaining}s`
-    panelStatus.style.color = colors.gray
+    this.write(panelStatus, `Retry ${attempt}/${maxAttempts} in ${remaining}s`, colors.gray)
 
     this.reconnectCountdown = setInterval(() => {
       remaining--
@@ -97,19 +88,47 @@ export class ConnectionDot {
           this.reconnectCountdown = null
         }
 
-        panelStatus.textContent = `Retry ${attempt}/${maxAttempts} connecting...`
+        this.write(panelStatus, `Retry ${attempt}/${maxAttempts} connecting...`, colors.gray)
 
         return
       }
 
-      panelStatus.textContent = `Retry ${attempt}/${maxAttempts} in ${remaining}s`
+      this.write(panelStatus, `Retry ${attempt}/${maxAttempts} in ${remaining}s`, colors.gray)
     }, 1000)
   }
 
+  private all(selector: string): HTMLElement[] {
+    return Array.from(document.querySelectorAll<HTMLElement>(selector))
+  }
+
+  private write(elements: HTMLElement[], text: string, color: string): void {
+    for (const element of elements) {
+      element.textContent = text
+      element.style.color = color
+    }
+  }
+
+  private applyBadge(
+    dot: HTMLElement | null,
+    color: string,
+    title: string,
+    glow: boolean,
+    pulse: boolean,
+    cursor: string,
+    handler: ((e: MouseEvent) => void) | null
+  ): void {
+    if (!dot) return
+
+    this.setDotStyle(dot, color, glow, pulse)
+    dot.style.cursor = cursor
+    dot.title = title
+    dot.onclick = handler
+  }
+
   private updatePanel(
-    panelDot: HTMLElement | null,
-    panelStatus: HTMLElement | null,
-    panelRetry: HTMLButtonElement | null,
+    panelDot: HTMLElement[],
+    panelStatus: HTMLElement[],
+    panelRetry: HTMLButtonElement[],
     options: {
       dotColor: string
       statusText: string
@@ -118,18 +137,15 @@ export class ConnectionDot {
       retryHandler?: (e: MouseEvent) => void
     }
   ): void {
-    if (panelDot) this.setDotStyle(panelDot, options.dotColor, false, false)
+    for (const element of panelDot) this.setDotStyle(element, options.dotColor, false, false)
 
-    if (panelStatus) {
-      panelStatus.textContent = options.statusText
-      panelStatus.style.color = options.statusColor
-    }
+    this.write(panelStatus, options.statusText, options.statusColor)
 
-    if (panelRetry) {
-      panelRetry.style.display = options.retryVisible ? "block" : "none"
+    for (const element of panelRetry) {
+      element.style.display = options.retryVisible ? "block" : "none"
 
       if (options.retryHandler) {
-        panelRetry.onclick = options.retryHandler
+        element.onclick = options.retryHandler
       }
     }
   }

--- a/javascript/packages/dev-tools/src/dev-server/types.ts
+++ b/javascript/packages/dev-tools/src/dev-server/types.ts
@@ -59,10 +59,10 @@ export interface WelcomeMessage {
   project: string
 }
 
+export const DEV_SERVER_FIXED_EVENT = "herb:dev-server-fixed"
+
 export type HerbMessage = WelcomeMessage | PatchMessage | ReloadMessage | ErrorMessage | FixedMessage
-
 export type ConnectionState = "connected" | "disconnected" | "given-up"
-
 export type MessageHandler = (message: HerbMessage) => void
 
 export interface ConnectionOptions {

--- a/javascript/packages/dev-tools/src/herb-dev-tools.ts
+++ b/javascript/packages/dev-tools/src/herb-dev-tools.ts
@@ -153,6 +153,7 @@ export class HerbDevTools {
       this.panel = new RuntimePanel({
         onOpenFile: (file, line, column) => this.devToolsOverlay?.openFileInEditor(file, line, column),
         onOpen: () => this.devToolsOverlay?.closeMenu(),
+        onRender: () => this.devServerClient?.refreshConnection(),
       })
 
       this.devToolsOverlay?.syncRuntimePanelToggle()

--- a/javascript/packages/dev-tools/src/index.ts
+++ b/javascript/packages/dev-tools/src/index.ts
@@ -1,4 +1,7 @@
-export { HerbDevTools, DEV_TOOLS_START_EVENT } from './herb-dev-tools.js'
+export { DEV_SERVER_FIXED_EVENT } from './dev-server/types.js'
+export { DEV_TOOLS_START_EVENT } from './herb-dev-tools.js'
+
+export { HerbDevTools } from './herb-dev-tools.js'
 export { RuntimePanel } from './runtime/panel.js'
 
 export type { HerbDevToolsOptions } from './herb-dev-tools.js'

--- a/javascript/packages/dev-tools/src/overlay/overlay.ts
+++ b/javascript/packages/dev-tools/src/overlay/overlay.ts
@@ -224,9 +224,9 @@ export class HerbOverlay {
           <div class="herb-menu-header">Herb Debug Tools</div>
 
           <div id="herbDevServerSection" class="herb-dev-server-section">
-            <span id="herbDevServerDot" class="herb-dev-server-dot"></span>
-            <span id="herbDevServerStatus" class="herb-dev-server-status">Dev Server</span>
-            <button id="herbDevServerRetry" class="herb-dev-server-retry">Retry</button>
+            <span id="herbDevServerDot" data-herb-dev-server-dot class="herb-dev-server-dot"></span>
+            <span id="herbDevServerStatus" data-herb-dev-server-status class="herb-dev-server-status">Dev Server</span>
+            <button id="herbDevServerRetry" data-herb-dev-server-retry class="herb-dev-server-retry">Retry</button>
           </div>
 
           <div class="herb-toggle-item">

--- a/javascript/packages/dev-tools/src/runtime/panel.css
+++ b/javascript/packages/dev-tools/src/runtime/panel.css
@@ -172,6 +172,35 @@
   color: #111827;
 }
 
+.herb-dev-tools-connection {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  flex: 0 1 auto;
+  min-width: 0;
+  padding: 2px 8px;
+  border: 1px solid #e5e7eb;
+  border-radius: 999px;
+  background: #f9fafb;
+  font-size: 11px;
+}
+
+.herb-dev-tools-connection-dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: #9ca3af;
+  flex: none;
+}
+
+.herb-dev-tools-connection-status {
+  color: #6b7280;
+  min-width: 0;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
 .herb-dev-tools-summary {
   flex: 1;
   min-width: 0;

--- a/javascript/packages/dev-tools/src/runtime/panel.ts
+++ b/javascript/packages/dev-tools/src/runtime/panel.ts
@@ -21,6 +21,7 @@ export interface RuntimePanelOptions {
   autoInit?: boolean
   onOpenFile?: (file: string, line: number, column: number) => void
   onOpen?: () => void
+  onRender?: () => void
 }
 
 interface OpenTarget {
@@ -193,6 +194,7 @@ export class RuntimePanel {
   private bumped = false
   private primed = false
   private onOpenFile: ((file: string, line: number, column: number) => void) | null = null
+  private onRender: (() => void) | null = null
   private onOpen: (() => void) | null = null
   private state: PanelState = { dismissed: false, open: false, expanded: false, origin: ALL_ORIGINS, severity: ALL_SEVERITIES, view: 'cards', width: null, height: null }
   private root: HTMLElement | null = null
@@ -210,6 +212,7 @@ export class RuntimePanel {
   constructor(options: RuntimePanelOptions = {}) {
     this.onOpenFile = options.onOpenFile ?? null
     this.onOpen = options.onOpen ?? null
+    this.onRender = options.onRender ?? null
     this.styleElement = injectStyle('runtime-panel', panelStyles)
 
     if (options.autoInit !== false) {
@@ -807,6 +810,8 @@ export class RuntimePanel {
     this.bindHandlers()
     this.bindResizeHandles()
 
+    this.onRender?.()
+
     void this.hydrateHighlighting()
   }
 
@@ -1030,6 +1035,15 @@ export class RuntimePanel {
     ].join('')
   }
 
+  private connectionHTML(): string {
+    return [
+      `<span class="herb-dev-tools-connection">`,
+      `<span class="herb-dev-tools-connection-dot" data-herb-dev-server-dot></span>`,
+      `<span class="herb-dev-tools-connection-status" data-herb-dev-server-status>Dev Server</span>`,
+      `</span>`,
+    ].join('')
+  }
+
   private toneMarkerHTML(): string {
     const tone = this.headerTone
 
@@ -1054,6 +1068,7 @@ export class RuntimePanel {
       marker,
       `<span class="herb-dev-tools-title">${escapeHTML(this.overlayHeadline(entries))}</span>`,
       this.overlayLocationHTML(entries),
+      this.connectionHTML(),
       `<div class="herb-dev-tools-window-controls">`,
       this.viewButtonHTML(),
       this.overlayScopeButtonHTML(),
@@ -1185,7 +1200,12 @@ export class RuntimePanel {
 
   private headerControlsHTML(overlay: OverlayMode | null): string[] {
     if (overlay === 'blocking') {
-      return [`<div class="herb-dev-tools-window-controls">`, this.viewButtonHTML(), this.overlayScopeButtonHTML(), `</div>`]
+      return [
+        `<div class="herb-dev-tools-window-controls">`,
+        this.viewButtonHTML(),
+        this.overlayScopeButtonHTML(),
+        `</div>`,
+      ]
     }
 
     if (overlay === 'dismissible') {

--- a/javascript/packages/dev-tools/test/dev-server-diagnostics.test.ts
+++ b/javascript/packages/dev-tools/test/dev-server-diagnostics.test.ts
@@ -4,6 +4,7 @@ import { afterEach, beforeEach, describe, expect, test } from "vitest"
 import { stripAnsiColors } from "@herb-tools/highlighter"
 import { diagnosticsFromError } from "../src/dev-server/diagnostics"
 
+import { HerbClient } from "../src/dev-server/client"
 import { RuntimePanel } from "../src/runtime/panel"
 
 import type { ErrorMessage } from "../src/dev-server/types"
@@ -150,6 +151,41 @@ describe("a dev server error in the panel", () => {
     )
 
     expect(stripAnsiColors(excerpt.textContent ?? "")).toContain("<form>")
+  })
+
+  test("shows the dev server connection in its own header, not only in the badge", async () => {
+    const panel = createPanel()
+
+    panel.report(diagnosticsFromError(errorMessage()))
+
+    const dot = document.querySelector(".herb-dev-tools-connection-dot") as HTMLElement | null
+    const status = document.querySelector(".herb-dev-tools-connection-status") as HTMLElement | null
+
+    expect(dot).not.toBeNull()
+    expect(status).not.toBeNull()
+    expect(status!.textContent).toBe("Dev Server")
+  })
+
+  test("keeps that indicator through a re-render, since the panel rewrites its own header", () => {
+    const panel = createPanel()
+
+    panel.report(diagnosticsFromError(errorMessage()))
+    panel.report(diagnosticsFromError(errorMessage({ line: 9 })))
+
+    expect(document.querySelectorAll(".herb-dev-tools-connection-dot")).toHaveLength(1)
+  })
+
+  test("announces a fix on the document, for a page that did not start the dev tools", async () => {
+    const client = new HerbClient({})
+    const heard: string[] = []
+
+    document.addEventListener("herb:dev-server-fixed", (event) => {
+      heard.push((event as CustomEvent).detail.file)
+    })
+
+    client["handleFixed"]({ type: "fixed", file: "app/views/posts/index.html.erb" })
+
+    expect(heard).toEqual(["app/views/posts/index.html.erb"])
   })
 
   test("renders no excerpt when the server sent no source", () => {

--- a/lib/herb/engine/report/error_page.rb
+++ b/lib/herb/engine/report/error_page.rb
@@ -50,10 +50,11 @@ module Herb
           .herb-error .herb-error-provenance code { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; }
         CSS
 
-        #: (untyped, ?dev_tools: String?, ?enabled: bool) -> void
-        def initialize(app, dev_tools: nil, enabled: true)
+        #: (untyped, ?dev_tools: (String | ^() -> String?)?, ?dev_server_port: (Integer | String | ^() -> untyped)?, ?enabled: bool) -> void
+        def initialize(app, dev_tools: nil, dev_server_port: nil, enabled: true)
           @app = app
           @dev_tools = dev_tools
+          @dev_server_port = dev_server_port
           @enabled = enabled
         end
 
@@ -201,6 +202,7 @@ module Herb
             %(<html lang="en"><head><meta charset="utf-8">),
             %(<meta name="viewport" content="width=device-width, initial-scale=1">),
             %(<meta name="herb-debug-mode" content="true">),
+            dev_server_port_meta_tag,
             "<title>#{escape(title(diagnostics))}</title>",
             "<style>#{STYLES}</style>",
             "</head><body>",
@@ -222,17 +224,44 @@ module Herb
 
         #: () -> String
         def script_tag
-          return "" unless @dev_tools
+          path = dev_tools_path
+
+          return "" unless path
 
           <<~HTML
             <script type="module">
-              import { HerbDevTools } from #{JSON.generate(@dev_tools)}
+              import { HerbDevTools } from #{JSON.generate(path)}
+
+              document.addEventListener("herb:dev-server-fixed", () => window.location.reload())
 
               HerbDevTools.start({
                 devServer: { onFixed: () => window.location.reload() }
               })
             </script>
           HTML
+        end
+
+        #: () -> String?
+        def dev_tools_path
+          path = resolved(@dev_tools)
+
+          path.is_a?(String) && !path.empty? ? path : nil
+        end
+
+        #: () -> String
+        def dev_server_port_meta_tag
+          port = resolved(@dev_server_port).to_s
+
+          return "" if port.empty?
+
+          %(<meta name="herb-dev-server-port" content="#{escape(port)}">)
+        end
+
+        #: (untyped) -> untyped
+        def resolved(value)
+          value.respond_to?(:call) ? value.call : value
+        rescue StandardError
+          nil
         end
 
         #: (Hash[Symbol, untyped]) -> String

--- a/sig/herb/engine/report/error_page.rbs
+++ b/sig/herb/engine/report/error_page.rbs
@@ -31,8 +31,8 @@ module Herb
 
         STYLES: String
 
-        # : (untyped, ?dev_tools: String?, ?enabled: bool) -> void
-        def initialize: (untyped, ?dev_tools: String?, ?enabled: bool) -> void
+        # : (untyped, ?dev_tools: (String | ^() -> String?)?, ?dev_server_port: (Integer | String | ^() -> untyped)?, ?enabled: bool) -> void
+        def initialize: (untyped, ?dev_tools: (String | ^() -> String?)?, ?dev_server_port: (Integer | String | ^() -> untyped)?, ?enabled: bool) -> void
 
         # : (untyped) -> untyped
         def call: (untyped) -> untyped
@@ -74,6 +74,15 @@ module Herb
 
         # : () -> String
         def script_tag: () -> String
+
+        # : () -> String?
+        def dev_tools_path: () -> String?
+
+        # : () -> String
+        def dev_server_port_meta_tag: () -> String
+
+        # : (untyped) -> untyped
+        def resolved: (untyped) -> untyped
 
         # : (Hash[Symbol, untyped]) -> String
         def provenance: (Hash[Symbol, untyped]) -> String

--- a/test/engine/report/error_page_test.rb
+++ b/test/engine/report/error_page_test.rb
@@ -281,6 +281,51 @@ module Engine
         refute_includes body.first, "devServer: false"
       end
 
+      test "hears that even when something else started the dev tools first" do
+        _status, _headers, body = middleware(raising_app(parse_error), dev_tools: "/assets/herb.js").call(HTML_ENV)
+
+        assert_includes body.first, %(document.addEventListener("herb:dev-server-fixed", () => window.location.reload()))
+      end
+
+      test "names the dev server port, so the tools reach a project that moved it" do
+        _status, _headers, body = middleware(raising_app(parse_error), dev_server_port: 9999).call(HTML_ENV)
+
+        assert_includes body.first, %(<meta name="herb-dev-server-port" content="9999">)
+      end
+
+      test "asks for that port at the time it serves too" do
+        _status, _headers, body = middleware(raising_app(parse_error), dev_server_port: -> { 4321 }).call(HTML_ENV)
+
+        assert_includes body.first, %(<meta name="herb-dev-server-port" content="4321">)
+      end
+
+      test "leaves the port out when nobody named one, so the default still applies" do
+        _status, _headers, body = middleware(raising_app(parse_error)).call(HTML_ENV)
+
+        refute_includes body.first, "herb-dev-server-port"
+      end
+
+      test "asks for the path at the time it serves, for a pipeline that boots later" do
+        resolved = -> { "/assets/herb-abc123.js" }
+
+        _status, _headers, body = middleware(raising_app(parse_error), dev_tools: resolved).call(HTML_ENV)
+
+        assert_includes body.first, %(import { HerbDevTools } from "/assets/herb-abc123.js")
+      end
+
+      test "costs the overlay and not the page when it cannot answer" do
+        _status, _headers, body = middleware(raising_app(parse_error), dev_tools: -> { raise "no pipeline" }).call(HTML_ENV)
+
+        refute_includes body.first, "HerbDevTools"
+        assert_includes body.first, "This template could not be compiled"
+      end
+
+      test "leaves the script out when it names nothing yet" do
+        _status, _headers, body = middleware(raising_app(parse_error), dev_tools: -> {}).call(HTML_ENV)
+
+        refute_includes body.first, "HerbDevTools"
+      end
+
       test "leaves the script out when it is not" do
         _status, _headers, body = middleware(raising_app(parse_error)).call(HTML_ENV)
 


### PR DESCRIPTION
This pull request makes the dev tools usable by a page that did not start them. Mounting `Report::ErrorPage` in a Rails app surfaced problems.

Fixing the template did not reload the page. The error page boots the dev tools by importing the bundle and calling:

```js
HerbDevTools.start({
  devServer: { onFixed: () => window.location.reload() }
})
```

In a Rails app that call is ignored. ReActionView's bundle auto-initialises on import whenever it sees `meta[name="herb-debug-mode"]`, which the error page emits, so by the time the inline script runs `HerbDevTools.current` is already set and `start()` returns early with `already started, ignoring this start() call`. The `onFixed` callback went nowhere.

The symptom was that fixing the error did nothing, while changing anything *else* in the template reloaded immediately, because `handleReload` calls `window.location.reload()` unconditionally while `handleFixed` only calls the callback that was never registered.

A second websocket opened from the page confirmed the server was doing its part all along:

```
["installed on error page", "probe-open", "welcome", "fixed:show.html.erb"]   stillErrorPage: true
```

`handleFixed` now also dispatches `herb:dev-server-fixed` on the document, and the error page listens for that as well as passing `onFixed`. A page can observe a fix without owning the client.