### PR TITLE
Engine: Narrow `herb:state` error locations

### DIFF
--- a/javascript/packages/client/test/fixtures/contract/a-boolean-attribute-inside-a-block.json
+++ b/javascript/packages/client/test/fixtures/contract/a-boolean-attribute-inside-a-block.json
@@ -51,7 +51,7 @@
           "default": "false",
           "derived": null,
           "line": 1,
-          "column": 0,
+          "column": 16,
           "scope": "region",
           "value": false
         }

--- a/javascript/packages/client/test/fixtures/contract/a-keyed-collection-with-declared-item-state.json
+++ b/javascript/packages/client/test/fixtures/contract/a-keyed-collection-with-declared-item-state.json
@@ -90,7 +90,7 @@
           "default": "\"all\"",
           "derived": null,
           "line": 1,
-          "column": 0,
+          "column": 16,
           "scope": "region",
           "value": "all"
         },
@@ -100,7 +100,7 @@
           "default": "false",
           "derived": null,
           "line": 1,
-          "column": 78,
+          "column": 94,
           "scope": 0,
           "value": false
         }

--- a/lib/herb/analysis/ruby_locals_index/state_locals.rb
+++ b/lib/herb/analysis/ruby_locals_index/state_locals.rb
@@ -14,7 +14,7 @@ module Herb
           known = declared.to_h { |name, _location| [name, :seeded] }
 
           directives(document).flat_map { |node, signature|
-            declarations_in(signature, known).map do |declaration|
+            declarations_in(node, signature, known).map do |declaration|
               Local.new(declaration.name, node.location, usages(declaration.name, references, offsets))
             end
           }
@@ -36,8 +36,8 @@ module Herb
           found
         end
 
-        def declarations_in(signature, known)
-          Herb::Engine::Slots::StateDirectives.parse(signature, known, visitor: Herb::Engine::Slots::StateDirectives::Silent, location: nil)
+        def declarations_in(node, signature, known)
+          Herb::Engine::Slots::StateDirectives.parse(signature, known, visitor: Herb::Engine::Slots::StateDirectives::Silent, node: node)
         end
 
         def usages(name, references, offsets)

--- a/lib/herb/engine/slots/state_compiler.rb
+++ b/lib/herb/engine/slots/state_compiler.rb
@@ -223,35 +223,48 @@ module Herb
           return unless signature
 
           scope = @visitor.current_collection
-          declared = StateDirectives.parse(signature, @strict_locals, visitor: @visitor, location: node.location, enclosing: scope ? @region_states : {})
+          declared = StateDirectives.parse(signature, @strict_locals, visitor: @visitor, node: node, enclosing: scope ? @region_states : {})
           empty = {} #: Hash[String, StateDirectives::Declaration]
           bucket = scope ? (@item_states[scope] ||= empty) : @region_states
 
           location = node.location&.start
 
           declared = declared.map { |declaration|
-            declaration.with(line: location&.line, column: location&.column)
+            declaration.line ? declaration : declaration.with(line: location&.line, column: location&.column)
           }
 
           declared.each do |declaration|
+            spelled = declaration_location(declaration) || node.location
+
             if @strict_locals.key?(declaration.name)
-              next @visitor.slot_error("`#{declaration.name}` is both a strict local and a state. A local comes from the caller and a state is owned by the client, so rename one of the two.", node.location, :declaration)
+              next @visitor.slot_error("`#{declaration.name}` is both a strict local and a state. A local comes from the caller and a state is owned by the client, so rename one of the two.", spelled, :declaration)
             end
 
             if bucket.key?(declaration.name)
-              next @visitor.slot_error("The state `#{declaration.name}` is declared twice in the same scope. Remove one of the two declarations.", node.location, :declaration)
+              next @visitor.slot_error("The state `#{declaration.name}` is declared twice in the same scope. Remove one of the two declarations.", spelled, :declaration)
             end
 
             shadowed = scope ? @region_states.key?(declaration.name) : @item_states.values.any? { |declarations| declarations.key?(declaration.name) }
 
             if shadowed
-              next @visitor.slot_error("The state `#{declaration.name}` is declared in both an item and its region. A later read could mean either one, so give them different names.", node.location, :declaration)
+              next @visitor.slot_error("The state `#{declaration.name}` is declared in both an item and its region. A later read could mean either one, so give them different names.", spelled, :declaration)
             end
 
             bucket[declaration.name] = declaration
           end
 
           @state_directives << { node: node, parent: parent, scope: scope, inline: @visitor.inline? }
