### PR TITLE
Engine: Implement `RemoveCommentsVisitor`

### DIFF
--- a/docs/docs/projects/engine.md
+++ b/docs/docs/projects/engine.md
@@ -236,6 +236,7 @@ Herb ships the following transform visitors:
 |-------------------------------|------------------------------------------------------------------------------|
 | `AutoCloseOmittedTagsVisitor` | Replaces omitted closing tags with explicit ones                             |
 | `ContentForVisitor`           | Appends HTML to the end of every matching element                            |
+| `RemoveCommentsVisitor`       | Removes comments, so the output never contains one                           |
 | `HTMLSafeAssertionsVisitor`   | Checks every `.html_safe` call at runtime                                    |
 | `ComponentVisitor`            | Rewrites capitalized tags into `render` calls (experimental)                 |
 | `DebugVisitor`                | Annotates output with the template and position it came from                 |
@@ -376,6 +377,55 @@ The engine renders:
 ```
 
 The closing tag is inserted where the parser determined the element ends, which keeps the surrounding whitespace (and therefore the rendering of `inline-block` elements) identical to the template without the visitor.
+
+### `RemoveCommentsVisitor`
+
+Removes comments, so that the compiled output never contains one.
+
+An HTML comment is served to the browser and is readable by anyone who looks at the page source, so a note the template author wrote for other developers ends up in production.
+
+```ruby
+require "herb/engine/remove_comments_visitor"
+
+Herb::Engine.new(source, visitors: [Herb::Engine::RemoveCommentsVisitor.new])
+```
+
+Given this template:
+
+```html+erb
+<div>
+  <p><%= product.name %></p><!-- TODO: drop this once the new checkout ships -->
+</div>
+```
+
+The engine renders:
+
+```html
+<div>
+  <p>Coffee</p>
+</div>
+```
+
+Everything nested inside a comment goes with it, so ERB written inside one is removed before it is compiled and never runs. A conditional comment is an HTML comment too, which means the markup it guards is removed along with it.
+
+ERB comments go as well. The compiler already leaves `<%# comment %>` and `<% # comment %>` out of the output on its own, so removing them makes it something the template is guaranteed instead of something the compiler happens to do.
+
+What Herb writes to itself is not a comment. A directive is an ERB comment whose content starts with `herb:` or `locals:`, which makes it an instruction to Herb or to Action View instead of a note for people, so `<%# herb:state (pending: false) %>`, `<%# herb:key user.id %>`, `<%# herb:disable html-tag-name-lowercase %>` and `<%# locals: (title:) %>` all stay where they are. The compiler leaves them out of the output the way it leaves any ERB comment out.
+
+A marker is an HTML comment naming `herb-`, which is how a pass hands something to the browser, the way `Slots::Visitor` writes `<!--herb-slot:0-->` around a slot. Markers stay, in the output as well, so the visitor can go anywhere in the stack:
+
+```ruby
+Herb::Engine.new(source, visitors: [
+  Herb::Engine::RemoveCommentsVisitor.new,
+  Herb::Engine::Slots::Visitor.new
+])
+```
+
+Either order renders the same markup, with the template's own comments gone and every slot marker left in place.
+
+The whitespace around a comment is left where it was, so removing one never changes how the elements next to it are laid out. A comment on a line of its own leaves that line's whitespace behind. That includes an ERB comment, where the compiler on its own would have trimmed the line away.
+
+Comment syntax inside a `<script>` or `<style>` element is part of that element's text instead of an HTML comment, so it stays.
 
 ### `ContentForVisitor`
 

--- a/lib/herb/ast/helpers.rb
+++ b/lib/herb/ast/helpers.rb
@@ -40,6 +40,13 @@ module Herb
         opening.start_with?("<%#")
       end
 
+      #: (Herb::AST::Node?) -> bool
+      def erb_comment_node?(node)
+        return false unless node.is_a?(Herb::AST::ERBContentNode)
+
+        erb_comment?(erb_opening(node)) || inline_ruby_comment?(node)
+      end
+
       #: (String) -> bool
       def erb_graphql?(opening)
         opening.start_with?("<%graphql")

