### PR TITLE
Highlighter: Color `<%#` and its content as a comment

### DIFF
--- a/javascript/packages/highlighter/src/syntax-renderer.ts
+++ b/javascript/packages/highlighter/src/syntax-renderer.ts
@@ -213,7 +213,7 @@ export class SyntaxRenderer {
         break
 
       case "TOKEN_ERB_START":
-        state.inErbComment = tokenText.startsWith("<%#")
+        state.inErbComment = state.inErbComment || tokenText.startsWith("<%#")
         break
     }
   }

--- a/javascript/packages/highlighter/src/syntax-renderer.ts
+++ b/javascript/packages/highlighter/src/syntax-renderer.ts
@@ -17,6 +17,7 @@ type SyntaxRenderState = {
   expectingAttributeName: boolean
   expectingAttributeValue: boolean
   inComment: boolean
+  inErbComment: boolean
 }
 
 export class SyntaxRenderer {
@@ -97,6 +98,7 @@ export class SyntaxRenderer {
       expectingAttributeName: false,
       expectingAttributeValue: false,
       inComment: false,
+      inErbComment: false,
     }
 
     for (let i = 0; i < tokens.length; i++) {
@@ -115,12 +117,17 @@ export class SyntaxRenderer {
       const color = this.getContextualColor(state, token, tokenText)
 
       if (token.type === "TOKEN_ERB_CONTENT") {
-        const highlightedRuby = this.highlightRubyCode(tokenText)
-        highlighted += highlightedRuby
+        highlighted += state.inErbComment
+          ? this.applyColor(tokenText, this.colors.TOKEN_HTML_COMMENT_START)
+          : this.highlightRubyCode(tokenText)
       } else if (color !== undefined) {
         highlighted += this.applyColor(tokenText, color)
       } else {
         highlighted += tokenText
+      }
+
+      if (token.type === "TOKEN_ERB_END" && state.inErbComment) {
+        state.inErbComment = false
       }
 
       lastEnd = token.range.to
@@ -204,6 +211,10 @@ export class SyntaxRenderer {
       case "TOKEN_HTML_COMMENT_END":
         state.inComment = false
         break
+
+      case "TOKEN_ERB_START":
+        state.inErbComment = tokenText.startsWith("<%#")
+        break
     }
   }
 
@@ -220,6 +231,10 @@ export class SyntaxRenderer {
       token.type !== "TOKEN_ERB_CONTENT" &&
       token.type !== "TOKEN_ERB_END"
     ) {
+      return this.colors.TOKEN_HTML_COMMENT_START
+    }
+
+    if (state.inErbComment && token.type !== "TOKEN_ERB_CONTENT") {
       return this.colors.TOKEN_HTML_COMMENT_START
     }
 
@@ -242,7 +257,8 @@ export class SyntaxRenderer {
       case "TOKEN_QUOTE":
         if (state.inTag) {
           return "#98C379"
-        } break
+        }
+        break
     }
 
     if (!this.colors) {

--- a/javascript/packages/highlighter/src/syntax-renderer.ts
+++ b/javascript/packages/highlighter/src/syntax-renderer.ts
@@ -112,7 +112,7 @@ export class SyntaxRenderer {
 
       const tokenText = content.slice(token.range.from, token.range.to)
 
-      this.updateState(state, token, tokenText, nextToken, prevToken)
+      this.updateState(state, token, tokenText, content, nextToken, prevToken)
 
       const color = this.getContextualColor(state, token, tokenText)
 
@@ -140,11 +140,20 @@ export class SyntaxRenderer {
     return highlighted
   }
 
+  private isErbCommentTag(tagText: string, content: string, nextToken?: Token): boolean {
+    if (tagText.startsWith("<%#")) return true
+    if (tagText !== "<%-") return false
+    if (nextToken?.type !== "TOKEN_ERB_CONTENT") return false
+
+    return content.slice(nextToken.range.from, nextToken.range.to).startsWith("#")
+  }
+
   private updateState(
     state: SyntaxRenderState,
     token: Token,
     tokenText: string,
-    _nextToken?: Token,
+    content: string,
+    nextToken?: Token,
     _prevToken?: Token,
   ) {
     switch (token.type) {
@@ -213,7 +222,7 @@ export class SyntaxRenderer {
         break
 
       case "TOKEN_ERB_START":
-        state.inErbComment = state.inErbComment || tokenText.startsWith("<%#")
+        state.inErbComment = state.inErbComment || this.isErbCommentTag(tokenText, content, nextToken)
         break
     }
   }

--- a/javascript/packages/highlighter/test/__snapshots__/syntax-renderer.test.ts.snap
+++ b/javascript/packages/highlighter/test/__snapshots__/syntax-renderer.test.ts.snap
@@ -1,8 +1,12 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`SyntaxRenderer > ERB content highlighting > should highlight Ruby keywords in ERB blocks 1`] = `"[38;2;190;80;70m<%[0m [38;2;198;120;221mif[0m [38;2;198;120;221mtrue[0m %[38;2;190;80;70m>[0m"`;
-
 exports[`SyntaxRenderer > ERB content highlighting > highlights ERB comments as comments 1`] = `"[38;2;92;99;112m<%#[0m[38;2;92;99;112m if true [0m[38;2;92;99;112m%>[0m"`;
+
+exports[`SyntaxRenderer > ERB content highlighting > highlights trim mode ERB comments as comments 1`] = `"[38;2;92;99;112m<%-[0m[38;2;92;99;112m# if true [0m[38;2;92;99;112m-%>[0m"`;
+
+exports[`SyntaxRenderer > ERB content highlighting > keeps Ruby colors for escaped ERB tags starting with a hash 1`] = `"[38;2;190;80;70m<%%[0m# [38;2;198;120;221mif[0m [38;2;198;120;221mtrue[0m [38;2;190;80;70m%>[0m"`;
+
+exports[`SyntaxRenderer > ERB content highlighting > should highlight Ruby keywords in ERB blocks 1`] = `"[38;2;190;80;70m<%[0m [38;2;198;120;221mif[0m [38;2;198;120;221mtrue[0m %[38;2;190;80;70m>[0m"`;
 
 exports[`SyntaxRenderer > color disabled mode > should return plain text when NO_COLOR is set 1`] = `"<div>test</div>"`;
 

--- a/javascript/packages/highlighter/test/__snapshots__/syntax-renderer.test.ts.snap
+++ b/javascript/packages/highlighter/test/__snapshots__/syntax-renderer.test.ts.snap
@@ -2,6 +2,8 @@
 
 exports[`SyntaxRenderer > ERB content highlighting > should highlight Ruby keywords in ERB blocks 1`] = `"[38;2;190;80;70m<%[0m [38;2;198;120;221mif[0m [38;2;198;120;221mtrue[0m %[38;2;190;80;70m>[0m"`;
 
+exports[`SyntaxRenderer > ERB content highlighting > highlights ERB comments as comments 1`] = `"[38;2;92;99;112m<%#[0m[38;2;92;99;112m if true [0m[38;2;92;99;112m%>[0m"`;
+
 exports[`SyntaxRenderer > color disabled mode > should return plain text when NO_COLOR is set 1`] = `"<div>test</div>"`;
 
 exports[`SyntaxRenderer > comment state tracking > should preserve ERB highlighting in comments 1`] = `"[38;2;92;99;112m<!--[0m [38;2;190;80;70m<%[0m code[38;2;190;80;70m %[0m>[38;2;92;99;112m --[0m>"`;

--- a/javascript/packages/highlighter/test/syntax-renderer.test.ts
+++ b/javascript/packages/highlighter/test/syntax-renderer.test.ts
@@ -5,6 +5,7 @@ import { Range } from "@herb-tools/core"
 import { Herb } from "@herb-tools/node-wasm"
 import { SyntaxRenderer } from "../src/syntax-renderer.js"
 import { ANSI_REGEX } from "../src/ansi.js"
+import { colorize } from "../src/color.js"
 
 describe("SyntaxRenderer", () => {
   let renderer: SyntaxRenderer
@@ -175,6 +176,33 @@ describe("SyntaxRenderer", () => {
       const result = renderer.highlight("<%# if true %>")
 
       expect(result).toMatchSnapshot()
+    })
+
+    it("preserves ERB comment state across nested openers and resets after the closing delimiter", () => {
+      const nestedHerb = {
+        isLoaded: true,
+        load: async () => {},
+        lex: () => ({
+          errors: [],
+          value: [
+            { type: "TOKEN_ERB_START", range: Range.from(0, 3) },
+            { type: "TOKEN_ERB_CONTENT", range: Range.from(3, 12) },
+            { type: "TOKEN_ERB_START", range: Range.from(12, 14) },
+            { type: "TOKEN_ERB_CONTENT", range: Range.from(14, 23) },
+            { type: "TOKEN_ERB_END", range: Range.from(23, 25) },
+            { type: "TOKEN_ERB_START", range: Range.from(25, 27) },
+            { type: "TOKEN_ERB_CONTENT", range: Range.from(27, 36) },
+            { type: "TOKEN_ERB_END", range: Range.from(36, 38) },
+          ],
+        }),
+      }
+      const nestedRenderer = new SyntaxRenderer(themes.onedark, nestedHerb as any)
+      const content = "<%# mention <% if true %><% if true %>"
+      const result = nestedRenderer.highlight(content)
+
+      expect(result.replace(ANSI_REGEX, "")).toBe(content)
+      expect(result).toContain(colorize(" if true ", themes.onedark.TOKEN_HTML_COMMENT_START))
+      expect(result.split(colorize("if", themes.onedark.RUBY_KEYWORD)).length - 1).toBe(1)
     })
   })
 

--- a/javascript/packages/highlighter/test/syntax-renderer.test.ts
+++ b/javascript/packages/highlighter/test/syntax-renderer.test.ts
@@ -170,6 +170,12 @@ describe("SyntaxRenderer", () => {
 
       expect(result).toMatchSnapshot()
     })
+
+    it("highlights ERB comments as comments", async () => {
+      const result = renderer.highlight("<%# if true %>")
+
+      expect(result).toMatchSnapshot()
+    })
   })
 
   describe("comment state tracking", () => {

--- a/javascript/packages/highlighter/test/syntax-renderer.test.ts
+++ b/javascript/packages/highlighter/test/syntax-renderer.test.ts
@@ -178,6 +178,18 @@ describe("SyntaxRenderer", () => {
       expect(result).toMatchSnapshot()
     })
 
+    it("highlights trim mode ERB comments as comments", async () => {
+      const result = renderer.highlight("<%-# if true -%>")
+
+      expect(result).toMatchSnapshot()
+    })
+
+    it("keeps Ruby colors for escaped ERB tags starting with a hash", async () => {
+      const result = renderer.highlight("<%%# if true %>")
+
+      expect(result).toMatchSnapshot()
+    })
+
     it("preserves ERB comment state across nested openers and resets after the closing delimiter", () => {
       const nestedHerb = {
         isLoaded: true,

--- a/rust/herb-highlighter/src/syntax_renderer.rs
+++ b/rust/herb-highlighter/src/syntax_renderer.rs
@@ -183,7 +183,7 @@ impl SyntaxRenderer {
       "TOKEN_HTML_COMMENT_START" => state.in_comment = true,
       "TOKEN_HTML_COMMENT_END" => state.in_comment = false,
 
-      "TOKEN_ERB_START" => state.in_erb_comment = token_text.starts_with("<%#"),
+      "TOKEN_ERB_START" => state.in_erb_comment = state.in_erb_comment || token_text.starts_with("<%#"),
 
       _ => {}
     }

--- a/rust/herb-highlighter/src/syntax_renderer.rs
+++ b/rust/herb-highlighter/src/syntax_renderer.rs
@@ -84,14 +84,14 @@ impl SyntaxRenderer {
 
     let mut state = SyntaxRenderState::default();
 
-    for token in tokens {
+    for (index, token) in tokens.iter().enumerate() {
       if token.range.from > last_end {
         highlighted.push_str(slice(content, last_end, token.range.from));
       }
 
       let token_text = slice(content, token.range.from, token.range.to);
 
-      self.update_state(&mut state, token, token_text);
+      self.update_state(&mut state, token, token_text, content, tokens.get(index + 1));
 
       let color = self.contextual_color(&state, token, token_text);
 
@@ -119,7 +119,27 @@ impl SyntaxRenderer {
     highlighted
   }
 
-  fn update_state(&self, state: &mut SyntaxRenderState, token: &Token, token_text: &str) {
+  fn is_erb_comment_tag(&self, tag_text: &str, content: &str, next_token: Option<&Token>) -> bool {
+    if tag_text.starts_with("<%#") {
+      return true;
+    }
+
+    if tag_text != "<%-" {
+      return false;
+    }
+
+    let Some(next) = next_token else {
+      return false;
+    };
+
+    if next.token_type != "TOKEN_ERB_CONTENT" {
+      return false;
+    }
+
+    slice(content, next.range.from, next.range.to).starts_with('#')
+  }
+
+  fn update_state(&self, state: &mut SyntaxRenderState, token: &Token, token_text: &str, content: &str, next_token: Option<&Token>) {
     match token.token_type.as_str() {
       "TOKEN_HTML_TAG_START" => {
         state.in_tag = true;
@@ -183,7 +203,7 @@ impl SyntaxRenderer {
       "TOKEN_HTML_COMMENT_START" => state.in_comment = true,
       "TOKEN_HTML_COMMENT_END" => state.in_comment = false,
 
-      "TOKEN_ERB_START" => state.in_erb_comment = state.in_erb_comment || token_text.starts_with("<%#"),
+      "TOKEN_ERB_START" => state.in_erb_comment = state.in_erb_comment || self.is_erb_comment_tag(token_text, content, next_token),
 
       _ => {}
     }

--- a/rust/herb-highlighter/src/syntax_renderer.rs
+++ b/rust/herb-highlighter/src/syntax_renderer.rs
@@ -23,6 +23,7 @@ struct SyntaxRenderState {
   expecting_attribute_name: bool,
   expecting_attribute_value: bool,
   in_comment: bool,
+  in_erb_comment: bool,
 }
 
 pub struct SyntaxRenderer {
@@ -95,9 +96,17 @@ impl SyntaxRenderer {
       let color = self.contextual_color(&state, token, token_text);
 
       if token.token_type == "TOKEN_ERB_CONTENT" {
-        highlighted.push_str(&self.highlight_ruby_code(token_text));
+        if state.in_erb_comment {
+          highlighted.push_str(&self.apply_color(token_text, Some(self.colors.token_html_comment_start)));
+        } else {
+          highlighted.push_str(&self.highlight_ruby_code(token_text));
+        }
       } else {
         highlighted.push_str(&self.apply_color(token_text, color));
+      }
+
+      if token.token_type == "TOKEN_ERB_END" && state.in_erb_comment {
+        state.in_erb_comment = false;
       }
 
       last_end = token.range.to;
@@ -174,6 +183,8 @@ impl SyntaxRenderer {
       "TOKEN_HTML_COMMENT_START" => state.in_comment = true,
       "TOKEN_HTML_COMMENT_END" => state.in_comment = false,
 
+      "TOKEN_ERB_START" => state.in_erb_comment = token_text.starts_with("<%#"),
+
       _ => {}
     }
   }
@@ -188,6 +199,10 @@ impl SyntaxRenderer {
       && token_type != "TOKEN_ERB_CONTENT"
       && token_type != "TOKEN_ERB_END"
     {
+      return Some(self.colors.token_html_comment_start);
+    }
+
+    if state.in_erb_comment && token_type != "TOKEN_ERB_CONTENT" {
       return Some(self.colors.token_html_comment_start);
     }
 

--- a/rust/herb-highlighter/tests/snapshots/syntax_renderer_test__highlights_erb_comments_as_comments.snap
+++ b/rust/herb-highlighter/tests/snapshots/syntax_renderer_test__highlights_erb_comments_as_comments.snap
@@ -1,0 +1,5 @@
+---
+source: herb-highlighter/tests/syntax_renderer_test.rs
+expression: "renderer(Theme::OneDark).highlight(\"<%# if true %>\")"
+---
+[38;2;92;99;112m<%#[0m[38;2;92;99;112m if true [0m[38;2;92;99;112m%>[0m

--- a/rust/herb-highlighter/tests/snapshots/syntax_renderer_test__highlights_trim_mode_erb_comments_as_comments.snap
+++ b/rust/herb-highlighter/tests/snapshots/syntax_renderer_test__highlights_trim_mode_erb_comments_as_comments.snap
@@ -1,0 +1,5 @@
+---
+source: herb-highlighter/tests/syntax_renderer_test.rs
+expression: "renderer(Theme::OneDark).highlight(\"<%-# if true -%>\")"
+---
+[38;2;92;99;112m<%-[0m[38;2;92;99;112m# if true [0m[38;2;92;99;112m-%>[0m

--- a/rust/herb-highlighter/tests/snapshots/syntax_renderer_test__keeps_ruby_colors_for_escaped_erb_tags_starting_with_a_hash.snap
+++ b/rust/herb-highlighter/tests/snapshots/syntax_renderer_test__keeps_ruby_colors_for_escaped_erb_tags_starting_with_a_hash.snap
@@ -1,0 +1,5 @@
+---
+source: herb-highlighter/tests/syntax_renderer_test.rs
+expression: "renderer(Theme::OneDark).highlight(\"<%%# if true %>\")"
+---
+[38;2;190;80;70m<%%[0m# [38;2;198;120;221mif[0m [38;2;198;120;221mtrue[0m [38;2;190;80;70m%>[0m

--- a/rust/herb-highlighter/tests/syntax_renderer_test.rs
+++ b/rust/herb-highlighter/tests/syntax_renderer_test.rs
@@ -91,6 +91,13 @@ fn highlights_ruby_keywords_in_erb_blocks() {
 }
 
 #[test]
+fn highlights_erb_comments_as_comments() {
+  with_color();
+
+  insta::assert_snapshot!(renderer(Theme::OneDark).highlight("<%# if true %>"));
+}
+
+#[test]
 fn tracks_html_comment_state() {
   with_color();
 

--- a/rust/herb-highlighter/tests/syntax_renderer_test.rs
+++ b/rust/herb-highlighter/tests/syntax_renderer_test.rs
@@ -2,7 +2,7 @@ mod common;
 
 use std::sync::Arc;
 
-use herb_highlighter::ansi::find_ansi_sequences;
+use herb_highlighter::ansi::{find_ansi_sequences, strip_ansi};
 use herb_highlighter::herb_backend::Herb;
 use herb_highlighter::syntax_renderer::SyntaxRenderer;
 use herb_highlighter::themes::{get_theme, Theme};
@@ -95,6 +95,33 @@ fn highlights_erb_comments_as_comments() {
   with_color();
 
   insta::assert_snapshot!(renderer(Theme::OneDark).highlight("<%# if true %>"));
+}
+
+#[test]
+fn preserves_erb_comment_state_across_nested_openers_and_resets_after_the_closing_delimiter() {
+  with_color();
+
+  let nested_renderer = SyntaxRenderer::with_backend(
+    get_theme(Theme::OneDark).clone(),
+    StubBackend::with_tokens(vec![
+      token("TOKEN_ERB_START", 0, 3),
+      token("TOKEN_ERB_CONTENT", 3, 12),
+      token("TOKEN_ERB_START", 12, 14),
+      token("TOKEN_ERB_CONTENT", 14, 23),
+      token("TOKEN_ERB_END", 23, 25),
+      token("TOKEN_ERB_START", 25, 27),
+      token("TOKEN_ERB_CONTENT", 27, 36),
+      token("TOKEN_ERB_END", 36, 38),
+    ]),
+  );
+  let content = "<%# mention <% if true %><% if true %>";
+  let result = nested_renderer.highlight(content);
+  let comment_color = get_theme(Theme::OneDark).token_html_comment_start;
+  let keyword_color = get_theme(Theme::OneDark).ruby_keyword;
+
+  assert_eq!(strip_ansi(&result), content);
+  assert!(result.contains(&herb_highlighter::color::colorize(" if true ", comment_color)));
+  assert_eq!(result.matches(&herb_highlighter::color::colorize("if", keyword_color)).count(), 1);
 }
 
 #[test]

--- a/rust/herb-highlighter/tests/syntax_renderer_test.rs
+++ b/rust/herb-highlighter/tests/syntax_renderer_test.rs
@@ -98,6 +98,20 @@ fn highlights_erb_comments_as_comments() {
 }
 
 #[test]
+fn highlights_trim_mode_erb_comments_as_comments() {
+  with_color();
+
+  insta::assert_snapshot!(renderer(Theme::OneDark).highlight("<%-# if true -%>"));
+}
+
+#[test]
+fn keeps_ruby_colors_for_escaped_erb_tags_starting_with_a_hash() {
+  with_color();
+
+  insta::assert_snapshot!(renderer(Theme::OneDark).highlight("<%%# if true %>"));
+}
+
+#[test]
 fn preserves_erb_comment_state_across_nested_openers_and_resets_after_the_closing_delimiter() {
   with_color();
 


### PR DESCRIPTION
Relates to #2434

ERB comment tags now render the opening tag, content, and closing tag with the existing comment color in both the TypeScript and Rust highlighters. Ruby keyword highlighting remains unchanged for regular ERB blocks.

The Rust snapshot records the ANSI-colored output produced with `with_color()`.

Validation:
- `git diff --check` passed.
- Rust `rustfmt --check` passed.
- TS/Rust structural parity check passed.
- Focused Rust test could not complete because the project build script requires `bundle show prism` and Bundler is unavailable.
- Prettier check reports the two touched TypeScript files as not clean; no unrelated formatting churn was applied.