+        end
+
+        #: (StateDirectives::Declaration) -> Herb::Location?
+        def declaration_location(declaration)
+          line = declaration.line
+
+          return nil unless line
+
+          column = declaration.column || 0
+
+          Herb::Location.from(line, column, line, column + declaration.name.length)
         end
 
         #: (String?) -> Symbol

--- a/lib/herb/engine/slots/state_directives.rb
+++ b/lib/herb/engine/slots/state_directives.rb
@@ -12,6 +12,7 @@ module Herb
       class StateDirectives
         PATTERN = /\A-?\s*herb:state\s*(?<signature>\(.*\))\s*-?\z/m #: Regexp
         BARE = /\A[a-z_][a-zA-Z0-9_]*\z/ #: Regexp
+        PREFIX = "def __herb_states" #: String
 
         KINDS = {
           "Prism::TrueNode" => :boolean,
@@ -58,7 +59,9 @@ module Herb
           :names,     #: Array[String]
           :enclosing, #: Hash[String, Declaration]
           :visitor,   #: untyped
-          :location   #: Herb::Location?
+          :location,  #: Herb::Location?
+          :signature, #: String
+          :anchor     #: Herb::Position?
         )
 
         module Silent
@@ -82,12 +85,15 @@ module Herb
             PATTERN.match(node.content&.value.to_s.strip)&.[](:signature)
           end
 
-          #: (String, Hash[String, Symbol], visitor: untyped, location: Herb::Location?, ?enclosing: Hash[String, Declaration]) -> Array[Declaration]
-          def parse(signature, locals, visitor:, location:, enclosing: {})
-            result = Prism.parse("def __herb_states#{signature}; end")
+          #: (String, Hash[String, Symbol], visitor: untyped, node: untyped, ?enclosing: Hash[String, Declaration]) -> Array[Declaration]
+          def parse(signature, locals, visitor:, node:, enclosing: {})
+            result = Prism.parse("#{PREFIX}#{signature}; end")
+            location = node&.location
+            anchor = node ? anchor_of(node, signature) : nil
+            whole = anchor ? span(anchor, signature, 0, signature.length) : location
 
             if result.failure?
-              visitor.slot_error("`herb:state #{signature}` does not parse as a keyword signature. Declare each state as a keyword parameter with a default, like `(pending: false)`.", location, :declaration)
+              visitor.slot_error("`herb:state #{signature}` does not parse as a keyword signature. Declare each state as a keyword parameter with a default, like `(pending: false)`.", whole, :declaration)
 
               return []
             end
@@ -96,7 +102,7 @@ module Herb
             parameters = definition.is_a?(Prism::DefNode) ? definition.parameters : nil
 
             unless parameters && parameters.requireds.empty? && parameters.optionals.empty? && parameters.rest.nil? && parameters.posts.empty? && parameters.keyword_rest.nil? && parameters.block.nil? && !parameters.keywords.empty?
-              visitor.slot_error("`herb:state #{signature}` declares no keyword parameters. Declare each state with a default, like `(pending: false)`.", location, :declaration)
+              visitor.slot_error("`herb:state #{signature}` declares no keyword parameters. Declare each state with a default, like `(pending: false)`.", whole, :declaration)
 
               return []
             end
@@ -109,7 +115,9 @@ module Herb
               names: parameters.keywords.map { |keyword| keyword.name.to_s },
               enclosing: enclosing,
               visitor: visitor,
