### PR TITLE
Config: Add `severity` to the `all` pseudo rule

### DIFF
--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -264,13 +264,29 @@ linter:
       enabled: false
 ```
 
+`all` also accepts `severity`, which sets the default severity for every rule that doesn't specify its own:
+
+```yaml [.herb.yml]
+linter:
+  rules:
+    all:
+      severity: warning
+
+    # Individual rules can still set their own
+    html-img-require-alt:
+      severity: error
+```
+
+This is the shortest way to make a whole project report at one level. It supports the split form too, so `severity: { editor: hint, cli: error }` keeps the editor quiet while CI still fails.
+
 A few details worth knowing:
 
 - **Explicit configuration always wins.** A rule that appears in `rules` follows its own `enabled` setting, no matter what `all` says.
 - **Listing a rule without `enabled` enables it.** `html-img-require-alt: { severity: warning }` under `all: enabled: false` turns the rule on, the same way it would without `all`.
 - **`all: enabled: true` bypasses version gating.** Normally the `version` in your `.herb.yml` holds back rules introduced in later releases. Enabling everything means exactly that, so nothing gets held back. Under `all: enabled: false` version gating makes no difference either way, since those rules are off regardless.
 - **`--only` and `--all-rules` still take precedence**, since both flags ignore the rule configuration entirely.
-- Only `enabled` is meaningful on `all`. Other rule options like `severity` or `exclude` aren't inherited by the individual rules.
+- **`severity` on `all` sets the default severity.** Every rule that doesn't set its own `severity` reports at the one `all` gives, overriding the rule's built-in default.
+- Only `enabled` and `severity` are meaningful on `all`. Other rule options like `include`, `only`, `exclude`, and `frameworks` aren't inherited by the individual rules. Use `linter.include` and `linter.exclude` to scope the whole linter.
 
 ::: warning
 `all` is a reserved name inside `rules`, it's never treated as an actual rule.

--- a/javascript/packages/linter/src/linter.ts
+++ b/javascript/packages/linter/src/linter.ts
@@ -612,7 +612,8 @@ export class Linter {
    *
    * Priority:
    * 1. User config severity override (if specified in config)
-   * 2. Rule's default severity (from defaultConfig.severity)
+   * 2. The `all` pseudo rule's severity (if specified in config)
+   * 3. Rule's default severity (from defaultConfig.severity)
    *
    * @param unboundOffenses - Array of offenses without severity
    * @param ruleName - Name of the rule that produced the offenses
@@ -632,7 +633,8 @@ export class Linter {
     const defaultSeverityConfig = ruleInstance.defaultConfig?.severity ?? DEFAULT_RULE_CONFIG.severity
 
     const userRuleConfig = this.config?.linter?.rules?.[ruleName]
-    const severityConfig = userRuleConfig?.severity ?? defaultSeverityConfig
+    const allSeverityConfig = this.config?.linter?.rules?.[ALL_RULES_KEY]?.severity
+    const severityConfig = userRuleConfig?.severity ?? allSeverityConfig ?? defaultSeverityConfig
     const severity = resolveSeverity(severityConfig, this.mode)
 
     return unboundOffenses.map(offense => ({

--- a/javascript/packages/linter/test/linter.test.ts
+++ b/javascript/packages/linter/test/linter.test.ts
@@ -995,6 +995,97 @@ describe("@herb-tools/linter", () => {
       expect(enabled.map(ruleClass => ruleClass.ruleName)).toEqual(["disabled-rule"])
     })
 
+    test("`all: severity` applies to rules without an explicit severity", () => {
+      const html = '<DIV>test</DIV>'
+      const config = Config.fromObject({
+        linter: {
+          rules: {
+            all: { severity: "warning" }
+          }
+        }
+      })
+
+      const linter = new Linter(Herb, [HTMLTagNameLowercaseRule], config)
+      const lintResult = linter.lint(html)
+
+      expect(lintResult.offenses).toHaveLength(2)
+      expect(lintResult.offenses.map(offense => offense.severity)).toEqual(["warning", "warning"])
+      expect(lintResult.errors).toBe(0)
+      expect(lintResult.warnings).toBe(2)
+    })
+
+    test("an explicit rule severity wins over `all: severity`", () => {
+      const html = '<DIV id=\'1\'>test</DIV>'
+      const config = Config.fromObject({
+        linter: {
+          rules: {
+            all: { severity: "warning" },
+            "html-attribute-double-quotes": { severity: "info" }
+          }
+        }
+      })
+
+      const linter = new Linter(Herb, [HTMLTagNameLowercaseRule, HTMLAttributeDoubleQuotesRule], config)
+      const lintResult = linter.lint(html)
+
+      expect(lintResult.errors).toBe(0)
+      expect(lintResult.warnings).toBe(2)
+      expect(lintResult.info).toBe(1)
+    })
+
+    test("`all: severity` overrides a rule's own default severity", () => {
+      const html = '<DIV>test</DIV>'
+      const config = Config.fromObject({
+        linter: {
+          rules: {
+            all: { severity: "hint" }
+          }
+        }
+      })
+
+      const linter = new Linter(Herb, [HTMLTagNameLowercaseRule], config)
+      const lintResult = linter.lint(html)
+
+      expect(lintResult.offenses.map(offense => offense.severity)).toEqual(["hint", "hint"])
+      expect(lintResult.hints).toBe(2)
+    })
+
+    test("`all: severity` supports the editor and cli split form", () => {
+      const html = '<DIV>test</DIV>'
+      const config = Config.fromObject({
+        linter: {
+          rules: {
+            all: { severity: { editor: "hint", cli: "error" } }
+          }
+        }
+      })
+
+      const cliLinter = new Linter(Herb, [HTMLTagNameLowercaseRule], config)
+
+      const editorLinter = new Linter(Herb, [HTMLTagNameLowercaseRule], config)
+      editorLinter.mode = "editor"
+
+      expect(cliLinter.lint(html).offenses.map(offense => offense.severity)).toEqual(["error", "error"])
+      expect(editorLinter.lint(html).offenses.map(offense => offense.severity)).toEqual(["hint", "hint"])
+    })
+
+    test("rules keep their own default severity when `all` sets only `enabled`", () => {
+      const html = '<DIV>test</DIV>'
+      const config = Config.fromObject({
+        linter: {
+          rules: {
+            all: { enabled: true }
+          }
+        }
+      })
+
+      const linter = new Linter(Herb, [HTMLTagNameLowercaseRule], config)
+      const lintResult = linter.lint(html)
+
+      expect(lintResult.offenses.map(offense => offense.severity)).toEqual(["error", "error"])
+      expect(lintResult.errors).toBe(2)
+    })
+
     test("`--all-rules` takes precedence over the `all` pseudo rule", () => {
       const { enabled } = Linter.filterRulesByConfig(
         [EnabledRule, DisabledRule],

--- a/rust/herb-config/src/config.rs
+++ b/rust/herb-config/src/config.rs
@@ -124,6 +124,10 @@ impl Config {
     self.get_rule_config(ALL_RULES_KEY).and_then(|rule| rule.enabled)
   }
 
+  pub fn default_rule_severity(&self) -> Option<SeverityConfig> {
+    self.get_rule_config(ALL_RULES_KEY).and_then(|rule| rule.severity)
+  }
+
   pub fn is_rule_disabled(&self, rule_name: &str) -> bool {
     match self.get_rule_config(rule_name) {
       Some(rule) => rule.enabled == Some(false),
@@ -291,7 +295,11 @@ impl Config {
   }
 
   pub fn get_configured_severity(&self, rule_name: &str, default_severity: SeverityConfig, mode: LinterMode) -> Severity {
-    let severity = self.get_rule_config(rule_name).and_then(|rule| rule.severity).unwrap_or(default_severity);
+    let severity = self
+      .get_rule_config(rule_name)
+      .and_then(|rule| rule.severity)
+      .or_else(|| self.default_rule_severity())
+      .unwrap_or(default_severity);
 
     resolve_severity(severity, mode)
   }
@@ -302,7 +310,11 @@ impl Config {
     }
 
     for offense in offenses {
-      if let Some(severity) = self.get_rule_config(offense.rule()).and_then(|rule| rule.severity) {
+      if let Some(severity) = self
+        .get_rule_config(offense.rule())
+        .and_then(|rule| rule.severity)
+        .or_else(|| self.default_rule_severity())
+      {
         offense.set_severity(resolve_severity(severity, mode));
       }
     }

--- a/rust/herb-config/tests/config_test.rs
+++ b/rust/herb-config/tests/config_test.rs
@@ -525,6 +525,70 @@ mod config_instance_methods {
   }
 
   #[test]
+  fn default_rule_severity_returns_none_when_all_is_not_configured() {
+    assert_eq!(
+      config_from_yaml("linter:\n  rules:\n    html-tag-name-lowercase:\n      severity: warning\n").default_rule_severity(),
+      None
+    );
+  }
+
+  #[test]
+  fn default_rule_severity_returns_the_all_pseudo_rule_setting() {
+    assert_eq!(
+      config_from_yaml("linter:\n  rules:\n    all:\n      severity: warning\n").default_rule_severity(),
+      Some(Severity::Warning.into())
+    );
+  }
+
+  #[test]
+  fn get_configured_severity_falls_back_to_the_all_pseudo_rule() {
+    let config = config_from_yaml("linter:\n  rules:\n    all:\n      severity: warning\n");
+
+    assert_eq!(
+      config.get_configured_severity("rule-a", Severity::Error.into(), LinterMode::Cli),
+      Severity::Warning
+    );
+  }
+
+  #[test]
+  fn get_configured_severity_prefers_the_rule_severity_over_the_all_pseudo_rule() {
+    let config = config_from_yaml("linter:\n  rules:\n    all:\n      severity: warning\n    rule-a:\n      severity: info\n");
+
+    assert_eq!(
+      config.get_configured_severity("rule-a", Severity::Error.into(), LinterMode::Cli),
+      Severity::Info
+    );
+    assert_eq!(
+      config.get_configured_severity("rule-b", Severity::Error.into(), LinterMode::Cli),
+      Severity::Warning
+    );
+  }
+
+  #[test]
+  fn get_configured_severity_resolves_the_all_pseudo_rule_with_mode() {
+    let config = config_from_yaml("linter:\n  rules:\n    all:\n      severity:\n        editor: hint\n        cli: error\n");
+
+    assert_eq!(
+      config.get_configured_severity("rule-a", Severity::Warning.into(), LinterMode::Editor),
+      Severity::Hint
+    );
+    assert_eq!(
+      config.get_configured_severity("rule-a", Severity::Warning.into(), LinterMode::Cli),
+      Severity::Error
+    );
+  }
+
+  #[test]
+  fn get_configured_severity_keeps_the_default_when_all_sets_only_enabled() {
+    let config = config_from_yaml("linter:\n  rules:\n    all:\n      enabled: true\n");
+
+    assert_eq!(
+      config.get_configured_severity("rule-a", Severity::Warning.into(), LinterMode::Cli),
+      Severity::Warning
+    );
+  }
+
+  #[test]
   fn is_rule_disabled_returns_true_for_unconfigured_rules_when_all_is_disabled() {
     assert!(config_from_yaml("linter:\n  rules:\n    all:\n      enabled: false\n").is_rule_disabled("html-img-require-alt"));
   }


### PR DESCRIPTION
The `all` pseudo rule sets the default `enabled` state for every rule that isn't listed explicitly. It's validated against the same schema as a real rule entry, so `severity` has been accepted there from the start, but nothing ever read it. Setting it validated cleanly and did nothing, and every rule kept reporting at its own default.

```yaml
linter:
  rules:
    all:
      severity: warning
```

This pull request makes that config do what it looks like it does. `severity` on `all` becomes the default for every rule that doesn't set its own, taking the same position in the resolution chain that `enabled` already occupies.