### PR TITLE
Highlighter: Color `<%#` and its content as a comment

### DIFF
--- a/javascript/packages/highlighter/src/syntax-renderer.ts
+++ b/javascript/packages/highlighter/src/syntax-renderer.ts
@@ -8,6 +8,8 @@ import type { ColorScheme } from "./themes.js"
 const HIGHLIGHTED_METHODS = ["raise"]
 const HIGHLIGHTED_WORDS = new Set([...RUBY_KEYWORDS, ...HIGHLIGHTED_METHODS])
 
+const ERB_COMMENT_TAG_OPENING = "<%#"
+
 type SyntaxRenderState = {
   inTag: boolean
   inQuotes: boolean
@@ -17,6 +19,7 @@ type SyntaxRenderState = {
   expectingAttributeName: boolean
   expectingAttributeValue: boolean
   inComment: boolean
+  inERBComment: boolean
 }
 
 export class SyntaxRenderer {
@@ -97,6 +100,7 @@ export class SyntaxRenderer {
       expectingAttributeName: false,
       expectingAttributeValue: false,
       inComment: false,
+      inERBComment: false,
     }
 
     for (let i = 0; i < tokens.length; i++) {
@@ -114,7 +118,7 @@ export class SyntaxRenderer {
 
       const color = this.getContextualColor(state, token, tokenText)
 
-      if (token.type === "TOKEN_ERB_CONTENT") {
+      if (token.type === "TOKEN_ERB_CONTENT" && !state.inERBComment) {
         const highlightedRuby = this.highlightRubyCode(tokenText)
         highlighted += highlightedRuby
       } else if (color !== undefined) {
@@ -204,6 +208,12 @@ export class SyntaxRenderer {
       case "TOKEN_HTML_COMMENT_END":
         state.inComment = false
         break
+
+      // Every ERB tag re-decides this, so the flag never has to be cleared on
+      // `TOKEN_ERB_END` — which keeps the closing `%>` inside the comment.
+      case "TOKEN_ERB_START":
+        state.inERBComment = tokenText === ERB_COMMENT_TAG_OPENING
+        break
     }
   }
 
@@ -212,6 +222,15 @@ export class SyntaxRenderer {
     token: Token,
     tokenText: string,
   ): Color | null {
+    if (
+      state.inERBComment &&
+      (token.type === "TOKEN_ERB_START" ||
+        token.type === "TOKEN_ERB_CONTENT" ||
+        token.type === "TOKEN_ERB_END")
+    ) {
+      return this.colors.TOKEN_HTML_COMMENT_START
+    }
+
     if (
       state.inComment &&
       token.type !== "TOKEN_HTML_COMMENT_START" &&

--- a/javascript/packages/highlighter/test/syntax-renderer.test.ts
+++ b/javascript/packages/highlighter/test/syntax-renderer.test.ts
@@ -4,7 +4,15 @@ import { themes } from "../src/themes.js"
 import { Range } from "@herb-tools/core"
 import { Herb } from "@herb-tools/node-wasm"
 import { SyntaxRenderer } from "../src/syntax-renderer.js"
-import { ANSI_REGEX } from "../src/ansi.js"
+import { ANSI_REGEX, stripAnsiColors } from "../src/ansi.js"
+import { colorize } from "../src/color.js"
+
+/** A stub backend that lexes to a fixed token list. */
+const rendererFor = (value: unknown[]) => ({
+  isLoaded: true,
+  load: async () => {},
+  lex: () => ({ errors: [], value }),
+})
 
 describe("SyntaxRenderer", () => {
   let renderer: SyntaxRenderer
@@ -225,6 +233,71 @@ describe("SyntaxRenderer", () => {
       const result = erbCommentRenderer.highlight(content)
 
       expect(result).toMatchSnapshot()
+    })
+
+    it("should highlight an ERB comment tag and its content as a comment", async () => {
+      const content = "<%# note %>"
+      const commentRenderer = new SyntaxRenderer(
+        themes.onedark,
+        rendererFor([
+          { type: "TOKEN_ERB_START", range: Range.from(0, 3) },
+          { type: "TOKEN_ERB_CONTENT", range: Range.from(3, 9) },
+          { type: "TOKEN_ERB_END", range: Range.from(9, 11) },
+        ]) as any,
+      )
+      await commentRenderer.initialize()
+
+      const result = commentRenderer.highlight(content)
+      const comment = themes.onedark.TOKEN_HTML_COMMENT_START
+
+      expect(result).toContain(colorize("<%#", comment))
+      expect(result).toContain(colorize(" note ", comment))
+      expect(result).toContain(colorize("%>", comment))
+      expect(result).not.toContain(colorize("<%#", themes.onedark.TOKEN_ERB_START))
+      expect(stripAnsiColors(result)).toBe(content)
+    })
+
+    it("should not highlight Ruby keywords inside an ERB comment", async () => {
+      const content = "<%# if end %>"
+      const commentRenderer = new SyntaxRenderer(
+        themes.onedark,
+        rendererFor([
+          { type: "TOKEN_ERB_START", range: Range.from(0, 3) },
+          { type: "TOKEN_ERB_CONTENT", range: Range.from(3, 11) },
+          { type: "TOKEN_ERB_END", range: Range.from(11, 13) },
+        ]) as any,
+      )
+      await commentRenderer.initialize()
+
+      const result = commentRenderer.highlight(content)
+
+      expect(result).not.toContain(colorize("if", themes.onedark.RUBY_KEYWORD))
+      expect(result).not.toContain(colorize("end", themes.onedark.RUBY_KEYWORD))
+      expect(result).toContain(colorize(" if end ", themes.onedark.TOKEN_HTML_COMMENT_START))
+      expect(stripAnsiColors(result)).toBe(content)
+    })
+
+    it("should still highlight a regular ERB tag that follows a comment", async () => {
+      const content = "<%# note %><% if x %>"
+      const commentRenderer = new SyntaxRenderer(
+        themes.onedark,
+        rendererFor([
+          { type: "TOKEN_ERB_START", range: Range.from(0, 3) },
+          { type: "TOKEN_ERB_CONTENT", range: Range.from(3, 9) },
+          { type: "TOKEN_ERB_END", range: Range.from(9, 11) },
+          { type: "TOKEN_ERB_START", range: Range.from(11, 13) },
+          { type: "TOKEN_ERB_CONTENT", range: Range.from(13, 19) },
+          { type: "TOKEN_ERB_END", range: Range.from(19, 21) },
+        ]) as any,
+      )
+      await commentRenderer.initialize()
+
+      const result = commentRenderer.highlight(content)
+
+      expect(result).toContain(colorize("<%#", themes.onedark.TOKEN_HTML_COMMENT_START))
+      expect(result).toContain(colorize("<%", themes.onedark.TOKEN_ERB_START))
+      expect(result).toContain(colorize("if", themes.onedark.RUBY_KEYWORD))
+      expect(stripAnsiColors(result)).toBe(content)
     })
   })
 })

--- a/rust/herb-highlighter/src/syntax_renderer.rs
+++ b/rust/herb-highlighter/src/syntax_renderer.rs
@@ -8,6 +8,7 @@ use crate::ruby_keywords::RUBY_KEYWORDS;
 use crate::themes::ColorScheme;
 
 const HIGHLIGHTED_METHODS: &[&str] = &["raise"];
+const ERB_COMMENT_TAG_OPENING: &str = "<%#";
 
 fn is_highlighted_word(word: &str) -> bool {
   RUBY_KEYWORDS.contains(&word) || HIGHLIGHTED_METHODS.contains(&word)
@@ -23,6 +24,7 @@ struct SyntaxRenderState {
   expecting_attribute_name: bool,
   expecting_attribute_value: bool,
   in_comment: bool,
+  in_erb_comment: bool,
 }
 
 pub struct SyntaxRenderer {
@@ -94,7 +96,7 @@ impl SyntaxRenderer {
 
       let color = self.contextual_color(&state, token, token_text);
 
-      if token.token_type == "TOKEN_ERB_CONTENT" {
+      if token.token_type == "TOKEN_ERB_CONTENT" && !state.in_erb_comment {
         highlighted.push_str(&self.highlight_ruby_code(token_text));
       } else {
         highlighted.push_str(&self.apply_color(token_text, color));
@@ -174,12 +176,22 @@ impl SyntaxRenderer {
       "TOKEN_HTML_COMMENT_START" => state.in_comment = true,
       "TOKEN_HTML_COMMENT_END" => state.in_comment = false,
 
+      // Every ERB tag re-decides this, so the flag never has to be cleared on
+      // `TOKEN_ERB_END` — which keeps the closing `%>` inside the comment.
+      "TOKEN_ERB_START" => state.in_erb_comment = token_text == ERB_COMMENT_TAG_OPENING,
+
       _ => {}
     }
   }
 
   fn contextual_color(&self, state: &SyntaxRenderState, token: &Token, token_text: &str) -> Option<Color> {
     let token_type = token.token_type.as_str();
+
+    if state.in_erb_comment
+      && matches!(token_type, "TOKEN_ERB_START" | "TOKEN_ERB_CONTENT" | "TOKEN_ERB_END")
+    {
+      return Some(self.colors.token_html_comment_start);
+    }
 
     if state.in_comment
       && token_type != "TOKEN_HTML_COMMENT_START"

--- a/rust/herb-highlighter/tests/syntax_renderer_test.rs
+++ b/rust/herb-highlighter/tests/syntax_renderer_test.rs
@@ -3,11 +3,12 @@ mod common;
 use std::sync::Arc;
 
 use herb_highlighter::ansi::find_ansi_sequences;
+use herb_highlighter::color::colorize;
 use herb_highlighter::herb_backend::Herb;
 use herb_highlighter::syntax_renderer::SyntaxRenderer;
 use herb_highlighter::themes::{get_theme, Theme};
 
-use common::{no_color, token, with_color, StubBackend};
+use common::{no_color, strip_ansi_colors, token, with_color, StubBackend};
 
 fn renderer(theme: Theme) -> SyntaxRenderer {
   SyntaxRenderer::with_backend(get_theme(theme).clone(), Arc::new(Herb))
@@ -122,4 +123,87 @@ fn preserves_erb_highlighting_in_comments() {
   );
 
   insta::assert_snapshot!(erb_comment_renderer.highlight("<!-- <% code %> -->"));
+}
+
+#[test]
+fn highlights_an_erb_comment_tag_and_its_content_as_a_comment() {
+  with_color();
+
+  let theme = get_theme(Theme::OneDark).clone();
+  let comment = theme.token_html_comment_start;
+  let erb_start = theme.token_erb_start;
+
+  let renderer = SyntaxRenderer::with_backend(
+    theme,
+    StubBackend::with_tokens(vec![
+      token("TOKEN_ERB_START", 0, 3),
+      token("TOKEN_ERB_CONTENT", 3, 9),
+      token("TOKEN_ERB_END", 9, 11),
+    ]),
+  );
+
+  let content = "<%# note %>";
+  let result = renderer.highlight(content);
+
+  assert!(result.contains(&colorize("<%#", comment)));
+  assert!(result.contains(&colorize(" note ", comment)));
+  assert!(result.contains(&colorize("%>", comment)));
+  assert!(!result.contains(&colorize("<%#", erb_start)));
+  assert_eq!(strip_ansi_colors(&result), content);
+}
+
+#[test]
+fn does_not_highlight_ruby_keywords_inside_an_erb_comment() {
+  with_color();
+
+  let theme = get_theme(Theme::OneDark).clone();
+  let comment = theme.token_html_comment_start;
+  let keyword = theme.ruby_keyword;
+
+  let renderer = SyntaxRenderer::with_backend(
+    theme,
+    StubBackend::with_tokens(vec![
+      token("TOKEN_ERB_START", 0, 3),
+      token("TOKEN_ERB_CONTENT", 3, 11),
+      token("TOKEN_ERB_END", 11, 13),
+    ]),
+  );
+
+  let content = "<%# if end %>";
+  let result = renderer.highlight(content);
+
+  assert!(!result.contains(&colorize("if", keyword)));
+  assert!(!result.contains(&colorize("end", keyword)));
+  assert!(result.contains(&colorize(" if end ", comment)));
+  assert_eq!(strip_ansi_colors(&result), content);
+}
+
+#[test]
+fn still_highlights_a_regular_erb_tag_that_follows_a_comment() {
+  with_color();
+
+  let theme = get_theme(Theme::OneDark).clone();
+  let comment = theme.token_html_comment_start;
+  let erb_start = theme.token_erb_start;
+  let keyword = theme.ruby_keyword;
+
+  let renderer = SyntaxRenderer::with_backend(
+    theme,
+    StubBackend::with_tokens(vec![
+      token("TOKEN_ERB_START", 0, 3),
+      token("TOKEN_ERB_CONTENT", 3, 9),
+      token("TOKEN_ERB_END", 9, 11),
+      token("TOKEN_ERB_START", 11, 13),
+      token("TOKEN_ERB_CONTENT", 13, 19),
+      token("TOKEN_ERB_END", 19, 21),
+    ]),
+  );
+
+  let content = "<%# note %><% if x %>";
+  let result = renderer.highlight(content);
+
+  assert!(result.contains(&colorize("<%#", comment)));
+  assert!(result.contains(&colorize("<%", erb_start)));
+  assert!(result.contains(&colorize("if", keyword)));
+  assert_eq!(strip_ansi_colors(&result), content);
 }


### PR DESCRIPTION
Closes #2434

## Problem

ERB comment tags are highlighted exactly like `<%` and `<%=`. The opening tag gets the ERB tag color, and the body is run through the Ruby keyword highlighter — so in `<%# if end %>` the words `if` and `end` light up as Ruby keywords inside what is only a comment.

## Approach

`<%#` is already its own `TOKEN_ERB_START` value — it's listed in the lexer's `erb_open_patterns` (`src/lexer.c`), so the token stream for `<%# note %>` is:

```
TOKEN_ERB_START    "<%#"
TOKEN_ERB_CONTENT  " note "
TOKEN_ERB_END      "%>"
```

That means the renderer can key off the opening tag without any lexer or parser change. It tracks whether the current ERB tag is a comment and then colors the opening tag, the content and the closing `%>` with the comment color, skipping Ruby keyword highlighting for the body.

One detail worth calling out: the flag is re-decided on **every** `TOKEN_ERB_START`, so it never has to be cleared on `TOKEN_ERB_END`. That is what keeps the closing `%>` inside the comment, while a regular ERB tag that follows a comment still highlights normally — `<%# note %><% if x %>` colors the first tag as a comment and the second as ordinary ERB with `if` as a keyword.

Applied to both the TypeScript and the Rust implementation, as the issue asks.

## Color choice

This reuses the existing `TOKEN_HTML_COMMENT_START` color rather than introducing a new theme key, so all five bundled themes and any custom theme work unchanged — every theme already defines a muted comment color. If you'd rather ERB comments be themable separately, I'm happy to follow up with an optional `TOKEN_ERB_COMMENT` key that falls back to this one.

## Tests

Three new cases in each implementation, covering the comment tag itself, keyword suppression inside the body, and the "regular tag after a comment" reset. They use explicit assertions rather than snapshots so they document the expected colors directly.

- `javascript/packages/highlighter/test/syntax-renderer.test.ts`
- `rust/herb-highlighter/tests/syntax_renderer_test.rs`

Rust suite run locally — **186 passed, 0 failed** for `cargo test -p herb-highlighter`, including every pre-existing `insta` snapshot test, so nothing was invalidated:

```
test highlights_an_erb_comment_tag_and_its_content_as_a_comment ... ok
test does_not_highlight_ruby_keywords_inside_an_erb_comment ... ok
test still_highlights_a_regular_erb_tag_that_follows_a_comment ... ok
...
test result: ok. 13 passed; 0 failed  (syntax_renderer_test)
```

For the TypeScript side I couldn't build the wasm backend locally (no Emscripten on this machine), so I verified the renderer against the real lexer by driving `SyntaxRenderer` with the published `@herb-tools/node-wasm` token stream, and ran the new tests plus the existing `comment state tracking` tests — all passing. I also checked that no committed snapshot contains `<%#`, so none of them should shift.