--- a/lib/herb/engine/remove_comments_visitor.rb
+++ b/lib/herb/engine/remove_comments_visitor.rb
@@ -1,0 +1,106 @@
+# frozen_string_literal: true
+# typed: false
+
+require_relative "../../herb"
+require_relative "slots/markers"
+
+module Herb
+  class Engine
+    # Removes comments from the template, so that the compiled output never contains one.
+    #
+    # An HTML comment is served to the browser and is readable by anyone who looks at the page
+    # source, so a note the template author wrote for other developers ends up in production.
+    # This drops every `<!-- -->` comment, along with everything nested inside it, before the
+    # compiler sees the template. ERB inside a removed comment is dropped with it and never runs.
+    #
+    # ERB comments go too. The compiler already leaves `<%# comment %>` and `<% # comment %>` out
+    # of the output on its own, so removing them makes it something the template is guaranteed
+    # instead of something the compiler happens to do.
+    #
+    # What Herb writes to itself is not a comment. A directive, which is an ERB comment whose
+    # content starts with `herb:` or `locals:`, is an instruction to Herb or to Action View
+    # instead of a note for people, so `<%# herb:state %>`, `<%# herb:key %>`,
+    # `<%# herb:disable %>` and `<%# locals: (title:) %>` all stay where they are. The compiler
+    # leaves them out of the output the same way it leaves any ERB comment out.
+    #
+    # A marker, which `Slots::Markers` recognizes, is how a pass hands something to the browser,
+    # the way `Slots::Visitor` writes `<!--herb-slot:0-->` around a slot. Those stay too, in the
+    # output as well, so this visitor can run before or after the pass that writes them.
+    #
+    # Whitespace around a comment is left alone, so removing one never changes how the elements
+    # next to it are laid out. A comment on a line of its own leaves that line's whitespace
+    # behind, an ERB comment included, which the compiler on its own would have trimmed away with
+    # the line.
+    #
+    # Comment syntax inside a `<script>` or `<style>` element is part of that element's text
+    # instead of an HTML comment, so it stays. A conditional comment is an HTML comment, so it
+    # goes, and the markup it guards goes with it.
+    #
+    # This visitor is not loaded by default. Require it explicitly and pass it to the engine:
+    #
+    #     require "herb/engine/remove_comments_visitor"
+    #
+    #     Herb::Engine.new(source, visitors: [Herb::Engine::RemoveCommentsVisitor.new])
+    #
+    class RemoveCommentsVisitor < Herb::Visitor
+      CHILD_LISTS = [:children, :body, :statements].freeze #: Array[Symbol]
+      DIRECTIVE = /\A\s*-?\s*#?\s*(?:herb:|locals:)/ #: Regexp
+
+      #: (Herb::AST::Node) -> void
+      def visit_node(node)
+        CHILD_LISTS.each do |name|
+          next unless node.respond_to?(name)
+
+          children = node.public_send(name)
+
+          next unless children.is_a?(Array)
+
+          children.reject! { |child| comment?(child) }
+        end
+      end
+
+      #: () -> String
+      def inspect
+        "#<#{self.class.name}>"
+      end
+
+      private
+
+      #: (Herb::AST::Node?) -> bool
+      def comment?(node)
+        case node
+        when Herb::AST::HTMLCommentNode
+          !marker?(node)
+        when Herb::AST::ERBContentNode
+          erb_comment_node?(node) && !directive?(node)
+        else
+          false
+        end
+      end
+
+      #: (Herb::AST::HTMLCommentNode) -> bool
+      def marker?(node)
+        Slots::Markers.marker?(comment_text(node))
+      end
+
+      #: (Herb::AST::HTMLCommentNode) -> String
+      def comment_text(node)
+        first = (node.children || []).first
+
+        opening = case first
+                  when Herb::AST::LiteralNode, Herb::AST::HTMLTextNode
+                    first.content.to_s
+                  else
+                    ""
+                  end
+
+        "#{node.comment_start&.value}#{opening}"
+      end
+
+      #: (Herb::AST::ERBContentNode) -> bool
+      def directive?(node)
+        DIRECTIVE.match?(node.content&.value.to_s)
+      end
+    end
+  end
+end

--- a/lib/herb/engine/slots/markers.rb
+++ b/lib/herb/engine/slots/markers.rb
@@ -8,6 +8,13 @@ module Herb
         DEFAULT_TYPE = :child #: Symbol
         ITEM_STATICS = "item" #: String
         SEED_VALUE_TYPES = "[true, false, ::Integer, ::String, ::Symbol, nil]" #: String
