### PR TITLE
Linter: Match Prism when classifying `herb:state` default literals

### DIFF
--- a/javascript/packages/client/src/directives.ts
+++ b/javascript/packages/client/src/directives.ts
@@ -149,11 +149,11 @@ export function classifyDefault(source: string): StateDefaultKind {
     return "nil"
   }
 
-  if (/^-?\d[\d_]*\.\d/.test(source)) {
+  if (/^-?\d[\d_]*(?:\.\d[\d_]*(?:[eE][-+]?\d[\d_]*)?|[eE][-+]?\d[\d_]*)$/.test(source)) {
     return "float"
   }
 
-  if (/^-?\d[\d_]*$/.test(source)) {
+  if (/^-?(?:\d[\d_]*|0[xX][\da-fA-F][\da-fA-F_]*|0[oO][0-7][0-7_]*|0[bB][01][01_]*|0[dD]\d[\d_]*)$/.test(source)) {
     return "integer"
   }
 
@@ -162,6 +162,10 @@ export function classifyDefault(source: string): StateDefaultKind {
   }
 
   if (/^'(?:[^'\\]|\\.)*'$/s.test(source)) {
+    return "string"
+  }
+
+  if (/^\?(?:\\[a-zA-Z0-9\\]|[^\s\\])$/.test(source)) {
     return "string"
   }
 

--- a/javascript/packages/client/test/directives.test.ts
+++ b/javascript/packages/client/test/directives.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect } from "vitest"
-import { mentionsAnyState } from "../src/directives"
+import { classifyDefault, mentionsAnyState } from "../src/directives"
 
 describe("mentionsAnyState", () => {
   test("a bare read mentions the state", () => {
@@ -16,5 +16,46 @@ describe("mentionsAnyState", () => {
     expect(mentionsAnyState("reopen", ["open"])).toBe(false)
     expect(mentionsAnyState("open_at", ["open"])).toBe(false)
     expect(mentionsAnyState("open!", ["open"])).toBe(false)
+  })
+})
+
+describe("classifyDefault", () => {
+  test("classifies the literals Prism calls floats", () => {
+    for (const source of ["1.0", "-1.5", "1_000.5", "1e3", "1E3", "1.5e-3", "1_0e1_0"]) {
+      expect(classifyDefault(source)).toBe("float")
+    }
+  })
+
+  test("classifies every integer radix Ruby accepts", () => {
+    for (const source of ["0", "1", "-5", "1_000", "017", "0x1f", "0X1F", "-0x10", "0o17", "0b1010", "0d99"]) {
+      expect(classifyDefault(source)).toBe("integer")
+    }
+  })
+
+  test("classifies quoted and character strings", () => {
+    for (const source of ['"x"', "'x'", "?a", "?\\n"]) {
+      expect(classifyDefault(source)).toBe("string")
+    }
+  })
+
+  test("classifies symbols", () => {
+    for (const source of [":a", ':"a"', ":a?"]) {
+      expect(classifyDefault(source)).toBe("symbol")
+    }
+  })
+
+  test("falls back to seeded rather than guessing a kind", () => {
+    for (const source of ["1r", "2i", '"a#{b}"', "%q(x)", "%(x)", "%s(a)", "1."]) {
+      expect(classifyDefault(source)).toBe("seeded")
+    }
+  })
+
+  test("keeps the kinds it already recognized", () => {
+    expect(classifyDefault("")).toBe("missing")
+    expect(classifyDefault("true")).toBe("boolean")
+    expect(classifyDefault("nil")).toBe("nil")
+    expect(classifyDefault("[]")).toBe("array")
+    expect(classifyDefault("{ a: 1 }")).toBe("hash")
+    expect(classifyDefault("open_initially")).toBe("bare")
   })
 })

--- a/javascript/packages/linter/test/rules/herb-state-valid-declaration.test.ts
+++ b/javascript/packages/linter/test/rules/herb-state-valid-declaration.test.ts
@@ -59,6 +59,22 @@ describe("HerbStateValidDeclarationRule", () => {
     `)
   })
 
+  test("flags a Float default written with an exponent", () => {
+    expectError("The state `rate` has a Float default. Use an Integer or a String instead, since Ruby and JavaScript print floats differently.", [1, 22])
+
+    assertOffenses(dedent`
+      <%# herb:state (rate: 1e3) %>
+      <div></div>
+    `)
+  })
+
+  test("allows an Integer default written in another radix", () => {
+    expectNoOffenses(dedent`
+      <%# herb:state (mask: 0b1010, color: 0xff, mode: 0o17) %>
+      <div></div>
+    `)
+  })
+
   test("flags an Array default", () => {
     expectError("The state `selected` has an Array default. Declare a per-row boolean inside the loop instead, like `selected: false`. A list on the page is a collection of items, not a state.")
 

--- a/lib/herb/engine/slots/state_compiler.rb
+++ b/lib/herb/engine/slots/state_compiler.rb
@@ -227,11 +227,7 @@ module Herb
           empty = {} #: Hash[String, StateDirectives::Declaration]
           bucket = scope ? (@item_states[scope] ||= empty) : @region_states
 
-          location = node.location&.start
-
-          declared = declared.map { |declaration|
-            declaration.line ? declaration : declaration.with(line: location&.line, column: location&.column)
-          }
+          start = node.location&.start
 
           declared.each do |declaration|
             spelled = declaration_location(declaration) || node.location
@@ -250,7 +246,7 @@ module Herb
               next @visitor.slot_error("The state `#{declaration.name}` is declared in both an item and its region. A later read could mean either one, so give them different names.", spelled, :declaration)
             end
 
-            bucket[declaration.name] = declaration
+            bucket[declaration.name] = declaration.line ? declaration : declaration.with(line: start&.line, column: start&.column)
           end
 
           @state_directives << { node: node, parent: parent, scope: scope, inline: @visitor.inline? }

--- a/lib/herb/engine/slots/state_directives.rb
+++ b/lib/herb/engine/slots/state_directives.rb
@@ -375,7 +375,7 @@ module Herb
           #: (untyped, Parsing) -> Declaration
           def declaration_for(keyword, parsing)
             declaration = classify(keyword, parsing)
-            spot = spelled(keyword, parsing)&.start
+            spot = parsing.anchor ? spelled(keyword, parsing)&.start : nil
 
             spot ? declaration.with(line: spot.line, column: spot.column) : declaration
           end


### PR DESCRIPTION
`Herb::Engine::Slots::StateDirectives` classifies a default by parsing it with Prism and reading the node type. `classifyDefault` in `@herb-tools/client` classifies with regexes, because that module ships to the browser where Prism is unavailable. The two disagreed on several literal forms Ruby accepts.

The engine refuses a Float default outright, while the linter that exists to catch that first saw `seeded` and said nothing, so the author met a compile error with no warning ahead of it.