### PR TITLE
Dev Tools: Redesign the diagnostics panel and the dev tools menu

### DIFF
--- a/javascript/packages/dev-tools/README.md
+++ b/javascript/packages/dev-tools/README.md
@@ -72,11 +72,11 @@ yarn dev
 
 Set `HERB_DEMO_PORT` to move it. Set `HERB_DEMO_TARGET=dist` to serve the same page against `dist/herb-dev-tools.esm.js`, which is how to check the published artifact instead of the working tree. Run `yarn build` first in that case.
 
-## Runtime Diagnostics
+## Diagnostics
 
-The runtime diagnostics panel docks a badge in the Herb menu and opens a list of diagnostic cards when that badge is clicked. Findings reach it two ways. A page calls the JavaScript API below, or it embeds a JSON payload that the panel reads on start and on every Turbo navigation.
+The diagnostics panel docks a badge in the Herb menu and opens a list of diagnostic cards when that badge is clicked. Findings reach it two ways. A page calls the JavaScript API below, or it embeds a JSON payload that the panel reads on start and on every Turbo navigation.
 
-`Herb::Engine::Report` is the producer on the Ruby side. `Report::Middleware` injects its payload into a page that rendered, and [`Report::ErrorPage`](#when-the-page-did-not-render) serves a page of its own for one that did not. The [payload reference](#runtime-report-payload) is the contract between them, and `test/engine-payload.test.ts` holds the reader to it using a fixture the engine generates.
+`Herb::Engine::Runtime` is the producer on the Ruby side. `Runtime::Middleware` injects its payload into a page that rendered, and [`Runtime::ErrorPage`](#when-the-page-did-not-render) serves a page of its own for one that did not. The [payload reference](#runtime-report-payload) is the contract between them, and `test/engine-payload.test.ts` holds the reader to it using a fixture the engine generates.
 
 The normative definition of every shape on this page is [`src/runtime/report.ts`](https://github.com/marcoroth/herb/blob/main/javascript/packages/dev-tools/src/runtime/report.ts). Where this prose and those types disagree, the types win.
 
@@ -251,7 +251,7 @@ window.HerbDevTools.close()
 
 `close()` closes the panel and leaves the badge in place, which is what the panel's own × does. Neither one touches the stored "hidden for this session" state, and neither can close an overlay. Use [`overlay`](#overlay) for that.
 
-The Herb menu carries a **Runtime Diagnostics** toggle that does the same thing without the console. Switching it off is the panel header's "Hide for this session", and switching it back on is `show()`. Both write the same stored state, so the two can never disagree. Neither one brings back entries that were cleared, because clearing discards them for good.
+The Herb menu carries a **Diagnostics** toggle that does the same thing without the console. Switching it off is the panel header's "Hide for this session", and switching it back on is `show()`. Both write the same stored state, so the two can never disagree. Neither one brings back entries that were cleared, because clearing discards them for good.
 
 #### When the panel is off
 
@@ -323,7 +323,7 @@ The header ends with a control that expands the panel to fill the window, which 
 
 `Escape` does what the close button does, so it closes the panel and leaves the badge. It does not collapse an expanded panel back into the corner, because closing is what a reader reaches for Escape to do. It is only listened for while the panel fills the window, so a docked panel never takes the key away from the page.
 
-The panel header's "Hide for this session" and the Herb menu's **Runtime Diagnostics** toggle are the same switch. Either one hides the badge for the session, and the toggle or `show()` brings it back.
+The panel header's "Hide for this session" and the Herb menu's **Diagnostics** toggle are the same switch. Either one hides the badge for the session, and the toggle or `show()` brings it back.
 
 Every class and data attribute the panel owns is prefixed `herb-dev-tools-`.
 
@@ -527,10 +527,10 @@ Every part of the payload is optional-tolerant. A malformed or partial payload s
 
 ### When the page did not render
 
-A template that fails to compile takes the whole response with it, so there is no page for the engine to inject a payload into and nothing for the dev tools to attach to. `Herb::Engine::Report::ErrorPage` serves a document of its own for that case.
+A template that fails to compile takes the whole response with it, so there is no page for the engine to inject a payload into and nothing for the dev tools to attach to. `Herb::Engine::Runtime::ErrorPage` serves a document of its own for that case.
 
 ```ruby
-config.middleware.use Herb::Engine::Report::ErrorPage, dev_tools: "/assets/herb-dev-tools.js"
+config.middleware.use Herb::Engine::Runtime::ErrorPage, dev_tools: "/assets/herb-dev-tools.js"
 ```
 
 It rescues a `Herb::Engine::CompilationError`, walking the `cause` chain because Action View wraps the failure in an error of its own, and answers `500` with a page carrying the same payload every other page carries. The diagnostics in it ask for a [blocking overlay](#overlay), so the panel takes the screen as soon as it starts.

--- a/javascript/packages/dev-tools/demo/rack/README.md
+++ b/javascript/packages/dev-tools/demo/rack/README.md
@@ -11,8 +11,8 @@ The app serves the dev tools bundle from `dist/` itself, so there is one server 
 
 | Route | What it shows |
 | --- | --- |
-| `/valid` | A template that compiles. `Report::Middleware` injects what the page reported and the panel docks a badge in the corner. |
-| `/broken` | A template that does not. The engine raises, nothing renders, and `Report::ErrorPage` answers with a page carrying the diagnostics as a blocking overlay. |
+| `/valid` | A template that compiles. `Runtime::Middleware` injects what the page reported and the panel docks a badge in the corner. |
+| `/broken` | A template that does not. The engine raises, nothing renders, and `Runtime::ErrorPage` answers with a page carrying the diagnostics as a blocking overlay. |
 | `/broken.json` | The same failure asked for as JSON. The middleware raises on, so an XHR still fails the way it would have. |
 | `/boom` | An error that is not Herb's, raised on untouched. |
 

--- a/javascript/packages/dev-tools/demo/rack/config.ru
+++ b/javascript/packages/dev-tools/demo/rack/config.ru
@@ -3,8 +3,9 @@
 require "herb"
 require "herb/engine"
 require "herb/engine/validators"
-require "herb/engine/report/error_page"
-require "herb/engine/report/middleware"
+require "herb/engine/runtime/error_page"
+require "herb/engine/runtime/middleware"
+require "herb/engine/runtime/session"
 
 module Demo
   VIEWS = File.expand_path("views", __dir__) #: String
@@ -60,7 +61,7 @@ module Demo
 
     #: () -> untyped
     def valid
-      Herb::Engine::Report::Session.record(
+      Herb::Engine::Runtime::Session.record(
         Herb::Diagnostic.new(
           template: "demo/rack/views/valid.html.erb",
           message: "This byline was rendered without checking that the author is present.",
@@ -120,7 +121,7 @@ module Demo
   end
 end
 
-use Herb::Engine::Report::ErrorPage, dev_tools: Demo::DEV_TOOLS
-use Herb::Engine::Report::Middleware
+use Herb::Engine::Runtime::ErrorPage, dev_tools: Demo::DEV_TOOLS
+use Herb::Engine::Runtime::Middleware
 
 run Demo::App.new

--- a/javascript/packages/dev-tools/rolldown.config.mjs
+++ b/javascript/packages/dev-tools/rolldown.config.mjs
@@ -1,5 +1,7 @@
 import postcss from "rollup-plugin-postcss"
 
+import pkg from "./package.json" with { type: "json" }
+
 // rolldown rejects `.css` in the module graph outright, so `moduleTypes` hands
 // the file over as JavaScript and lets the postcss plugin's transform, which
 // returns the stylesheet as an injected JS module, be what rolldown parses.
@@ -13,6 +15,7 @@ export const browserDefines = {
   "process.env.NO_COLOR": "undefined",
   "process.stdout.isTTY": "false",
   "process.stdout.columns": "0",
+  __HERB_DEV_TOOLS_VERSION__: JSON.stringify(pkg.version),
 }
 
 export default [

--- a/javascript/packages/dev-tools/src/base.css
+++ b/javascript/packages/dev-tools/src/base.css
@@ -9,8 +9,9 @@
 }
 
 .herb-floating-menu:has(.herb-dev-tools-attached .herb-dev-tools-badge) .herb-menu-trigger {
+  align-self: stretch;
   border-radius: 0;
-  border-left: none;
+  border-left: 1px solid var(--herb-rule);
 }
 
 .herb-dev-tools-badge-slot {

--- a/javascript/packages/dev-tools/src/dev-server/connection-dot.ts
+++ b/javascript/packages/dev-tools/src/dev-server/connection-dot.ts
@@ -1,9 +1,23 @@
-import type { HerbClient } from "./client"
 import { colors } from "./colors"
+
+import type { HerbClient } from "./client"
+
+const CONNECTING_HOLD = 1000
+
+type UpdatePanelOptions = {
+  dotColor: string
+  statusText: string
+  statusColor: string
+  retryVisible: boolean
+  retryHandler?: (e: MouseEvent) => void
+  keepStatusWhileRetrying?: boolean
+}
 
 export class ConnectionDot {
   private client: HerbClient
   private reconnectCountdown: ReturnType<typeof setInterval> | null = null
+  private countdownHold: ReturnType<typeof setTimeout> | null = null
+  private connectingSince: number | null = null
 
   constructor(client: HerbClient) {
     this.client = client
@@ -12,22 +26,35 @@ export class ConnectionDot {
   apply(): void {
     if (this.reconnectCountdown) {
       clearInterval(this.reconnectCountdown)
+
       this.reconnectCountdown = null
     }
 
-    const dot = document.getElementById("herbConnectionDot")
+    if (this.countdownHold) {
+      clearTimeout(this.countdownHold)
 
+      this.countdownHold = null
+    }
+
+    const dot = document.getElementById("herbConnectionDot")
     const panelDot = this.all("[data-herb-dev-server-dot]")
     const panelStatus = this.all("[data-herb-dev-server-status]")
-    const panelRetry = this.all("[data-herb-dev-server-retry]") as HTMLButtonElement[]
+    const panelRetry = this.all<HTMLButtonElement>("[data-herb-dev-server-retry]")
 
-    if (!dot && panelDot.length === 0 && panelStatus.length === 0) return
-    const retryHandler = (e: MouseEvent) => { e.stopPropagation(); this.client.retry() }
+    if (!dot && panelDot.length === 0 && panelStatus.length === 0) {
+      return
+    }
+
+    const retryHandler = (event: MouseEvent) => {
+      event.stopPropagation()
+
+      this.client.retry()
+    }
 
     const state = this.client.getState()
 
     switch (state) {
-      case "connected":
+      case "connected": {
         this.applyBadge(dot, colors.green, "Connected to herb dev server", true, true, "default", null)
 
         this.updatePanel(panelDot, panelStatus, panelRetry, {
@@ -38,8 +65,9 @@ export class ConnectionDot {
         })
 
         break
+      }
 
-      case "disconnected":
+      case "disconnected": {
         this.applyBadge(dot, colors.red, "Disconnected from herb dev server", false, false, "default", null)
 
         this.updatePanel(panelDot, panelStatus, panelRetry, {
@@ -48,11 +76,13 @@ export class ConnectionDot {
           statusColor: colors.gray,
           retryVisible: true,
           retryHandler,
+          keepStatusWhileRetrying: true,
         })
 
         break
+      }
 
-      case "given-up":
+      case "given-up": {
         this.applyBadge(dot, colors.amber, "Connection to herb dev server failed — click to retry", false, false, "pointer", retryHandler)
 
         this.updatePanel(panelDot, panelStatus, panelRetry, {
@@ -64,41 +94,77 @@ export class ConnectionDot {
         })
 
         break
+      }
     }
   }
 
   updateReconnectCountdown(attempt: number, maxAttempts: number, delay: number): void {
     const panelStatus = this.all("[data-herb-dev-server-status]")
-    if (panelStatus.length === 0) return
+
+    if (panelStatus.length === 0) {
+      return
+    }
 
     if (this.reconnectCountdown) {
       clearInterval(this.reconnectCountdown)
+
       this.reconnectCountdown = null
     }
 
-    let remaining = Math.ceil(delay / 1000)
-    this.write(panelStatus, `Retry ${attempt}/${maxAttempts} in ${remaining}s`, colors.gray)
+    if (this.countdownHold) {
+      clearTimeout(this.countdownHold)
 
-    this.reconnectCountdown = setInterval(() => {
-      remaining--
+      this.countdownHold = null
+    }
 
-      if (remaining <= 0) {
+    const deadline = Date.now() + delay
+    let announced = false
+
+    const tick = () => {
+      const remaining = Math.max(0, Math.ceil((deadline - Date.now()) / 1000))
+
+      if (remaining === 0) {
         if (this.reconnectCountdown) {
           clearInterval(this.reconnectCountdown)
           this.reconnectCountdown = null
         }
 
-        this.write(panelStatus, `Retry ${attempt}/${maxAttempts} connecting...`, colors.gray)
+        if (!announced) {
+          announced = true
+          this.connectingSince = Date.now()
+        }
+
+        this.write(panelStatus, `Retrying... (${attempt}/${maxAttempts})`, colors.gray)
 
         return
       }
 
-      this.write(panelStatus, `Retry ${attempt}/${maxAttempts} in ${remaining}s`, colors.gray)
-    }, 1000)
+      this.write(panelStatus, `Retrying in ${remaining}s (${attempt}/${maxAttempts})`, colors.gray)
+    }
+
+    const begin = () => {
+      this.countdownHold = null
+
+      tick()
+
+      this.reconnectCountdown = setInterval(tick, 200)
+    }
+
+    const held = (this.connectingSince === null) ? 0 : Math.max(0, CONNECTING_HOLD - (Date.now() - this.connectingSince))
+
+    if (held === 0) {
+      begin()
+    } else {
+      this.countdownHold = setTimeout(begin, held)
+    }
   }
 
-  private all(selector: string): HTMLElement[] {
-    return Array.from(document.querySelectorAll<HTMLElement>(selector))
+  private all<T extends Element = HTMLElement>(selector: string): T[] {
+    return Array.from(document.querySelectorAll<T>(selector))
+  }
+
+  private get holdingConnecting(): boolean {
+    return this.connectingSince !== null && Date.now() - this.connectingSince < CONNECTING_HOLD
   }
 
   private write(elements: HTMLElement[], text: string, color: string): void {
@@ -108,38 +174,28 @@ export class ConnectionDot {
     }
   }
 
-  private applyBadge(
-    dot: HTMLElement | null,
-    color: string,
-    title: string,
-    glow: boolean,
-    pulse: boolean,
-    cursor: string,
-    handler: ((e: MouseEvent) => void) | null
-  ): void {
+  private applyBadge(dot: HTMLElement | null, color: string, title: string, glow: boolean, pulse: boolean, cursor: string, handler: ((e: MouseEvent) => void) | null): void {
     if (!dot) return
 
     this.setDotStyle(dot, color, glow, pulse)
+
     dot.style.cursor = cursor
     dot.title = title
     dot.onclick = handler
   }
 
-  private updatePanel(
-    panelDot: HTMLElement[],
-    panelStatus: HTMLElement[],
-    panelRetry: HTMLButtonElement[],
-    options: {
-      dotColor: string
-      statusText: string
-      statusColor: string
-      retryVisible: boolean
-      retryHandler?: (e: MouseEvent) => void
+  private updatePanel(panelDot: HTMLElement[], panelStatus: HTMLElement[], panelRetry: HTMLButtonElement[], options: UpdatePanelOptions): void {
+    for (const element of panelDot) {
+      this.setDotStyle(element, options.dotColor, false, false)
     }
-  ): void {
-    for (const element of panelDot) this.setDotStyle(element, options.dotColor, false, false)
 
-    this.write(panelStatus, options.statusText, options.statusColor)
+    if (!(options.keepStatusWhileRetrying && this.holdingConnecting)) {
+      this.write(panelStatus, options.statusText, options.statusColor)
+    }
+
+    for (const element of panelStatus) {
+      element.parentElement?.setAttribute("data-herb-dev-tools-tip", options.statusText)
+    }
 
     for (const element of panelRetry) {
       element.style.display = options.retryVisible ? "block" : "none"

--- a/javascript/packages/dev-tools/src/dev-server/connection.ts
+++ b/javascript/packages/dev-tools/src/dev-server/connection.ts
@@ -2,6 +2,8 @@ import type { HerbMessage, ConnectionOptions } from "./types"
 
 const DEFAULT_RECONNECT_INTERVAL = 1000
 const DEFAULT_MAX_RECONNECT_ATTEMPTS = 10
+const RECONNECT_BACKOFF_FACTOR = 2
+const MAX_RECONNECT_DELAY = 15000
 
 export class Connection {
   private socket: WebSocket | null = null
@@ -118,8 +120,8 @@ export class Connection {
     this.reconnectAttempts++
 
     const delay = Math.min(
-      this.reconnectInterval * Math.pow(1.5, this.reconnectAttempts - 1),
-      10000
+      this.reconnectInterval * Math.pow(RECONNECT_BACKOFF_FACTOR, this.reconnectAttempts - 1),
+      MAX_RECONNECT_DELAY
     )
 
     this.options.onReconnecting?.(this.reconnectAttempts, this.maxReconnectAttempts, delay)

--- a/javascript/packages/dev-tools/src/herb-dev-tools.ts
+++ b/javascript/packages/dev-tools/src/herb-dev-tools.ts
@@ -10,7 +10,6 @@ import type { DiagnosticSink, HerbClientOptions } from './dev-server/types.js'
 import type { RuntimeReportHandle } from './runtime/panel.js'
 import type { RuntimeDiagnostic } from './runtime/report.js'
 
-
 const NOOP_HANDLE: RuntimeReportHandle = { dismiss() {} }
 
 export const DEV_TOOLS_START_EVENT = 'herb:dev-tools-start'
@@ -144,9 +143,8 @@ export class HerbDevTools {
         onMenuOpen: () => this.panel?.close(),
         onReinitialize: () => this.panel?.refresh(),
         isRuntimePanelVisible: runtimePanelEnabled ? () => this.panel === null || !this.panel.dismissed : undefined,
-        onRuntimePanelToggle: runtimePanelEnabled
-          ? visible => (visible ? this.panel?.show() : this.panel?.dismiss())
-          : undefined,
+        onRuntimePanelToggle: runtimePanelEnabled ? visible => (visible ? this.panel?.show() : this.panel?.dismiss()) : undefined,
+        reportedFor: runtimePanelEnabled ? template => this.panel?.reportedFor(template) ?? null : undefined,
       })
     }
 

--- a/javascript/packages/dev-tools/src/overlay/overlay.css
+++ b/javascript/packages/dev-tools/src/overlay/overlay.css
@@ -1,45 +1,109 @@
+.herb-floating-menu,
+.herb-tooltip,
+.herb-overlay-label {
+  --herb-surface: #ffffff;
+  --herb-surface-soft: #fafafa;
+  --herb-line: #e4e4e7;
+  --herb-rule: #d4d4d8;
+  --herb-ink: #09090b;
+  --herb-ink-soft: #27272a;
+  --herb-ink-muted: #52525b;
+  --herb-ink-faint: #71717a;
+  --herb-accent: #4caf50;
+  --herb-accent-strong: green;
+  --herb-accent-line: #81c784;
+  --herb-accent-soft: color-mix(in srgb, #4caf50 8%, #ffffff);
+  --herb-mono: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  --herb-sans: system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+}
+
+:where(.herb-floating-menu, .herb-tooltip) :where(button, select, input) {
+  box-sizing: border-box;
+  margin: 0;
+  min-height: 0;
+  font: inherit;
+  text-align: inherit;
+  text-transform: none;
+  letter-spacing: normal;
+  vertical-align: middle;
+  appearance: none;
+  -webkit-appearance: none;
+}
+
 .herb-overlay-label {
   position: absolute;
-  top: -18px;
+  top: -20px;
   left: 4px;
-  background: rgba(0, 0, 0, 0.8);
-  color: white;
-  padding: 2px 6px;
-  font-size: 11px;
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, monospace;
-  font-weight: 500;
-  border-radius: 3px;
+  padding: 3px 7px;
+  border: 1px solid var(--herb-rule);
+  border-radius: 6px;
+  background: var(--herb-surface);
+  color: var(--herb-ink-soft);
+  font-family: var(--herb-mono);
+  font-size: 10.5px;
+  font-weight: 600;
+  line-height: 1.3;
+  white-space: nowrap;
   display: block;
   z-index: 1000;
   cursor: pointer;
-  transition: all 0.2s ease;
-  white-space: nowrap;
-  line-height: 1.2;
+  transition: border-color 0.15s ease, color 0.15s ease;
+}
+
+.herb-overlay-label {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+}
+
+.herb-overlay-label-count {
+  flex: none;
+  min-width: 14px;
+  padding: 0 4px;
+  border-radius: 999px;
+  background: #71717a;
+  color: #ffffff;
+  font-size: 9.5px;
+  font-weight: 700;
+  line-height: 14px;
+  text-align: center;
+}
+
+.herb-overlay-label-count-error {
+  background: #dc2626;
+}
+
+.herb-overlay-label-count-warning {
+  background: #b45309;
+}
+
+.herb-overlay-label-count-info,
+.herb-overlay-label-count-hint {
+  background: #1d4ed8;
 }
 
 .herb-overlay-label:hover {
-  background: rgba(0, 0, 0, 0.9);
-  transform: scale(1.02);
-  color: #374151;
+  border-color: var(--herb-rule);
+  color: var(--herb-ink);
   z-index: 1001;
 }
 
 [data-herb-debug-outline-type*="view"] > .herb-overlay-label {
-  background: #dbeafe;
-  color: #1e40af;
-  border-color: #93c5fd;
+  background: #eff6ff;
+  border-color: #bfdbfe;
+  color: #1d4ed8;
 }
 
 [data-herb-debug-outline-type*="partial"] > .herb-overlay-label {
-  background: #d1fae5;
-  color: #065f46;
-  border-color: #6ee7b7;
+  background: #ecfdf5;
+  border-color: #a7f3d0;
+  color: #047857;
 }
 
 [data-herb-debug-outline-type*="component"] > .herb-overlay-label {
-  background: #fef3c7;
-  color: #92400e;
-  border-color: #fcd34d;
+  background: #fffbeb;
+  border-color: #fde68a;
+  color: #b45309;
 }
 
 [data-herb-debug-outline-type*="erb-output"] {
@@ -48,21 +112,19 @@
 
 .herb-tooltip {
   position: fixed;
-  background: white;
-  border: 1px solid #e5e7eb;
-  padding: 16px 20px;
+  display: flex;
+  flex-direction: column;
+  border: 1px solid var(--herb-rule);
   border-radius: 12px;
-  font-family: 'SF Mono', 'Monaco', 'Inconsolata', 'Fira Code', monospace;
+  background: var(--herb-surface);
+  font-family: var(--herb-sans);
   font-size: 14px;
   opacity: 0;
   visibility: hidden;
   pointer-events: none;
-  transition: opacity 0.2s ease, visibility 0.2s ease;
+  transition: opacity 0.15s ease, visibility 0.15s ease;
   z-index: 10001;
-  box-shadow: 0 10px 40px rgba(0,0,0,0.12), 0 2px 8px rgba(0,0,0,0.08);
-  display: flex;
-  flex-direction: column;
-  gap: 12px;
+  box-shadow: 0 4px 14px rgba(9, 9, 11, 0.08);
   white-space: nowrap;
   overflow: visible;
   max-width: calc(100vw - 16px);
@@ -75,42 +137,42 @@
 }
 
 .herb-tooltip .herb-location {
-  color: #6b7280;
-  font-size: 13px;
-  font-weight: 500;
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: 12px;
-  cursor: pointer;
-  transition: all 0.2s ease;
-  background: #f8f9fa;
-  margin: -16px -20px 0 -20px;
-  padding: 12px 20px;
+  padding: 10px 14px;
+  border-bottom: 1px solid var(--herb-line);
   border-radius: 12px 12px 0 0;
+  background: var(--herb-surface-soft);
+  color: var(--herb-ink-soft);
+  font-family: var(--herb-mono);
+  font-size: 12px;
+  cursor: pointer;
+  transition: color 0.15s ease, background 0.15s ease;
 }
 
 .herb-tooltip .herb-location:hover {
-  color: #374151;
-  background: #f1f3f4;
+  background: #f4f4f5;
+  color: var(--herb-ink);
 }
 
 .herb-copy-path-btn {
-  background: transparent;
-  border: none;
-  font-size: 14px;
-  cursor: pointer;
-  padding: 4px;
-  border-radius: 4px;
-  transition: all 0.2s ease;
-  color: #6b7280;
-  flex-shrink: 0;
   position: relative;
+  flex-shrink: 0;
+  padding: 3px;
+  border: none;
+  border-radius: 5px;
+  background: transparent;
+  color: var(--herb-ink-muted);
+  font-size: 13px;
+  cursor: pointer;
+  transition: background 0.15s ease, color 0.15s ease;
 }
 
 .herb-copy-path-btn:hover {
-  background: rgba(107, 114, 128, 0.1);
-  color: #374151;
+  background: rgba(113, 113, 122, 0.12);
+  color: var(--herb-ink);
 }
 
 .herb-copy-path-btn:active {
@@ -123,16 +185,17 @@
   bottom: calc(100% + 8px);
   left: 50%;
   transform: translateX(-50%);
-  background: #1f2937;
-  color: white;
-  padding: 6px 10px;
+  padding: 5px 9px;
   border-radius: 6px;
-  font-size: 12px;
+  background: #18181b;
+  color: #ffffff;
+  font-family: var(--herb-sans);
+  font-size: 11.5px;
   white-space: nowrap;
   opacity: 0;
   visibility: hidden;
   pointer-events: none;
-  transition: all 0.2s ease;
+  transition: all 0.15s ease;
   z-index: 10002;
 }
 
@@ -143,10 +206,10 @@
   left: 50%;
   transform: translateX(-50%);
   border: 4px solid transparent;
-  border-top-color: #1f2937;
+  border-top-color: #18181b;
   opacity: 0;
   visibility: hidden;
-  transition: all 0.2s ease;
+  transition: all 0.15s ease;
   z-index: 10002;
 }
 
@@ -165,19 +228,20 @@
 .herb-copy-path-btn::after {
   content: attr(data-tooltip);
   position: absolute;
-  top: -36px;
+  top: -34px;
   left: 50%;
   transform: translateX(-50%);
-  background: #1f2937;
-  color: white;
-  padding: 6px 10px;
+  padding: 5px 9px;
   border-radius: 6px;
-  font-size: 12px;
+  background: #18181b;
+  color: #ffffff;
+  font-family: var(--herb-sans);
+  font-size: 11.5px;
   white-space: nowrap;
   opacity: 0;
   visibility: hidden;
   pointer-events: none;
-  transition: all 0.2s ease;
+  transition: all 0.15s ease;
   z-index: 10003;
 }
 
@@ -188,10 +252,10 @@
   left: 50%;
   transform: translateX(-50%);
   border: 4px solid transparent;
-  border-bottom-color: #1f2937;
+  border-bottom-color: #18181b;
   opacity: 0;
   visibility: hidden;
-  transition: all 0.2s ease;
+  transition: all 0.15s ease;
   z-index: 10003;
 }
 
@@ -202,12 +266,14 @@
 }
 
 .herb-tooltip .herb-erb-code {
-  color: #111827;
-  font-size: 16px;
-  font-weight: 600;
+  padding: 14px;
+  color: var(--herb-ink);
+  font-family: var(--herb-mono);
+  font-size: 14px;
+  font-weight: 500;
   cursor: text;
   user-select: text;
-  letter-spacing: -0.025em;
+  letter-spacing: -0.01em;
 }
 
 .herb-tooltip::before {
@@ -227,7 +293,7 @@
   left: 50%;
   transform: translateX(-50%);
   border: 6px solid transparent;
-  border-top-color: #e5e7eb;
+  border-top-color: var(--herb-rule);
   z-index: 10000;
   pointer-events: none;
 }
@@ -237,197 +303,202 @@
   top: 0;
   right: 0;
   z-index: 2147483643;
-  font-family: system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+  font-family: var(--herb-sans);
 }
 
 .herb-menu-trigger {
-  padding: 4px 7px;
-  border-radius: 0 0 0 10px;
-  background: white;
-  border: 1px solid #c0c0c0;
-  border-top: none;
-  border-right: none;
-  box-shadow: 0px 1px 3px rgba(0, 0, 0, 0.1);
-  cursor: pointer;
-  transition: all 0.2s ease;
+  position: relative;
+  z-index: 2147483640;
   display: flex;
   align-items: center;
   justify-content: center;
-  gap: 4px;
-  position: relative;
-  z-index: 2147483640;
+  gap: 5px;
+  padding: 5px 9px;
+  border: 1px solid var(--herb-rule);
+  border-top: none;
+  border-right: none;
+  border-radius: 0 0 0 12px;
+  background: var(--herb-surface);
+  cursor: pointer;
   font-size: 12px;
+  transition: background 0.15s ease, border-color 0.15s ease;
 }
 
 .herb-menu-trigger:hover {
-  background: #f9fafb;
-  border-color: #9ca3af;
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+  background: var(--herb-surface-soft);
+  border-color: var(--herb-rule);
 }
 
 .herb-menu-trigger:active {
-  transform: scale(0.98);
+  background: #f4f4f5;
 }
 
 .herb-menu-trigger.has-active-options {
-  background: #dbeafe;
-  border-color: #3b82f6;
+  background: var(--herb-accent-soft);
+  border-color: var(--herb-accent-line);
 }
 
 .herb-menu-trigger.has-active-options:hover {
-  background: #bfdbfe;
-  border-color: #2563eb;
+  background: color-mix(in srgb, var(--herb-accent) 16%, #ffffff);
+  border-color: var(--herb-accent);
 }
 
 .herb-menu-trigger.has-active-options .herb-text {
-  color: #1d4ed8;
+  color: var(--herb-accent-strong);
 }
 
 .herb-icon {
-  font-size: 14px;
+  font-size: 13px;
   line-height: 1;
   display: block;
 }
 
 .herb-text {
+  color: var(--herb-ink-soft);
+  font-family: var(--herb-mono);
   font-size: 11px;
   font-weight: 600;
-  color: #555;
-  letter-spacing: 0.2px;
 }
 
 .herb-connection-dot {
-  width: 8px;
-  height: 8px;
+  width: 7px;
+  height: 7px;
   border-radius: 50%;
-  background: #d1d5db;
+  background: var(--herb-rule);
   display: block;
   transition: background 0.3s ease, box-shadow 0.3s ease;
 }
 
-.herb-dev-server-section {
-  padding: 8px 20px;
-  border-bottom: 1px solid #e5e7eb;
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  font-size: 11px;
-  min-height: 32px;
-}
-
-.herb-dev-server-dot {
-  width: 8px;
-  height: 8px;
-  border-radius: 50%;
-  background: #d1d5db;
-  flex-shrink: 0;
-  transition: background 0.3s ease;
-}
-
-.herb-dev-server-status {
-  color: #6b7280;
-}
-
-.herb-dev-server-retry {
-  display: none;
-  margin-left: auto;
-  font-size: 10px;
-  padding: 2px 8px;
-  border: 1px solid #d1d5db;
-  border-radius: 4px;
-  background: white;
-  cursor: pointer;
-  color: #374151;
-  transition: background 0.15s ease, border-color 0.15s ease;
-}
-
-.herb-dev-server-retry:hover {
-  background: #f3f4f6;
-  border-color: #9ca3af;
-}
-
 .herb-menu-panel {
   position: absolute;
-  top: 28px;
+  top: 30px;
   right: 10px;
-  background: white;
-  border-radius: 8px;
-  border: 1px solid #c0c0c0;
-  box-shadow: 0px 2px 8px rgba(0, 0, 0, 0.1);
+  min-width: 330px;
   padding: 0;
-  min-width: 280px;
+  border: 1px solid var(--herb-rule);
+  border-radius: 10px;
+  background: var(--herb-surface);
+  color: var(--herb-ink-soft);
+  box-shadow: 0 1px 3px rgba(9, 9, 11, 0.08);
+  overflow: hidden;
   opacity: 0;
   visibility: hidden;
-  transform: translateY(-10px) scale(0.95);
-  transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
-  transform-origin: top right;
 }
 
 .herb-menu-panel.open {
   opacity: 1;
   visibility: visible;
-  transform: translateY(0) scale(1);
 }
 
 .herb-menu-header {
-  padding: 16px 20px;
-  border-bottom: 1px solid #e5e7eb;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  box-sizing: content-box;
+  min-height: 26px;
+  padding: 10px 14px;
+  border-bottom: 1px solid var(--herb-rule);
+  color: var(--herb-ink);
+  font-size: 13px;
   font-weight: 600;
-  font-size: 14px;
-  color: #374151;
-  background: #f9fafb;
-  border-radius: 8px 8px 0 0;
+  letter-spacing: -0.01em;
+}
+
+.herb-menu-title {
+  flex: 1;
+  min-width: 0;
+}
+
+.herb-dev-server-section {
+  display: flex;
+  align-items: center;
+  flex: none;
+  gap: 6px;
+  font-family: var(--herb-mono);
+  font-size: 11px;
+  font-weight: 400;
+}
+
+.herb-dev-server-dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--herb-rule);
+  flex-shrink: 0;
+  transition: background 0.3s ease;
+}
+
+.herb-dev-server-status {
+  color: var(--herb-ink-muted);
+}
+
+.herb-dev-server-section-disabled .herb-dev-server-status {
+  color: var(--herb-ink-faint);
+}
+
+.herb-dev-server-retry {
+  display: none;
+  margin-left: auto;
+  padding: 2px 8px;
+  border: 1px solid var(--herb-rule);
+  border-radius: 6px;
+  background: var(--herb-surface);
+  color: var(--herb-ink-soft);
+  font: inherit;
+  font-size: 10px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.15s ease, border-color 0.15s ease;
+}
+
+.herb-dev-server-retry:hover {
+  background: #f4f4f5;
+  border-color: var(--herb-ink-faint);
 }
 
 .herb-toggle-item {
-  padding: 12px 20px;
-  border-bottom: 1px solid #f3f4f6;
+  padding: 10px 14px;
+  border-bottom: 1px solid var(--herb-line);
 }
 
 .herb-toggle-item:last-child {
   border-bottom: none;
-  border-radius: 0 0 8px 8px;
 }
 
 .herb-nested-toggle {
-  margin-top: 8px;
-  padding-left: 24px;
-  border-left: 2px solid #f3f4f6;
+  margin-top: 10px;
+  padding-left: 22px;
+  border-left: 2px solid var(--herb-line);
   transition: all 0.3s ease;
 }
 
-.herb-nested-label {
-  opacity: 0.8;
-}
-
 .herb-nested-label .herb-toggle-text {
-  font-size: 13px;
-  color: #6b7280;
+  font-size: 12.5px;
+  color: var(--herb-ink-muted);
 }
 
 .herb-nested-switch {
-  width: 36px;
-  height: 20px;
-  background: #e5e7eb;
+  width: 34px;
+  height: 19px;
 }
 
 .herb-nested-switch::after {
-  width: 14px;
-  height: 14px;
+  width: 13px;
+  height: 13px;
   top: 3px;
   left: 3px;
 }
 
 .herb-toggle-input:checked + .herb-nested-switch::after {
-  transform: translateX(16px);
+  transform: translateX(15px);
 }
 
 .herb-toggle-label {
   display: flex;
   align-items: center;
+  gap: 12px;
   cursor: pointer;
   user-select: none;
-  gap: 12px;
 }
 
 .herb-toggle-input {
@@ -436,178 +507,162 @@
 
 .herb-toggle-switch {
   position: relative;
-  width: 44px;
-  height: 24px;
-  background: #cbd5e1;
-  border-radius: 12px;
-  transition: background 0.3s ease;
   flex-shrink: 0;
+  width: 40px;
+  height: 22px;
+  border-radius: 999px;
+  background: #d4d4d8;
+  transition: background 0.2s ease;
 }
 
 .herb-toggle-switch::after {
   content: '';
   position: absolute;
-  width: 18px;
-  height: 18px;
-  background: white;
-  border-radius: 50%;
   top: 3px;
   left: 3px;
-  transition: transform 0.3s ease;
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  background: #ffffff;
+  box-shadow: 0 1px 2px rgba(9, 9, 11, 0.25);
+  transition: transform 0.2s ease;
 }
 
 .herb-toggle-input:checked + .herb-toggle-switch {
-  background: #8b5cf6;
+  background: var(--herb-accent);
 }
 
 .herb-toggle-input:checked + .herb-toggle-switch::after {
-  transform: translateX(20px);
+  transform: translateX(18px);
+}
+
+.herb-toggle-label:hover .herb-toggle-switch {
+  background: var(--herb-ink-faint);
+}
+
+.herb-toggle-label:hover .herb-toggle-input:checked + .herb-toggle-switch {
+  background: var(--herb-accent-strong);
 }
 
 .herb-toggle-text {
-  font-size: 14px;
-  color: #374151;
   flex: 1;
+  color: var(--herb-ink-soft);
+  font-size: 13px;
+  font-weight: 500;
 }
 
 .herb-outline-preview {
   padding: 2px 8px;
-  border-radius: 4px;
   border: 2px dotted transparent;
+  border-radius: 6px;
 }
 
 .herb-outline-view {
-  border-color: #3b82f6;
+  border-color: #93c5fd;
   background-color: #eff6ff;
 }
 
 .herb-outline-partial {
-  border-color: #10b981;
+  border-color: #6ee7b7;
   background-color: #ecfdf5;
 }
 
 .herb-outline-component {
-  border-color: #f59e0b;
+  border-color: #fcd34d;
   background-color: #fffbeb;
 }
 
 .herb-outline-erb {
-  border-color: #a78bfa;
+  border-color: #c4b5fd;
   background-color: #f5f3ff;
 }
 
-.herb-toggle-label:hover .herb-toggle-switch {
-  background: #94a3b8;
-}
-
-.herb-toggle-label:hover .herb-toggle-input:checked + .herb-toggle-switch {
-  background: #7c3aed;
-}
-
 .herb-editor-section {
-  padding: 16px 20px;
-  border-bottom: 1px solid #f3f4f6;
-  background: linear-gradient(135deg, #fafbfc 0%, #f8f9fa 100%);
-  position: relative;
-  overflow: hidden;
-}
-
-.herb-editor-section::before {
-  content: '';
-  position: absolute;
-  top: 0;
-  left: 0;
-  right: 0;
-  height: 2px;
-  background: linear-gradient(90deg, transparent, rgba(139, 92, 246, 0.2), transparent);
+  padding: 12px 14px;
+  border-top: 1px solid var(--herb-rule);
+  background: var(--herb-surface-soft);
 }
 
 .herb-editor-label {
   display: flex;
   flex-direction: column;
-  gap: 10px;
+  gap: 8px;
   cursor: default;
 }
 
 .herb-editor-text {
-  font-size: 12px;
-  font-weight: 600;
-  color: #6b7280;
-  text-transform: uppercase;
-  letter-spacing: 0.5px;
   display: flex;
   align-items: center;
   gap: 6px;
+  color: var(--herb-ink-faint);
+  font-family: var(--herb-mono);
+  font-size: 10.5px;
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
 }
 
 .herb-editor-select {
   width: 100%;
-  padding: 10px 36px 10px 12px;
-  background: white;
-  border: 1.5px solid #e5e7eb;
+  padding: 9px 34px 9px 11px;
+  border: 1px solid var(--herb-rule);
   border-radius: 8px;
-  font-size: 13.5px;
+  background: var(--herb-surface);
+  color: var(--herb-ink);
+  font-family: var(--herb-sans);
+  font-size: 13px;
   font-weight: 500;
-  color: #1f2937;
   cursor: pointer;
-  transition: all 0.2s cubic-bezier(0.4, 0, 0.2, 1);
-  font-family: "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
   appearance: none;
-  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' fill='none' stroke='%2371717a' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M4 6.5 8 10.5 12 6.5'/%3E%3C/svg%3E");
+  background-position: right 10px center;
+  background-repeat: no-repeat;
+  background-size: 14px 14px;
+  transition: border-color 0.15s ease, box-shadow 0.15s ease;
 }
 
 .herb-editor-select option {
-  font-family: "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+  font-family: var(--herb-sans);
   font-size: 14px;
   font-weight: 400;
   padding: 8px 12px;
 }
 
 .herb-editor-select:hover {
-  border-color: #8b5cf6;
-  background-color: #fafafa;
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.08), 0 0 0 1px rgba(139, 92, 246, 0.1);
-  transform: translateY(-1px);
+  border-color: var(--herb-ink-faint);
 }
 
 .herb-editor-select:focus {
   outline: none;
-  border-color: #8b5cf6;
-  background-color: white;
-  box-shadow: 0 0 0 3px rgba(139, 92, 246, 0.15), 0 2px 8px rgba(139, 92, 246, 0.1);
-  transform: translateY(-1px);
-}
-
-.herb-editor-select:active {
-  transform: translateY(0);
-  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
+  border-color: var(--herb-accent);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--herb-accent) 25%, transparent);
 }
 
 .herb-disable-all-section {
-  padding: 16px 20px;
-  border-top: 1px solid #f3f4f6;
-  background: #f9fafb;
-  border-radius: 0 0 8px 8px;
+  padding: 0 14px 12px;
+  background: var(--herb-surface-soft);
 }
 
 .herb-disable-all-btn {
   width: 100%;
-  background: #ef4444;
-  color: white;
-  border: none;
   padding: 8px 16px;
-  border-radius: 6px;
+  border: 1px solid #dc2626;
+  border-radius: 8px;
+  background: #ef4444;
+  color: #ffffff;
+  font: inherit;
   font-size: 13px;
-  font-weight: 500;
+  font-weight: 600;
   cursor: pointer;
-  transition: background 0.2s ease;
+  transition: background 0.15s ease, border-color 0.15s ease, color 0.15s ease;
 }
 
 .herb-disable-all-btn:hover {
+  border-color: #b91c1c;
   background: #dc2626;
 }
 
 .herb-disable-all-btn:active {
+  border-color: #991b1b;
   background: #b91c1c;
 }

--- a/javascript/packages/dev-tools/src/overlay/overlay.ts
+++ b/javascript/packages/dev-tools/src/overlay/overlay.ts
@@ -11,6 +11,7 @@ export interface HerbOverlayOptions {
   onReinitialize?: () => void;
   isRuntimePanelVisible?: () => boolean;
   onRuntimePanelToggle?: (visible: boolean) => void;
+  reportedFor?: (template: string) => { count: number, tone: string } | null;
 }
 
 export class HerbOverlay {
@@ -189,7 +190,7 @@ export class HerbOverlay {
         <label class="herb-toggle-label">
           <input type="checkbox" id="herbToggleRuntimePanel" class="herb-toggle-input">
           <span class="herb-toggle-switch"></span>
-          <span class="herb-toggle-text">Runtime Diagnostics</span>
+          <span class="herb-toggle-text">Diagnostics</span>
         </label>
       </div>
     `;
@@ -210,6 +211,8 @@ export class HerbOverlay {
       return;
     }
 
+    const devServer = this.options.devServerClient != null;
+
     const menuHTML = `
       <div class="herb-floating-menu">
         <span class="herb-dev-tools-badge-slot" data-herb-dev-tools-badge-slot></span>
@@ -217,16 +220,21 @@ export class HerbOverlay {
         <button class="herb-menu-trigger" id="herbMenuTrigger">
           <span class="herb-icon">🌿</span>
           <span class="herb-text">Herb</span>
-          <span id="herbConnectionDot" class="herb-connection-dot" data-herb-connection-dot></span>
+          ${devServer ? `<span id="herbConnectionDot" class="herb-connection-dot" data-herb-connection-dot></span>` : ``}
         </button>
 
         <div class="herb-menu-panel" id="herbMenuPanel">
-          <div class="herb-menu-header">Herb Dev Tools</div>
+          <div class="herb-menu-header">
+            <span class="herb-menu-title">Herb Dev Tools</span>
 
-          <div id="herbDevServerSection" class="herb-dev-server-section">
-            <span id="herbDevServerDot" data-herb-dev-server-dot class="herb-dev-server-dot"></span>
-            <span id="herbDevServerStatus" data-herb-dev-server-status class="herb-dev-server-status">Dev Server</span>
-            <button id="herbDevServerRetry" data-herb-dev-server-retry class="herb-dev-server-retry">Retry</button>
+            ${devServer ? `<div id="herbDevServerSection" class="herb-dev-server-section">
+              <span id="herbDevServerDot" data-herb-dev-server-dot class="herb-dev-server-dot"></span>
+              <span id="herbDevServerStatus" data-herb-dev-server-status class="herb-dev-server-status">Dev Server</span>
+              <button id="herbDevServerRetry" data-herb-dev-server-retry class="herb-dev-server-retry">Retry</button>
+            </div>` : `<div id="herbDevServerSection" class="herb-dev-server-section herb-dev-server-section-disabled">
+              <span class="herb-dev-server-dot"></span>
+              <span class="herb-dev-server-status">Dev Server disabled</span>
+            </div>`}
           </div>
 
           <div class="herb-toggle-item">
@@ -616,13 +624,31 @@ export class HerbOverlay {
     const relativePath = element.getAttribute('data-herb-debug-file-relative-path') || shortName;
     const fullPath = element.getAttribute('data-herb-debug-file-full-path') || relativePath;
     const label = document.createElement('div');
+    const name = document.createElement('span');
 
     label.className = 'herb-overlay-label';
-    label.textContent = shortName;
     label.setAttribute('data-label-setup', 'true');
 
+    name.className = 'herb-overlay-label-name';
+    name.textContent = shortName;
+
+    label.appendChild(name);
+
+    const reported = this.options.reportedFor?.(relativePath) ?? null;
+
+    if (reported !== null) {
+      const badge = document.createElement('span');
+      const word = reported.count === 1 ? 'diagnostic' : 'diagnostics';
+
+      badge.className = `herb-overlay-label-count herb-overlay-label-count-${reported.tone}`;
+      badge.textContent = String(reported.count);
+      badge.title = `${reported.count} ${word} reported for ${relativePath}`;
+
+      label.appendChild(badge);
+    }
+
     label.addEventListener('mouseenter', () => {
-      label.textContent = relativePath;
+      name.textContent = relativePath;
 
       document.querySelectorAll('.herb-overlay-label').forEach(otherLabel => {
         (otherLabel as HTMLElement).style.zIndex = '1000';
@@ -632,7 +658,7 @@ export class HerbOverlay {
     });
 
     label.addEventListener('mouseleave', () => {
-      label.textContent = shortName;
+      name.textContent = shortName;
       label.style.zIndex = '1000';
     });
 

--- a/javascript/packages/dev-tools/src/runtime/highlighting.ts
+++ b/javascript/packages/dev-tools/src/runtime/highlighting.ts
@@ -21,8 +21,8 @@ export interface ExcerptOptions {
 
 export interface RuntimeHighlighting {
   excerpt(source: string, diagnostic: NormalizedDiagnostic, options?: ExcerptOptions): string | null
-  combined(path: string, source: string, diagnostics: NormalizedDiagnostic[]): string | null
   diff(path: string, source: string, fix: NormalizedFix): string | null
+  file(source: string): string | null
 }
 
 let setup: Promise<RuntimeHighlighting | null> | null = null
@@ -92,25 +92,9 @@ async function build(): Promise<RuntimeHighlighting> {
       }
     },
 
-    combined(path, source, diagnostics) {
-      const markable = diagnostics.filter(diagnostic => diagnostic.location !== null && diagnostic.severity !== null)
-
-      if (markable.length === 0) {
-        return null
-      }
-
+    file(source) {
       try {
-        const rendered = inlineRenderer.render(
-          path,
-          source,
-          markable.map(diagnostic => toDiagnostic(diagnostic, source)),
-          true,
-          false,
-          MAX_WIDTH,
-          false,
-        )
-
-        return dropLeadingBlocks(rendered, 1)
+        return syntaxRenderer.highlight(source)
       } catch (_error) {
         return null
       }

--- a/javascript/packages/dev-tools/src/runtime/panel.css
+++ b/javascript/packages/dev-tools/src/runtime/panel.css
@@ -4,6 +4,20 @@
   --herb-dev-tools-severity-info: #3b82f6;
   --herb-dev-tools-severity-hint: #10b981;
   --herb-dev-tools-severity-metric: #9ca3af;
+  --herb-dev-tools-brand: #4caf50;
+  --herb-dev-tools-brand-strong: green;
+  --herb-dev-tools-brand-line: #81c784;
+  --herb-dev-tools-brand-soft: color-mix(in srgb, #4caf50 8%, #ffffff);
+  --herb-dev-tools-page: #fafafa;
+  --herb-dev-tools-surface: #ffffff;
+  --herb-dev-tools-line: #e4e4e7;
+  --herb-dev-tools-border: #d4d4d8;
+  --herb-dev-tools-rule: #d4d4d8;
+  --herb-dev-tools-ink: #09090b;
+  --herb-dev-tools-ink-soft: #27272a;
+  --herb-dev-tools-ink-muted: #52525b;
+  --herb-dev-tools-ink-faint: #71717a;
+  --herb-dev-tools-mono: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
   position: fixed;
   right: 12px;
   bottom: 12px;
@@ -14,6 +28,19 @@
   gap: 8px;
   font-family: system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
   pointer-events: none;
+}
+
+:where(.herb-dev-tools-runtime-root) :where(button, select, input) {
+  box-sizing: border-box;
+  margin: 0;
+  min-height: 0;
+  font: inherit;
+  text-align: inherit;
+  text-transform: none;
+  letter-spacing: normal;
+  vertical-align: middle;
+  appearance: none;
+  -webkit-appearance: none;
 }
 
 .herb-dev-tools-runtime-root > * {
@@ -32,12 +59,11 @@
   border: 1px solid var(--herb-dev-tools-badge-accent);
   border-radius: 999px;
   background: var(--herb-dev-tools-badge-surface);
-  color: color-mix(in srgb, var(--herb-dev-tools-badge-accent) 45%, #111827);
+  color: color-mix(in srgb, var(--herb-dev-tools-badge-accent) 40%, #09090b);
   font-size: 12px;
   font-weight: 600;
   line-height: 1;
   cursor: pointer;
-  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.15);
 }
 
 .herb-dev-tools-badge-error {
@@ -85,12 +111,12 @@
   flex-direction: column;
   width: min(560px, calc(100vw - 24px));
   max-height: min(70vh, 640px);
-  border: 1px solid #d1d5db;
+  border: 1px solid var(--herb-dev-tools-border);
   border-radius: 10px;
-  background: #ffffff;
-  color: #1f2937;
+  background: var(--herb-dev-tools-surface);
+  color: var(--herb-dev-tools-ink-soft);
   font-size: 12px;
-  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.22);
+  box-shadow: 0 1px 3px rgba(9, 9, 11, 0.08);
   overflow: hidden;
 }
 
@@ -115,7 +141,7 @@
 
 .herb-dev-tools-resize:hover::after,
 .herb-dev-tools-resize:active::after {
-  background: rgba(59, 130, 246, 0.55);
+  background: color-mix(in srgb, var(--herb-dev-tools-brand) 65%, transparent);
 }
 
 .herb-dev-tools-resize-left {
@@ -161,15 +187,17 @@
   align-items: center;
   gap: 8px;
   padding: 10px 12px;
-  background: #f9fafb;
-  border-bottom: 1px solid #e5e7eb;
+  background: var(--herb-dev-tools-surface);
+  border-bottom: 1px solid var(--herb-dev-tools-border);
 }
 
 .herb-dev-tools-title {
   flex: 1;
   min-width: 0;
+  font-size: 13px;
   font-weight: 600;
-  color: #111827;
+  letter-spacing: -0.01em;
+  color: var(--herb-dev-tools-ink);
 }
 
 .herb-dev-tools-connection {
@@ -179,9 +207,9 @@
   flex: 0 1 auto;
   min-width: 0;
   padding: 2px 8px;
-  border: 1px solid #e5e7eb;
+  border: 1px solid var(--herb-dev-tools-border);
   border-radius: 999px;
-  background: #f9fafb;
+  background: var(--herb-dev-tools-surface);
   font-size: 11px;
 }
 
@@ -215,21 +243,27 @@
 .herb-dev-tools-hide,
 .herb-dev-tools-expand,
 .herb-dev-tools-close {
-  border: 1px solid transparent;
+  box-sizing: border-box;
+  display: inline-flex;
+  align-items: center;
+  height: 26px;
+  border: 1px solid var(--herb-dev-tools-border);
   border-radius: 6px;
-  background: transparent;
-  color: #4b5563;
+  background: var(--herb-dev-tools-surface);
+  color: var(--herb-dev-tools-ink-soft);
   cursor: pointer;
   font-size: 11px;
-  padding: 3px 6px;
+  font-weight: 500;
+  padding: 0 6px;
 }
 
 .herb-dev-tools-clear:hover,
 .herb-dev-tools-hide:hover,
 .herb-dev-tools-expand:hover,
 .herb-dev-tools-close:hover {
-  background: #e5e7eb;
-  color: #111827;
+  border-color: var(--herb-dev-tools-ink-faint);
+  background: #f4f4f5;
+  color: var(--herb-dev-tools-ink);
 }
 
 .herb-dev-tools-clear,
@@ -241,11 +275,94 @@
   text-overflow: ellipsis;
 }
 
+.herb-dev-tools-filters-actions {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex: none;
+  margin-left: auto;
+}
+
+.herb-dev-tools-filters .herb-dev-tools-clear,
+.herb-dev-tools-collapse-all {
+  box-sizing: border-box;
+  display: inline-flex;
+  align-items: center;
+  flex: none;
+  height: 24px;
+  padding: 0 8px;
+  border: 1px solid var(--herb-dev-tools-border);
+  border-radius: 999px;
+  background: var(--herb-dev-tools-surface);
+  color: var(--herb-dev-tools-ink-soft);
+  font: inherit;
+  font-size: 11px;
+  font-weight: 500;
+  cursor: pointer;
+}
+
+.herb-dev-tools-collapse-all:hover {
+  border-color: var(--herb-dev-tools-ink-faint);
+  color: var(--herb-dev-tools-ink);
+}
+
 .herb-dev-tools-window-controls {
   display: flex;
   align-items: center;
-  gap: 2px;
+  gap: 6px;
   flex: none;
+}
+
+[data-herb-dev-tools-tip] {
+  position: relative;
+}
+
+[data-herb-dev-tools-tip]::after {
+  content: attr(data-herb-dev-tools-tip);
+  position: absolute;
+  top: calc(100% + 6px);
+  left: 0;
+  z-index: 20;
+  width: max-content;
+  max-width: 220px;
+  padding: 5px 8px;
+  border-radius: 6px;
+  background: #18181b;
+  color: #ffffff;
+  font-family: system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+  font-size: 11px;
+  font-weight: 400;
+  line-height: 1.4;
+  text-align: left;
+  white-space: normal;
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+  transition: opacity 0.12s ease, visibility 0.12s ease;
+}
+
+[data-herb-dev-tools-tip]:hover::after,
+[data-herb-dev-tools-tip]:focus-visible::after {
+  opacity: 1;
+  visibility: visible;
+}
+
+.herb-dev-tools-header [data-herb-dev-tools-tip]::after,
+.herb-dev-tools-command [data-herb-dev-tools-tip]::after,
+.herb-dev-tools-fix-diff [data-herb-dev-tools-tip]::after,
+.herb-dev-tools-filters-actions [data-herb-dev-tools-tip]::after,
+.herb-dev-tools-group-toggle[data-herb-dev-tools-tip]::after {
+  left: auto;
+  right: 0;
+}
+
+.herb-dev-tools-fix-diff [data-herb-dev-tools-tip]::after {
+  background: #f4f4f5;
+  color: #18181b;
+}
+
+[data-herb-dev-tools-tip]:hover {
+  z-index: 20;
 }
 
 .herb-dev-tools-expand,
@@ -264,40 +381,42 @@
   display: flex;
   flex-wrap: wrap;
   gap: 6px;
-  padding: 8px 12px;
-  border-bottom: 1px solid #e5e7eb;
-  background: #f9fafb;
+  padding: 7px 12px;
+  background: var(--herb-dev-tools-surface);
 }
 
 .herb-dev-tools-filters-severity {
-  border-bottom: 1px solid #e5e7eb;
-  background: #ffffff;
+  border-top: 1px solid var(--herb-dev-tools-line);
+  border-bottom: 1px solid var(--herb-dev-tools-line);
 }
 
 .herb-dev-tools-filter {
-  border: 1px solid #d1d5db;
+  border: 1px solid var(--herb-dev-tools-border);
   border-radius: 999px;
-  background: #ffffff;
-  color: #4b5563;
+  background: var(--herb-dev-tools-surface);
+  color: var(--herb-dev-tools-ink-soft);
   font-size: 11px;
+  font-weight: 500;
   padding: 3px 9px;
   cursor: pointer;
 }
 
 .herb-dev-tools-filter:hover {
-  border-color: #9ca3af;
+  border-color: var(--herb-dev-tools-ink-faint);
+  color: var(--herb-dev-tools-ink);
 }
 
 .herb-dev-tools-filter.herb-dev-tools-filter-active {
-  background: #111827;
-  border-color: #111827;
+  background: var(--herb-dev-tools-ink);
+  border-color: var(--herb-dev-tools-ink);
   color: #ffffff;
 }
 
 .herb-dev-tools-body {
   flex: 1;
   overflow-y: auto;
-  padding: 8px 12px 12px;
+  padding: 10px 12px 14px;
+  background: var(--herb-dev-tools-page);
 }
 
 .herb-dev-tools-empty {
@@ -307,6 +426,15 @@
 }
 
 .herb-dev-tools-group {
+  box-sizing: border-box;
+  margin-top: 0;
+  padding: 0;
+  border: 1px solid var(--herb-dev-tools-border);
+  border-radius: 10px;
+  background: var(--herb-dev-tools-surface);
+}
+
+.herb-dev-tools-group + .herb-dev-tools-group {
   margin-top: 10px;
 }
 
@@ -314,29 +442,98 @@
   display: flex;
   align-items: center;
   gap: 8px;
-  margin: 0 0 6px;
-  font-size: 11px;
+  margin: 0;
+  padding: 8px 12px;
+  border-bottom: 1px solid var(--herb-dev-tools-border);
+  border-radius: 9px 9px 0 0;
+  background: var(--herb-dev-tools-page);
+  font-size: 12px;
   font-weight: 600;
-  color: #374151;
-  font-family: 'SF Mono', Monaco, Consolas, monospace;
-  word-break: break-all;
+  color: var(--herb-dev-tools-ink);
+  overflow-wrap: anywhere;
+}
+
+.herb-dev-tools-group-title::before {
+  content: '';
+  flex: none;
+  width: 14px;
+  height: 14px;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' fill='none' stroke='%232e7d32' stroke-width='1.6' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M9 1.5H4.5A1.5 1.5 0 0 0 3 3v10a1.5 1.5 0 0 0 1.5 1.5h7A1.5 1.5 0 0 0 13 13V5.5z'/%3E%3Cpath d='M9 1.5V5.5H13'/%3E%3C/svg%3E");
+  background-position: center;
+  background-repeat: no-repeat;
+  background-size: 14px 14px;
+}
+
+.herb-dev-tools-group-title[data-herb-dev-tools-action] {
+  cursor: pointer;
+}
+
+.herb-dev-tools-group-title[data-herb-dev-tools-action]:hover {
+  background: #f4f4f5;
+}
+
+.herb-dev-tools-group-toggle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: none;
+  width: 20px;
+  height: 20px;
+  padding: 0;
+  border: 0;
+  border-radius: 5px;
+  background: transparent;
+  color: var(--herb-dev-tools-ink-faint);
+  cursor: pointer;
+  transition: transform 0.15s ease;
+}
+
+.herb-dev-tools-group-toggle:hover {
+  color: var(--herb-dev-tools-ink);
+}
+
+.herb-dev-tools-group-collapsed .herb-dev-tools-group-toggle {
+  transform: rotate(-90deg);
+}
+
+.herb-dev-tools-group-collapsed .herb-dev-tools-group-title {
+  border-bottom: 0;
+  border-radius: 9px;
+}
+
+.herb-dev-tools-overlay-focused .herb-dev-tools-group-collapsed .herb-dev-tools-group-title {
+  border-radius: 11px;
+}
+
+.herb-dev-tools-group-collapsed > :not(.herb-dev-tools-group-title) {
+  display: none;
 }
 
 .herb-dev-tools-group-count {
-  flex-shrink: 0;
-  padding: 1px 6px;
-  border-radius: 999px;
-  background: #e5e7eb;
-  color: #4b5563;
-  font-size: 10px;
+  flex: none;
+  margin-left: auto;
+  box-sizing: border-box;
+  min-width: 20px;
+  padding: 0 6px;
+  border-radius: 2em;
+  background: rgba(129, 139, 152, 0.16);
+  color: var(--herb-dev-tools-ink-soft);
+  font-family: var(--herb-dev-tools-mono);
+  font-size: 10.5px;
+  font-weight: 600;
+  line-height: 18px;
+  text-align: center;
 }
 
 .herb-dev-tools-card {
-  border: 1px solid #e5e7eb;
-  border-radius: 8px;
-  padding: 10px;
-  margin-bottom: 8px;
-  background: #ffffff;
+  padding: 12px;
+  margin: 0;
+  border: 0;
+  background: none;
+}
+
+.herb-dev-tools-card + .herb-dev-tools-card {
+  border-top: 1px solid var(--herb-dev-tools-line);
 }
 
 .herb-dev-tools-card-head {
@@ -381,16 +578,16 @@
 }
 
 .herb-dev-tools-code {
-  color: #1d4ed8;
-  font-family: 'SF Mono', Monaco, Consolas, monospace;
-  font-size: 11px;
+  color: var(--herb-dev-tools-ink);
+  font-size: 12px;
+  font-weight: 600;
   text-decoration: none;
 }
 
 .herb-dev-tools-origin {
   margin-left: auto;
-  color: #9ca3af;
-  font-size: 10px;
+  color: var(--herb-dev-tools-ink-faint);
+  font-size: 11px;
 }
 
 .herb-dev-tools-icon {
@@ -433,19 +630,42 @@
 }
 
 .herb-dev-tools-suggestion {
-  margin: 0 0 6px;
-  padding: 6px 8px;
-  border-left: 3px solid #10b981;
-  background: #ecfdf5;
-  color: #065f46;
+  margin: 0;
+  padding: 0;
+  color: var(--herb-dev-tools-ink-soft);
   line-height: 1.45;
 }
 
 .herb-dev-tools-excerpt,
 .herb-dev-tools-fix-diff {
-  margin: 6px 0;
-  border-radius: 6px;
+  position: relative;
+  margin: 8px 0;
+  border-radius: 10px;
   overflow: hidden;
+}
+
+.herb-dev-tools-fix-copy {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  z-index: 2;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  padding: 0;
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  border-radius: 6px;
+  background: rgba(24, 24, 27, 0.72);
+  color: #d4d4d8;
+  cursor: pointer;
+}
+
+.herb-dev-tools-fix-copy:hover {
+  border-color: rgba(255, 255, 255, 0.32);
+  background: rgba(24, 24, 27, 0.92);
+  color: #ffffff;
 }
 
 .herb-dev-tools-fix-diff {
@@ -458,16 +678,50 @@
 }
 
 .herb-dev-tools-fix {
-  margin-top: 8px;
-  border: 1px solid #e5e7eb;
-  border-radius: 6px;
-  background: #f9fafb;
-  color: #374151;
+  margin-top: 0;
+  border: 1px solid var(--herb-dev-tools-border);
+  border-radius: 8px;
+  background: var(--herb-dev-tools-page);
+  color: var(--herb-dev-tools-ink-soft);
+}
+
+.herb-dev-tools-fix-tabs {
+  display: flex;
+  gap: 4px;
+  padding: 0 8px 8px;
+}
+
+.herb-dev-tools-fix-tab {
+  padding: 3px 9px;
+  border: 1px solid var(--herb-dev-tools-border);
+  border-radius: 999px;
+  background: var(--herb-dev-tools-surface);
+  color: var(--herb-dev-tools-ink-soft);
+  font: inherit;
+  font-size: 10.5px;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.herb-dev-tools-fix-tab:hover:not(.herb-dev-tools-fix-tab-active) {
+  border-color: var(--herb-dev-tools-ink-faint);
+  color: var(--herb-dev-tools-ink);
+}
+
+.herb-dev-tools-fix-tab-active {
+  border-color: var(--herb-dev-tools-ink);
+  background: var(--herb-dev-tools-ink);
+  color: #ffffff;
+}
+
+.herb-dev-tools-fix-tab-active:hover {
+  border-color: var(--herb-dev-tools-ink-soft);
+  background: var(--herb-dev-tools-ink-soft);
 }
 
 .herb-dev-tools-fix-summary {
   padding: 6px 8px;
-  color: #374151;
+  color: var(--herb-dev-tools-ink-soft);
   font-size: 11px;
   line-height: 1.45;
   cursor: pointer;
@@ -477,29 +731,100 @@
   color: #111827;
 }
 
+.herb-dev-tools-command-lead {
+  margin: 10px 0 4px;
+  color: var(--herb-dev-tools-ink-muted);
+  font-size: 11px;
+}
+
+.herb-dev-tools-command {
+  --herb-dev-tools-command-surface: #f4f4f5;
+  position: relative;
+  margin: 0;
+  border: 1px solid var(--herb-dev-tools-border);
+  border-radius: 8px;
+  background: var(--herb-dev-tools-command-surface);
+}
+
+.herb-dev-tools-command::after {
+  content: '';
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  right: 0;
+  width: 58px;
+  border-radius: 0 7px 7px 0;
+  background: linear-gradient(to right, transparent, var(--herb-dev-tools-command-surface) 45%);
+  pointer-events: none;
+}
+
 .herb-dev-tools-fix-command {
-  padding: 1px 5px;
-  border-radius: 4px;
-  background: #e5e7eb;
-  color: #111827;
-  font-family: 'SF Mono', Monaco, Consolas, monospace;
-  font-size: 10px;
+  display: block;
+  padding: 8px 40px 8px 12px;
+  border-radius: 0;
+  background: none;
+  color: var(--herb-dev-tools-ink);
+  font-family: var(--herb-dev-tools-mono);
+  font-size: 11.5px;
+  line-height: 1.5;
+  white-space: pre;
+  overflow-x: auto;
+}
+
+.herb-dev-tools-command-copy {
+  position: absolute;
+  top: 5px;
+  right: 5px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1;
+  width: 26px;
+  height: 26px;
+  padding: 0;
+  border: 0;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--herb-dev-tools-ink-faint);
+  cursor: pointer;
+}
+
+.herb-dev-tools-command-copy:hover {
+  color: var(--herb-dev-tools-ink);
 }
 
 .herb-dev-tools-stack {
-  margin-top: 8px;
-  border-top: 1px solid #f3f4f6;
-  padding-top: 6px;
+  margin-top: 10px;
+  border-top: 1px solid var(--herb-dev-tools-line);
+  padding-top: 8px;
 }
 
-.herb-dev-tools-stack-title {
+.herb-dev-tools-hint,
+.herb-dev-tools-autofix {
+  margin-top: 10px;
+  border-top: 1px solid var(--herb-dev-tools-line);
+  padding-top: 8px;
+}
+
+.herb-dev-tools-hint {
+  margin-bottom: 10px;
+}
+
+.herb-dev-tools-stack-title,
+.herb-dev-tools-autofix-title,
+.herb-dev-tools-hint-title {
   display: flex;
   align-items: baseline;
   gap: 8px;
-  margin: 0 0 4px;
+  margin: 0 0 6px;
   font-size: 10px;
   font-weight: 600;
-  color: #6b7280;
+  color: var(--herb-dev-tools-ink-muted);
+}
+
+.herb-dev-tools-autofix-note {
+  font-weight: 400;
+  color: var(--herb-dev-tools-ink-faint);
 }
 
 .herb-dev-tools-stack-order {
@@ -516,22 +841,63 @@
 .herb-dev-tools-frame {
   display: flex;
   align-items: baseline;
-  gap: 6px;
-  padding: 2px 0;
+  gap: 8px;
+  padding: 3px 0;
+}
+
+.herb-dev-tools-frame::after {
+  content: '';
+  order: 1;
+  flex: 1 1 20px;
+  min-width: 20px;
+  border-bottom: 1px dotted var(--herb-dev-tools-border);
+  transform: translateY(-3px);
+}
+
+.herb-dev-tools-frame:not(:has(.herb-dev-tools-frame-via))::after {
+  display: none;
 }
 
 .herb-dev-tools-frame-via {
-  flex-shrink: 0;
-  min-width: 66px;
-  color: #9ca3af;
-  font-size: 10px;
+  order: 2;
+  flex: none;
+  padding: 2px 7px;
+  border: 1px solid var(--herb-dev-tools-rule);
+  border-radius: 6px;
+  background: var(--herb-dev-tools-surface);
+  color: var(--herb-dev-tools-ink-soft);
+  font-family: var(--herb-dev-tools-mono);
+  font-size: 10.5px;
+  font-weight: 600;
+  line-height: 1.3;
+}
+
+.herb-dev-tools-frame-via-template {
+  border-color: #bfdbfe;
+  background: #eff6ff;
+  color: #1d4ed8;
+}
+
+.herb-dev-tools-frame-via-partial {
+  border-color: #a7f3d0;
+  background: #ecfdf5;
+  color: #047857;
+}
+
+.herb-dev-tools-frame-via-component {
+  border-color: #fde68a;
+  background: #fffbeb;
+  color: #b45309;
 }
 
 .herb-dev-tools-frame-target {
-  color: #374151;
-  font-family: 'SF Mono', Monaco, Consolas, monospace;
+  order: 0;
+  flex: 0 1 auto;
+  min-width: 0;
+  color: var(--herb-dev-tools-ink-soft);
+  font-family: var(--herb-dev-tools-mono);
   font-size: 11px;
-  word-break: break-all;
+  overflow-wrap: anywhere;
 }
 
 .herb-dev-tools-runtime-root.herb-dev-tools-attached {
@@ -546,6 +912,7 @@
   order: 0;
   box-sizing: border-box;
   align-self: stretch;
+  height: 100%;
   align-items: center;
   padding: 5px 8px;
   border: 1px solid #c0c0c0;
@@ -602,7 +969,7 @@
 }
 
 .herb-dev-tools-path:focus-visible {
-  outline: 2px solid #2563eb;
+  outline: 2px solid var(--herb-dev-tools-brand);
   outline-offset: 2px;
   border-radius: 3px;
 }
@@ -612,20 +979,20 @@
   align-items: center;
   gap: 3px;
   padding: 1px 6px;
-  border: 1px solid #d1d5db;
+  border: 1px solid var(--herb-dev-tools-border);
   border-radius: 999px;
-  background: #ffffff;
-  color: #4b5563;
+  background: var(--herb-dev-tools-surface);
+  color: var(--herb-dev-tools-ink-soft);
   font-size: 10px;
-  font-weight: 500;
+  font-weight: 600;
   line-height: 1.6;
   text-decoration: none;
 }
 
 .herb-dev-tools-docs:hover {
-  border-color: #9ca3af;
-  background: #f9fafb;
-  color: #111827;
+  border-color: var(--herb-dev-tools-ink-faint);
+  background: #f4f4f5;
+  color: var(--herb-dev-tools-ink);
 }
 
 .herb-dev-tools-docs-glyph {
@@ -650,56 +1017,108 @@
 }
 
 .herb-dev-tools-provenance {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 4px 20px;
-  margin-top: 28px;
-  padding-top: 14px;
-  border-top: 1px solid #e5e7eb;
-  color: #6b7280;
-  font-size: 11.5px;
+  display: block;
+  margin-top: 20px;
+  padding: 4px 0;
+  color: var(--herb-dev-tools-ink-muted);
+  font-size: 12px;
 }
 
-.herb-dev-tools-provenance-list {
+.herb-dev-tools-provenance-row {
+  display: flex;
+  align-items: baseline;
+  gap: 10px;
+  padding: 9px 0;
+}
+
+.herb-dev-tools-provenance-key {
+  order: 0;
+  flex: none;
+}
+
+.herb-dev-tools-provenance-block .herb-dev-tools-provenance-key {
+  align-self: flex-start;
+}
+
+.herb-dev-tools-provenance-block {
   display: flex;
   flex-wrap: wrap;
   align-items: baseline;
+  gap: 6px 10px;
+  padding: 9px 0;
+}
+
+.herb-dev-tools-provenance-block + .herb-dev-tools-provenance-block,
+.herb-dev-tools-provenance-block + .herb-dev-tools-provenance-row,
+.herb-dev-tools-provenance-row + .herb-dev-tools-provenance-block {
+  border-top: 1px solid var(--herb-dev-tools-line);
+}
+
+.herb-dev-tools-provenance-items {
+  order: 2;
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 3px;
+  min-width: 0;
+}
+
+.herb-dev-tools-provenance-item {
+  color: var(--herb-dev-tools-ink-soft);
+  text-align: right;
+}
+
+.herb-dev-tools-provenance-value {
+  order: 2;
+  flex: 1;
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  align-items: baseline;
   gap: 4px 10px;
+  min-width: 0;
+  color: var(--herb-dev-tools-ink-soft);
+  text-align: right;
 }
 
 .herb-dev-tools-provenance code {
+  padding: 0;
+  background: none;
+  color: inherit;
   white-space: nowrap;
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
   font-size: 11px;
 }
 
-.herb-dev-tools-view {
-  flex: none;
-  padding: 4px 10px;
-  border: 1px solid currentColor;
-  border-radius: 999px;
-  background: transparent;
-  color: inherit;
-  font: inherit;
-  font-size: 11px;
-  font-weight: 600;
-  cursor: pointer;
-  opacity: 0.85;
+.herb-dev-tools-more {
+  display: flex;
+  justify-content: center;
+  margin-top: 16px;
 }
 
-.herb-dev-tools-view:hover {
+.herb-dev-tools-more .herb-dev-tools-scope {
+  padding: 7px 16px;
+  border: 1px solid var(--herb-dev-tools-border);
+  border-radius: 8px;
+  background: var(--herb-dev-tools-surface);
+  color: var(--herb-dev-tools-ink-soft);
   opacity: 1;
 }
 
-.herb-dev-tools-combined {
-  margin: 10px 0 0;
-  border-radius: 8px;
-  overflow: hidden;
+.herb-dev-tools-more .herb-dev-tools-scope:hover {
+  border-color: var(--herb-dev-tools-ink-faint);
+  background: #f4f4f5;
+  color: var(--herb-dev-tools-ink);
 }
 
 .herb-dev-tools-scope {
+  box-sizing: border-box;
+  display: inline-flex;
+  align-items: center;
   flex: none;
-  padding: 4px 10px;
+  height: 26px;
+  padding: 0 10px;
   border: 1px solid currentColor;
   border-radius: 999px;
   background: transparent;
@@ -725,7 +1144,7 @@
   border: 0;
   border-radius: 0;
   box-shadow: none;
-  background: #f3f4f6;
+  background: #fafafa;
   z-index: 2147483642;
 }
 
@@ -753,9 +1172,17 @@
   --herb-dev-tools-accent: #374151;
 }
 
+.herb-dev-tools-expanded {
+  --herb-dev-tools-gutter: 28px;
+}
+
+.herb-dev-tools-overlay {
+  --herb-dev-tools-gutter: max(28px, calc((100% - 1280px) / 2));
+}
+
 .herb-dev-tools-expanded .herb-dev-tools-header {
   gap: 12px;
-  padding: 18px 28px;
+  padding: 18px var(--herb-dev-tools-gutter);
 }
 
 .herb-dev-tools-expanded .herb-dev-tools-title {
@@ -768,18 +1195,27 @@
 
 .herb-dev-tools-expanded .herb-dev-tools-filters {
   gap: 8px;
-  padding: 12px 28px;
+  padding: 9px var(--herb-dev-tools-gutter);
+}
+
+.herb-dev-tools-expanded .herb-dev-tools-body {
+  box-sizing: border-box;
+  width: 100%;
+  padding: 28px var(--herb-dev-tools-gutter) 72px;
 }
 
 .herb-dev-tools-overlay-focused {
-  --herb-dev-tools-gutter: max(28px, calc((100% - 1040px) / 2 + 28px));
+  border-color: var(--herb-dev-tools-border);
+  border-radius: 14px;
+  background: var(--herb-dev-tools-page);
+  color: var(--herb-dev-tools-ink-soft);
 }
 
 .herb-dev-tools-overlay-focused .herb-dev-tools-header {
   padding-inline: var(--herb-dev-tools-gutter);
-  background: color-mix(in srgb, var(--herb-dev-tools-accent) 9%, #ffffff);
-  border-bottom: 1px solid color-mix(in srgb, var(--herb-dev-tools-accent) 28%, #ffffff);
-  color: color-mix(in srgb, var(--herb-dev-tools-accent) 45%, #111827);
+  background: color-mix(in srgb, var(--herb-dev-tools-accent) 6%, #ffffff);
+  border-bottom: 1px solid color-mix(in srgb, var(--herb-dev-tools-accent) 26%, #ffffff);
+  color: var(--herb-dev-tools-ink);
 }
 
 .herb-dev-tools-overlay-focused .herb-dev-tools-filters {
@@ -787,25 +1223,46 @@
 }
 
 .herb-dev-tools-overlay-focused .herb-dev-tools-header .herb-dev-tools-dot {
-  width: 9px;
-  height: 9px;
-}
-
-.herb-dev-tools-overlay-focused .herb-dev-tools-title {
-  color: inherit;
+  width: 22px;
+  height: 22px;
+  border-radius: 7px;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 22 22'%3E%3Cg fill='%23ffffff'%3E%3Crect x='10' y='5.25' width='2' height='7.5' rx='1'/%3E%3Ccircle cx='11' cy='15.75' r='1.25'/%3E%3C/g%3E%3C/svg%3E");
+  background-position: center;
+  background-repeat: no-repeat;
+  background-size: 22px 22px;
 }
 
 .herb-dev-tools-overlay-focused .herb-dev-tools-title {
   flex: none;
+  color: inherit;
+  letter-spacing: -0.01em;
 }
 
 .herb-dev-tools-overlay-focused .herb-dev-tools-summary {
-  color: color-mix(in srgb, var(--herb-dev-tools-accent) 30%, #4b5563);
-}
-
-.herb-dev-tools-overlay-focused .herb-dev-tools-summary {
+  box-sizing: border-box;
+  display: inline-flex;
+  align-items: center;
   flex: 0 1 auto;
-  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  height: 26px;
+  color: var(--herb-dev-tools-ink-muted);
+  font-family: var(--herb-dev-tools-mono);
+}
+
+.herb-dev-tools-overlay-focused .herb-dev-tools-summary.herb-dev-tools-path {
+  padding: 0 10px;
+  border: 1px solid var(--herb-dev-tools-border);
+  border-radius: 8px;
+  background: var(--herb-dev-tools-surface);
+  color: var(--herb-dev-tools-ink-soft);
+}
+
+.herb-dev-tools-overlay-focused .herb-dev-tools-connection {
+  box-sizing: border-box;
+  height: 26px;
+  padding: 0 10px;
+  border-color: var(--herb-dev-tools-border);
+  border-radius: 8px;
+  background: var(--herb-dev-tools-surface);
 }
 
 .herb-dev-tools-expanded .herb-dev-tools-window-controls {
@@ -817,24 +1274,265 @@
 }
 
 .herb-dev-tools-overlay-focused .herb-dev-tools-summary.herb-dev-tools-path:hover {
-  color: color-mix(in srgb, var(--herb-dev-tools-accent) 55%, #111827);
+  border-color: var(--herb-dev-tools-rule);
+  color: var(--herb-dev-tools-ink);
+}
+
+@media (max-width: 900px) {
+  .herb-dev-tools-overlay-focused .herb-dev-tools-header {
+    flex-wrap: wrap;
+  }
+
+  .herb-dev-tools-overlay-focused .herb-dev-tools-summary.herb-dev-tools-path {
+    order: 1;
+    flex: 0 1 100%;
+  }
 }
 
 .herb-dev-tools-overlay-focused .herb-dev-tools-ansi {
-  padding: 12px 14px;
+  padding: 14px 16px;
   font-size: 13px;
 }
 
 .herb-dev-tools-overlay-focused .herb-dev-tools-body {
   box-sizing: border-box;
   width: 100%;
-  padding: 28px var(--herb-dev-tools-gutter) 72px;
+  padding: 36px var(--herb-dev-tools-gutter) 80px;
+}
+
+.herb-dev-tools-overlay-focused .herb-dev-tools-hero {
+  display: block;
+  margin: 0 0 18px;
+}
+
+.herb-dev-tools-overlay-focused .herb-dev-tools-hero-title {
+  margin: 0 0 7px;
+  color: var(--herb-dev-tools-ink);
+  font-size: 30px;
+  font-weight: 600;
+  line-height: 1.15;
+  letter-spacing: -0.02em;
+  overflow-wrap: anywhere;
+}
+
+.herb-dev-tools-overlay-focused .herb-dev-tools-hero-path {
+  display: block;
+  margin: 0 0 18px;
+  padding: 0;
+  border: 0;
+  background: none;
+  color: var(--herb-dev-tools-ink-faint);
+  font-family: var(--herb-dev-tools-mono);
+  font-size: 12px;
+  overflow-wrap: anywhere;
+}
+
+.herb-dev-tools-overlay-focused .herb-dev-tools-hero-path:hover {
+  color: var(--herb-dev-tools-ink-soft);
+}
+
+.herb-dev-tools-overlay-focused .herb-dev-tools-hero-message {
+  max-width: 72ch;
+  margin: 0 0 16px;
+  color: var(--herb-dev-tools-ink-soft);
+  font-size: 19px;
+  font-weight: 300;
+  line-height: 1.45;
+}
+
+.herb-dev-tools-overlay-focused .herb-dev-tools-hero-chips {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+}
+
+.herb-dev-tools-hero-group {
+  display: flex;
+  align-items: center;
+  margin-left: auto;
+  border: 1px solid var(--herb-dev-tools-border);
+  border-radius: 6px;
+  background: var(--herb-dev-tools-surface);
+  overflow: hidden;
+}
+
+.herb-dev-tools-hero-pair {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  height: 24px;
+  padding: 0 7px;
+  font-family: var(--herb-dev-tools-mono);
+  font-size: 12px;
+}
+
+.herb-dev-tools-hero-pair + .herb-dev-tools-hero-pair {
+  border-left: 1px solid var(--herb-dev-tools-border);
+}
+
+.herb-dev-tools-hero-key {
+  color: var(--herb-dev-tools-ink-faint);
+}
+
+.herb-dev-tools-hero-value {
+  color: var(--herb-dev-tools-ink-soft);
+}
+
+.herb-dev-tools-hero-chip {
+  display: inline-flex;
+  align-items: center;
+  height: 24px;
+  padding: 0 8px;
+  border-radius: 6px;
+  font-family: var(--herb-dev-tools-mono);
+  font-size: 12px;
+  font-weight: 600;
+  line-height: 1;
+}
+
+.herb-dev-tools-hero-chip-soft {
+  background: color-mix(in srgb, var(--herb-dev-tools-accent) 22%, #ffffff);
+  color: color-mix(in srgb, var(--herb-dev-tools-accent) 55%, #09090b);
+}
+
+.herb-dev-tools-hero-chip-solid {
+  background: var(--herb-dev-tools-accent);
+  color: #ffffff;
+}
+
+.herb-dev-tools-overlay-hero .herb-dev-tools-header .herb-dev-tools-summary,
+.herb-dev-tools-overlay-hero .herb-dev-tools-card .herb-dev-tools-message {
+  display: none;
 }
 
 .herb-dev-tools-overlay-focused .herb-dev-tools-group {
+  box-sizing: border-box;
   margin-top: 0;
+  padding: 0;
+  border: 1px solid var(--herb-dev-tools-border);
+  border-radius: 12px;
+  background: var(--herb-dev-tools-surface);
 }
 
+.herb-dev-tools-overlay-focused .herb-dev-tools-group + .herb-dev-tools-group {
+  margin-top: 16px;
+}
+
+.herb-dev-tools-overlay-focused .herb-dev-tools-group-title {
+  align-items: center;
+  gap: 10px;
+  margin: 0;
+  padding: 10px 16px;
+  border-radius: 11px 11px 0 0;
+  font-size: 13.5px;
+  color: var(--herb-dev-tools-ink);
+}
+
+.herb-dev-tools-overlay-focused .herb-dev-tools-group-title::before {
+  width: 15px;
+  height: 15px;
+  background-size: 15px 15px;
+}
+
+.herb-dev-tools-overlay-focused .herb-dev-tools-group-count {
+  margin-left: auto;
+}
+
+.herb-dev-tools-overlay-focused .herb-dev-tools-card {
+  padding: 14px 16px 16px;
+}
+
+.herb-dev-tools-overlay-focused .herb-dev-tools-card-head {
+  gap: 8px;
+  margin-bottom: 10px;
+}
+
+.herb-dev-tools-overlay-focused .herb-dev-tools-code {
+  font-size: 13px;
+}
+
+.herb-dev-tools-overlay-focused .herb-dev-tools-origin {
+  font-size: 11.5px;
+  color: var(--herb-dev-tools-ink-faint);
+}
+
+.herb-dev-tools-overlay-focused .herb-dev-tools-docs,
+.herb-dev-tools-overlay-focused .herb-dev-tools-repeat,
+.herb-dev-tools-overlay-focused .herb-dev-tools-metric {
+  border-radius: 6px;
+  font-family: var(--herb-dev-tools-mono);
+}
+
+.herb-dev-tools-overlay-focused .herb-dev-tools-docs {
+  border-color: var(--herb-dev-tools-line);
+}
+
+.herb-dev-tools-overlay-focused .herb-dev-tools-message {
+  margin-bottom: 10px;
+  color: var(--herb-dev-tools-ink);
+  font-size: 15px;
+  line-height: 1.5;
+}
+
+.herb-dev-tools-overlay-focused .herb-dev-tools-suggestion {
+  font-size: 13.5px;
+}
+
+.herb-dev-tools-overlay-focused .herb-dev-tools-excerpt,
+.herb-dev-tools-overlay-focused .herb-dev-tools-fix-diff {
+  border-radius: 10px;
+}
+
+.herb-dev-tools-overlay-focused .herb-dev-tools-fix {
+  border-color: var(--herb-dev-tools-line);
+  border-radius: 10px;
+  background: #fbfbfb;
+}
+
+.herb-dev-tools-overlay-focused .herb-dev-tools-fix-summary {
+  padding: 9px 12px;
+  font-size: 12px;
+}
+
+.herb-dev-tools-overlay-focused .herb-dev-tools-stack {
+  margin-top: 14px;
+  padding-top: 12px;
+  border-top: 1px solid var(--herb-dev-tools-line);
+}
+
+.herb-dev-tools-overlay-focused .herb-dev-tools-stack-title {
+  margin-bottom: 6px;
+  font-size: 11px;
+  color: var(--herb-dev-tools-ink-muted);
+}
+
+.herb-dev-tools-overlay-focused .herb-dev-tools-frame {
+  align-items: baseline;
+  gap: 10px;
+  padding: 5px 0;
+}
+
+.herb-dev-tools-overlay-focused .herb-dev-tools-frame::after {
+  content: '';
+  order: 1;
+  flex: 1 1 24px;
+  min-width: 24px;
+  border-bottom: 1px dotted var(--herb-dev-tools-rule);
+  transform: translateY(-3px);
+}
+
+.herb-dev-tools-overlay-focused .herb-dev-tools-frame:not(:has(.herb-dev-tools-frame-via))::after {
+  display: none;
+}
+
+.herb-dev-tools-overlay-focused .herb-dev-tools-frame-via {
+  font-size: 10.5px;
+}
+
+.herb-dev-tools-overlay-focused .herb-dev-tools-frame-target {
+  font-size: 12px;
+}
 
 .herb-dev-tools-expanded .herb-dev-tools-close {
   flex: none;
@@ -843,20 +1541,53 @@
   padding: 3px 8px;
 }
 
-.herb-dev-tools-expanded .herb-dev-tools-scope {
-  opacity: 1;
+.herb-dev-tools-copy {
+  box-sizing: border-box;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  flex: none;
+  height: 26px;
+  padding: 0 10px;
+  border: 1px solid var(--herb-dev-tools-border);
+  border-radius: 8px;
+  background: var(--herb-dev-tools-surface);
+  color: var(--herb-dev-tools-ink-soft);
+  font: inherit;
+  font-size: 11px;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.herb-dev-tools-copy-compact {
+  width: 26px;
+  height: 26px;
+  padding: 0;
+  justify-content: center;
+  border-radius: 6px;
+}
+
+.herb-dev-tools-copy:hover {
+  border-color: var(--herb-dev-tools-ink-faint);
+  background: #f4f4f5;
+  color: var(--herb-dev-tools-ink);
 }
 
 .herb-dev-tools-overlay-focused .herb-dev-tools-close,
 .herb-dev-tools-overlay-focused .herb-dev-tools-scope {
-  border-color: color-mix(in srgb, var(--herb-dev-tools-accent) 32%, #ffffff);
-  color: inherit;
+  border-color: var(--herb-dev-tools-border);
+  border-radius: 8px;
+  background: var(--herb-dev-tools-surface);
+  color: var(--herb-dev-tools-ink-soft);
+  font-weight: 600;
+  opacity: 1;
 }
 
 .herb-dev-tools-overlay-focused .herb-dev-tools-close:hover,
 .herb-dev-tools-overlay-focused .herb-dev-tools-scope:hover {
-  background: color-mix(in srgb, var(--herb-dev-tools-accent) 16%, #ffffff);
-  color: inherit;
+  border-color: var(--herb-dev-tools-ink-faint);
+  background: #f4f4f5;
+  color: var(--herb-dev-tools-ink);
 }
 
 .herb-dev-tools-runtime-root .herb-dev-tools-panel.herb-dev-tools-expanded,
@@ -866,24 +1597,10 @@
   top: 24px;
   right: 24px;
   width: auto;
-  max-width: none;
+  max-width: 1280px;
   max-height: none;
+  margin-inline: auto;
   z-index: 2147483642;
-}
-
-.herb-dev-tools-panel.herb-dev-tools-expanded .herb-dev-tools-group {
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(min(100%, max(640px, (100% - 12px) / 2)), 1fr));
-  align-items: start;
-  gap: 20px 12px;
-}
-
-.herb-dev-tools-panel.herb-dev-tools-expanded .herb-dev-tools-card {
-  margin-bottom: 0;
-}
-
-.herb-dev-tools-panel.herb-dev-tools-expanded .herb-dev-tools-group-title {
-  grid-column: 1 / -1;
 }
 
 .herb-dev-tools-element {
@@ -922,6 +1639,9 @@
 }
 
 .herb-dev-tools-element code {
+  padding: 0;
+  background: none;
+  color: inherit;
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
   font-size: 0.72rem;
 }

--- a/javascript/packages/dev-tools/src/runtime/panel.ts
+++ b/javascript/packages/dev-tools/src/runtime/panel.ts
@@ -13,6 +13,33 @@ import type { NormalizedDiagnostic, NormalizedRuntimeReport, OverlayMode, Runtim
 
 export type BadgeTone = RuntimeSeverity | 'metric'
 
+const ALL_ORIGINS = '*'
+const ALL_SEVERITIES = '*'
+const MIN_PANEL_WIDTH = 440
+const MIN_PANEL_HEIGHT = 180
+const VIEWPORT_MARGIN = 24
+const RESIZE_EDGES = ['left', 'bottom', 'corner'] as const
+const STATE_KEY = 'herb-dev-tools-runtime-panel'
+const ROOT_CLASS = 'herb-dev-tools-runtime-root'
+const LINKABLE_SCHEMES = ['http:', 'https:', 'file:']
+const MARKDOWN_CONTEXT_LINES = 3
+
+declare const __HERB_DEV_TOOLS_VERSION__: string
+
+const VIA_LABELS: Record<string, string> = {
+  layout: 'layout',
+  template: 'view',
+  partial: 'partial',
+  component: 'component',
+}
+
+const SEVERITY_FILTERS: Array<{ value: string, label: string, matches: (diagnostic: NormalizedDiagnostic) => boolean }> = [
+  { value: 'error', label: 'Errors', matches: diagnostic => diagnostic.kind === 'diagnostic' && diagnostic.severity === 'error' },
+  { value: 'warning', label: 'Warnings', matches: diagnostic => diagnostic.kind === 'diagnostic' && diagnostic.severity === 'warning' },
+  { value: 'notice', label: 'Notices', matches: diagnostic => diagnostic.kind === 'diagnostic' && (diagnostic.severity === 'info' || diagnostic.severity === 'hint') },
+  { value: 'metric', label: 'Metrics', matches: diagnostic => diagnostic.kind === 'metric' },
+]
+
 export interface RuntimeReportHandle {
   dismiss(): void
 }
@@ -43,40 +70,19 @@ interface PanelState {
   expanded: boolean
   origin: string
   severity: string
-  view: PanelView
   width: number | null
   height: number | null
 }
 
-const ALL_ORIGINS = '*'
-const ALL_SEVERITIES = '*'
-const MIN_PANEL_WIDTH = 440
-const MIN_PANEL_HEIGHT = 180
-const VIEWPORT_MARGIN = 24
-const PANEL_VIEWS = ['cards', 'combined'] as const
-const RESIZE_EDGES = ['left', 'bottom', 'corner'] as const
-
 type ResizeEdge = typeof RESIZE_EDGES[number]
-type PanelView = typeof PANEL_VIEWS[number]
 
 function clamp(value: number, low: number, high: number): number {
   return Math.min(Math.max(value, low), Math.max(low, high))
 }
 
-function asView(value: unknown): PanelView {
-  return PANEL_VIEWS.includes(value as PanelView) ? (value as PanelView) : 'cards'
-}
-
 function asSize(value: unknown): number | null {
   return typeof value === 'number' && Number.isFinite(value) && value > 0 ? Math.round(value) : null
 }
-
-const SEVERITY_FILTERS: Array<{ value: string, label: string, matches: (diagnostic: NormalizedDiagnostic) => boolean }> = [
-  { value: 'error', label: 'Errors', matches: diagnostic => diagnostic.kind === 'diagnostic' && diagnostic.severity === 'error' },
-  { value: 'warning', label: 'Warnings', matches: diagnostic => diagnostic.kind === 'diagnostic' && diagnostic.severity === 'warning' },
-  { value: 'notice', label: 'Notices', matches: diagnostic => diagnostic.kind === 'diagnostic' && (diagnostic.severity === 'info' || diagnostic.severity === 'hint') },
-  { value: 'metric', label: 'Metrics', matches: diagnostic => diagnostic.kind === 'metric' },
-]
 
 function matchesSeverity(diagnostic: NormalizedDiagnostic, severity: string): boolean {
   if (severity === ALL_SEVERITIES) {
@@ -85,15 +91,9 @@ function matchesSeverity(diagnostic: NormalizedDiagnostic, severity: string): bo
 
   return SEVERITY_FILTERS.find(filter => filter.value === severity)?.matches(diagnostic) ?? true
 }
-const STATE_KEY = 'herb-dev-tools-runtime-panel'
-const ROOT_CLASS = 'herb-dev-tools-runtime-root'
-const LINKABLE_SCHEMES = ['http:', 'https:', 'file:']
 
-const VIA_LABELS: Record<string, string> = {
-  layout: 'layout',
-  template: 'template',
-  partial: 'partial',
-  component: 'component',
+function devToolsVersion(): string | null {
+  return typeof __HERB_DEV_TOOLS_VERSION__ === 'string' ? __HERB_DEV_TOOLS_VERSION__ : null
 }
 
 function cornerIcon(paths: string[]): string {
@@ -105,8 +105,29 @@ function cornerIcon(paths: string[]): string {
   ].join('')
 }
 
+const CHECK_ICON = [
+  `<svg class="herb-dev-tools-icon" viewBox="0 0 16 16" width="12" height="12" aria-hidden="true"`,
+  ` fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round">`,
+  `<path d="M3 8.5 6.5 12 13 4.5"/>`,
+  `</svg>`,
+].join('')
+
+const CHEVRON_ICON = [
+  `<svg class="herb-dev-tools-icon" viewBox="0 0 16 16" width="12" height="12" aria-hidden="true"`,
+  ` fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">`,
+  `<path d="M4 6.5 8 10.5 12 6.5"/>`,
+  `</svg>`,
+].join('')
+
+const COPY_ICON = [
+  `<svg class="herb-dev-tools-icon" viewBox="0 0 16 16" width="12" height="12" aria-hidden="true"`,
+  ` fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">`,
+  `<rect x="5.5" y="5.5" width="8" height="9" rx="1.5"/>`,
+  `<path d="M10.5 5.5v-2a1.5 1.5 0 0 0-1.5-1.5H4a1.5 1.5 0 0 0-1.5 1.5v7A1.5 1.5 0 0 0 4 12h1.5"/>`,
+  `</svg>`,
+].join('')
+
 const EXPAND_ICON = cornerIcon(['M6 2H2v4', 'M10 2h4v4', 'M6 14H2v-4', 'M10 14h4v-4'])
-const COLLAPSE_ICON = cornerIcon(['M2 6h4V2', 'M14 6h-4V2', 'M2 10h4v4', 'M14 10h-4v4'])
 
 const BADGE_GLYPHS: Record<BadgeTone, string> = {
   error: '⛔',
@@ -157,6 +178,131 @@ function openTargetAttributes(target: OpenTarget | null): string {
   return ` data-herb-dev-tools-file="${escapeHTML(target.file)}" data-herb-dev-tools-line="${target.line}" data-herb-dev-tools-column="${target.column}"`
 }
 
+function fence(language: string, body: string): string[] {
+  return ['```' + language, body, '```']
+}
+
+function excerptWindow(source: string, line: number, context: number, mark: number | null = null): string[] {
+  const lines = source.split('\n')
+  const first = Math.max(1, line - context)
+  const last = Math.min(lines.length, line + context)
+
+  if (last < first) {
+    return []
+  }
+
+  const width = String(last).length
+
+  return lines.slice(first - 1, last).map((text, index) => {
+    const number = first + index
+    const marker = number === mark ? '>' : ' '
+
+    return `${marker} ${String(number).padStart(width, ' ')} | ${text}`
+  })
+}
+
+async function copyInto(element: HTMLElement, text: string, label: string) {
+  const original = element.innerHTML
+
+  try {
+    await navigator.clipboard.writeText(text)
+
+    element.innerHTML = CHECK_ICON
+    element.setAttribute('data-herb-dev-tools-tip', 'Copied')
+  } catch {
+    element.setAttribute('data-herb-dev-tools-tip', 'Copy failed')
+  }
+
+  window.setTimeout(() => {
+    element.innerHTML = original
+    element.setAttribute('data-herb-dev-tools-tip', label)
+  }, 1600)
+}
+
+async function copyCommand(element: HTMLElement) {
+  const command = element.getAttribute('data-herb-dev-tools-command')
+
+  if (command === null) {
+    return
+  }
+
+  await copyInto(element, command, 'Copy this command')
+}
+
+function fixCommand(diagnostic: NormalizedDiagnostic, unsafe: boolean): string {
+  const flag = unsafe ? '--fix-unsafely' : '--fix'
+  const parts = ['npx @herb-tools/linter']
+
+  if (diagnostic.template !== UNKNOWN_TEMPLATE) {
+    parts.push(diagnostic.template)
+  }
+
+  parts.push(flag)
+
+  if (diagnostic.code !== null) {
+    parts.push(`--only ${diagnostic.code}`)
+  }
+
+  return parts.join(' ')
+}
+
+function sentenceCase(value: string): string {
+  return value.charAt(0).toUpperCase() + value.slice(1)
+}
+
+function fixKey(diagnostic: NormalizedDiagnostic): string {
+  return diagnosticKey(diagnostic).replace(/\u0000/g, '|')
+}
+
+function tip(text: string, label: string = text): string {
+  return ` aria-label="${escapeHTML(label)}" data-herb-dev-tools-tip="${escapeHTML(text)}"`
+}
+
+function hideButtonHTML(): string {
+  const label = 'Hide the panel for the rest of this browser session'
+
+  return `<button type="button" class="herb-dev-tools-hide" data-herb-dev-tools-action="dismiss"${tip(label)}>Hide for this session</button>`
+}
+
+function closeButtonHTML(action: string, label: string): string {
+  return `<button type="button" class="herb-dev-tools-close" data-herb-dev-tools-action="${action}"${tip(label)}>×</button>`
+}
+
+function heroPairHTML(key: string, value: string): string {
+  return [
+    `<span class="herb-dev-tools-hero-pair">`,
+    `<span class="herb-dev-tools-hero-key">${escapeHTML(key)}</span>`,
+    `<span class="herb-dev-tools-hero-value">${escapeHTML(value)}</span>`,
+    `</span>`,
+  ].join('')
+}
+
+function visitorLabel(visitor: string): string {
+  const unwrapped = visitor.replace(/^#</, '').replace(/>$/, '')
+
+  return unwrapped.replace(/^(?:[A-Za-z_][A-Za-z0-9_]*::)+/, '')
+}
+
+function provenanceListHTML(key: string, items: string[]): string {
+  const chips = items.map(item => `<code class="herb-dev-tools-provenance-item">${escapeHTML(item)}</code>`).join('')
+
+  return [
+    `<div class="herb-dev-tools-provenance-block">`,
+    `<span class="herb-dev-tools-provenance-key">${escapeHTML(key)}</span>`,
+    `<span class="herb-dev-tools-provenance-items">${chips}</span>`,
+    `</div>`,
+  ].join('')
+}
+
+function provenanceRowHTML(key: string, value: string): string {
+  return [
+    `<div class="herb-dev-tools-provenance-row">`,
+    `<span class="herb-dev-tools-provenance-key">${escapeHTML(key)}</span>`,
+    `<span class="herb-dev-tools-provenance-value">${value}</span>`,
+    `</div>`,
+  ].join('')
+}
+
 function ansiHTML(ansi: string, className: string, target: OpenTarget | null = null): string {
   return `<herb-ansi class="${className}"${openTargetAttributes(target)}>${escapeHTML(ansi)}</herb-ansi>`
 }
@@ -186,6 +332,9 @@ function mergeDiagnostics(existing: NormalizedDiagnostic, incoming: NormalizedDi
 }
 
 export class RuntimePanel {
+  private collapsed = new Set<string>()
+  private fixViews = new Map<string, 'diff' | 'file'>()
+  private openFixes = new Set<string>()
   private entries: PanelEntry[] = []
   private renderTree: RenderTreeNode[] = []
   private sources: Record<string, string> = {}
@@ -196,7 +345,7 @@ export class RuntimePanel {
   private onOpenFile: ((file: string, line: number, column: number) => void) | null = null
   private onRender: (() => void) | null = null
   private onOpen: (() => void) | null = null
-  private state: PanelState = { dismissed: false, open: false, expanded: false, origin: ALL_ORIGINS, severity: ALL_SEVERITIES, view: 'cards', width: null, height: null }
+  private state: PanelState = { dismissed: false, open: false, expanded: false, origin: ALL_ORIGINS, severity: ALL_SEVERITIES, width: null, height: null }
   private root: HTMLElement | null = null
   private highlighting: RuntimeHighlighting | null = null
   private hydrating = false
@@ -280,6 +429,7 @@ export class RuntimePanel {
   public clear(origin?: string) {
     if (origin === undefined) {
       this.entries = []
+      this.collapsed.clear()
     } else {
       const wanted = trimOrigin(origin)
 
@@ -337,6 +487,7 @@ export class RuntimePanel {
 
   public close() {
     this.state.open = false
+    this.state.expanded = false
     this.cleared = false
 
     this.saveState()
@@ -504,6 +655,103 @@ export class RuntimePanel {
     this.render()
   }
 
+  private async copyFixed(element: HTMLElement) {
+    const key = element.getAttribute('data-herb-dev-tools-fix-key')
+
+    if (key === null) {
+      return
+    }
+
+    const entry = this.entries.find(candidate => fixKey(candidate.diagnostic) === key)
+    const source = entry?.diagnostic.fix?.source
+
+    if (source === undefined) {
+      return
+    }
+
+    await copyInto(element, source, 'Copy the fixed template')
+  }
+
+  private showFixView(key: string | null, view: string | null) {
+    if (key === null || (view !== 'diff' && view !== 'file')) {
+      return
+    }
+
+    if (this.fixViews.get(key) === view) {
+      return
+    }
+
+    this.fixViews.set(key, view)
+    this.render()
+  }
+
+  private get visibleTemplates(): string[] {
+    return [...new Set(this.visibleEntries().map(entry => entry.diagnostic.template))]
+  }
+
+  private get allGroupsCollapsed(): boolean {
+    const templates = this.visibleTemplates
+
+    return templates.length > 0 && templates.every(template => this.collapsed.has(template))
+  }
+
+  private toggleAllGroups() {
+    const templates = this.visibleTemplates
+
+    if (this.allGroupsCollapsed) {
+      for (const template of templates) {
+        this.collapsed.delete(template)
+      }
+    } else {
+      for (const template of templates) {
+        this.collapsed.add(template)
+      }
+    }
+
+    this.render()
+  }
+
+  private collapseAllButtonHTML(): string {
+    if (this.visibleTemplates.length < 2) {
+      return ''
+    }
+
+    const collapsed = this.allGroupsCollapsed
+    const label = collapsed ? 'Expand all' : 'Collapse all'
+    const description = collapsed ? 'Show the diagnostics for every file' : 'Hide the diagnostics for every file'
+
+    return [
+      `<button type="button" class="herb-dev-tools-collapse-all" data-herb-dev-tools-action="collapse-all"`,
+      `${tip(description, label)}>${label}</button>`,
+    ].join('')
+  }
+
+  private toggleGroup(template: string | null) {
+    if (template === null) {
+      return
+    }
+
+    if (this.collapsed.has(template)) {
+      this.collapsed.delete(template)
+    } else {
+      this.collapsed.add(template)
+    }
+
+    this.render()
+  }
+
+  public reportedFor(template: string): { count: number, tone: BadgeTone } | null {
+    const matching = this.entries.filter(entry => entry.diagnostic.template === template)
+
+    if (matching.length === 0) {
+      return null
+    }
+
+    const count = matching.reduce((total, entry) => total + entry.count, 0)
+
+    return { count, tone: severityOf(matching) ?? 'metric' }
+  }
+
   public refresh() {
     if (this.destroyed) {
       return
@@ -607,12 +855,11 @@ export class RuntimePanel {
         expanded: parsed?.expanded === true,
         origin: typeof parsed?.origin === 'string' ? parsed.origin : ALL_ORIGINS,
         severity: typeof parsed?.severity === 'string' ? parsed.severity : ALL_SEVERITIES,
-        view: asView(parsed?.view),
         width: asSize(parsed?.width),
         height: asSize(parsed?.height),
       }
     } catch (_error) {
-      this.state = { dismissed: false, open: false, expanded: false, origin: ALL_ORIGINS, severity: ALL_SEVERITIES, view: 'cards', width: null, height: null }
+      this.state = { dismissed: false, open: false, expanded: false, origin: ALL_ORIGINS, severity: ALL_SEVERITIES, width: null, height: null }
     }
   }
 
@@ -805,7 +1052,18 @@ export class RuntimePanel {
       this.root.className = slot ? `${ROOT_CLASS} herb-dev-tools-attached` : ROOT_CLASS
     }
 
+    const scroller = this.root.querySelector<HTMLElement>('.herb-dev-tools-body')
+    const scrollTop = scroller === null ? null : scroller.scrollTop
+
     this.root.innerHTML = this.rootHTML()
+
+    if (scrollTop !== null && scrollTop > 0) {
+      const restored = this.root.querySelector<HTMLElement>('.herb-dev-tools-body')
+
+      if (restored !== null) {
+        restored.scrollTop = scrollTop
+      }
+    }
 
     this.bindHandlers()
     this.bindResizeHandles()
@@ -853,6 +1111,7 @@ export class RuntimePanel {
       : [
         ` herb-dev-tools-overlay herb-dev-tools-overlay-${overlay}`,
         this.overlayShowAll ? '' : ` herb-dev-tools-overlay-focused herb-dev-tools-tone-${this.headerTone}`,
+        this.heroEntry === null ? '' : ' herb-dev-tools-overlay-hero',
         this.overlayEdgeToEdge ? ' herb-dev-tools-overlay-fullscreen' : '',
       ].join('')
     const bumpClass = this.bumped ? ' herb-dev-tools-bump' : ''
@@ -880,7 +1139,7 @@ export class RuntimePanel {
     return [
       backdrop,
       badge,
-      `<section class="herb-dev-tools-panel${openClass}${expandedClass}${overlayClass}" aria-label="Herb Runtime Diagnostics"${modal}${this.sizeStyle()}>`,
+      `<section class="herb-dev-tools-panel${openClass}${expandedClass}${overlayClass}" aria-label="Herb Diagnostics"${modal}${this.sizeStyle()}>`,
       this.resizeHandlesHTML(),
       this.headerHTML(),
       this.filtersHTML(),
@@ -934,6 +1193,22 @@ export class RuntimePanel {
     if (element === null) {
       return
     }
+
+    root.querySelectorAll<HTMLDetailsElement>('details[data-herb-dev-tools-fix-key]').forEach((details) => {
+      details.addEventListener('toggle', () => {
+        const key = details.getAttribute('data-herb-dev-tools-fix-key')
+
+        if (key === null) {
+          return
+        }
+
+        if (details.open) {
+          this.openFixes.add(key)
+        } else {
+          this.openFixes.delete(key)
+        }
+      })
+    })
 
     root.querySelectorAll<HTMLElement>('[data-herb-dev-tools-resize]').forEach((handle) => {
       handle.addEventListener('pointerdown', (event) => {
@@ -1029,15 +1304,21 @@ export class RuntimePanel {
 
     return [
       `<header class="herb-dev-tools-header">`,
-      `<span class="herb-dev-tools-title">Herb Runtime Diagnostics</span>`,
+      `<span class="herb-dev-tools-title">Herb Diagnostics</span>`,
       ...this.headerControlsHTML(overlay),
       `</header>`,
     ].join('')
   }
 
   private connectionHTML(): string {
+    if (this.overlay !== 'blocking') {
+      return ''
+    }
+
+    const label = 'Whether this page is connected to the Herb dev server, which recompiles the template and clears this screen once it builds'
+
     return [
-      `<span class="herb-dev-tools-connection">`,
+      `<span class="herb-dev-tools-connection"${tip(label, 'Herb dev server connection')}>`,
       `<span class="herb-dev-tools-connection-dot" data-herb-dev-server-dot></span>`,
       `<span class="herb-dev-tools-connection-status" data-herb-dev-server-status>Dev Server</span>`,
       `</span>`,
@@ -1061,7 +1342,7 @@ export class RuntimePanel {
 
     const close = overlay === 'blocking'
       ? ''
-      : `<button type="button" class="herb-dev-tools-close" data-herb-dev-tools-action="dismiss-overlay" aria-label="${label}" title="${label}">×</button>`
+      : closeButtonHTML('dismiss-overlay', label)
 
     return [
       `<header class="herb-dev-tools-header">`,
@@ -1070,7 +1351,7 @@ export class RuntimePanel {
       this.overlayLocationHTML(entries),
       this.connectionHTML(),
       `<div class="herb-dev-tools-window-controls">`,
-      this.viewButtonHTML(),
+      this.copyButtonHTML(),
       this.overlayScopeButtonHTML(),
       close,
       `</div>`,
@@ -1110,7 +1391,7 @@ export class RuntimePanel {
 
     const origins = new Set(entries.map(entry => entry.diagnostic.origin))
 
-    return origins.size === 1 ? [...origins][0] : 'Herb Runtime Diagnostics'
+    return origins.size === 1 ? [...origins][0] : 'Herb Diagnostics'
   }
 
   private overlayLocation(entries: PanelEntry[]): string | null {
@@ -1142,43 +1423,20 @@ export class RuntimePanel {
     ].join('')
   }
 
-  public get view(): 'cards' | 'combined' {
-    return this.state.view
-  }
-
-  public toggleView() {
-    this.state.view = this.state.view === 'combined' ? 'cards' : 'combined'
-
-    this.saveState()
-    this.render()
-  }
-
-  private viewButtonHTML(): string {
-    if (!this.showingExpanded || this.combinableGroups === 0) {
-      return ''
-    }
-
-    const combined = this.state.view === 'combined'
-    const label = combined ? 'One card per offense' : 'One block per file'
-    const description = combined ? 'Show each offense on its own card' : 'Show every offense of a file in one block'
-
-    return [
-      `<button type="button" class="herb-dev-tools-view" data-herb-dev-tools-action="view"`,
-      ` aria-pressed="${combined}" title="${escapeHTML(description)}" aria-label="${escapeHTML(description)}">`,
-      `${escapeHTML(label)}</button>`,
-    ].join('')
-  }
-
   private overlayScopeButtonHTML(): string {
-    if (this.overlay === null) {
+    if (this.overlay === null || !this.overlayShowAll) {
       return ''
     }
 
-    if (this.overlayShowAll) {
-      const shown = this.overlayEntries(this.overlay).length
-      const label = shown === 1 ? 'Back to the error' : 'Back to the errors'
+    const shown = this.overlayEntries(this.overlay).length
+    const label = shown === 1 ? 'Back to the error' : 'Back to the errors'
 
-      return `<button type="button" class="herb-dev-tools-scope" data-herb-dev-tools-action="overlay-scope">${label}</button>`
+    return `<button type="button" class="herb-dev-tools-scope" data-herb-dev-tools-action="overlay-scope">${label}</button>`
+  }
+
+  private overlayMoreButtonHTML(): string {
+    if (this.overlay === null || this.overlayShowAll) {
+      return ''
     }
 
     const hidden = this.count - this.visibleCount
@@ -1193,8 +1451,10 @@ export class RuntimePanel {
       : `Show the other ${hidden} diagnostics this page reported`
 
     return [
+      `<div class="herb-dev-tools-more">`,
       `<button type="button" class="herb-dev-tools-scope" data-herb-dev-tools-action="overlay-scope"`,
-      ` title="${escapeHTML(description)}" aria-label="${escapeHTML(description)}">${label}</button>`,
+      `${tip(description)}>${label}</button>`,
+      `</div>`,
     ].join('')
   }
 
@@ -1202,7 +1462,6 @@ export class RuntimePanel {
     if (overlay === 'blocking') {
       return [
         `<div class="herb-dev-tools-window-controls">`,
-        this.viewButtonHTML(),
         this.overlayScopeButtonHTML(),
         `</div>`,
       ]
@@ -1213,20 +1472,18 @@ export class RuntimePanel {
 
       return [
         `<div class="herb-dev-tools-window-controls">`,
-        this.viewButtonHTML(),
         this.overlayScopeButtonHTML(),
-        `<button type="button" class="herb-dev-tools-close" data-herb-dev-tools-action="dismiss-overlay" aria-label="${label}" title="${label}">×</button>`,
+        closeButtonHTML('dismiss-overlay', label),
         `</div>`,
       ]
     }
 
     return [
-      this.clearButtonHTML(),
-      `<button type="button" class="herb-dev-tools-hide" data-herb-dev-tools-action="dismiss">Hide for this session</button>`,
+      hideButtonHTML(),
       `<div class="herb-dev-tools-window-controls">`,
-      this.viewButtonHTML(),
+      this.copyButtonHTML(),
       this.expandButtonHTML(),
-      `<button type="button" class="herb-dev-tools-close" data-herb-dev-tools-action="close" aria-label="Close panel">×</button>`,
+      closeButtonHTML('close', 'Close the panel'),
       `</div>`,
     ]
   }
@@ -1236,37 +1493,19 @@ export class RuntimePanel {
   }
 
   private clearButtonHTML(): string {
-    const count = this.visibleCount
+    const count = this.count
 
     if (count === 0) {
       return ''
     }
 
-    const scoped = this.state.origin !== ALL_ORIGINS
-    const label = scoped ? `Clear ${this.state.origin}` : 'Clear all'
     const entries = `${count} ${count === 1 ? 'entry' : 'entries'}`
-
-    const description = scoped
-      ? `Clear the ${entries} from ${this.state.origin}`
-      : `Clear all ${entries} and empty the panel`
+    const description = `Clear all ${entries} and empty the panel`
 
     return [
       `<button type="button" class="herb-dev-tools-clear" data-herb-dev-tools-action="clear"`,
-      ` aria-label="${escapeHTML(description)}"`,
-      ` title="${escapeHTML(description)}. Reload the page to read its report again.">`,
-      `${escapeHTML(label)}</button>`,
-    ].join('')
-  }
-
-  private expandButtonHTML(): string {
-    const label = this.state.expanded ? 'Collapse panel back to the corner' : 'Expand panel to fill the window'
-    const icon = this.state.expanded ? COLLAPSE_ICON : EXPAND_ICON
-
-    return [
-      `<button type="button" class="herb-dev-tools-expand" data-herb-dev-tools-action="expand"`,
-      ` aria-expanded="${this.state.expanded}" aria-label="${label}" title="${label}">`,
-      icon,
-      `</button>`,
+      tip(`${description}. Reload the page to read its report again`, description),
+      `>Clear</button>`,
     ].join('')
   }
 
@@ -1317,7 +1556,10 @@ export class RuntimePanel {
       buttons.push(this.filterButtonHTML('origin', origin, origin, count, this.state.origin === origin))
     }
 
-    return `<div class="herb-dev-tools-filters">${buttons.join('')}</div>`
+    const actions = `${this.collapseAllButtonHTML()}${this.clearButtonHTML()}`
+    const trailing = actions === '' ? '' : `<div class="herb-dev-tools-filters-actions">${actions}</div>`
+
+    return `<div class="herb-dev-tools-filters">${buttons.join('')}${trailing}</div>`
   }
 
   private severityFiltersHTML(): string {
@@ -1342,6 +1584,265 @@ export class RuntimePanel {
     }
 
     return `<div class="herb-dev-tools-filters herb-dev-tools-filters-severity">${buttons.join('')}</div>`
+  }
+
+  private get heroEntry(): PanelEntry | null {
+    if (!this.overlayFocused) {
+      return null
+    }
+
+    const entries = this.visibleEntries()
+
+    return entries.length === 1 ? entries[0] : null
+  }
+
+  private heroChipsHTML(diagnostic: NormalizedDiagnostic): string {
+    const pairs: string[] = []
+    const version = this.meta.herb_version
+
+    if (version !== undefined) {
+      pairs.push(heroPairHTML('Herb', version))
+    }
+
+    if (diagnostic.phase !== null) {
+      pairs.push(heroPairHTML('Phase', diagnostic.phase))
+    }
+
+    const group = pairs.length === 0 ? '' : `<div class="herb-dev-tools-hero-group">${pairs.join('')}</div>`
+
+    const mode = diagnostic.overlay === null
+      ? ''
+      : `<span class="herb-dev-tools-hero-chip herb-dev-tools-hero-chip-soft">${escapeHTML(sentenceCase(diagnostic.overlay))}</span>`
+
+    const marker = diagnostic.kind === 'metric'
+      ? `<span class="herb-dev-tools-hero-chip herb-dev-tools-hero-chip-solid">${escapeHTML(diagnostic.value ?? 'metric')}</span>`
+      : `<span class="herb-dev-tools-hero-chip herb-dev-tools-hero-chip-solid">${escapeHTML(sentenceCase(diagnostic.severity ?? 'error'))}</span>`
+
+    const chips = `${marker}${mode}${group}`
+
+    return chips.length === 0 ? '' : `<div class="herb-dev-tools-hero-chips">${chips}</div>`
+  }
+
+  private markdownExcerpt(diagnostic: NormalizedDiagnostic): string[] {
+    const source = this.sources[diagnostic.template]
+    const start = diagnostic.location?.start
+
+    if (source === undefined || start === undefined) {
+      return []
+    }
+
+    const body = excerptWindow(source, start.line, MARKDOWN_CONTEXT_LINES, start.line)
+
+    return body.length === 0 ? [] : ['', ...fence('erb', body.join('\n'))]
+  }
+
+  private markdownFix(diagnostic: NormalizedDiagnostic): string[] {
+    const fix = diagnostic.fix
+
+    if (fix === null) {
+      return []
+    }
+
+    const unsafe = fix.kind === 'unsafe'
+    const lead = unsafe ? 'Not applied, and this fix is unsafe. Applying it:' : 'Not applied. Applying it:'
+    const window = excerptWindow(fix.source, diagnostic.location?.start.line ?? 1, MARKDOWN_CONTEXT_LINES)
+    const after = window.length === 0 ? [] : ['', 'The template would become:', '', ...fence('erb', window.join('\n'))]
+
+    return [
+      '',
+      `### Fix (${fix.kind})`,
+      '',
+      lead,
+      '',
+      ...fence('bash', fixCommand(diagnostic, unsafe)),
+      ...after,
+    ]
+  }
+
+  private markdownFor(entry: PanelEntry): string[] {
+    const diagnostic = entry.diagnostic
+    const start = diagnostic.location?.start
+    const location = start === undefined ? diagnostic.template : `${diagnostic.template}:${start.line}:${start.column}`
+    const facts: string[] = [`- Origin: ${diagnostic.origin}`]
+
+    if (diagnostic.severity !== null) {
+      facts.push(`- Severity: ${diagnostic.severity}`)
+    }
+
+    if (diagnostic.phase !== null) {
+      facts.push(`- Phase: ${diagnostic.phase}`)
+    }
+
+    if (entry.count > 1) {
+      facts.push(`- Reported: ${entry.count} times`)
+    }
+
+    const suggestion = diagnostic.suggestion === null ? [] : ['', `> ${diagnostic.suggestion}`]
+    const frames = buildRenderStack(this.renderTree, diagnostic).map((frame) => {
+      const role = frame.via === null ? '' : ` (${VIA_LABELS[frame.via] ?? frame.via})`
+
+      return `- \`${frameLabel(frame)}\`${role}`
+    })
+
+    const stack = frames.length === 0 ? [] : ['', '### Render stack', '', ...frames]
+
+    return [
+      `## ${diagnostic.code ?? diagnostic.origin}`,
+      '',
+      `\`${location}\``,
+      '',
+      diagnostic.message,
+      ...suggestion,
+      '',
+      ...facts,
+      ...this.markdownExcerpt(diagnostic),
+      ...stack,
+      ...this.markdownFix(diagnostic),
+    ]
+  }
+
+  public markdown(): string {
+    const entries = this.visibleEntries()
+    const sections = entries.map(entry => this.markdownFor(entry).join('\n'))
+    const { herb_version: version, parser_options: options, visitors } = this.meta
+    const provenance: string[] = []
+
+    if (version !== undefined) {
+      provenance.push(`- Compiled by Herb::Engine ${version}`)
+    }
+
+    if (options !== undefined) {
+      const pairs = Object.entries(options).map(([key, value]) => `\`${key}: ${value}\``).join(', ')
+
+      if (pairs.length > 0) {
+        provenance.push(`- Parser options: ${pairs}`)
+      }
+    }
+
+    if (visitors !== undefined && visitors.length > 0) {
+      provenance.push(`- Visitors: ${visitors.map(visitor => `\`${visitorLabel(visitor)}\``).join(', ')}`)
+    }
+
+    const devTools = devToolsVersion()
+
+    if (devTools !== null) {
+      provenance.push(`- Herb Dev Tools ${devTools}`)
+    }
+
+    const footer = provenance.length === 0 ? [] : [['---', '', ...provenance].join('\n')]
+
+    return [...sections, ...footer].join('\n\n').replace(/\n{3,}/g, '\n\n') + '\n'
+  }
+
+  private async copyMarkdown(element: HTMLElement) {
+    const label = element.querySelector('.herb-dev-tools-copy-label')
+    const icon = element.querySelector('.herb-dev-tools-icon')
+    const original = icon === null ? null : icon.outerHTML
+    const restore = element.getAttribute('data-herb-dev-tools-tip')
+
+    const settle = (text: string) => {
+      if (label !== null) {
+        label.textContent = text
+      }
+
+      if (restore !== null) {
+        element.setAttribute('data-herb-dev-tools-tip', text)
+      }
+
+      window.setTimeout(() => {
+        if (label !== null) {
+          label.textContent = 'Copy as Markdown'
+        }
+
+        const current = element.querySelector('.herb-dev-tools-icon')
+
+        if (current !== null && original !== null) {
+          current.outerHTML = original
+        }
+
+        if (restore !== null) {
+          element.setAttribute('data-herb-dev-tools-tip', restore)
+        }
+      }, 1600)
+    }
+
+    try {
+      await navigator.clipboard.writeText(this.markdown())
+
+      if (icon !== null) {
+        icon.outerHTML = CHECK_ICON
+      }
+
+      settle('Copied')
+    } catch {
+      settle('Copy failed')
+    }
+  }
+
+  private expandButtonHTML(): string {
+    if (this.state.expanded) {
+      return ''
+    }
+
+    const label = 'Expand the panel to fill the window'
+
+    return [
+      `<button type="button" class="herb-dev-tools-expand" data-herb-dev-tools-action="expand"`,
+      ` aria-expanded="false"${tip(label)}>`,
+      EXPAND_ICON,
+      `</button>`,
+    ].join('')
+  }
+
+  private copyButtonHTML(): string {
+    if (this.visibleEntries().length === 0) {
+      return ''
+    }
+
+    if (this.overlayFocused) {
+      return [
+        `<button type="button" class="herb-dev-tools-copy" data-herb-dev-tools-action="copy-markdown">`,
+        COPY_ICON,
+        `<span class="herb-dev-tools-copy-label">Copy as Markdown</span>`,
+        `</button>`,
+      ].join('')
+    }
+
+    return [
+      `<button type="button" class="herb-dev-tools-copy herb-dev-tools-copy-compact"`,
+      ` data-herb-dev-tools-action="copy-markdown"${tip('Copy this page as Markdown')}>`,
+      COPY_ICON,
+      `</button>`,
+    ].join('')
+  }
+
+  private heroHTML(): string {
+    const entry = this.heroEntry
+
+    if (entry === null) {
+      return ''
+    }
+
+    const diagnostic = entry.diagnostic
+    const start = diagnostic.location?.start
+    const title = diagnostic.code ?? diagnostic.origin
+
+    const location = start === undefined
+      ? diagnostic.template
+      : `${diagnostic.template}:${start.line}:${start.column}`
+
+    const path = diagnostic.template === UNKNOWN_TEMPLATE
+      ? `<span class="herb-dev-tools-hero-path">${escapeHTML(location)}</span>`
+      : this.pathHTML(location, diagnostic.template, start?.line ?? 1, start?.column ?? 1, 'herb-dev-tools-hero-path')
+
+    return [
+      `<header class="herb-dev-tools-hero">`,
+      `<h1 class="herb-dev-tools-hero-title">${escapeHTML(title)}</h1>`,
+      path,
+      `<p class="herb-dev-tools-hero-message">${inlineCodeHTML(diagnostic.message)}</p>`,
+      this.heroChipsHTML(diagnostic),
+      `</header>`,
+    ].join('')
   }
 
   private bodyHTML(): string {
@@ -1372,15 +1873,25 @@ export class RuntimePanel {
     const sections: string[] = []
 
     for (const [template, groupEntries] of groups) {
+      const collapsed = this.collapsed.has(template)
+      const label = collapsed ? `Show the diagnostics for ${template}` : `Hide the diagnostics for ${template}`
+
       sections.push([
-        `<section class="herb-dev-tools-group">`,
-        `<h2 class="herb-dev-tools-group-title">${this.pathHTML(template, template, this.firstLineFor(groupEntries), 1, 'herb-dev-tools-group-path')}<span class="herb-dev-tools-group-count">${groupEntries.length}</span></h2>`,
-        this.groupBodyHTML(template, groupEntries),
+        `<section class="herb-dev-tools-group${collapsed ? ' herb-dev-tools-group-collapsed' : ''}">`,
+        `<h2 class="herb-dev-tools-group-title" data-herb-dev-tools-action="collapse-group"`,
+        ` data-herb-dev-tools-template="${escapeHTML(template)}">`,
+        this.pathHTML(template, template, this.firstLineFor(groupEntries), 1, 'herb-dev-tools-group-path'),
+        `<span class="herb-dev-tools-group-count">${groupEntries.length}</span>`,
+        `<button type="button" class="herb-dev-tools-group-toggle" data-herb-dev-tools-action="collapse-group"`,
+        ` data-herb-dev-tools-template="${escapeHTML(template)}" aria-expanded="${!collapsed}"`,
+        `${tip(label)}>${CHEVRON_ICON}</button>`,
+        `</h2>`,
+        this.groupBodyHTML(groupEntries),
         `</section>`,
       ].join(''))
     }
 
-    return sections.join('')
+    return `${this.heroHTML()}${sections.join('')}${this.overlayMoreButtonHTML()}`
   }
 
   private provenanceHTML(): string {
@@ -1392,23 +1903,25 @@ export class RuntimePanel {
     const parts: string[] = []
 
     if (version !== undefined) {
-      parts.push(`<span>Compiled by Herb ${escapeHTML(version)}</span>`)
+      parts.push(provenanceRowHTML('Compiled by Herb::Engine', escapeHTML(version)))
     }
 
     if (options !== undefined) {
-      const pairs = Object.entries(options)
-        .map(([key, value]) => `<code>${escapeHTML(key)}: ${escapeHTML(value)}</code>`)
-        .join(', ')
+      const pairs = Object.entries(options).map(([key, value]) => `${key}: ${value}`)
 
       if (pairs.length > 0) {
-        parts.push(`<span>Parser options: ${pairs}</span>`)
+        parts.push(provenanceListHTML('Parser options', pairs))
       }
     }
 
     if (visitors !== undefined && visitors.length > 0) {
-      const names = visitors.map(visitor => `<code>${escapeHTML(visitor)}</code>`).join(' ')
+      parts.push(provenanceListHTML('Visitors', visitors.map(visitorLabel)))
+    }
 
-      parts.push(`<span class="herb-dev-tools-provenance-list">Visitors: ${names}</span>`)
+    const devTools = devToolsVersion()
+
+    if (devTools !== null) {
+      parts.push(provenanceRowHTML('Herb Dev Tools', escapeHTML(devTools)))
     }
 
     if (parts.length === 0) {
@@ -1418,45 +1931,8 @@ export class RuntimePanel {
     return `<footer class="herb-dev-tools-provenance">${parts.join('')}</footer>`
   }
 
-  private combinable(template: string, entries: PanelEntry[]): boolean {
-    if (this.sources[template] === undefined) {
-      return false
-    }
-
-    return entries.some(entry => entry.diagnostic.location !== null && entry.diagnostic.severity !== null)
-  }
-
-  private get combinableGroups(): number {
-    const groups = new Map<string, PanelEntry[]>()
-
-    for (const entry of this.visibleEntries()) {
-      const existing = groups.get(entry.diagnostic.template) ?? []
-
-      existing.push(entry)
-      groups.set(entry.diagnostic.template, existing)
-    }
-
-    return [...groups].filter(([template, entries]) => this.combinable(template, entries)).length
-  }
-
-  private groupBodyHTML(template: string, entries: PanelEntry[]): string {
-    if (this.state.view !== 'combined' || !this.combinable(template, entries)) {
-      return entries.map(entry => this.cardHTML(entry)).join('')
-    }
-
-    if (this.highlighting === null) {
-      return `<div class="herb-dev-tools-combined" data-herb-dev-tools-excerpt-pending></div>`
-    }
-
-    const rendered = this.highlighting.combined(template, this.sources[template], entries.map(entry => entry.diagnostic))
-
-    if (rendered === null) {
-      return entries.map(entry => this.cardHTML(entry)).join('')
-    }
-
-    const target = this.onOpenFile === null || template === UNKNOWN_TEMPLATE ? null : { file: template, line: this.firstLineFor(entries), column: 1 }
-
-    return `<div class="herb-dev-tools-combined">${ansiHTML(rendered, 'herb-dev-tools-ansi', target)}</div>`
+  private groupBodyHTML(entries: PanelEntry[]): string {
+    return entries.map(entry => this.cardHTML(entry)).join('')
   }
 
   private cardHTML(entry: PanelEntry): string {
@@ -1481,7 +1957,14 @@ export class RuntimePanel {
 
     const repeat = entry.count > 1 ? `<span class="herb-dev-tools-repeat" title="Reported ${entry.count} times">×${entry.count}</span>` : ''
     const feature = this.featureButtonHTML(entry)
-    const suggestion = diagnostic.suggestion === null ? '' : `<p class="herb-dev-tools-suggestion">${inlineCodeHTML(diagnostic.suggestion)}</p>`
+    const suggestion = diagnostic.suggestion === null
+      ? ''
+      : [
+        `<div class="herb-dev-tools-hint">`,
+        `<p class="herb-dev-tools-hint-title">Suggestion</p>`,
+        `<p class="herb-dev-tools-suggestion">${inlineCodeHTML(diagnostic.suggestion)}</p>`,
+        `</div>`,
+      ].join('')
     const element = this.elementHTML(entry)
 
     return [
@@ -1587,21 +2070,64 @@ export class RuntimePanel {
       return `<div class="herb-dev-tools-fix-pending" data-herb-dev-tools-fix-pending hidden></div>`
     }
 
-    const rendered = this.highlighting.diff(diagnostic.template, source, fix)
+    const key = fixKey(diagnostic)
+    const view = this.fixViews.get(key) ?? 'diff'
+    const open = this.openFixes.has(key)
+
+    const rendered = view === 'file'
+      ? this.highlighting.file(fix.source)
+      : this.highlighting.diff(diagnostic.template, source, fix)
 
     if (rendered === null) {
       return ''
     }
 
     const unsafe = fix.kind === 'unsafe'
-    const lead = unsafe ? 'Not applied. This fix is unsafe. Running' : 'Not applied. Running'
-    const command = unsafe ? 'herb lint --fix-unsafely' : 'herb lint --fix'
+    const note = unsafe ? 'not applied, unsafe' : 'not applied, safe'
+    const command = fixCommand(diagnostic, unsafe)
+    const copy = 'Copy this command'
+
+    const tab = (value: 'diff' | 'file', label: string, description: string) => [
+      `<button type="button" class="herb-dev-tools-fix-tab${view === value ? ' herb-dev-tools-fix-tab-active' : ''}"`,
+      ` data-herb-dev-tools-action="fix-view" data-herb-dev-tools-fix-view="${value}"`,
+      ` data-herb-dev-tools-fix-key="${escapeHTML(key)}"`,
+      ` aria-pressed="${view === value}"${tip(description, label)}>${label}</button>`,
+    ].join('')
+
+    const copyFixed = view === 'file'
+      ? [
+        `<button type="button" class="herb-dev-tools-fix-copy" data-herb-dev-tools-action="copy-fixed"`,
+        ` data-herb-dev-tools-fix-key="${escapeHTML(key)}"${tip('Copy the fixed template')}>`,
+        COPY_ICON,
+        `</button>`,
+      ].join('')
+      : ''
+
+    const tabs = [
+      `<div class="herb-dev-tools-fix-tabs">`,
+      tab('diff', 'Diff', 'Show only the lines the fix changes'),
+      tab('file', 'Fixed file', 'Show the whole template as the fix would leave it'),
+      `</div>`,
+    ].join('')
 
     return [
-      `<details class="herb-dev-tools-fix" data-herb-dev-tools-fix="${escapeHTML(fix.kind)}">`,
-      `<summary class="herb-dev-tools-fix-summary">${escapeHTML(lead)} <code class="herb-dev-tools-fix-command">${escapeHTML(command)}</code> would change this template to</summary>`,
-      `<div class="herb-dev-tools-fix-diff">${ansiHTML(rendered, 'herb-dev-tools-ansi')}</div>`,
+      `<div class="herb-dev-tools-autofix">`,
+      `<p class="herb-dev-tools-autofix-title">Autofix<span class="herb-dev-tools-autofix-note">${escapeHTML(note)}</span></p>`,
+      `<details class="herb-dev-tools-fix" data-herb-dev-tools-fix="${escapeHTML(fix.kind)}"`,
+      ` data-herb-dev-tools-fix-key="${escapeHTML(key)}"${open ? ' open' : ''}>`,
+      `<summary class="herb-dev-tools-fix-summary">Preview the change</summary>`,
+      tabs,
+      `<div class="herb-dev-tools-fix-diff">${copyFixed}${ansiHTML(rendered, 'herb-dev-tools-ansi')}</div>`,
       `</details>`,
+      `<p class="herb-dev-tools-command-lead">Run this to fix it:</p>`,
+      `<div class="herb-dev-tools-command">`,
+      `<code class="herb-dev-tools-fix-command">${escapeHTML(command)}</code>`,
+      `<button type="button" class="herb-dev-tools-command-copy" data-herb-dev-tools-action="copy-command"`,
+      ` data-herb-dev-tools-command="${escapeHTML(command)}"${tip(copy)}>`,
+      COPY_ICON,
+      `</button>`,
+      `</div>`,
+      `</div>`,
     ].join('')
   }
 
@@ -1613,7 +2139,13 @@ export class RuntimePanel {
     }
 
     const items = frames.map((frame) => {
-      const via = frame.via === null ? '' : `<span class="herb-dev-tools-frame-via">${escapeHTML(VIA_LABELS[frame.via] ?? frame.via)}</span>`
+      const via = frame.via === null
+        ? ''
+        : [
+          `<span class="herb-dev-tools-frame-via herb-dev-tools-frame-via-${escapeHTML(frame.via)}">`,
+          escapeHTML(VIA_LABELS[frame.via] ?? frame.via),
+          `</span>`,
+        ].join('')
 
       return `<li class="herb-dev-tools-frame">${via}${this.pathHTML(frameLabel(frame), frame.template, frame.line ?? 1, frame.column ?? 1, 'herb-dev-tools-frame-target')}</li>`
     })
@@ -1672,26 +2204,33 @@ export class RuntimePanel {
           }
         } else if (action === 'close') {
           this.close()
-        } else if (action === 'expand') {
-          this.toggleExpanded()
         } else if (action === 'collapse') {
           this.collapse()
+        } else if (action === 'expand') {
+          this.expand()
         } else if (action === 'dismiss-overlay') {
           this.dismissOverlay()
-        } else if (action === 'view') {
-          this.toggleView()
         } else if (action === 'overlay-scope') {
           this.toggleOverlayScope()
+        } else if (action === 'copy-markdown') {
+          void this.copyMarkdown(element)
+        } else if (action === 'copy-command') {
+          void copyCommand(element)
+        } else if (action === 'copy-fixed') {
+          void this.copyFixed(element)
+        } else if (action === 'collapse-group') {
+          this.toggleGroup(element.getAttribute('data-herb-dev-tools-template'))
+        } else if (action === 'collapse-all') {
+          this.toggleAllGroups()
+        } else if (action === 'fix-view') {
+          this.showFixView(element.getAttribute('data-herb-dev-tools-fix-key'), element.getAttribute('data-herb-dev-tools-fix-view'))
         } else if (action === 'feature') {
           this.featureFrom(element)
         } else if (action === 'dismiss') {
           this.dismiss()
         } else if (action === 'clear') {
-          this.clear(this.state.origin === ALL_ORIGINS ? undefined : this.state.origin)
-
-          if (this.entries.length === 0) {
-            this.close()
-          }
+          this.clear()
+          this.close()
         } else if (action === 'filter') {
           const origin = element.getAttribute('data-herb-dev-tools-origin')
           const severity = element.getAttribute('data-herb-dev-tools-severity')

--- a/javascript/packages/dev-tools/test/dev-server-diagnostics.test.ts
+++ b/javascript/packages/dev-tools/test/dev-server-diagnostics.test.ts
@@ -193,10 +193,10 @@ describe("a dev server error in the panel", () => {
     expect(stripAnsiColors(excerpt.textContent ?? "")).toContain("<form>")
   })
 
-  test("shows the dev server connection in its own header, not only in the badge", async () => {
+  test("shows the dev server connection on a blocking screen, not only in the badge", async () => {
     const panel = createPanel()
 
-    panel.report(diagnosticsFromError(errorMessage()))
+    panel.report(diagnosticsFromError(errorMessage()).map(diagnostic => ({ ...diagnostic, overlay: "blocking" as const })))
 
     const dot = document.querySelector(".herb-dev-tools-connection-dot") as HTMLElement | null
     const status = document.querySelector(".herb-dev-tools-connection-status") as HTMLElement | null
@@ -206,11 +206,19 @@ describe("a dev server error in the panel", () => {
     expect(status!.textContent).toBe("Dev Server")
   })
 
-  test("keeps that indicator through a re-render, since the panel rewrites its own header", () => {
+  test("leaves it off a dismissible overlay, where the page underneath still works", () => {
     const panel = createPanel()
 
     panel.report(diagnosticsFromError(errorMessage()))
-    panel.report(diagnosticsFromError(errorMessage({ line: 9 })))
+
+    expect(document.querySelector(".herb-dev-tools-connection-dot")).toBeNull()
+  })
+
+  test("keeps that indicator through a re-render, since the panel rewrites its own header", () => {
+    const panel = createPanel()
+
+    panel.report(diagnosticsFromError(errorMessage()).map(diagnostic => ({ ...diagnostic, overlay: "blocking" as const })))
+    panel.report(diagnosticsFromError(errorMessage({ line: 9 })).map(diagnostic => ({ ...diagnostic, overlay: "blocking" as const })))
 
     expect(document.querySelectorAll(".herb-dev-tools-connection-dot")).toHaveLength(1)
   })

--- a/javascript/packages/dev-tools/test/listener-lifecycle.test.ts
+++ b/javascript/packages/dev-tools/test/listener-lifecycle.test.ts
@@ -303,7 +303,7 @@ describe("runtime diagnostics menu toggle", () => {
 
     expect(toggle()).not.toBeNull()
     expect(toggle()!.closest(".herb-toggle-item")).not.toBeNull()
-    expect(toggle()!.parentElement!.querySelector(".herb-toggle-text")!.textContent).toBe("Runtime Diagnostics")
+    expect(toggle()!.parentElement!.querySelector(".herb-toggle-text")!.textContent).toBe("Diagnostics")
     expect(toggle()!.checked).toBe(true)
   })
 

--- a/javascript/packages/dev-tools/test/runtime-panel.test.ts
+++ b/javascript/packages/dev-tools/test/runtime-panel.test.ts
@@ -181,15 +181,49 @@ describe("clear control", () => {
     return document.querySelector(`.herb-dev-tools-filter[data-herb-dev-tools-origin="${origin}"]`) as HTMLElement
   }
 
-  test("sits with the hide button and not in the window controls", () => {
+  test("ends the origin row, beside the filters it clears", () => {
     embed(PAYLOAD)
     createPanel().open()
 
     const header = document.querySelector(".herb-dev-tools-header")!
+    const origins = document.querySelector(".herb-dev-tools-filters") as HTMLElement
+    const actions = origins.querySelector(".herb-dev-tools-filters-actions") as HTMLElement
 
-    expect(clearButton()!.parentElement).toBe(header)
-    expect(clearButton()!.nextElementSibling!.className).toBe("herb-dev-tools-hide")
-    expect(header.querySelector(".herb-dev-tools-window-controls")!.contains(clearButton())).toBe(false)
+    expect(clearButton()!.parentElement).toBe(actions)
+    expect(clearButton()).toBe(actions.lastElementChild)
+    expect(actions).toBe(origins.lastElementChild)
+    expect(header.contains(clearButton())).toBe(false)
+
+    const row = origins.getBoundingClientRect()
+
+    expect(clearButton()!.getBoundingClientRect().right)
+      .toBeCloseTo(row.right - parseFloat(getComputedStyle(origins).paddingRight), 0)
+  })
+
+  test("shares the row with a control that collapses every file at once", () => {
+    embed(PAYLOAD)
+
+    const panel = createPanel()
+
+    panel.open()
+
+    const toggle = () => document.querySelector('[data-herb-dev-tools-action="collapse-all"]') as HTMLButtonElement
+    const collapsed = () => document.querySelectorAll(".herb-dev-tools-group-collapsed").length
+    const groups = () => document.querySelectorAll(".herb-dev-tools-group").length
+
+    expect(groups()).toBeGreaterThan(1)
+    expect(toggle().textContent).toBe("Collapse all")
+    expect(collapsed()).toBe(0)
+
+    toggle().click()
+
+    expect(collapsed()).toBe(groups())
+    expect(toggle().textContent).toBe("Expand all")
+
+    toggle().click()
+
+    expect(collapsed()).toBe(0)
+    expect(toggle().textContent).toBe("Collapse all")
   })
 
   test("empties everything while the All filter is active", () => {
@@ -200,7 +234,7 @@ describe("clear control", () => {
     panel.open()
 
     expect(cards()).toHaveLength(3)
-    expect(clearButton()!.textContent).toBe("Clear all")
+    expect(clearButton()!.textContent).toBe("Clear")
 
     clearButton()!.click()
 
@@ -208,7 +242,7 @@ describe("clear control", () => {
     expect(panel.count).toBe(0)
   })
 
-  test("clears only the filtered origin and leaves the rest", () => {
+  test("empties everything even while an origin filter is active", () => {
     embed(PAYLOAD)
 
     const panel = createPanel()
@@ -216,14 +250,12 @@ describe("clear control", () => {
     panel.open()
     chip("Herb Linter").click()
 
-    expect(clearButton()!.textContent).toBe("Clear Herb Linter")
+    expect(clearButton()!.textContent).toBe("Clear")
 
     clearButton()!.click()
 
-    const origins = cards().map(card => card.getAttribute("data-herb-dev-tools-origin"))
-
-    expect(origins).toEqual(["Acme Scanner", "Herb Engine Runtime"])
-    expect(panel.count).toBe(2)
+    expect(cards()).toHaveLength(0)
+    expect(panel.count).toBe(0)
   })
 
   test("names its scope for assistive technology", () => {
@@ -237,7 +269,7 @@ describe("clear control", () => {
 
     chip("Herb Linter").click()
 
-    expect(clearButton()!.getAttribute("aria-label")).toBe("Clear the 1 entry from Herb Linter")
+    expect(clearButton()!.getAttribute("aria-label")).toBe("Clear all 3 entries and empty the panel")
   })
 
   test("leaves the dismissed state alone", () => {
@@ -268,7 +300,7 @@ describe("clear control", () => {
     expect(panel.dismissed).toBe(false)
   })
 
-  test("stays open when the control only clears one origin", () => {
+  test("closes even when an origin filter was narrowing the view", () => {
     embed(PAYLOAD)
 
     const panel = createPanel()
@@ -277,8 +309,8 @@ describe("clear control", () => {
     ;(document.querySelector('[data-herb-dev-tools-origin="Herb Linter"]') as HTMLButtonElement).click()
     clearButton()!.click()
 
-    expect(root()).not.toBeNull()
-    expect(panel.count).toBe(2)
+    expect(root()).toBeNull()
+    expect(panel.count).toBe(0)
   })
 
   test("still explains itself when the API empties it", () => {
@@ -845,9 +877,12 @@ describe("fix diffs", () => {
     expect(details.tagName).toBe("DETAILS")
     expect(details.open).toBe(false)
     expect(details.getAttribute("data-herb-dev-tools-fix")).toBe("safe")
-    expect(summary.textContent).toContain("Not applied")
-    expect(summary.querySelector(".herb-dev-tools-fix-command")!.textContent).toBe("herb lint --fix")
-    expect(summary.textContent).not.toContain("unsafe")
+    expect(summary.textContent).toBe("Preview the change")
+    expect(document.querySelector(".herb-dev-tools-fix-command")!.textContent).toBe("npx @herb-tools/linter app/views/posts/_actions.html.erb --fix --only html-no-nested-forms")
+
+    const note = document.querySelector(".herb-dev-tools-autofix-note")!
+
+    expect(note.textContent).toBe("not applied, safe")
 
     const rendered = details.querySelector(".herb-dev-tools-fix-diff herb-ansi") as HTMLElement
 
@@ -868,9 +903,8 @@ describe("fix diffs", () => {
     const summary = details.querySelector(".herb-dev-tools-fix-summary")!
 
     expect(details.getAttribute("data-herb-dev-tools-fix")).toBe("unsafe")
-    expect(summary.textContent).toContain("Not applied")
-    expect(summary.textContent).toContain("unsafe")
-    expect(summary.querySelector(".herb-dev-tools-fix-command")!.textContent).toBe("herb lint --fix-unsafely")
+    expect(document.querySelector(".herb-dev-tools-autofix-note")!.textContent).toBe("not applied, unsafe")
+    expect(document.querySelector(".herb-dev-tools-fix-command")!.textContent).toBe("npx @herb-tools/linter app/views/posts/_actions.html.erb --fix-unsafely --only html-no-nested-forms")
   })
 
   test("falls back to a safe label for an unrecognized kind", async () => {
@@ -883,7 +917,7 @@ describe("fix diffs", () => {
     const details = await waitForFix()
 
     expect(details.getAttribute("data-herb-dev-tools-fix")).toBe("safe")
-    expect(details.querySelector(".herb-dev-tools-fix-command")!.textContent).toBe("herb lint --fix")
+    expect(document.querySelector(".herb-dev-tools-fix-command")!.textContent).toBe("npx @herb-tools/linter app/views/posts/_actions.html.erb --fix --only html-no-nested-forms")
   })
 
   test("gives the diff a foreground that differs from its background", async () => {
@@ -966,10 +1000,6 @@ describe("fix diffs", () => {
 })
 
 describe("expanded presentation", () => {
-  function expandButton() {
-    return document.querySelector('[data-herb-dev-tools-action="expand"]') as HTMLButtonElement
-  }
-
   function panel() {
     return document.querySelector(".herb-dev-tools-panel") as HTMLElement
   }
@@ -989,9 +1019,9 @@ describe("expanded presentation", () => {
       title: getComputedStyle(title).color,
     }
 
-    expect(neutral.band).toBe("rgb(249, 250, 251)")
-    expect(neutral.border).toBe("rgb(229, 231, 235)")
-    expect(neutral.title).toBe("rgb(17, 24, 39)")
+    expect(neutral.band).toBe("rgb(255, 255, 255)")
+    expect(neutral.border).toBe("rgb(212, 212, 216)")
+    expect(neutral.title).toBe("rgb(9, 9, 11)")
 
     instance.clear()
     instance.report(diagnostic({ kind: "metric", value: "3 SQL queries", code: "two" }))
@@ -1014,25 +1044,30 @@ describe("expanded presentation", () => {
 
     expect(cluster).toBe(header.lastElementChild)
     expect(Array.from(cluster.children).map(node => node.getAttribute("data-herb-dev-tools-action")))
-      .toEqual(["expand", "close"])
+      .toEqual(["copy-markdown", "expand", "close"])
 
     expect(header.querySelector(".herb-dev-tools-hide")!.parentElement).toBe(header)
   })
 
-  test("matches the close button's hit target and optical weight", () => {
+  test("offers the expand control only while docked, since closing is what collapses", () => {
     embed(PAYLOAD)
 
     const instance = createPanel()
 
     instance.open()
 
-    const expand = expandButton().getBoundingClientRect()
+    const expand = document.querySelector('[data-herb-dev-tools-action="expand"]') as HTMLElement
+
+    expect(expand).not.toBeNull()
+    expect(expand.getAttribute("aria-expanded")).toBe("false")
+
     const close = (document.querySelector(".herb-dev-tools-close") as HTMLElement).getBoundingClientRect()
 
-    expect(expand.width).toBe(close.width)
-    expect(expand.height).toBe(close.height)
-    expect(expand.width).toBeGreaterThanOrEqual(24)
-    expect(parseFloat(getComputedStyle(expandButton()).fontSize)).toBeGreaterThan(15)
+    expect(expand.getBoundingClientRect().width).toBe(close.width)
+
+    instance.expand()
+
+    expect(document.querySelector('[data-herb-dev-tools-action="expand"]')).toBeNull()
   })
 
   test("keeps every control reachable in the anchored header", () => {
@@ -1136,48 +1171,54 @@ describe("expanded presentation", () => {
     expect(panel().classList.contains("herb-dev-tools-expanded")).toBe(false)
     expect(document.querySelector(".herb-dev-tools-backdrop")).toBeNull()
 
-    expandButton().click()
+    instance.toggleExpanded()
 
     expect(instance.expanded).toBe(true)
     expect(panel().classList.contains("herb-dev-tools-expanded")).toBe(true)
     expect(document.querySelector(".herb-dev-tools-backdrop")).not.toBeNull()
 
-    expandButton().click()
+    instance.toggleExpanded()
 
     expect(instance.expanded).toBe(false)
     expect(panel().classList.contains("herb-dev-tools-expanded")).toBe(false)
     expect(document.querySelector(".herb-dev-tools-backdrop")).toBeNull()
   })
 
-  test("names the control after what the click will do", () => {
+  test("closing an expanded panel collapses it, so it reopens docked", () => {
     embed(PAYLOAD)
 
     const instance = createPanel()
 
     instance.open()
+    ;(document.querySelector('[data-herb-dev-tools-action="expand"]') as HTMLButtonElement).click()
 
-    expect(expandButton().getAttribute("aria-label")).toBe("Expand panel to fill the window")
-    expect(expandButton().getAttribute("aria-expanded")).toBe("false")
+    expect(instance.expanded).toBe(true)
+    ;(document.querySelector(".herb-dev-tools-close") as HTMLButtonElement).click()
 
-    instance.expand()
+    expect(instance.expanded).toBe(false)
 
-    expect(expandButton().getAttribute("aria-label")).toBe("Collapse panel back to the corner")
-    expect(expandButton().getAttribute("aria-expanded")).toBe("true")
+    instance.open()
+
+    expect(instance.expanded).toBe(false)
+    expect(panel().classList.contains("herb-dev-tools-expanded")).toBe(false)
   })
 
-  test("survives a reload through sessionStorage", () => {
+  test("does not carry an expanded panel across a reload", () => {
     embed(PAYLOAD)
 
     const instance = createPanel()
 
     instance.open()
     instance.expand()
+    instance.close()
     instance.destroy()
 
     const reloaded = createPanel()
 
-    expect(reloaded.expanded).toBe(true)
-    expect(panel().classList.contains("herb-dev-tools-expanded")).toBe(true)
+    reloaded.open()
+
+    expect(reloaded.expanded).toBe(false)
+    expect(panel().classList.contains("herb-dev-tools-expanded")).toBe(false)
   })
 
   test("fills the window minus the inset when expanded", () => {
@@ -1194,6 +1235,20 @@ describe("expanded presentation", () => {
     expect(rect.top).toBeCloseTo(24, 0)
     expect(rect.width).toBeCloseTo(window.innerWidth - 48, 0)
     expect(rect.height).toBeCloseTo(window.innerHeight - 48, 0)
+  })
+
+  test("stops widening once it has the room it needs", () => {
+    embed(PAYLOAD)
+
+    const instance = createPanel()
+
+    instance.open()
+    instance.expand()
+
+    const styles = getComputedStyle(panel())
+
+    expect(styles.maxWidth).toBe("1280px")
+    expect(styles.marginLeft).toBe(styles.marginRight)
   })
 
   test("collapses back to the exact anchored position with the panel still open", () => {
@@ -2025,7 +2080,6 @@ describe("overlay", () => {
     expect(badge()).toBeNull()
     expect(document.querySelector(".herb-dev-tools-close")).toBeNull()
     expect(document.querySelector(".herb-dev-tools-hide")).toBeNull()
-    expect(document.querySelector(".herb-dev-tools-expand")).toBeNull()
     expect(document.querySelector(".herb-dev-tools-clear")).toBeNull()
 
     escape()
@@ -2504,7 +2558,7 @@ describe("overlay", () => {
       diagnostic({ code: "two", origin: "Herb Validator", overlay: "blocking" }),
     ])
 
-    expect(document.querySelector(".herb-dev-tools-title")!.textContent).toBe("Herb Runtime Diagnostics")
+    expect(document.querySelector(".herb-dev-tools-title")!.textContent).toBe("Herb Diagnostics")
     expect(document.querySelector(".herb-dev-tools-summary")!.textContent).toBe("2 errors")
   })
 
@@ -2869,7 +2923,7 @@ describe("overlay heading bar", () => {
 
     const scope = () => document.querySelector('[data-herb-dev-tools-action="overlay-scope"]') as HTMLButtonElement
 
-    expect(scope().title).toBe("Show the other 2 diagnostics this page reported")
+    expect(scope().getAttribute("data-herb-dev-tools-tip")).toBe("Show the other 2 diagnostics this page reported")
 
     instance.clear("unknown")
     instance.report([
@@ -2877,7 +2931,7 @@ describe("overlay heading bar", () => {
       diagnostic({ code: "broke", overlay: "blocking" }),
     ])
 
-    expect(scope().title).toBe("Show the one other diagnostic this page reported")
+    expect(scope().getAttribute("data-herb-dev-tools-tip")).toBe("Show the one other diagnostic this page reported")
   })
 
   test("keeps one bar layout across the focused and widened views", () => {
@@ -2912,7 +2966,7 @@ describe("overlay heading bar", () => {
 
     expect(controls()).toBe(header().lastElementChild)
     expect(Array.from(controls().children).map(node => node.getAttribute("data-herb-dev-tools-action")))
-      .toEqual(["overlay-scope", "dismiss-overlay"])
+      .toEqual(["copy-markdown", "dismiss-overlay"])
 
     instance.toggleOverlayScope()
 
@@ -2953,7 +3007,7 @@ describe("overlay severity accent", () => {
 
     expect(styles.backgroundColor).not.toBe("rgb(220, 38, 38)")
     expect(styles.color).not.toBe("rgb(255, 255, 255)")
-    expect(styles.backgroundColor).not.toBe("rgb(249, 250, 251)")
+    expect(styles.backgroundColor).not.toBe("rgb(255, 255, 255)")
     expect(styles.borderBottomColor).not.toBe("rgb(229, 231, 235)")
     expect(styles.boxShadow).toBe("none")
   })
@@ -3033,7 +3087,7 @@ describe("heading bar across the overlay toggle", () => {
 
     expect(widened.padding).toBe(featured.padding)
     expect(widened.background).not.toBe(featured.background)
-    expect(widened.background).toBe("rgb(249, 250, 251)")
+    expect(widened.background).toBe("rgb(255, 255, 255)")
     expect(header().querySelector(".herb-dev-tools-dot")).toBeNull()
   })
 
@@ -3050,7 +3104,7 @@ describe("heading bar across the overlay toggle", () => {
     instance.toggleOverlayScope()
 
     expect(chrome().padding).toBe(featured.padding)
-    expect(chrome().background).toBe("rgb(249, 250, 251)")
+    expect(chrome().background).toBe("rgb(255, 255, 255)")
   })
 
   test("leaves the docked panel header untinted", () => {
@@ -3061,7 +3115,7 @@ describe("heading bar across the overlay toggle", () => {
 
     const docked = chrome()
 
-    expect(docked.background).toBe("rgb(249, 250, 251)")
+    expect(docked.background).toBe("rgb(255, 255, 255)")
     expect(docked.shadow).toBe("none")
     expect(header().querySelector(".herb-dev-tools-dot")).toBeNull()
   })
@@ -3119,7 +3173,7 @@ describe("expanding the docked panel", () => {
     instance.report(diagnostic({ code: "errored", severity: "error" }))
 
     expect(chrome().background).toBe(warning)
-    expect(chrome().background).toBe("rgb(249, 250, 251)")
+    expect(chrome().background).toBe("rgb(255, 255, 255)")
     expect(header().querySelector(".herb-dev-tools-dot")).toBeNull()
   })
 
@@ -3429,7 +3483,6 @@ describe("header control alignment", () => {
       gap,
       padding,
       title: element.querySelector(".herb-dev-tools-title")!.getBoundingClientRect(),
-      clear: element.querySelector(".herb-dev-tools-clear")!.getBoundingClientRect(),
       hide: element.querySelector(".herb-dev-tools-hide")!.getBoundingClientRect(),
       controls: element.querySelector(".herb-dev-tools-window-controls")!.getBoundingClientRect(),
     }
@@ -3441,13 +3494,12 @@ describe("header control alignment", () => {
     createPanel().open()
     ;(document.querySelector(".herb-dev-tools-panel") as HTMLElement).style.width = "640px"
 
-    const { box, gap, padding, title, clear, hide, controls } = measure()
+    const { box, gap, padding, title, hide, controls } = measure()
 
     expect(title.left).toBeCloseTo(box.left + padding, 0)
-    expect(clear.left).toBeGreaterThan(box.left + box.width / 2)
+    expect(hide.left).toBeGreaterThan(box.left + box.width / 2)
     expect(title.right).toBeGreaterThan(box.left + box.width / 2)
 
-    expect(hide.left - clear.right).toBeCloseTo(gap, 0)
     expect(controls.left - hide.right).toBeCloseTo(gap, 0)
     expect(controls.right).toBeCloseTo(box.right - padding, 0)
   })
@@ -3461,11 +3513,10 @@ describe("header control alignment", () => {
     instance.expand()
     ;(document.querySelector(".herb-dev-tools-panel") as HTMLElement).style.width = "640px"
 
-    const { element, box, gap, padding, title, clear, hide, controls } = measure()
+    const { element, box, gap, padding, title, hide, controls } = measure()
 
-    expect(clear.left).toBeGreaterThan(box.left + box.width / 2)
+    expect(hide.left).toBeGreaterThan(box.left + box.width / 2)
     expect(title.right).toBeGreaterThan(box.left + box.width / 2)
-    expect(hide.left - clear.right).toBeCloseTo(gap, 0)
     expect(controls.left - hide.right).toBeCloseTo(gap, 0)
     expect(controls.right).toBeCloseTo(box.right - padding, 0)
     expect(element.scrollWidth).toBeLessThanOrEqual(element.clientWidth)
@@ -3885,143 +3936,5 @@ describe("what a blocking screen calls itself", () => {
     ])
 
     expect(title()).toBe("Herb Parser")
-  })
-})
-
-describe("one block per file", () => {
-  const SOURCE = `<div class="actions">\n  <form action="/posts">\n    <button>Delete</button>\n  </form>\n</div>\n`
-
-  function payload() {
-    return {
-      version: 1,
-      sources: { "app/views/posts/_actions.html.erb": SOURCE },
-      diagnostics: [
-        {
-          template: "app/views/posts/_actions.html.erb",
-          message: "Nested `<form>` elements are not allowed.",
-          code: "html-no-nested-forms",
-          severity: "error",
-          origin: "Herb Linter",
-          location: { start: { line: 2, column: 3 }, end: { line: 2, column: 24 } },
-        },
-        {
-          template: "app/views/posts/_actions.html.erb",
-          message: "Button has no accessible name.",
-          code: "html-button-name",
-          severity: "warning",
-          origin: "Herb Linter",
-          location: { start: { line: 3, column: 5 }, end: { line: 3, column: 26 } },
-        },
-      ],
-    }
-  }
-
-  function viewButton() {
-    return document.querySelector('[data-herb-dev-tools-action="view"]') as HTMLButtonElement | null
-  }
-
-  function combined() {
-    return document.querySelector(".herb-dev-tools-combined")
-  }
-
-  test("offers the toggle once the panel fills the window", async () => {
-    embed(payload())
-
-    const instance = createPanel()
-
-    instance.open()
-
-    expect(viewButton()).toBeNull()
-
-    instance.expand()
-
-    await waitForExcerpt()
-
-    expect(viewButton()!.textContent).toBe("One block per file")
-    expect(viewButton()!.getAttribute("aria-pressed")).toBe("false")
-  })
-
-  test("replaces the cards with a single block", async () => {
-    embed(payload())
-
-    const instance = createPanel()
-
-    instance.open()
-    instance.expand()
-
-    await waitForExcerpt()
-
-    expect(cards()).toHaveLength(2)
-    expect(combined()).toBeNull()
-
-    instance.toggleView()
-
-    await waitFor(() => combined(), "the combined block")
-
-    expect(cards()).toHaveLength(0)
-    expect(document.querySelectorAll(".herb-dev-tools-combined")).toHaveLength(1)
-    expect(viewButton()!.textContent).toBe("One card per offense")
-  })
-
-  test("marks every offence in the one block", async () => {
-    embed(payload())
-
-    const instance = createPanel()
-
-    instance.open()
-    instance.expand()
-    instance.toggleView()
-
-    const element = await waitFor(
-      () => document.querySelector(".herb-dev-tools-combined herb-ansi") as HTMLElement | null,
-      "the combined block",
-    )
-
-    const plain = element.textContent!.split("").filter(character => character.charCodeAt(0) !== 27).join("")
-      .replace(/\[[0-9;]*m/g, "")
-
-    expect(plain).toContain("Nested `<form>` elements are not allowed.")
-    expect(plain).toContain("Button has no accessible name.")
-
-    const lines = plain.split("\n")
-
-    expect(lines.some(line => line.includes("1 \u2502 <div class=\"actions\">"))).toBe(true)
-    expect(lines.some(line => line.includes("5 \u2502 </div>"))).toBe(true)
-    expect(lines.filter(line => line.includes("~")).length).toBe(2)
-  })
-
-  test("keeps the cards for a file it has no source for", async () => {
-    embed({ version: 1, diagnostics: payload().diagnostics })
-
-    const instance = createPanel()
-
-    instance.open()
-    instance.expand()
-    instance.toggleView()
-
-    expect(instance.view).toBe("combined")
-    expect(combined()).toBeNull()
-    expect(cards()).toHaveLength(2)
-    expect(viewButton()).toBeNull()
-  })
-
-  test("remembers the choice for the session", async () => {
-    embed(payload())
-
-    const first = createPanel()
-
-    first.open()
-    first.expand()
-    first.toggleView()
-
-    expect(first.view).toBe("combined")
-
-    first.destroy()
-    document.body.innerHTML = ""
-    embed(payload())
-
-    const second = createPanel()
-
-    expect(second.view).toBe("combined")
   })
 })

--- a/lib/herb/engine.rb
+++ b/lib/herb/engine.rb
@@ -436,7 +436,13 @@ module Herb
 
       formatter = Diagnostic::Formatter.new(input, errors, filename: filename)
 
-      raise CompilationError.new(formatter.summary, details: formatter, diagnostics: errors)
+      raise CompilationError.new(
+        formatter.summary,
+        details: formatter,
+        diagnostics: errors,
+        visitors: @visitors.descriptions,
+        parser_options: @parser_options
+      )
     end
 
     def context_options(properties)

--- a/lib/herb/engine/errors.rb
+++ b/lib/herb/engine/errors.rb
@@ -6,11 +6,13 @@ require_relative "../diagnostic"
 module Herb
   class Engine
     class CompilationError < StandardError
-      attr_reader :details, :diagnostics
+      attr_reader :details, :diagnostics, :visitors, :parser_options
 
-      def initialize(message, details: nil, diagnostics: [])
+      def initialize(message, details: nil, diagnostics: [], visitors: [], parser_options: {})
         @details = details
         @diagnostics = diagnostics
+        @visitors = visitors
+        @parser_options = parser_options
 
         super(message)
       end
@@ -79,19 +81,14 @@ module Herb
       CONTEXT_LINES = 3 #: Integer
 
       attr_reader :source #: String
-      attr_reader :visitors #: Array[String]
-      attr_reader :parser_options #: Hash[Symbol, untyped]
       attr_reader :filename #: String?
 
       #: (String, diagnostics: Array[Herb::Diagnostic], source: String, ?filename: String?, ?visitors: Array[String], ?parser_options: Hash[Symbol, untyped], ?details: untyped) -> void
       def initialize(message, diagnostics:, source:, filename: nil, visitors: [], parser_options: {}, details: nil)
-        @diagnostics = diagnostics
         @source = source
-        @visitors = visitors
-        @parser_options = parser_options
         @filename = filename
 
-        super(message, details: details, diagnostics: diagnostics)
+        super(message, details: details, diagnostics: diagnostics, visitors: visitors, parser_options: parser_options)
       end
 
       #: () -> Integer?

--- a/lib/herb/engine/runtime/error_page.rb
+++ b/lib/herb/engine/runtime/error_page.rb
@@ -138,8 +138,6 @@ module Herb
           report.note(:herb_version, Herb::VERSION)
           report.note(:error_class, error.class.name)
 
-          return unless error.is_a?(Herb::Engine::ParseError)
-
           report.note(:visitors, error.visitors) unless error.visitors.empty?
           report.note(:parser_options, error.parser_options) unless error.parser_options.empty?
         end
@@ -274,7 +272,7 @@ module Herb
 
           rows = [] #: Array[String]
 
-          rows << %(<p>Compiled by Herb #{escape(version.to_s)}.</p>) if version
+          rows << %(<p>Compiled by Herb::Engine #{escape(version.to_s)}.</p>) if version
 
           unless options.empty?
             pairs = options.map { |key, value| %(<li><code>#{escape(key.to_s)}: #{escape(value.inspect)}</code></li>) }

--- a/sig/herb/engine/errors.rbs
+++ b/sig/herb/engine/errors.rbs
@@ -7,7 +7,11 @@ module Herb
 
       attr_reader diagnostics: untyped
 
-      def initialize: (untyped message, ?details: untyped, ?diagnostics: untyped) -> untyped
+      attr_reader visitors: untyped
+
+      attr_reader parser_options: untyped
+
+      def initialize: (untyped message, ?details: untyped, ?diagnostics: untyped, ?visitors: untyped, ?parser_options: untyped) -> untyped
 
       def detailed_message: (?highlight: untyped, **untyped) -> untyped
 
@@ -43,10 +47,6 @@ module Herb
       CONTEXT_LINES: Integer
 
       attr_reader source: String
-
-      attr_reader visitors: Array[String]
-
-      attr_reader parser_options: Hash[Symbol, untyped]
 
       attr_reader filename: String?
 


### PR DESCRIPTION
Reworks the diagnostics panel and the Herb Dev Tools menu around one visual language, taking the cue from Laravel's exception page. Bolder borders, fewer shadows, a green accent drawn from the docs theme, and a hero that puts the rule code and the file front and center on the full-screen view.

### Panel

- Diagnostics group per file into cards with their own header, collapsible by clicking that header, plus an expand and collapse all control on the filter row
- The autofix renders as a **Diff** or **Fixed file** tab. The fixed file drops its line numbers so it can be copied, and it has a copy button of its own
- A command field carries `npx @herb-tools/linter <file> --fix --only <code>` with a copy button, and the fix now travels with the copied markdown
- The overlay caps at 1280px. The blocking overlay keeps its header bar full width while its content stays on the same measure
- The combined inline view and the separate shrink control are gone. One close button now collapses the panel and closes it

### Menu

- Adopts the panel's header height, spacing and controls
- The dev server indicator moved into the header, and it renders an explicit `Dev Server disabled` state when the integration is off
- Outline labels carry a badge with the count of diagnostics reported for them
- Opens instantly, with no transform or transition

### Engine

`CompilationError` held the diagnostics and the formatter, but the compile provenance lived on `ParseError` alone. `Runtime::ErrorPage` collected it behind a `return unless error.is_a?(ParseError)` guard, so a template that failed validation rendered an error page with no record of which visitors ran or which parser options produced it. `visitors` and `parser_options` now live on `CompilationError`, the validation raise in `Engine#validate!` passes them, and the guard is gone. The provenance footer says "Compiled by Herb::Engine", since the engine is what compiled the template.

### Fixes found along the way

- Buttons do not inherit fonts, so the host page's `button` rules and the UA stylesheet reached our controls and every one of them computed `font-family: Arial`. A `:where()` reset now covers both surfaces
- `diagnosticKey` joins on U+0000, which HTML attributes rewrite to U+FFFD, so the fix view toggle never matched its own key and silently did nothing
- The reconnect countdown skipped its last second and lost `Retrying...` to a status write. The backoff now reaches 15s, for about 105s of retrying before it gives up
- Re-rendering reset the scroll position and closed open fix sections

---

| . | . |
| --- | --- |
| <img width="1630" height="1352" alt="CleanShot 2026-08-29 at 09 17 21@2x" src="https://github.com/user-attachments/assets/988b650f-6011-4fae-8a66-aafedcb4609d" /> | <img width="1626" height="1348" alt="CleanShot 2026-08-29 at 09 16 57@2x" src="https://github.com/user-attachments/assets/133a4159-5102-416e-87da-011a0321011c" /> |
| <img width="1634" height="1182" alt="CleanShot 2026-08-29 at 09 16 40@2x" src="https://github.com/user-attachments/assets/6d3e46fc-01fa-4a00-a3c6-600bb0187d87" /> | <img width="1650" height="1342" alt="CleanShot 2026-08-29 at 09 18 39@2x" src="https://github.com/user-attachments/assets/faa98c17-bae2-41f1-a527-15ae91465b8d" /> |
| <img width="1646" height="1346" alt="CleanShot 2026-08-29 at 09 18 55@2x" src="https://github.com/user-attachments/assets/9ed6e2f6-3d46-4174-9055-44ee3933cbf4" /> | . |