-              location: location
+              location: location,
+              signature: signature,
+              anchor: anchor
             )
 
             parameters.keywords.map { |keyword|
@@ -352,20 +360,41 @@ module Herb
 
           private
 
+          #: (untyped, String) -> Herb::Position?
+          def anchor_of(node, signature)
+            content = node.content
+            start = content&.location&.start
+
+            return nil unless start
+
+            offset = content.value.to_s.index(signature)
+
+            offset ? position_at(start, content.value.to_s, offset) : nil
+          end
+
           #: (untyped, Parsing) -> Declaration
           def declaration_for(keyword, parsing)
+            declaration = classify(keyword, parsing)
+            spot = spelled(keyword, parsing)&.start
+
+            spot ? declaration.with(line: spot.line, column: spot.column) : declaration
+          end
+
+          #: (untyped, Parsing) -> Declaration
+          def classify(keyword, parsing)
             name = keyword.name.to_s
             visitor = parsing.visitor
-            location = parsing.location
 
             unless keyword.is_a?(Prism::OptionalKeywordParameterNode)
-              return refused(name, "The state `#{name}` has no default. Give it one, since the server renders a value for every state, like `(#{name}: false)`.", visitor, location)
+              return refused(name, "The state `#{name}` has no default. Give it one, since the server renders a value for every state, like `(#{name}: false)`.", visitor, spelled(keyword, parsing))
             end
 
             value = keyword.value
             kind = KINDS[value.class.name]
 
             return Declaration.new(name: name, kind: kind, default: value.slice, derived: nil, line: nil, column: nil) if kind
+
+            location = located(value.location, parsing)
 
             case value
             when Prism::FloatNode
@@ -382,6 +411,41 @@ module Herb
             end
           end
 
+          #: (untyped, Parsing) -> Herb::Location?
+          def spelled(keyword, parsing)
+            anchor = parsing.anchor
+
+            return parsing.location unless anchor
+
+            start = keyword.name_loc.start_character_offset - PREFIX.length
+
+            span(anchor, parsing.signature, start, start + keyword.name.to_s.length)
+          end
+
+          #: (untyped, Parsing) -> Herb::Location?
+          def located(location, parsing)
+            anchor = parsing.anchor
+
+            return parsing.location unless anchor && location
+
+            span(anchor, parsing.signature, location.start_character_offset - PREFIX.length, location.end_character_offset - PREFIX.length)
+          end
+
+          #: (Herb::Position, String, Integer, Integer) -> Herb::Location
+          def span(anchor, source, start_offset, end_offset)
+            Herb::Location.new(position_at(anchor, source, start_offset), position_at(anchor, source, end_offset))
+          end
+
+          #: (Herb::Position, String, Integer) -> Herb::Position
+          def position_at(anchor, source, offset)
+            consumed = source.slice(0, offset).to_s
+            last = consumed.rindex("\n")
+
+            return Herb::Position.new(anchor.line, anchor.column + consumed.length) unless last
+
+            Herb::Position.new(anchor.line + consumed.count("\n"), consumed.length - last - 1)
+          end
+
           #: (String, String, untyped, Herb::Location?, ?String) -> Declaration
           def refused(name, message, visitor, location, default = "nil")
             visitor.slot_error(message, location, :declaration)
@@ -393,7 +457,7 @@ module Herb
           def derived_default(name, value, parsing)
             declared = parsing.declared
             visitor = parsing.visitor
-            location = parsing.location
+            location = located(value.location, parsing)
 
             said = visitor.diagnostic_count
             read = tree_read(value, declared, visitor, location) #: untyped
@@ -433,7 +497,7 @@ module Herb
           def bare_default(name, value, parsing)
             identifier = value.name.to_s
             visitor = parsing.visitor
-            location = parsing.location
+            location = located(value.location, parsing)
 
             unless value.receiver.nil? && value.arguments.nil? && value.block.nil? && BARE.match?(identifier)
               return Declaration.new(name: name, kind: :seeded, default: value.slice, derived: nil, line: nil, column: nil)

--- a/sig/herb/analysis/ruby_locals_index/state_locals.rbs
+++ b/sig/herb/analysis/ruby_locals_index/state_locals.rbs
@@ -10,7 +10,7 @@ module Herb
 
         def self?.directives: (untyped document) -> untyped
 
-        def self?.declarations_in: (untyped signature, untyped known) -> untyped
+        def self?.declarations_in: (untyped node, untyped signature, untyped known) -> untyped
 
         def self?.usages: (untyped name, untyped references, untyped offsets) -> untyped
       end

--- a/sig/herb/engine/slots/state_compiler.rbs
+++ b/sig/herb/engine/slots/state_compiler.rbs
@@ -61,6 +61,9 @@ module Herb
         # : (untyped, Array[untyped]) -> void
         def register_state_directive: (untyped, Array[untyped]) -> void
 
+        # : (StateDirectives::Declaration) -> Herb::Location?
+        def declaration_location: (StateDirectives::Declaration) -> Herb::Location?
+
         # : (String?) -> Symbol
         def local_kind: (String?) -> Symbol
 

--- a/sig/herb/engine/slots/state_directives.rbs
+++ b/sig/herb/engine/slots/state_directives.rbs
@@ -10,6 +10,8 @@ module Herb
 
         BARE: Regexp
 
+        PREFIX: String
+
         KINDS: Hash[String, Symbol]
 
         class Declaration < Data
@@ -95,12 +97,16 @@ module Herb
 
           attr_reader location(): Herb::Location?
 
-          def self.new: (Hash[String, Symbol] locals, Hash[String, Declaration] declared, Array[String] names, Hash[String, Declaration] enclosing, untyped visitor, Herb::Location? location) -> instance
-                      | (locals: Hash[String, Symbol], declared: Hash[String, Declaration], names: Array[String], enclosing: Hash[String, Declaration], visitor: untyped, location: Herb::Location?) -> instance
+          attr_reader signature(): String
 
-          def self.members: () -> [ :locals, :declared, :names, :enclosing, :visitor, :location ]
+          attr_reader anchor(): Herb::Position?
 
-          def members: () -> [ :locals, :declared, :names, :enclosing, :visitor, :location ]
+          def self.new: (Hash[String, Symbol] locals, Hash[String, Declaration] declared, Array[String] names, Hash[String, Declaration] enclosing, untyped visitor, Herb::Location? location, String signature, Herb::Position? anchor) -> instance
+                      | (locals: Hash[String, Symbol], declared: Hash[String, Declaration], names: Array[String], enclosing: Hash[String, Declaration], visitor: untyped, location: Herb::Location?, signature: String, anchor: Herb::Position?) -> instance
+
+          def self.members: () -> [ :locals, :declared, :names, :enclosing, :visitor, :location, :signature, :anchor ]
+
+          def members: () -> [ :locals, :declared, :names, :enclosing, :visitor, :location, :signature, :anchor ]
         end
 
         module Silent
@@ -114,8 +120,8 @@ module Herb
         # : (untyped) -> String?
         def self.signature_of: (untyped) -> String?
 
-        # : (String, Hash[String, Symbol], visitor: untyped, location: Herb::Location?, ?enclosing: Hash[String, Declaration]) -> Array[Declaration]
-        def self.parse: (String, Hash[String, Symbol], visitor: untyped, location: Herb::Location?, ?enclosing: Hash[String, Declaration]) -> Array[Declaration]
+        # : (String, Hash[String, Symbol], visitor: untyped, node: untyped, ?enclosing: Hash[String, Declaration]) -> Array[Declaration]
+        def self.parse: (String, Hash[String, Symbol], visitor: untyped, node: untyped, ?enclosing: Hash[String, Declaration]) -> Array[Declaration]
 
         # : (String, Hash[String, Declaration], untyped, Herb::Location?) -> (Read | Combo | Symbol)?
         def self.condition_read: (String, Hash[String, Declaration], untyped, Herb::Location?) -> (Read | Combo | Symbol)?
@@ -168,8 +174,26 @@ module Herb
         # : (String, Hash[String, Declaration]) -> bool
         def self.mentions_any?: (String, Hash[String, Declaration]) -> bool
 
+        # : (untyped, String) -> Herb::Position?
+        private def self.anchor_of: (untyped, String) -> Herb::Position?
+
         # : (untyped, Parsing) -> Declaration
         private def self.declaration_for: (untyped, Parsing) -> Declaration
+
+        # : (untyped, Parsing) -> Declaration
+        private def self.classify: (untyped, Parsing) -> Declaration
+
+        # : (untyped, Parsing) -> Herb::Location?
+        private def self.spelled: (untyped, Parsing) -> Herb::Location?
+
+        # : (untyped, Parsing) -> Herb::Location?
+        private def self.located: (untyped, Parsing) -> Herb::Location?
+
+        # : (Herb::Position, String, Integer, Integer) -> Herb::Location
+        private def self.span: (Herb::Position, String, Integer, Integer) -> Herb::Location
+
+        # : (Herb::Position, String, Integer) -> Herb::Position
+        private def self.position_at: (Herb::Position, String, Integer) -> Herb::Position
 
         # : (String, String, untyped, Herb::Location?, ?String) -> Declaration
         private def self.refused: (String, String, untyped, Herb::Location?, ?String) -> Declaration

--- a/test/engine/slots/diagnostics_test.rb
+++ b/test/engine/slots/diagnostics_test.rb
@@ -26,6 +26,20 @@ module Engine
         <p data-herb-name="body"><%= @b %></p>
       ERB
 
+      TWICE_DECLARED = <<~ERB
+        <%# herb:state (open: false) %>
+        <%# herb:state (open: true) %>
+        <div><%= open %></div>
+      ERB
+
+      SPREAD_DIRECTIVE = <<~ERB
+        <%# herb:state (
+          open: false,
+          rate: 1.0
+        ) %>
+        <div><%= rate %></div>
+      ERB
+
       TWO_DIRECTIVES = <<~ERB
         <%# herb:state (open: false) %>
         <div><%= open %></div>
