### PR TITLE
Ruby: Run every test with `rake test`

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -7,18 +7,8 @@ require "rake/testtask"
 Rake::TestTask.new(:test) do |t|
   t.libs << "test"
   t.libs << "lib"
-  t.test_files = FileList["test/**/*_test.rb"].exclude("test/engine/**/*_test.rb", "test/integration/**/*_test.rb")
+  t.test_files = FileList["test/**/*_test.rb"]
 end
-
-task :test_tip do
-  puts "TIP: This only runs core tests. Other test tasks available:"
-  puts "  rake test:all"
-  puts "  rake test:engine"
-  puts "  rake test:integration"
-  puts
-end
-
-Rake::Task[:test].enhance([:test_tip])
 
 Rake::TestTask.new("test:engine") do |t|
   t.libs << "test"


### PR DESCRIPTION
`rake test` excluded `test/engine/**` and `test/integration/**`, so the default task skipped 1772 of the 4213 tests and a change to the engine could look green locally and fail in CI. It printed a tip saying so, which is easy to read past.

The split was made when the core tests ran in a few hundred milliseconds and the CLI tests were the slow ones. That is no longer the shape of the suite. Core alone now takes 12.9s, and the two excluded directories add 0.1s on top, because almost all of it is fixed startup rather than per-test time.

`test:engine` and `test:integration` stay, for running one directory while working in it. `test:all` stays too, since CI and the nx target call it by name.