+        PREFIX = "herb-" #: String
+        COMMENT = %r{\A<!--/?#{PREFIX}} #: Regexp
+
+        #: (String) -> bool
+        def self.marker?(text)
+          COMMENT.match?(text)
+        end
 
         #: (String) -> String
         def self.seeds_expression(pairs)
@@ -16,9 +23,9 @@ module Herb
 
         #: (Integer, Symbol) -> String
         def slot_open(index, type)
-          return "<!--herb-slot:#{index}-->" if type == DEFAULT_TYPE
+          return "<!--#{PREFIX}slot:#{index}-->" if type == DEFAULT_TYPE
 
-          "<!--herb-slot:#{index}:#{type}-->"
+          "<!--#{PREFIX}slot:#{index}:#{type}-->"
         end
 
         #: (Array[[Integer, Symbol, String?]]) -> String
@@ -28,12 +35,12 @@ module Herb
 
         #: (Integer) -> String
         def slot_close(index)
-          "<!--/herb-slot:#{index}-->"
+          "<!--/#{PREFIX}slot:#{index}-->"
         end
 
         #: (Integer, Integer | String) -> String
         def branch(slot_index, branch_index)
-          "<!--herb-branch:#{slot_index}:#{branch_index}-->"
+          "<!--#{PREFIX}branch:#{slot_index}:#{branch_index}-->"
         end
 
         #: (Integer, Integer | String) -> String
@@ -48,7 +55,7 @@ module Herb
 
         #: () -> String
         def seeds_open_prefix
-          "<!--herb-seeds:"
+          "<!--#{PREFIX}seeds:"
         end
 
         #: () -> String
@@ -58,7 +65,7 @@ module Herb
 
         #: (Integer) -> String
         def item_open_prefix(slot_index)
-          "<!--herb-item:#{slot_index}:"
+          "<!--#{PREFIX}item:#{slot_index}:"
         end
 
         #: () -> String
@@ -68,12 +75,12 @@ module Herb
 
         #: (Integer) -> String
         def item_close(slot_index)
-          "<!--/herb-item:#{slot_index}-->"
+          "<!--/#{PREFIX}item:#{slot_index}-->"
         end
 
         #: (String, String) -> String
         def region_open_prefix(file, version)
-          "<!--herb-region:#{file}:#{version}:"
+          "<!--#{PREFIX}region:#{file}:#{version}:"
         end
 
         #: () -> String
@@ -83,7 +90,7 @@ module Herb
 
         #: (String) -> String
         def region_close(file)
-          "<!--/herb-region:#{file}-->"
+          "<!--/#{PREFIX}region:#{file}-->"
         end
 
         #: (String, String) -> String

--- a/sig/herb/ast/helpers.rbs
+++ b/sig/herb/ast/helpers.rbs
@@ -18,6 +18,9 @@ module Herb
       # : (String) -> bool
       def erb_comment?: (String) -> bool
 
+      # : (Herb::AST::Node?) -> bool
+      def erb_comment_node?: (Herb::AST::Node?) -> bool
+
       # : (String) -> bool
       def erb_graphql?: (String) -> bool
 

--- a/sig/herb/engine/remove_comments_visitor.rbs
+++ b/sig/herb/engine/remove_comments_visitor.rbs
@@ -1,0 +1,66 @@
+# Generated from lib/herb/engine/remove_comments_visitor.rb with RBS::Inline
+
+module Herb
+  class Engine
+    # Removes comments from the template, so that the compiled output never contains one.
+    #
+    # An HTML comment is served to the browser and is readable by anyone who looks at the page
+    # source, so a note the template author wrote for other developers ends up in production.
+    # This drops every `<!-- -->` comment, along with everything nested inside it, before the
+    # compiler sees the template. ERB inside a removed comment is dropped with it and never runs.
+    #
+    # ERB comments go too. The compiler already leaves `<%# comment %>` and `<% # comment %>` out
+    # of the output on its own, so removing them makes it something the template is guaranteed
+    # instead of something the compiler happens to do.
+    #
+    # What Herb writes to itself is not a comment. A directive, which is an ERB comment whose
+    # content starts with `herb:` or `locals:`, is an instruction to Herb or to Action View
+    # instead of a note for people, so `<%# herb:state %>`, `<%# herb:key %>`,
+    # `<%# herb:disable %>` and `<%# locals: (title:) %>` all stay where they are. The compiler
+    # leaves them out of the output the same way it leaves any ERB comment out.
+    #
+    # A marker, which `Slots::Markers` recognizes, is how a pass hands something to the browser,
+    # the way `Slots::Visitor` writes `<!--herb-slot:0-->` around a slot. Those stay too, in the
+    # output as well, so this visitor can run before or after the pass that writes them.
+    #
+    # Whitespace around a comment is left alone, so removing one never changes how the elements
+    # next to it are laid out. A comment on a line of its own leaves that line's whitespace
+    # behind, an ERB comment included, which the compiler on its own would have trimmed away with
+    # the line.
+    #
+    # Comment syntax inside a `<script>` or `<style>` element is part of that element's text
+    # instead of an HTML comment, so it stays. A conditional comment is an HTML comment, so it
+    # goes, and the markup it guards goes with it.
+    #
+    # This visitor is not loaded by default. Require it explicitly and pass it to the engine:
+    #
+    #     require "herb/engine/remove_comments_visitor"
+    #
+    #     Herb::Engine.new(source, visitors: [Herb::Engine::RemoveCommentsVisitor.new])
+    class RemoveCommentsVisitor < Herb::Visitor
+      CHILD_LISTS: Array[Symbol]
+
+      DIRECTIVE: Regexp
+
+      # : (Herb::AST::Node) -> void
+      def visit_node: (Herb::AST::Node) -> void
+
+      # : () -> String
+      def inspect: () -> String
+
+      private
+
+      # : (Herb::AST::Node?) -> bool
+      def comment?: (Herb::AST::Node?) -> bool
+
+      # : (Herb::AST::HTMLCommentNode) -> bool
+      def marker?: (Herb::AST::HTMLCommentNode) -> bool
+
+      # : (Herb::AST::HTMLCommentNode) -> String
+      def comment_text: (Herb::AST::HTMLCommentNode) -> String
+
+      # : (Herb::AST::ERBContentNode) -> bool
+      def directive?: (Herb::AST::ERBContentNode) -> bool
+    end
+  end
+end

--- a/sig/herb/engine/slots/markers.rbs
+++ b/sig/herb/engine/slots/markers.rbs
@@ -10,6 +10,13 @@ module Herb
 
         SEED_VALUE_TYPES: String
 
+        PREFIX: String
+
+        COMMENT: Regexp
+
+        # : (String) -> bool
+        def self.marker?: (String) -> bool
+
         # : (String) -> String
         def self.seeds_expression: (String) -> String
 

--- a/test/ast/helpers_test.rb
+++ b/test/ast/helpers_test.rb
@@ -102,5 +102,22 @@ module AST
         refute erb_statement?(conditional)
       end
     end
+
+    describe "#erb_comment_node?" do
+      test "recognizes both ways of writing a comment" do
+        assert erb_comment_node?(erb_node("<%# a comment %>"))
+        assert erb_comment_node?(erb_node("<%#= total %>"))
+        assert erb_comment_node?(erb_node("<%#- a comment -%>"))
+        assert erb_comment_node?(erb_node("<%-# a comment %>"))
+        assert erb_comment_node?(erb_node("<% # a comment %>"))
+      end
+
+      test "rejects a tag that is not a comment" do
+        refute erb_comment_node?(erb_node("<%= total %>"))
+        refute erb_comment_node?(erb_node("<% total = 1 %>"))
+        refute erb_comment_node?(erb_node("<div>hi</div>"))
+        refute erb_comment_node?(nil)
+      end
+    end
   end
 end

--- a/test/engine/remove_comments_visitor_test.rb
+++ b/test/engine/remove_comments_visitor_test.rb
@@ -1,0 +1,322 @@
+# frozen_string_literal: true
+
+require_relative "../test_helper"
+require_relative "../snapshot_utils"
+require_relative "../../lib/herb/engine"
+require_relative "../../lib/herb/engine/remove_comments_visitor"
+require_relative "../../lib/herb/engine/slots/visitor"
+
+module Engine
+  class RemoveCommentsVisitorTest < Minitest::Spec
+    include SnapshotUtils
+
+    def remove_comments_options
+      {
+        escape: false,
+        visitors: [Herb::Engine::RemoveCommentsVisitor.new],
+      }
+    end
+
+    test "visitor is not loaded when only requiring herb" do
+      load_path = $LOAD_PATH.map { |path| "-I#{path}" }.join(" ")
+      output = `#{Gem.ruby} #{load_path} -e 'require "herb"; print defined?(Herb::Engine::RemoveCommentsVisitor).inspect' 2>&1`
+
+      assert_equal "nil", output
+    end
+
+    test "html comment - compilation" do
+      template = "<div><!-- secret --></div>"
+
+      assert_compiled_snapshot(template, remove_comments_options)
+    end
+
+    test "html comment - render" do
+      template = "<div><!-- secret --></div>"
+
+      assert_evaluated_snapshot(template, {}, remove_comments_options)
+    end
+
+    test "html comment on its own line - compilation" do
+      template = <<~ERB
+        <div>
+          <!-- secret -->
+          <p>Content</p>
+        </div>
+      ERB
+
+      assert_compiled_snapshot(template, remove_comments_options)
+    end
+
+    test "html comment on its own line - render" do
+      template = <<~ERB
+        <div>
+          <!-- secret -->
+          <p>Content</p>
+        </div>
+      ERB
+
+      assert_evaluated_snapshot(template, {}, remove_comments_options)
+    end
+
+    test "multi-line html comment - render" do
+      template = <<~ERB
+        <div>
+          <!--
+            a note
+            over two lines
+          -->
+        </div>
+      ERB
+
+      assert_evaluated_snapshot(template, {}, remove_comments_options)
+    end
+
+    test "html comment containing markup - render" do
+      template = "<div><!-- <p>disabled</p> --><p>Content</p></div>"
+
+      assert_evaluated_snapshot(template, {}, remove_comments_options)
+    end
+
+    test "conditional comment - render" do
+      template = '<!--[if lt IE 9]><script src="html5shiv.js"></script><![endif]--><p>Content</p>'
+
+      assert_evaluated_snapshot(template, {}, remove_comments_options)
+    end
+
+    test "comment at the document, head and body level - render" do
+      template = <<~ERB
+        <!DOCTYPE html>
+        <!-- a note -->
+        <html>
+          <head><!-- a note --><title>Title</title></head>
+          <body><!-- a note --><p>Content</p></body>
+        </html>
+      ERB
+
+      assert_evaluated_snapshot(template, {}, remove_comments_options)
+    end
+
+    test "comment inside an erb branch - compilation" do
+      template = "<% if admin? %><!-- admin only --><p>Admin</p><% else %><!-- everyone --><p>User</p><% end %>"
+
+      assert_compiled_snapshot(template, remove_comments_options)
+    end
+
+    test "comment inside an erb branch - render" do
+      template = "<% if admin? %><!-- admin only --><p>Admin</p><% else %><!-- everyone --><p>User</p><% end %>"
+
+      assert_evaluated_snapshot(template, { admin?: false }, remove_comments_options)
+    end
+
+    test "comment inside an erb block - compilation" do
+      template = <<~ERB
+        <ul>
+          <% items.each do |item| %>
+            <!-- item -->
+            <li><%= item %></li>
+          <% end %>
+        </ul>
+      ERB
+
+      assert_compiled_snapshot(template, remove_comments_options)
+    end
+
+    test "comment inside an erb block - render" do
+      template = <<~ERB
+        <ul>
+          <% items.each do |item| %>
+            <!-- item -->
+            <li><%= item %></li>
+          <% end %>
+        </ul>
+      ERB
+
+      assert_evaluated_snapshot(template, { items: ["A", "B"] }, remove_comments_options)
+    end
+
+    test "erb comment - compilation" do
+      template = <<~ERB
+        <div>
+          <%# a comment %>
+          <% # another comment %>
+          <p>Content</p>
+        </div>
+      ERB
+
+      assert_compiled_snapshot(template, remove_comments_options)
+    end
+
+    test "erb comment - render" do
+      template = <<~ERB
+        <div>
+          <%# a comment %>
+          <% # another comment %>
+          <p>Content</p>
+        </div>
+      ERB
+
+      assert_evaluated_snapshot(template, {}, remove_comments_options)
+    end
+
+    test "erb comment in an attribute value - render" do
+      template = '<div class="<%# a comment %>">Content</div>'
+
+      assert_evaluated_snapshot(template, {}, remove_comments_options)
+    end
+
+    test "commented out erb output tag - render" do
+      template = "<div><%#= raise('should not run') %></div>"
+
+      assert_evaluated_snapshot(template, {}, remove_comments_options)
+    end
+
+    test "comment inside a script element is text and stays - render" do
+      template = "<script>// <!-- keep this --></script><style>/* <!-- and this --> */</style>"
+
+      assert_evaluated_snapshot(template, {}, remove_comments_options)
+    end
+
+    test "the comment is removed from the compiled output" do
+      template = "<div><!-- secret --></div>"
+
+      engine = Herb::Engine.new(template, remove_comments_options)
+
+      assert_equal "<div></div>", eval(engine.src)
+    end
+
+    test "without the visitor the comment is emitted" do
+      template = "<div><!-- secret --></div>"
+
+      engine = Herb::Engine.new(template, escape: false)
+
+      assert_equal template, eval(engine.src)
+    end
+
+    test "whitespace around a comment is preserved" do
+      template = "<span>One</span> <!-- between --> <span>Two</span>"
+
+      engine = Herb::Engine.new(template, remove_comments_options)
+
+      assert_equal "<span>One</span>  <span>Two</span>", eval(engine.src)
+    end
+
+    test "erb inside a removed comment never runs" do
+      template = "<div><!-- <%= raise('should not run') %> --></div>"
+
+      engine = Herb::Engine.new(template, remove_comments_options)
+
+      assert_equal "<div></div>", eval(engine.src)
+    end
+
+    test "a template that is only a comment compiles to an empty string" do
+      template = "<!-- nothing else -->"
+
+      engine = Herb::Engine.new(template, remove_comments_options)
+
+      assert_equal "", eval(engine.src)
+    end
+
+    test "herb directives and strict locals are kept" do
+      template = <<~ERB
+        <%# locals: (title:) %>
+        <%# herb:state (pending: false) %>
+        <%#- herb:disable html-tag-name-lowercase -%>
+        <%-# herb:disable erb-no-empty-tags %>
+        <%# a note %>
+        <% # another note %>
+        <!-- an html note -->
+        <div><%# herb:key title %><%= title %></div>
+      ERB
+
+      result = Herb.parse(template)
+
+      result.value.accept(Herb::Engine::RemoveCommentsVisitor.new)
+
+      contents = []
+
+      collect = lambda do |node|
+        contents << node.content&.value if node.is_a?(Herb::AST::ERBContentNode)
+        node.compact_child_nodes.each { |child| collect.call(child) }
+      end
+
+      collect.call(result.value)
+
+      assert_equal [
+        " locals: (title:) ",
+        " herb:state (pending: false) ",
+        "- herb:disable html-tag-name-lowercase ",
+        "# herb:disable erb-no-empty-tags ",
+        " herb:key title ",
+        " title "
+      ], contents
+    end
+
+    test "a marker written into the template is kept" do
+      template = "<!--herb-slot:0--><!--/herb-slot:0--><!-- a note -->"
+
+      engine = Herb::Engine.new(template, remove_comments_options)
+
+      assert_equal "<!--herb-slot:0--><!--/herb-slot:0-->", eval(engine.src)
+    end
+
+    test "keeps the markers the slots visitor leaves behind, running before it - render" do
+      template = "<!-- a note --><p>Hi <%= @name %>!</p>"
+
+      assert_evaluated_snapshot(
+        template,
+        { "@name" => "Marco" },
+        {
+          filename: "app/views/test.html.erb",
+          visitors: [Herb::Engine::RemoveCommentsVisitor.new, Herb::Engine::Slots::Visitor.new],
+        }
+      )
+    end
+
+    test "keeps the markers the slots visitor leaves behind, running after it - render" do
+      template = "<!-- a note --><p>Hi <%= @name %>!</p>"
+
+      assert_evaluated_snapshot(
+        template,
+        { "@name" => "Marco" },
+        {
+          filename: "app/views/test.html.erb",
+          visitors: [Herb::Engine::Slots::Visitor.new, Herb::Engine::RemoveCommentsVisitor.new],
+        }
+      )
+    end
+
+    test "the visitor removes every comment node from the AST" do
+      template = <<~ERB
+        <!-- document -->
+        <%# document %>
+        <div>
+          <!-- element -->
+          <%# element %>
+          <% if true %>
+            <!-- branch -->
+            <%# branch %>
+          <% end %>
+          <% [1].each do %>
+            <!-- block -->
+            <%# block %>
+          <% end %>
+        </div>
+      ERB
+
+      result = Herb.parse(template)
+
+      result.value.accept(Herb::Engine::RemoveCommentsVisitor.new)
+
+      comments = []
+
+      collect = lambda do |node|
+        comments << node if node.is_a?(Herb::AST::HTMLCommentNode) || node.is_a?(Herb::AST::ERBContentNode)
+        node.compact_child_nodes.each { |child| collect.call(child) }
+      end
+
+      collect.call(result.value)
+
+      assert_empty comments
+    end
+  end
+end

--- a/test/engine/slots/markers_test.rb
+++ b/test/engine/slots/markers_test.rb
@@ -504,6 +504,42 @@ module Engine
         assert_empty rewriter.seen
         assert_includes evaluate_herb_source(source, { "@name" => "Marco" }), "herb-slot"
       end
+
+      test "recognizes every marker it writes as a comment" do
+        markers = Herb::Engine::Slots::Markers.new
+
+        comments = [
+          markers.slot_open(0, :child),
+          markers.slot_open(0, :attribute),
+          markers.slot_close(0),
+          markers.branch(0, 1),
+          markers.seeds_open_prefix,
+          markers.item_open_prefix(0),
+          markers.item_close(0),
+          markers.region_open_prefix("app/views/test.html.erb", "0417e5d5"),
+          markers.region_close("app/views/test.html.erb")
+        ]
+
+        recognized = comments.select { |text| Herb::Engine::Slots::Markers.marker?(text) }
+
+        assert_equal comments, recognized
+      end
+
+      test "recognizes nothing else" do
+        markers = Herb::Engine::Slots::Markers.new
+
+        others = [
+          "<!-- a note -->",
+          "<!--herbivore-->",
+          "<!-- herb-slot:0 -->",
+          markers.statics_open("app/views/test.html.erb", "0417e5d5"),
+          markers.manifests_open
+        ]
+
+        recognized = others.select { |text| Herb::Engine::Slots::Markers.marker?(text) }
+
+        assert_equal [], recognized
+      end
     end
   end
 end

--- a/test/snapshots/engine/remove_comments_visitor_test/test_0002_html_comment_-_compilation_859fba72f119e4df71d3586ef18cf6eb.txt
+++ b/test/snapshots/engine/remove_comments_visitor_test/test_0002_html_comment_-_compilation_859fba72f119e4df71d3586ef18cf6eb.txt
@@ -1,0 +1,6 @@
+---
+source: "Engine::RemoveCommentsVisitorTest#test_0002_html comment - compilation"
+input: "{source: \"<div><!-- secret --></div>\", options: {escape: false, visitors: [#<Herb::Engine::RemoveCommentsVisitor>]}}"
+---
+_buf = ::String.new; _buf << '<div></div>'.freeze;
+_buf.to_s

--- a/test/snapshots/engine/remove_comments_visitor_test/test_0003_html_comment_-_render_6f539efa9725d90258a7fd91f24ba20c.txt
+++ b/test/snapshots/engine/remove_comments_visitor_test/test_0003_html_comment_-_render_6f539efa9725d90258a7fd91f24ba20c.txt
@@ -1,0 +1,5 @@
+---
+source: "Engine::RemoveCommentsVisitorTest#test_0003_html comment - render"
+input: "{source: \"<div><!-- secret --></div>\", locals: {}, options: {escape: false, visitors: [#<Herb::Engine::RemoveCommentsVisitor>]}}"
+---
+<div></div>

--- a/test/snapshots/engine/remove_comments_visitor_test/test_0004_html_comment_on_its_own_line_-_compilation_e8f5b93f20d5609d0b7e91ab3b06dcc5.txt
+++ b/test/snapshots/engine/remove_comments_visitor_test/test_0004_html_comment_on_its_own_line_-_compilation_e8f5b93f20d5609d0b7e91ab3b06dcc5.txt
@@ -1,0 +1,10 @@
+---
+source: "Engine::RemoveCommentsVisitorTest#test_0004_html comment on its own line - compilation"
+input: "{source: \"<div>\\n  <!-- secret -->\\n  <p>Content</p>\\n</div>\\n\", options: {escape: false, visitors: [#<Herb::Engine::RemoveCommentsVisitor>]}}"
+---
+_buf = ::String.new; _buf << '<div>
+  
+  <p>Content</p>
+</div>
+'.freeze;
+_buf.to_s

--- a/test/snapshots/engine/remove_comments_visitor_test/test_0005_html_comment_on_its_own_line_-_render_25d343e87cbe9d6c5e0ecb8d3e57fb00.txt
+++ b/test/snapshots/engine/remove_comments_visitor_test/test_0005_html_comment_on_its_own_line_-_render_25d343e87cbe9d6c5e0ecb8d3e57fb00.txt
@@ -1,0 +1,8 @@
+---
+source: "Engine::RemoveCommentsVisitorTest#test_0005_html comment on its own line - render"
+input: "{source: \"<div>\\n  <!-- secret -->\\n  <p>Content</p>\\n</div>\\n\", locals: {}, options: {escape: false, visitors: [#<Herb::Engine::RemoveCommentsVisitor>]}}"
+---
+<div>
+  
+  <p>Content</p>
+</div>

--- a/test/snapshots/engine/remove_comments_visitor_test/test_0006_multi-line_html_comment_-_render_72932496a3affe1f0d8fb2046077ce03.txt
+++ b/test/snapshots/engine/remove_comments_visitor_test/test_0006_multi-line_html_comment_-_render_72932496a3affe1f0d8fb2046077ce03.txt
@@ -1,0 +1,7 @@
+---
+source: "Engine::RemoveCommentsVisitorTest#test_0006_multi-line html comment - render"
+input: "{source: \"<div>\\n  <!--\\n    a note\\n    over two lines\\n  -->\\n</div>\\n\", locals: {}, options: {escape: false, visitors: [#<Herb::Engine::RemoveCommentsVisitor>]}}"
+---
+<div>
+  
+</div>

--- a/test/snapshots/engine/remove_comments_visitor_test/test_0007_html_comment_containing_markup_-_render_d1a47629c78467853b92f51920f06832.txt
+++ b/test/snapshots/engine/remove_comments_visitor_test/test_0007_html_comment_containing_markup_-_render_d1a47629c78467853b92f51920f06832.txt
@@ -1,0 +1,5 @@
+---
+source: "Engine::RemoveCommentsVisitorTest#test_0007_html comment containing markup - render"
+input: "{source: \"<div><!-- <p>disabled</p> --><p>Content</p></div>\", locals: {}, options: {escape: false, visitors: [#<Herb::Engine::RemoveCommentsVisitor>]}}"
+---
+<div><p>Content</p></div>

--- a/test/snapshots/engine/remove_comments_visitor_test/test_0008_conditional_comment_-_render_26240c15f6697dd7451ec118e2a2782a.txt
+++ b/test/snapshots/engine/remove_comments_visitor_test/test_0008_conditional_comment_-_render_26240c15f6697dd7451ec118e2a2782a.txt
@@ -1,0 +1,5 @@
+---
+source: "Engine::RemoveCommentsVisitorTest#test_0008_conditional comment - render"
+input: "{source: \"<!--[if lt IE 9]><script src=\\\"html5shiv.js\\\"></script><![endif]--><p>Content</p>\", locals: {}, options: {escape: false, visitors: [#<Herb::Engine::RemoveCommentsVisitor>]}}"
+---
+<p>Content</p>

--- a/test/snapshots/engine/remove_comments_visitor_test/test_0009_comment_at_the_document,_head_and_body_level_-_render_30a1efe0727e4dfd38a3c1690ffa2332.txt
+++ b/test/snapshots/engine/remove_comments_visitor_test/test_0009_comment_at_the_document,_head_and_body_level_-_render_30a1efe0727e4dfd38a3c1690ffa2332.txt
@@ -1,0 +1,10 @@
+---
+source: "Engine::RemoveCommentsVisitorTest#test_0009_comment at the document, head and body level - render"
+input: "{source: \"<!DOCTYPE html>\\n<!-- a note -->\\n<html>\\n  <head><!-- a note --><title>Title</title></head>\\n  <body><!-- a note --><p>Content</p></body>\\n</html>\\n\", locals: {}, options: {escape: false, visitors: [#<Herb::Engine::RemoveCommentsVisitor>]}}"
+---
+<!DOCTYPE html>
+
+<html>
+  <head><title>Title</title></head>
+  <body><p>Content</p></body>
+</html>

--- a/test/snapshots/engine/remove_comments_visitor_test/test_0010_comment_inside_an_erb_branch_-_compilation_b749d943e08b58a1853083c0ebe78074.txt
+++ b/test/snapshots/engine/remove_comments_visitor_test/test_0010_comment_inside_an_erb_branch_-_compilation_b749d943e08b58a1853083c0ebe78074.txt
@@ -1,0 +1,7 @@
+---
+source: "Engine::RemoveCommentsVisitorTest#test_0010_comment inside an erb branch - compilation"
+input: "{source: \"<% if admin? %><!-- admin only --><p>Admin</p><% else %><!-- everyone --><p>User</p><% end %>\", options: {escape: false, visitors: [#<Herb::Engine::RemoveCommentsVisitor>]}}"
+---
+_buf = ::String.new; if admin? 
+ _buf << '<p>Admin</p>'.freeze; else; _buf << '<p>User</p>'.freeze; end;
+_buf.to_s

--- a/test/snapshots/engine/remove_comments_visitor_test/test_0011_comment_inside_an_erb_branch_-_render_3268992fad7278e8623adeb2eef46881.txt
+++ b/test/snapshots/engine/remove_comments_visitor_test/test_0011_comment_inside_an_erb_branch_-_render_3268992fad7278e8623adeb2eef46881.txt
@@ -1,0 +1,5 @@
+---
+source: "Engine::RemoveCommentsVisitorTest#test_0011_comment inside an erb branch - render"
+input: "{source: \"<% if admin? %><!-- admin only --><p>Admin</p><% else %><!-- everyone --><p>User</p><% end %>\", locals: {admin?: false}, options: {escape: false, visitors: [#<Herb::Engine::RemoveCommentsVisitor>]}}"
+---
+<p>User</p>

--- a/test/snapshots/engine/remove_comments_visitor_test/test_0012_comment_inside_an_erb_block_-_compilation_973c69bd6cbe1698c1c00ea0bba6f242.txt
+++ b/test/snapshots/engine/remove_comments_visitor_test/test_0012_comment_inside_an_erb_block_-_compilation_973c69bd6cbe1698c1c00ea0bba6f242.txt
@@ -1,0 +1,12 @@
+---
+source: "Engine::RemoveCommentsVisitorTest#test_0012_comment inside an erb block - compilation"
+input: "{source: \"<ul>\\n  <% items.each do |item| %>\\n    <!-- item -->\\n    <li><%= item %></li>\\n  <% end %>\\n</ul>\\n\", options: {escape: false, visitors: [#<Herb::Engine::RemoveCommentsVisitor>]}}"
+---
+_buf = ::String.new; _buf << '<ul>
+'.freeze;   items.each do |item| 
+ _buf << '    
+    <li>'.freeze; _buf << (item).to_s; _buf << '</li>
+'.freeze;   end 
+ _buf << '</ul>
+'.freeze;
+_buf.to_s

--- a/test/snapshots/engine/remove_comments_visitor_test/test_0013_comment_inside_an_erb_block_-_render_102d79270a3052ff211cfe6895c23b3a.txt
+++ b/test/snapshots/engine/remove_comments_visitor_test/test_0013_comment_inside_an_erb_block_-_render_102d79270a3052ff211cfe6895c23b3a.txt
@@ -1,0 +1,10 @@
+---
+source: "Engine::RemoveCommentsVisitorTest#test_0013_comment inside an erb block - render"
+input: "{source: \"<ul>\\n  <% items.each do |item| %>\\n    <!-- item -->\\n    <li><%= item %></li>\\n  <% end %>\\n</ul>\\n\", locals: {items: [\"A\", \"B\"]}, options: {escape: false, visitors: [#<Herb::Engine::RemoveCommentsVisitor>]}}"
+---
+<ul>
+    
+    <li>A</li>
+    
+    <li>B</li>
+</ul>

--- a/test/snapshots/engine/remove_comments_visitor_test/test_0014_erb_comment_-_compilation_e5cb8fd85faa2da5d7b349a0ce686041.txt
+++ b/test/snapshots/engine/remove_comments_visitor_test/test_0014_erb_comment_-_compilation_e5cb8fd85faa2da5d7b349a0ce686041.txt
@@ -1,0 +1,11 @@
+---
+source: "Engine::RemoveCommentsVisitorTest#test_0014_erb comment - compilation"
+input: "{source: \"<div>\\n  <%# a comment %>\\n  <% # another comment %>\\n  <p>Content</p>\\n</div>\\n\", options: {escape: false, visitors: [#<Herb::Engine::RemoveCommentsVisitor>]}}"
+---
+_buf = ::String.new; _buf << '<div>
+  
+  
+  <p>Content</p>
+</div>
+'.freeze;
+_buf.to_s

--- a/test/snapshots/engine/remove_comments_visitor_test/test_0015_erb_comment_-_render_bd42e373660c19191f430e47610a17ec.txt
+++ b/test/snapshots/engine/remove_comments_visitor_test/test_0015_erb_comment_-_render_bd42e373660c19191f430e47610a17ec.txt
@@ -1,0 +1,9 @@
+---
+source: "Engine::RemoveCommentsVisitorTest#test_0015_erb comment - render"
+input: "{source: \"<div>\\n  <%# a comment %>\\n  <% # another comment %>\\n  <p>Content</p>\\n</div>\\n\", locals: {}, options: {escape: false, visitors: [#<Herb::Engine::RemoveCommentsVisitor>]}}"
+---
+<div>
+  
+  
+  <p>Content</p>
+</div>

--- a/test/snapshots/engine/remove_comments_visitor_test/test_0016_erb_comment_in_an_attribute_value_-_render_9bb37071445e7d81db8d82d5e77cdbee.txt
+++ b/test/snapshots/engine/remove_comments_visitor_test/test_0016_erb_comment_in_an_attribute_value_-_render_9bb37071445e7d81db8d82d5e77cdbee.txt
@@ -1,0 +1,5 @@
+---
+source: "Engine::RemoveCommentsVisitorTest#test_0016_erb comment in an attribute value - render"
+input: "{source: \"<div class=\\\"<%# a comment %>\\\">Content</div>\", locals: {}, options: {escape: false, visitors: [#<Herb::Engine::RemoveCommentsVisitor>]}}"
+---
+<div class="">Content</div>

--- a/test/snapshots/engine/remove_comments_visitor_test/test_0017_commented_out_erb_output_tag_-_render_2b8ff6fd5a4d6cee94caf55e9c37d053.txt
+++ b/test/snapshots/engine/remove_comments_visitor_test/test_0017_commented_out_erb_output_tag_-_render_2b8ff6fd5a4d6cee94caf55e9c37d053.txt
@@ -1,0 +1,5 @@
+---
+source: "Engine::RemoveCommentsVisitorTest#test_0017_commented out erb output tag - render"
+input: "{source: \"<div><%#= raise('should not run') %></div>\", locals: {}, options: {escape: false, visitors: [#<Herb::Engine::RemoveCommentsVisitor>]}}"
+---
+<div></div>

--- a/test/snapshots/engine/remove_comments_visitor_test/test_0018_comment_inside_a_script_element_is_text_and_stays_-_render_9896e94ecafd16e5fab4511bebaf3f19.txt
+++ b/test/snapshots/engine/remove_comments_visitor_test/test_0018_comment_inside_a_script_element_is_text_and_stays_-_render_9896e94ecafd16e5fab4511bebaf3f19.txt
@@ -1,0 +1,5 @@
+---
+source: "Engine::RemoveCommentsVisitorTest#test_0018_comment inside a script element is text and stays - render"
+input: "{source: \"<script>// <!-- keep this --></script><style>/* <!-- and this --> */</style>\", locals: {}, options: {escape: false, visitors: [#<Herb::Engine::RemoveCommentsVisitor>]}}"
+---
+<script>// <!-- keep this --></script><style>/* <!-- and this --> */</style>

--- a/test/snapshots/engine/remove_comments_visitor_test/test_0026_keeps_the_markers_the_slots_visitor_leaves_behind,_running_before_it_-_render_77e99a7e7fadaec496e85405029ebbaa.txt
+++ b/test/snapshots/engine/remove_comments_visitor_test/test_0026_keeps_the_markers_the_slots_visitor_leaves_behind,_running_before_it_-_render_77e99a7e7fadaec496e85405029ebbaa.txt
@@ -1,0 +1,5 @@
+---
+source: "Engine::RemoveCommentsVisitorTest#test_0026_keeps the markers the slots visitor leaves behind, running before it - render"
+input: "{source: \"<!-- a note --><p>Hi <%= @name %>!</p>\", locals: {\"@name\" => \"Marco\"}, options: {filename: \"app/views/test.html.erb\", visitors: [#<Herb::Engine::RemoveCommentsVisitor>, #<Herb::Engine::Slots::Visitor server>]}}"
+---
+<!--herb-region:app/views/test.html.erb:1f1c2346:0--><p>Hi <!--herb-slot:0-->Marco<!--/herb-slot:0-->!</p><!--/herb-region:app/views/test.html.erb-->

--- a/test/snapshots/engine/remove_comments_visitor_test/test_0027_keeps_the_markers_the_slots_visitor_leaves_behind,_running_after_it_-_render_367c49ad1bcff2c7c2ed19800d88dae4.txt
+++ b/test/snapshots/engine/remove_comments_visitor_test/test_0027_keeps_the_markers_the_slots_visitor_leaves_behind,_running_after_it_-_render_367c49ad1bcff2c7c2ed19800d88dae4.txt
@@ -1,0 +1,5 @@
+---
+source: "Engine::RemoveCommentsVisitorTest#test_0027_keeps the markers the slots visitor leaves behind, running after it - render"
+input: "{source: \"<!-- a note --><p>Hi <%= @name %>!</p>\", locals: {\"@name\" => \"Marco\"}, options: {filename: \"app/views/test.html.erb\", visitors: [#<Herb::Engine::Slots::Visitor server>, #<Herb::Engine::RemoveCommentsVisitor>]}}"
+---
+<!--herb-region:app/views/test.html.erb:fb7c3406:0--><p>Hi <!--herb-slot:0-->Marco<!--/herb-slot:0-->!</p><!--/herb-region:app/views/test.html.erb-->


### PR DESCRIPTION
This pull request implements `Herb::Engine::RemoveCommentsVisitor`, a transform visitor that takes the comments out of a template so the compiled output never contains one.

An HTML comment is served to the browser and is readable by anyone who looks at the page source, so a note the template author wrote for other developers ends up in production. The visitor drops every `<!-- -->` comment before the compiler sees the template, along with everything nested inside it, which means ERB written inside a comment is removed before it is compiled and never runs.

```ruby
require "herb/engine/remove_comments_visitor"

Herb::Engine.new(source, visitors: [Herb::Engine::RemoveCommentsVisitor.new])
```

Given this template:

```html+erb
<div>
  <p><%= product.name %></p><!-- TODO: drop this once the new checkout ships -->
</div>
```

The engine renders:

```html
<div>
  <p>Coffee</p>
</div>
```