### PR TITLE
Dev Tools: Rename the overlay menu header to "Herb Dev Tools"

### DIFF
--- a/javascript/packages/dev-tools/src/overlay/overlay.ts
+++ b/javascript/packages/dev-tools/src/overlay/overlay.ts
@@ -221,7 +221,7 @@ export class HerbOverlay {
         </button>
 
         <div class="herb-menu-panel" id="herbMenuPanel">
-          <div class="herb-menu-header">Herb Debug Tools</div>
+          <div class="herb-menu-header">Herb Dev Tools</div>
 
           <div id="herbDevServerSection" class="herb-dev-server-section">
             <span id="herbDevServerDot" data-herb-dev-server-dot class="herb-dev-server-dot"></span>


### PR DESCRIPTION
This pull request updates the dev tools overlay menu header to say "Herb Dev Tools" so it matches the name used everywhere else.