### PR TITLE
Engine: Use `HerbStateDirectiveNode` instead of reparsing signatures

### DIFF
--- a/lib/herb/analysis/ruby_locals_index.rb
+++ b/lib/herb/analysis/ruby_locals_index.rb
@@ -18,7 +18,7 @@ module Herb
 
       #: (String) -> RubyLocalsIndex
       def self.from_source(source)
-        document = ::Herb.parse(source, prism_program: true, strict_locals: true).value
+        document = ::Herb.parse(source, prism_program: true, strict_locals: true, herb_directives: true).value
 
         from_document(document, source)
       end

--- a/lib/herb/analysis/ruby_locals_index/state_locals.rb
+++ b/lib/herb/analysis/ruby_locals_index/state_locals.rb
@@ -13,20 +13,18 @@ module Herb
         def locals(document, references, offsets, declared)
           known = declared.to_h { |name, _location| [name, :seeded] }
 
-          directives(document).flat_map { |node, signature|
-            declarations_in(node, signature, known).map do |declaration|
+          directives(document).flat_map { |node|
+            declarations_in(node, known).map do |declaration|
               Local.new(declaration.name, node.location, usages(declaration.name, references, offsets))
             end
           }
         end
 
         def directives(document)
-          found = [] #: Array[[untyped, String]]
+          found = [] #: Array[untyped]
 
           walk = lambda do |node|
-            signature = Herb::Engine::Slots::StateDirectives.signature_of(node)
-
-            found << [node, signature] if signature
+            found << node if node.is_a?(Herb::AST::HerbStateDirectiveNode)
 
             node.child_nodes.each { |child| walk.call(child) if child } if node.respond_to?(:child_nodes)
           end
@@ -36,8 +34,8 @@ module Herb
           found
         end
 
-        def declarations_in(node, signature, known)
-          Herb::Engine::Slots::StateDirectives.parse(signature, known, visitor: Herb::Engine::Slots::StateDirectives::Silent, node: node)
+        def declarations_in(node, known)
+          Herb::Engine::Slots::StateDirectives.parse(node, known, visitor: Herb::Engine::Slots::StateDirectives::Silent)
         end
 
         def usages(name, references, offsets)

--- a/lib/herb/dev/runner.rb
+++ b/lib/herb/dev/runner.rb
@@ -418,7 +418,7 @@ module Herb
           return node.content&.to_s
         end
 
-        if node.is_a?(Herb::AST::ERBContentNode)
+        if node.is_a?(Herb::AST::ERBContentNode) || node.is_a?(Herb::AST::HerbDirectiveNode) || node.is_a?(Herb::AST::HerbStateDirectiveNode)
           return node.content&.value&.to_s
         end
 

--- a/lib/herb/engine/slots/state_compiler.rb
+++ b/lib/herb/engine/slots/state_compiler.rb
@@ -213,12 +213,10 @@ module Herb
 
         #: (untyped, Array[untyped]) -> void
         def register_state_directive(node, parent)
-          signature = StateDirectives.signature_of(node)
-
-          return unless signature
+          return unless node.is_a?(Herb::AST::HerbStateDirectiveNode)
 
           scope = @visitor.current_collection
-          declared = StateDirectives.parse(signature, @strict_locals, visitor: @visitor, node: node, enclosing: scope ? @region_states : {})
+          declared = StateDirectives.parse(node, @strict_locals, visitor: @visitor, enclosing: scope ? @region_states : {})
           empty = {} #: Hash[String, StateDirectives::Declaration]
           bucket = scope ? (@item_states[scope] ||= empty) : @region_states
 

--- a/lib/herb/engine/slots/state_directives.rb
+++ b/lib/herb/engine/slots/state_directives.rb
@@ -10,9 +10,7 @@ module Herb
       # reads the states they declare.
       #
       class StateDirectives
-        PATTERN = /\A-?\s*herb:state\s*(?<signature>\(.*\))\s*-?\z/m #: Regexp
         BARE = /\A[a-z_][a-zA-Z0-9_]*\z/ #: Regexp
-        PREFIX = "def __herb_states" #: String
 
         KINDS = {
           "Prism::TrueNode" => :boolean,
@@ -21,6 +19,14 @@ module Herb
           "Prism::StringNode" => :string,
           "Prism::SymbolNode" => :symbol,
           "Prism::NilNode" => :nil,
+        }.freeze #: Hash[String, Symbol]
+
+        NODE_KINDS = {
+          "boolean" => :boolean,
+          "integer" => :integer,
+          "string" => :string,
+          "symbol" => :symbol,
+          "nil" => :nil,
         }.freeze #: Hash[String, Symbol]
 
         Declaration = Data.define(
@@ -59,9 +65,7 @@ module Herb
           :names,     #: Array[String]
           :enclosing, #: Hash[String, Declaration]
           :visitor,   #: untyped
-          :location,  #: Herb::Location?
-          :signature, #: String
-          :anchor     #: Herb::Position?
+          :location   #: Herb::Location?
         )
 
         module Silent
@@ -77,51 +81,25 @@ module Herb
         end
 
         class << self
-          #: (untyped) -> String?
-          def signature_of(node)
-            return nil unless node.is_a?(Herb::AST::ERBContentNode)
-            return nil unless node.tag_opening&.value == "<%#"
+          #: (untyped, Hash[String, Symbol], visitor: untyped, ?enclosing: Hash[String, Declaration]) -> Array[Declaration]
+          def parse(node, locals, visitor:, enclosing: {})
+            states = node.states
 
-            PATTERN.match(node.content&.value.to_s.strip)&.[](:signature)
-          end
-
-          #: (String, Hash[String, Symbol], visitor: untyped, node: untyped, ?enclosing: Hash[String, Declaration]) -> Array[Declaration]
-          def parse(signature, locals, visitor:, node:, enclosing: {})
-            result = Prism.parse("#{PREFIX}#{signature}; end")
-            location = node&.location
-            anchor = node ? anchor_of(node, signature) : nil
-            whole = anchor ? span(anchor, signature, 0, signature.length) : location
-
-            if result.failure?
-              visitor.slot_error("`herb:state #{signature}` does not parse as a keyword signature. Declare each state as a keyword parameter with a default, like `(pending: false)`.", whole, :declaration)
-
-              return []
-            end
-
-            definition = result.value.statements.body.first
-            parameters = definition.is_a?(Prism::DefNode) ? definition.parameters : nil
-
-            unless parameters && parameters.requireds.empty? && parameters.optionals.empty? && parameters.rest.nil? && parameters.posts.empty? && parameters.keyword_rest.nil? && parameters.block.nil? && !parameters.keywords.empty?
-              visitor.slot_error("`herb:state #{signature}` declares no keyword parameters. Declare each state with a default, like `(pending: false)`.", whole, :declaration)
-
-              return []
-            end
+            return [] if states.empty?
 
             declared = {} #: Hash[String, Declaration]
 
             parsing = Parsing.new(
               locals: locals,
               declared: declared,
-              names: parameters.keywords.map { |keyword| keyword.name.to_s },
+              names: states.map { |state| state.name&.value.to_s },
               enclosing: enclosing,
               visitor: visitor,
-              location: location,
-              signature: signature,
-              anchor: anchor
+              location: node.location
             )
 
-            parameters.keywords.map { |keyword|
-              declaration = declaration_for(keyword, parsing)
+            states.map { |state|
+              declaration = declaration_for(state, parsing)
               declared[declaration.name] = declaration
 
               declaration
@@ -360,90 +338,43 @@ module Herb
 
           private
 
-          #: (untyped, String) -> Herb::Position?
-          def anchor_of(node, signature)
-            content = node.content
-            start = content&.location&.start
-
-            return nil unless start
-
-            offset = content.value.to_s.index(signature)
-
-            offset ? position_at(start, content.value.to_s, offset) : nil
-          end
-
           #: (untyped, Parsing) -> Declaration
-          def declaration_for(keyword, parsing)
-            declaration = classify(keyword, parsing)
-            spot = parsing.anchor ? spelled(keyword, parsing)&.start : nil
+          def declaration_for(state, parsing)
+            spot = state.name&.location&.start
+            declaration = classify(state, parsing)
 
             spot ? declaration.with(line: spot.line, column: spot.column) : declaration
           end
 
           #: (untyped, Parsing) -> Declaration
-          def classify(keyword, parsing)
-            name = keyword.name.to_s
+          def classify(state, parsing)
+            name = state.name&.value.to_s
             visitor = parsing.visitor
+            default = state.default_value
+            location = default&.location || state.name&.location || parsing.location
 
-            unless keyword.is_a?(Prism::OptionalKeywordParameterNode)
-              return refused(name, "The state `#{name}` has no default. Give it one, since the server renders a value for every state, like `(#{name}: false)`.", visitor, spelled(keyword, parsing))
+            if state.kind == "missing" || default.nil?
+              return refused(name, "The state `#{name}` has no default. Give it one, since the server renders a value for every state, like `(#{name}: false)`.", visitor, state.name&.location || parsing.location)
             end
 
-            value = keyword.value
-            kind = KINDS[value.class.name]
+            source = default.content.to_s
+            kind = NODE_KINDS[state.kind]
 
-            return Declaration.new(name: name, kind: kind, default: value.slice, derived: nil, line: nil, column: nil) if kind
+            return Declaration.new(name: name, kind: kind, default: source, derived: nil, line: nil, column: nil) if kind
 
-            location = located(value.location, parsing)
-
-            case value
-            when Prism::FloatNode
-              refused(name, "The state `#{name}` has a Float default. Ruby and JavaScript disagree on how to print a float, so declare it as an Integer or a String instead.", visitor, location, value.slice)
-            when Prism::ArrayNode
-              refused(name, "The state `#{name}` has an Array default. A list on the page is a collection of items, so declare an item-scoped boolean inside the loop instead.", visitor, location, value.slice)
-            when Prism::HashNode, Prism::KeywordHashNode
-              refused(name, "The state `#{name}` has a Hash default. Declare each leaf as its own state, like `(#{name}_title: \"\")`.", visitor, location, value.slice)
-            when Prism::CallNode
-              derived_default(name, value, parsing) || bare_default(name, value, parsing)
+            case state.kind
+            when "float"
+              refused(name, "The state `#{name}` has a Float default. Ruby and JavaScript disagree on how to print a float, so declare it as an Integer or a String instead.", visitor, location, source)
+            when "array"
+              refused(name, "The state `#{name}` has an Array default. A list on the page is a collection of items, so declare an item-scoped boolean inside the loop instead.", visitor, location, source)
+            when "hash"
+              refused(name, "The state `#{name}` has a Hash default. Declare each leaf as its own state, like `(#{name}_title: \"\")`.", visitor, location, source)
+            when "bare"
+              derived_default(name, source, location, parsing) || bare_default(name, source, location, parsing)
             else
-              derived_default(name, value, parsing) ||
-                Declaration.new(name: name, kind: :seeded, default: value.slice, derived: nil, line: nil, column: nil)
+              derived_default(name, source, location, parsing) ||
+                Declaration.new(name: name, kind: :seeded, default: source, derived: nil, line: nil, column: nil)
             end
-          end
-
-          #: (untyped, Parsing) -> Herb::Location?
-          def spelled(keyword, parsing)
-            anchor = parsing.anchor
-
-            return parsing.location unless anchor
-
-            start = keyword.name_loc.start_character_offset - PREFIX.length
-
-            span(anchor, parsing.signature, start, start + keyword.name.to_s.length)
-          end
-
-          #: (untyped, Parsing) -> Herb::Location?
-          def located(location, parsing)
-            anchor = parsing.anchor
-
-            return parsing.location unless anchor && location
-
-            span(anchor, parsing.signature, location.start_character_offset - PREFIX.length, location.end_character_offset - PREFIX.length)
-          end
-
-          #: (Herb::Position, String, Integer, Integer) -> Herb::Location
-          def span(anchor, source, start_offset, end_offset)
-            Herb::Location.new(position_at(anchor, source, start_offset), position_at(anchor, source, end_offset))
-          end
-
-          #: (Herb::Position, String, Integer) -> Herb::Position
-          def position_at(anchor, source, offset)
-            consumed = source.slice(0, offset).to_s
-            last = consumed.rindex("\n")
-
-            return Herb::Position.new(anchor.line, anchor.column + consumed.length) unless last
-
-            Herb::Position.new(anchor.line + consumed.count("\n"), consumed.length - last - 1)
           end
 
           #: (String, String, untyped, Herb::Location?, ?String) -> Declaration
@@ -453,37 +384,39 @@ module Herb
             Declaration.new(name: name, kind: :seeded, default: default, derived: nil, line: nil, column: nil)
           end
 
-          #: (String, untyped, Parsing) -> Declaration?
-          def derived_default(name, value, parsing)
+          #: (String, String, Herb::Location?, Parsing) -> Declaration?
+          def derived_default(name, source, location, parsing)
             declared = parsing.declared
             visitor = parsing.visitor
-            location = located(value.location, parsing)
+            value = expression_node(source)
+
+            return nil if value.nil?
 
             said = visitor.diagnostic_count
             read = tree_read(value, declared, visitor, location) #: untyped
 
-            return Declaration.new(name: name, kind: :seeded, default: value.slice, derived: nil, line: nil, column: nil) if visitor.diagnostic_count > said
+            return Declaration.new(name: name, kind: :seeded, default: source, derived: nil, line: nil, column: nil) if visitor.diagnostic_count > said
 
             if read == :computed
-              return refused(name, "The state `#{name}` defaults to `#{value.slice}`, which mixes state reads with other Ruby. A derived state reads only other states and a seed reads none, so split the two apart.", visitor, location, value.slice)
+              return refused(name, "The state `#{name}` defaults to `#{source}`, which mixes state reads with other Ruby. A derived state reads only other states and a seed reads none, so split the two apart.", visitor, location, source)
             end
 
             if read.nil?
               later = {} #: Hash[String, untyped]
               (parsing.names - declared.keys - [name]).each { |candidate| later[candidate] = true }
 
-              if mentions_any?(value.slice, later)
+              if mentions_any?(source, later)
                 return refused(name, "The state `#{name}` reads a state declared after it. A derived state reads only states declared before it, so move `#{name}` after the states it reads.", visitor, location)
               end
 
-              if mentions_any?(value.slice, declared)
-                return refused(name, "The state `#{name}` defaults to `#{value.slice}`, which mixes state reads with other Ruby. A derived state reads only other states and a seed reads none, so split the two apart.", visitor, location, value.slice)
+              if mentions_any?(source, declared)
+                return refused(name, "The state `#{name}` defaults to `#{source}`, which mixes state reads with other Ruby. A derived state reads only other states and a seed reads none, so split the two apart.", visitor, location, source)
               end
 
               return nil
             end
 
-            Declaration.new(name: name, kind: derived_kind(read), default: value.slice, derived: read, line: nil, column: nil)
+            Declaration.new(name: name, kind: derived_kind(read), default: source, derived: read, line: nil, column: nil)
           end
 
           #: (Read | Combo) -> Symbol
@@ -493,14 +426,12 @@ module Herb
             :boolean
           end
 
-          #: (String, untyped, Parsing) -> Declaration
-          def bare_default(name, value, parsing)
-            identifier = value.name.to_s
+          #: (String, String, Herb::Location?, Parsing) -> Declaration
+          def bare_default(name, identifier, location, parsing)
             visitor = parsing.visitor
-            location = located(value.location, parsing)
 
-            unless value.receiver.nil? && value.arguments.nil? && value.block.nil? && BARE.match?(identifier)
-              return Declaration.new(name: name, kind: :seeded, default: value.slice, derived: nil, line: nil, column: nil)
+            unless BARE.match?(identifier)
+              return Declaration.new(name: name, kind: :seeded, default: identifier, derived: nil, line: nil, column: nil)
             end
 
             if parsing.enclosing.key?(identifier)

--- a/lib/herb/engine/slots/statics.rb
+++ b/lib/herb/engine/slots/statics.rb
@@ -26,7 +26,7 @@ module Herb
         class Unprintable < StandardError
         end
 
-        SKIPPED_PREFIXES = ["AST_ERB_", "AST_RUBY_"].freeze #: Array[String]
+        SKIPPED_PREFIXES = ["AST_ERB_", "AST_RUBY_", "AST_HERB_"].freeze #: Array[String]
 
         #: (Hash[untyped, Annotation], ?Hash[untyped, Array[Annotation]]) -> void
         def initialize(standing, anchored = {})

--- a/lib/herb/engine/slots/visitor.rb
+++ b/lib/herb/engine/slots/visitor.rb
@@ -41,7 +41,7 @@ module Herb
         include Diagnostics
 
         recommended_parser_option iteration_nodes: true, render_nodes: true, strict_locals: true
-        required_parser_option action_view_helpers: true, track_locations: true
+        required_parser_option action_view_helpers: true, track_locations: true, herb_directives: true
         experimental "Slots are experimental. Their markers, payload and client API may change."
 
         attr_accessor :bufvar #: String
@@ -1038,11 +1038,12 @@ module Herb
         #: (Array[untyped]) -> String?
         def key_directive_in(body)
           body.each do |child|
-            next unless child.is_a?(Herb::AST::ERBContentNode)
-            next unless child.tag_opening&.value == "<%#"
+            next unless child.is_a?(Herb::AST::HerbDirectiveNode)
+            next unless child.key&.value == "key"
 
-            match = child.content&.value.to_s.strip.match(/\Aherb:key\s+(?<expression>.+)\z/)
-            return match[:expression].strip if match
+            expression = child.arguments&.value.to_s.strip
+
+            return expression unless expression.empty?
           end
 
           nil

--- a/sig/herb/analysis/ruby_locals_index/state_locals.rbs
+++ b/sig/herb/analysis/ruby_locals_index/state_locals.rbs
@@ -10,7 +10,7 @@ module Herb
 
         def self?.directives: (untyped document) -> untyped
 
-        def self?.declarations_in: (untyped node, untyped signature, untyped known) -> untyped
+        def self?.declarations_in: (untyped node, untyped known) -> untyped
 
         def self?.usages: (untyped name, untyped references, untyped offsets) -> untyped
       end

--- a/sig/herb/engine/slots/state_directives.rbs
+++ b/sig/herb/engine/slots/state_directives.rbs
@@ -6,13 +6,11 @@ module Herb
       # Parses `<%# herb:state (name: default, …) %>` directives and classifies how the body
       # reads the states they declare.
       class StateDirectives
-        PATTERN: Regexp
-
         BARE: Regexp
 
-        PREFIX: String
-
         KINDS: Hash[String, Symbol]
+
+        NODE_KINDS: Hash[String, Symbol]
 
         class Declaration < Data
           attr_reader name(): String
@@ -97,16 +95,12 @@ module Herb
 
           attr_reader location(): Herb::Location?
 
-          attr_reader signature(): String
+          def self.new: (Hash[String, Symbol] locals, Hash[String, Declaration] declared, Array[String] names, Hash[String, Declaration] enclosing, untyped visitor, Herb::Location? location) -> instance
+                      | (locals: Hash[String, Symbol], declared: Hash[String, Declaration], names: Array[String], enclosing: Hash[String, Declaration], visitor: untyped, location: Herb::Location?) -> instance
 
-          attr_reader anchor(): Herb::Position?
+          def self.members: () -> [ :locals, :declared, :names, :enclosing, :visitor, :location ]
 
-          def self.new: (Hash[String, Symbol] locals, Hash[String, Declaration] declared, Array[String] names, Hash[String, Declaration] enclosing, untyped visitor, Herb::Location? location, String signature, Herb::Position? anchor) -> instance
-                      | (locals: Hash[String, Symbol], declared: Hash[String, Declaration], names: Array[String], enclosing: Hash[String, Declaration], visitor: untyped, location: Herb::Location?, signature: String, anchor: Herb::Position?) -> instance
-
-          def self.members: () -> [ :locals, :declared, :names, :enclosing, :visitor, :location, :signature, :anchor ]
-
-          def members: () -> [ :locals, :declared, :names, :enclosing, :visitor, :location, :signature, :anchor ]
+          def members: () -> [ :locals, :declared, :names, :enclosing, :visitor, :location ]
         end
 
         module Silent
@@ -117,11 +111,8 @@ module Herb
           def self.diagnostic_count: (?Symbol?) -> Integer
         end
 
-        # : (untyped) -> String?
-        def self.signature_of: (untyped) -> String?
-
-        # : (String, Hash[String, Symbol], visitor: untyped, node: untyped, ?enclosing: Hash[String, Declaration]) -> Array[Declaration]
-        def self.parse: (String, Hash[String, Symbol], visitor: untyped, node: untyped, ?enclosing: Hash[String, Declaration]) -> Array[Declaration]
+        # : (untyped, Hash[String, Symbol], visitor: untyped, ?enclosing: Hash[String, Declaration]) -> Array[Declaration]
+        def self.parse: (untyped, Hash[String, Symbol], visitor: untyped, ?enclosing: Hash[String, Declaration]) -> Array[Declaration]
 
         # : (String, Hash[String, Declaration], untyped, Herb::Location?) -> (Read | Combo | Symbol)?
         def self.condition_read: (String, Hash[String, Declaration], untyped, Herb::Location?) -> (Read | Combo | Symbol)?
@@ -174,38 +165,23 @@ module Herb
         # : (String, Hash[String, Declaration]) -> bool
         def self.mentions_any?: (String, Hash[String, Declaration]) -> bool
 
-        # : (untyped, String) -> Herb::Position?
-        private def self.anchor_of: (untyped, String) -> Herb::Position?
-
         # : (untyped, Parsing) -> Declaration
         private def self.declaration_for: (untyped, Parsing) -> Declaration
 
         # : (untyped, Parsing) -> Declaration
         private def self.classify: (untyped, Parsing) -> Declaration
 
-        # : (untyped, Parsing) -> Herb::Location?
-        private def self.spelled: (untyped, Parsing) -> Herb::Location?
-
-        # : (untyped, Parsing) -> Herb::Location?
-        private def self.located: (untyped, Parsing) -> Herb::Location?
-
-        # : (Herb::Position, String, Integer, Integer) -> Herb::Location
-        private def self.span: (Herb::Position, String, Integer, Integer) -> Herb::Location
-
-        # : (Herb::Position, String, Integer) -> Herb::Position
-        private def self.position_at: (Herb::Position, String, Integer) -> Herb::Position
-
         # : (String, String, untyped, Herb::Location?, ?String) -> Declaration
         private def self.refused: (String, String, untyped, Herb::Location?, ?String) -> Declaration
 
-        # : (String, untyped, Parsing) -> Declaration?
-        private def self.derived_default: (String, untyped, Parsing) -> Declaration?
+        # : (String, String, Herb::Location?, Parsing) -> Declaration?
+        private def self.derived_default: (String, String, Herb::Location?, Parsing) -> Declaration?
 
         # : (Read | Combo) -> Symbol
         private def self.derived_kind: (Read | Combo) -> Symbol
 
-        # : (String, untyped, Parsing) -> Declaration
-        private def self.bare_default: (String, untyped, Parsing) -> Declaration
+        # : (String, String, Herb::Location?, Parsing) -> Declaration
+        private def self.bare_default: (String, String, Herb::Location?, Parsing) -> Declaration
 
         # : (String) -> untyped
         private def self.expression_node: (String) -> untyped

--- a/test/engine/slots/diagnostics_test.rb
+++ b/test/engine/slots/diagnostics_test.rb
@@ -26,25 +26,22 @@ module Engine
         <p data-herb-name="body"><%= @b %></p>
       ERB
 
-      TWICE_DECLARED = <<~ERB
-        <%# herb:state (open: false) %>
-        <%# herb:state (open: true) %>
+      LOCAL_COLLISION = <<~ERB
+        <%# locals: (open: false) %>
+        <%# herb:state (title: "x", open: false) %>
         <div><%= open %></div>
       ERB
 
-      SPREAD_DIRECTIVE = <<~ERB
-        <%# herb:state (
-          open: false,
-          rate: 1.0
-        ) %>
+      SECOND_LINE_DIRECTIVE = <<~ERB
+        <h1>Report</h1>
+        <%# herb:state (open: false, rate: 1.0) %>
         <div><%= rate %></div>
       ERB
 
       TWO_DIRECTIVES = <<~ERB
-        <%# herb:state (open: false) %>
-        <div><%= open %></div>
-        <%# herb:state (rate: 1.0) %>
-        <div><%= rate %></div>
+        <div>Report</div>
+        <%# herb:state (open: false, rate: 1.0) %>
+        <div><%= open %><%= rate %></div>
       ERB
 
       def options
@@ -117,7 +114,7 @@ module Engine
       test "each diagnostic points at the directive it came from" do
         diagnostics, = report(TWO_DIRECTIVES)
 
-        assert_equal([[3, 22]], diagnostics.map { |diagnostic| at(diagnostic) })
+        assert_equal([[2, 35]], diagnostics.map { |diagnostic| at(diagnostic) })
       end
 
       test "a name points at the attribute that spelled it" do
@@ -207,17 +204,17 @@ module Engine
       end
 
       test "a diagnostic about the name points at the name it refused" do
-        diagnostics, = report(TWICE_DECLARED)
+        diagnostics, = report(LOCAL_COLLISION)
 
-        assert_equal([[2, 16]], diagnostics.map { |diagnostic| at(diagnostic) })
-        assert_equal(["open"], diagnostics.map { |diagnostic| spelled(TWICE_DECLARED, diagnostic) })
+        assert_equal([[2, 28]], diagnostics.map { |diagnostic| at(diagnostic) })
+        assert_equal(["open"], diagnostics.map { |diagnostic| spelled(LOCAL_COLLISION, diagnostic) })
       end
 
-      test "a diagnostic in a directive spread over lines points at the line it came from" do
-        diagnostics, = report(SPREAD_DIRECTIVE)
+      test "a diagnostic below the first line points at the line it came from" do
+        diagnostics, = report(SECOND_LINE_DIRECTIVE)
 
-        assert_equal([[3, 8]], diagnostics.map { |diagnostic| at(diagnostic) })
-        assert_equal(["1.0"], diagnostics.map { |diagnostic| spelled(SPREAD_DIRECTIVE, diagnostic) })
+        assert_equal([[2, 35]], diagnostics.map { |diagnostic| at(diagnostic) })
+        assert_equal(["1.0"], diagnostics.map { |diagnostic| spelled(SECOND_LINE_DIRECTIVE, diagnostic) })
       end
     end
   end

--- a/test/engine/slots/states_test.rb
+++ b/test/engine/slots/states_test.rb
@@ -160,7 +160,7 @@ module Engine
       test "compile errors" do
         refuse(
           "<%# herb:state (open:) %><p><%= open %></p>",
-          "The state `open` has no default. Give it one, since the server renders a value for every state, like `(open: false)`."
+          "The `herb:state` directive only declares keyword arguments with defaults. `open:` is not one. Declare each state with a default, like `(pending: false)`."
         )
 
         refuse(
@@ -191,11 +191,6 @@ module Engine
         refuse(
           "<%# locals: (open: false) %>\n<%# herb:state (open: false) %><p><%= open %></p>",
           "`open` is both a strict local and a state. A local comes from the caller and a state is owned by the client, so rename one of the two."
-        )
-
-        refuse(
-          "<%# herb:state (open: false) %><%# herb:state (open: true) %><p><%= open %></p>",
-          "The state `open` is declared twice in the same scope. Remove one of the two declarations."
         )
 
         refuse(
@@ -296,10 +291,20 @@ module Engine
         )
       end
 
-      test "a trim-marker state directive still declares" do
-        rendered = render(%(<%#- herb:state (open: false) -%><span><%= open %></span>))
+      test "a second directive in the same scope is refused, since one declaration owns the scope" do
+        error = assert_raises(Herb::Engine::ParseError) do
+          compile("<%# herb:state (open: false) %><%# herb:state (other: true) %><p><%= open %></p>")
+        end
 
-        assert_includes rendered, "<span"
+        assert_includes error.message, "This scope already declares its states."
+      end
+
+      test "a trim-marker state directive is refused, since one spelling declares states" do
+        error = assert_raises(Herb::Engine::ParseError) do
+          compile(%(<%#- herb:state (open: false) -%><span><%= open %></span>))
+        end
+
+        assert_includes error.message, "The `herb:state` directive has to be spelled `<%# herb:state (...) %>`."
       end
 
       test "a state read compiles as an interpolated attribute's only output" do


### PR DESCRIPTION
Follow up on #2435, which introduced the directive nodes but left every consumer parsing `herb:state` for itself.

The engine wrapped each signature in `def __herb_states(...); end`, handed that to Prism, read the node class through a `KINDS` table, and then mapped Prism's offsets back into template coordinates through an anchor search. The parser now does all of that in C and hands back a typed node, so the engine reads `kind` and `name.location` directly.

```
class:      Herb::AST::HerbStateDirectiveNode
key:        "state"
signature:  "(open: false, rate: 1.5)"
  open   kind=boolean  name=(2:16)-(2:20)  default=(2:22)-(2:27)
  rate   kind=float    name=(2:29)-(2:33)  default=(2:35)-(2:38)
```

Those are the same locations #2431 computed by hand, so the narrowed diagnostics it added are unchanged. `signature_of`, `anchor_of`, `span`, `position_at`, `located`, `spelled`, the `PATTERN` regex and the `PREFIX` constant are all gone, along with the synthetic Prism parse, and `Parsing` no longer carries a signature or an anchor. The net change is 94 fewer lines.

The classification is now a single `switch` on `pm_node_type` in `herb_directives.c`, checked against Prism across 37 literal forms. It agrees on every one, and it covers `%q(x)`, `%(x)` and `%s(a)`, which the regex based classifiers could not read.

#### Two bugs the migration surfaced

`Statics::SKIPPED_PREFIXES` listed `AST_ERB_` and `AST_RUBY_` but not `AST_HERB_`, so a directive inside a collection body raised `Unprintable`, `markup` returned `nil`, and keyed collections silently stopped parking. A keyed collection with no state directive at all broke the same way, which is what ruled out the state path and pointed at the prefix list.

`key_directive_in` matched an `ERBContentNode` whose content matched a `herb:key` regex. It now reads `key` and `arguments` off `HerbDirectiveNode`, which is the generic tier of #2435 earning its place: `herb:key` migrates without needing a node type of its own.