@@ -58,6 +72,12 @@ module Engine
 
       def at(diagnostic)
         [diagnostic.location.start.line, diagnostic.location.start.column]
+      end
+
+      def spelled(template, diagnostic)
+        location = diagnostic.location
+
+        template.lines[location.start.line - 1].to_s[location.start.column...location.end.column]
       end
 
       test "one directive reports every state it got wrong" do
@@ -97,7 +117,7 @@ module Engine
       test "each diagnostic points at the directive it came from" do
         diagnostics, = report(TWO_DIRECTIVES)
 
-        assert_equal([[3, 0]], diagnostics.map { |diagnostic| at(diagnostic) })
+        assert_equal([[3, 22]], diagnostics.map { |diagnostic| at(diagnostic) })
       end
 
       test "a name points at the attribute that spelled it" do
@@ -158,7 +178,7 @@ module Engine
 
         shown = error.detailed_message.gsub(/\e\[[0-9;]*m/, "")
 
-        assert_equal ["app/views/test.html.erb:2:1:"], shown.scan(%r{app/views/test\.html\.erb:\d+:\d+:}).uniq
+        assert_equal ["app/views/test.html.erb:2:23:", "app/views/test.html.erb:2:35:", "app/views/test.html.erb:2:57:"], shown.scan(%r{app/views/test\.html\.erb:\d+:\d+:}).uniq
         assert_equal(
           [
             "slots-declaration: #{FLOAT_DEFAULT}",
@@ -177,6 +197,27 @@ module Engine
         diagnostics, = report(%(<%# herb:state (open: false) %><div><% if open %>a<% else %>b<% end %></div>))
 
         assert_empty diagnostics
+      end
+
+      test "a diagnostic points at the default it refused, not the whole directive" do
+        diagnostics, = report(THREE_BAD_STATES)
+
+        assert_equal([[2, 22], [2, 34], [2, 56]], diagnostics.map { |diagnostic| at(diagnostic) })
+        assert_equal(["1.0", "{ title: \"\" }", "[]"], diagnostics.map { |diagnostic| spelled(THREE_BAD_STATES, diagnostic) })
+      end
+
+      test "a diagnostic about the name points at the name it refused" do
+        diagnostics, = report(TWICE_DECLARED)
+
+        assert_equal([[2, 16]], diagnostics.map { |diagnostic| at(diagnostic) })
+        assert_equal(["open"], diagnostics.map { |diagnostic| spelled(TWICE_DECLARED, diagnostic) })
+      end
+
+      test "a diagnostic in a directive spread over lines points at the line it came from" do
+        diagnostics, = report(SPREAD_DIRECTIVE)
+
+        assert_equal([[3, 8]], diagnostics.map { |diagnostic| at(diagnostic) })
+        assert_equal(["1.0"], diagnostics.map { |diagnostic| spelled(SPREAD_DIRECTIVE, diagnostic) })
       end
     end
   end


### PR DESCRIPTION
This pull request updates the `herb:state` compile diagnostics to point at the span they are actually about, instead of highlighting the whole ERB comment.

Every finding raised while parsing a state signature was handed `node.location`, the location of the entire `<%# … %>` node. A single bad default lit up the whole directive, and a directive that declared three bad states reported three findings that all pointed at the same place.

**Before**

```erb
<%# herb:state (draft: 1.5) %>
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ The state `draft` has a Float default.
```

**After**

```erb
<%# herb:state (draft: 1.5) %>
                       ^^^ The state `draft` has a Float default.
```