### PR TITLE
Dev Server: Attribute a finding to whoever found it

### DIFF
--- a/javascript/packages/dev-tools/src/dev-server/diagnostics.ts
+++ b/javascript/packages/dev-tools/src/dev-server/diagnostics.ts
@@ -7,12 +7,13 @@ export function diagnosticsFromError(message: ErrorMessage): RuntimeDiagnostic[]
   return message.errors.map((error) => ({
     template: message.file,
     message: error.message,
-    code: error.name,
+    code: error.code ?? error.name,
     severity: "error" as const,
-    origin: DEV_SERVER_ORIGIN,
+    origin: error.origin ?? DEV_SERVER_ORIGIN,
     phase: "compile" as const,
     overlay: "dismissible" as const,
     location: { start: { line: error.line, column: error.column + 1 } },
+    ...(error.suggestion ? { suggestion: error.suggestion } : {}),
     ...(message.source === undefined ? {} : { source: message.source }),
   }))
 }

--- a/javascript/packages/dev-tools/src/dev-server/types.ts
+++ b/javascript/packages/dev-tools/src/dev-server/types.ts
@@ -40,6 +40,9 @@ export interface ParseError {
   message: string
   line: number
   column: number
+  code?: string
+  origin?: string
+  suggestion?: string | null
 }
 
 export interface ErrorMessage {

--- a/javascript/packages/dev-tools/src/herb-dev-tools.ts
+++ b/javascript/packages/dev-tools/src/herb-dev-tools.ts
@@ -10,7 +10,6 @@ import type { DiagnosticSink, HerbClientOptions } from './dev-server/types.js'
 import type { RuntimeReportHandle } from './runtime/panel.js'
 import type { RuntimeDiagnostic } from './runtime/report.js'
 
-import { DEV_SERVER_ORIGIN } from './dev-server/diagnostics.js'
 
 const NOOP_HANDLE: RuntimeReportHandle = { dismiss() {} }
 
@@ -58,6 +57,7 @@ export class HerbDevTools {
   }
 
   private devServerClient: HerbClient | null = null
+  private devServerReport: RuntimeReportHandle | null = null
   private devToolsOverlay: HerbOverlay | null = null
   private panel: RuntimePanel | null = null
   private styleElement: HTMLStyleElement | null = null
@@ -71,6 +71,7 @@ export class HerbDevTools {
 
     this.devServerClient?.disconnect()
     this.devServerClient = null
+    this.devServerReport = null
 
     this.devToolsOverlay?.destroy()
     this.devToolsOverlay = null
@@ -169,9 +170,12 @@ export class HerbDevTools {
 
     return {
       report: diagnostics => {
-        panel.report(diagnostics)
+        this.devServerReport = panel.report(diagnostics)
       },
-      clear: () => panel.clear(DEV_SERVER_ORIGIN),
+      clear: () => {
+        this.devServerReport?.dismiss()
+        this.devServerReport = null
+      },
     }
   }
 

--- a/javascript/packages/dev-tools/test/dev-server-diagnostics.test.ts
+++ b/javascript/packages/dev-tools/test/dev-server-diagnostics.test.ts
@@ -92,10 +92,31 @@ describe("diagnostics from a dev server error", () => {
     expect(diagnostic.severity).toBe("error")
   })
 
-  test("carries an origin the client can clear on its own", () => {
+  test("names whoever found it, not the road it took here", () => {
+    const message = errorMessage()
+
+    message.errors[0].origin = "Herb Parser"
+    message.errors[0].code = "missing-closing-tag"
+    message.errors[0].suggestion = "Close the `<form>` before the `</div>`."
+
+    const [diagnostic] = diagnosticsFromError(message)
+
+    expect(diagnostic.origin).toBe("Herb Parser")
+    expect(diagnostic.code).toBe("missing-closing-tag")
+    expect(diagnostic.suggestion).toBe("Close the `<form>` before the `</div>`.")
+  })
+
+  test("falls back to the dev server when it did not say who found it", () => {
     const [diagnostic] = diagnosticsFromError(errorMessage())
 
     expect(diagnostic.origin).toBe(DEV_SERVER_ORIGIN)
+    expect(diagnostic.code).toBe("missing-closing-tag")
+  })
+
+  test("leaves the suggestion off when there is none", () => {
+    const [diagnostic] = diagnosticsFromError(errorMessage())
+
+    expect("suggestion" in diagnostic).toBe(false)
   })
 
   test("carries the source the server sent, so the panel can draw a frame", () => {
@@ -133,6 +154,25 @@ describe("a dev server error in the panel", () => {
     expect(document.querySelector(".herb-dev-tools-card")?.textContent).toContain("missing-closing-tag")
 
     panel.clear(DEV_SERVER_ORIGIN)
+
+    expect(document.querySelector(".herb-dev-tools-card")).toBeNull()
+  })
+
+  test("is cleared by what was reported, since it no longer answers to the dev server's name", () => {
+    const panel = createPanel()
+    const message = errorMessage()
+
+    message.errors[0].origin = "Herb Parser"
+
+    const handle = panel.report(diagnosticsFromError(message))
+
+    expect(document.querySelector(".herb-dev-tools-card")).not.toBeNull()
+
+    panel.clear(DEV_SERVER_ORIGIN)
+
+    expect(document.querySelector(".herb-dev-tools-card")).not.toBeNull()
+
+    handle.dismiss()
 
     expect(document.querySelector(".herb-dev-tools-card")).toBeNull()
   })

--- a/lib/herb/dev/runner.rb
+++ b/lib/herb/dev/runner.rb
@@ -293,9 +293,14 @@ module Herb
             file: relative_path,
             source: current_content,
             errors: current_errors.map { |error|
+              diagnostic = error.to_diagnostic(template: relative_path)
+
               {
                 name: error.error_name,
-                message: error.message,
+                code: diagnostic.code,
+                origin: diagnostic.origin,
+                message: diagnostic.message,
+                suggestion: diagnostic.suggestion,
                 line: error.location.start.line,
                 column: error.location.start.column,
               }

--- a/test/dev/runner_test.rb
+++ b/test/dev/runner_test.rb
@@ -45,6 +45,23 @@ module Dev
       websocket.messages.first
     end
 
+    test "names the parser as what found the error, not itself as what delivered it" do
+      error = broadcast_for(BROKEN, "")[:errors].first
+      parsed = Herb.parse(BROKEN, strict: true, analyze: true).errors.first.to_diagnostic(template: "app/views/posts/index.html.erb")
+
+      assert_equal "Herb Parser", error[:origin]
+      assert_equal parsed.origin, error[:origin]
+    end
+
+    test "sends the code and suggestion the same error would carry off the page" do
+      error = broadcast_for(BROKEN, "")[:errors].first
+      parsed = Herb.parse(BROKEN, strict: true, analyze: true).errors.first.to_diagnostic(template: "app/views/posts/index.html.erb")
+
+      assert_equal parsed.code, error[:code]
+      assert_equal parsed.suggestion, error[:suggestion]
+      assert_equal parsed.message, error[:message]
+    end
+
     test "sends the whole file with the errors, so the panel can highlight it" do
       assert_equal BROKEN, broadcast_for(BROKEN, "")[:source]
     end


### PR DESCRIPTION
This pull request has the dev server build the diagnostics it broadcasts from `Herb::Errors::Error#to_diagnostic`, so the same parse error is described the same way whether it reaches the browser with the page or over the websocket.

A parse error shown on the error page comes from `to_diagnostic`. The same error arriving over the dev server was assembled by hand in `broadcast_errors`.

So the panel filed the same finding under a different origin depending on how it got there, showed the class name where it shows a code everywhere else, and dropped the suggestion. The dev server is how a finding arrived, not who found it.