### PR TITLE
Engine: Introduce `SourceAttributionVisitor`

### DIFF
--- a/docs/docs/projects/engine.md
+++ b/docs/docs/projects/engine.md
@@ -241,15 +241,16 @@ Herb ships the following transform visitors:
 | Visitor                       | Description                                                                  |
 |-------------------------------|------------------------------------------------------------------------------|
 | `AutoCloseOmittedTagsVisitor` | Replaces omitted closing tags with explicit ones                             |
-| `ContentForVisitor`           | Appends HTML to the end of every matching element                            |
-| `RemoveCommentsVisitor`       | Removes comments, so the output never contains one                           |
-| `HTMLSafeAssertionsVisitor`   | Checks every `.html_safe` call at runtime                                    |
 | `ComponentTags::Visitor`      | Rewrites capitalized tags into `render` calls (experimental)                 |
+| `ContentForVisitor`           | Appends HTML to the end of every matching element                            |
 | `DebugVisitor`                | Annotates output with the template and position it came from                 |
-| `OptimizeVisitor`             | Compile-time optimizations for Action View helpers (experimental)            |
-| `InstrumentationVisitor`      | Frames every ERB tag so a render can be attributed to it (experimental)      |
+| `HTMLSafeAssertionsVisitor`   | Checks every `.html_safe` call at runtime                                    |
 | `InlineRender::Visitor`       | Replaces a `render` of a static partial with the partial (experimental)      |
+| `InstrumentationVisitor`      | Frames every ERB tag so a render can be attributed to it (experimental)      |
+| `OptimizeVisitor`             | Compile-time optimizations for Action View helpers (experimental)            |
+| `RemoveCommentsVisitor`       | Removes comments, so the output never contains one                           |
 | `ScopedStyle::Visitor`        | Scopes a `<style scoped>` block to the file it was written in (experimental) |
+| `SourceAttributionVisitor`    | Stamps every element with the template and position it was written at        |
 
 Transform visitors are not loaded when you `require "herb"`. Require the ones you want and pass them to the engine:
 
@@ -731,6 +732,57 @@ Herb::Engine.new(source, visitors: [
 Without it the markers say only where in a file something was written, so a partial rendered three times puts three identical ones in the page. With it each carries the render it belongs to, which is what tells them apart.
 
 The wrapper is a real cost. A `<span>` is not valid everywhere an ERB tag can appear, `<ul>` being the obvious case, so a strict linter reading the rendered page will have findings about Herb's own instrumentation.
+
+### `SourceAttributionVisitor`
+
+Stamps every element with the template and the position it was written at, so a finding about the rendered page can be pointed back at the line that produced it.
+
+```ruby
+require "herb/engine/visitors/source_attribution_visitor"
+
+Herb::Engine.new(source, filename: path, visitors: [Herb::Engine::SourceAttributionVisitor.new])
+```
+
+```html+erb
+<div class="card">
+  <h1>Title</h1>
+</div>
+```
+
+```html
+<div class="card" data-herb-source="app/views/posts/_card.html.erb:1:1">
+  <h1 data-herb-source="app/views/posts/_card.html.erb:2:3">Title</h1>
+</div>
+```
+
+The attribute is `data-herb-source` unless `attribute:` names another one.
+
+Some things are only visible once a page is rendered. Two partials can each be valid on their own and still collide on an `id`, a heading order only exists once a layout and everything it renders are composed, and a `<form>` inside another `<form>` is usually two templates that never see each other. A linter reading the response answers those, and the positions it reports are offsets into the response, which is not a place anyone can go and fix anything. The stamp is what turns them back into a file and a line.
+
+An element that renders many times carries the line it was written at, not the line it rendered at, so the answer to a duplicate `id` is the line that renders more than once:
+
+```html
+<ul data-herb-source="app/views/posts/_card.html.erb:1:1">
+  <li data-herb-source="app/views/posts/_card.html.erb:3:5">a</li>
+  <li data-herb-source="app/views/posts/_card.html.erb:3:5">b</li>
+</ul>
+```
+
+A partial that `InlineRender::Visitor` brought into the template is stamped with the file it was written in, not the file it was inlined into.
+
+### Tag helpers and the parser option
+
+A tag helper is stamped too. The `action_view_helpers` parser option turns `<%= link_to "Home", "/" %>` into an `<a>` that the compiler writes out as markup, and that `<a>` is stamped at the position of the `<%=` that asked for it:
+
+```html
+<nav data-herb-source="app/views/posts/_card.html.erb:1:1">
+  <a href="/" data-herb-source="app/views/posts/_card.html.erb:2:3">Home</a>
+</nav>
+```
+
+This visitor declares that option with `recommended_parser_option`, so a stack that says nothing about it gets it.
+
+The stamp is markup Herb added, so strip it before reporting positions back, and leave the visitor out of anything but a development build.
 
 ### `OptimizeVisitor` <Badge type="warning" text="experimental" />
 

--- a/lib/herb/engine/visitors/source_attribution_visitor.rb
+++ b/lib/herb/engine/visitors/source_attribution_visitor.rb
@@ -1,0 +1,172 @@
+# frozen_string_literal: true
+# typed: false
+
+require_relative "../../../herb"
+require_relative "../../engine"
+require_relative "../../visitor/context_aware"
+require_relative "../../visitor/context/origin"
+
+module Herb
+  class Engine
+    # Stamps every element with the template and the position it was written at, so that something
+    # found on the rendered page can be pointed back at the line that produced it.
+    #
+    # Some things are only visible once a page is rendered. Two partials can each be valid on their
+    # own and still collide on an `id`, a heading order only exists once a layout and everything it
+    # renders are composed, and a `<form>` inside another `<form>` is usually two templates that
+    # never see each other. Linting the response is what answers those, and the positions it reports
+    # are offsets into the response, which is not a place anyone can go and fix anything. This is
+    # what turns them back into a file and a line.
+    #
+    #     require "herb/engine/visitors/source_attribution_visitor"
+    #
+    #     Herb::Engine.new(source, filename: path, visitors: [
+    #       Herb::Engine::SourceAttributionVisitor.new
+    #     ])
+    #
+    #     #=> <div data-herb-source="app/views/posts/_card.html.erb:8:3">
+    #
+    # A tag helper is stamped too. The `action_view_helpers` parser option turns
+    # `<%= link_to "Home", "/" %>` into an `<a>` that the compiler writes out as markup, and that
+    # `<a>` is stamped at the position of the `<%=` that asked for it.
+    #
+    #     #=> <a href="/" data-herb-source="app/views/posts/_card.html.erb:4:5">Home</a>
+    #
+    # That option is recommended here, so a stack that says nothing about it gets it. It is worth
+    # knowing that it decides more than attribution does. It is also what makes the compiler write
+    # a helper out as markup instead of calling it while the page renders, which is the same thing
+    # `OptimizeVisitor` and `Slots::Visitor` require it for. A host that wants its helpers called at
+    # render time sets `action_view_helpers: false` and takes the warning that comes with it, and
+    # everything written as literal markup is stamped either way.
+    #
+    # A helper the parser cannot resolve to a tag stays an ERB node with no element around it, so
+    # `form_with` and anything the host defined itself reach the response carrying nothing, and the
+    # nearest stamped ancestor is what places them.
+    #
+    # Nothing is wrapped to close that gap. A wrapper element inside `<ul>`, `<table>` or `<select>`
+    # is invalid markup, and it would be Herb's own markup tripping the structural rules this exists
+    # to run. An unstamped element is a worse answer that stays true. A wrong one would not.
+    #
+    # A partial that `InlineRender::Visitor` brought into this template is stamped with the file it
+    # was written in, not the file it was inlined into.
+    #
+    # The stamp is markup Herb added, so a consumer is expected to strip it before reporting
+    # positions back, and to leave the visitor out of anything but a development build.
+    #
+    class SourceAttributionVisitor < Herb::Visitor
+      include Herb::Visitor::ContextAware
+
+      required_parser_option track_locations: true
+      recommended_parser_option action_view_helpers: true
+
+      ATTRIBUTE = "data-herb-source" #: String
+
+      #: (?attribute: String) -> void
+      def initialize(attribute: ATTRIBUTE)
+        super()
+
+        @attribute = attribute.downcase
+        @file = nil #: String?
+      end
+
+      #: (Herb::AST::HTMLElementNode) -> void
+      def visit_html_element_node(node)
+        stamp(node.open_tag)
+
+        super
+      end
+
+      #: (Herb::AST::Node) -> void
+      def visit_child_nodes(node)
+        entry = origin.of(node)
+
+        return super unless entry
+
+        outer = @file
+        @file = entry.file
+
+        super
+
+        @file = outer
+      end
+
+      #: () -> String
+      def inspect
+        return "#<#{self.class.name}>" if @attribute == ATTRIBUTE
+
+        "#<#{self.class.name} attribute=#{@attribute.inspect}>"
+      end
+
+      private
+
+      #: () -> String
+      def current_file
+        @file || context.relative_file_path
+      end
+
+      #: (Herb::AST::Node?) -> void
+      def stamp(open_tag)
+        return unless open_tag.is_a?(Herb::AST::HTMLOpenTagNode) || open_tag.is_a?(Herb::AST::ERBOpenTagNode)
+        return if stamped?(open_tag)
+
+        position = position_of(open_tag)
+
+        return unless position
+
+        value = "#{current_file}:#{position[:line]}:#{position[:column]}"
+
+        open_tag.children << attribute_node(@attribute, value)
+
+        nil
+      end
+
+      #: ((Herb::AST::HTMLOpenTagNode | Herb::AST::ERBOpenTagNode)) -> Herb::serialized_position?
+      def position_of(open_tag)
+        start = open_tag.location&.start
+
+        return nil unless start
+        return nil if start.line.zero?
+
+        start.to_one_based
+      end
+
+      #: ((Herb::AST::HTMLOpenTagNode | Herb::AST::ERBOpenTagNode)) -> bool
+      def stamped?(open_tag)
+        open_tag.children.any? { |child|
+          child.is_a?(Herb::AST::HTMLAttributeNode) && attribute_name(child) == @attribute
+        }
+      end
+
+      #: (Herb::AST::HTMLAttributeNode) -> String?
+      def attribute_name(node)
+        children = node.name&.children
+
+        return nil unless children
+
+        name = children.filter_map { |child| child.content if child.is_a?(Herb::AST::LiteralNode) }.join
+
+        name.empty? ? nil : name.downcase
+      end
+
+      #: (String, String) -> Herb::AST::HTMLAttributeNode
+      def attribute_node(name, value)
+        name_node = Herb::AST::HTMLAttributeNameNode.build(
+          children: [Herb::AST::LiteralNode.build(content: +name)]
+        )
+
+        value_node = Herb::AST::HTMLAttributeValueNode.build(
+          open_quote: Herb::Token.from(:quote, '"'),
+          children: [Herb::AST::LiteralNode.build(content: Herb::Engine.h(value))],
+          close_quote: Herb::Token.from(:quote, '"'),
+          quoted: true
+        )
+
+        Herb::AST::HTMLAttributeNode.build(
+          name: name_node,
+          equals: Herb::Token.from(:equals, "="),
+          value: value_node
+        )
+      end
+    end
+  end
+end

--- a/sig/herb/engine/visitors/source_attribution_visitor.rbs
+++ b/sig/herb/engine/visitors/source_attribution_visitor.rbs
@@ -41,10 +41,6 @@ module Herb
     # is invalid markup, and it would be Herb's own markup tripping the structural rules this exists
     # to run. An unstamped element is a worse answer that stays true. A wrong one would not.
     #
-    # An element whose tag name is built at runtime, as in `<<%= tag %>>`, is not an element in the
-    # tree, so it is stamped no more than an unresolved helper is. Dynamic attributes are a different
-    # thing, and `<div <%= attrs %>>` is a `<div>` that gets stamped like any other.
-    #
     # A partial that `InlineRender::Visitor` brought into this template is stamped with the file it
     # was written in, not the file it was inlined into.
     #

--- a/sig/herb/engine/visitors/source_attribution_visitor.rbs
+++ b/sig/herb/engine/visitors/source_attribution_visitor.rbs
@@ -1,0 +1,91 @@
+# Generated from lib/herb/engine/visitors/source_attribution_visitor.rb with RBS::Inline
+
+module Herb
+  class Engine
+    # Stamps every element with the template and the position it was written at, so that something
+    # found on the rendered page can be pointed back at the line that produced it.
+    #
+    # Some things are only visible once a page is rendered. Two partials can each be valid on their
+    # own and still collide on an `id`, a heading order only exists once a layout and everything it
+    # renders are composed, and a `<form>` inside another `<form>` is usually two templates that
+    # never see each other. Linting the response is what answers those, and the positions it reports
+    # are offsets into the response, which is not a place anyone can go and fix anything. This is
+    # what turns them back into a file and a line.
+    #
+    #     require "herb/engine/visitors/source_attribution_visitor"
+    #
+    #     Herb::Engine.new(source, filename: path, visitors: [
+    #       Herb::Engine::SourceAttributionVisitor.new
+    #     ])
+    #
+    #     #=> <div data-herb-source="app/views/posts/_card.html.erb:8:3">
+    #
+    # A tag helper is stamped too. The `action_view_helpers` parser option turns
+    # `<%= link_to "Home", "/" %>` into an `<a>` that the compiler writes out as markup, and that
+    # `<a>` is stamped at the position of the `<%=` that asked for it.
+    #
+    #     #=> <a href="/" data-herb-source="app/views/posts/_card.html.erb:4:5">Home</a>
+    #
+    # That option is recommended here, so a stack that says nothing about it gets it. It is worth
+    # knowing that it decides more than attribution does. It is also what makes the compiler write
+    # a helper out as markup instead of calling it while the page renders, which is the same thing
+    # `OptimizeVisitor` and `Slots::Visitor` require it for. A host that wants its helpers called at
+    # render time sets `action_view_helpers: false` and takes the warning that comes with it, and
+    # everything written as literal markup is stamped either way.
+    #
+    # A helper the parser cannot resolve to a tag stays an ERB node with no element around it, so
+    # `form_with` and anything the host defined itself reach the response carrying nothing, and the
+    # nearest stamped ancestor is what places them.
+    #
+    # Nothing is wrapped to close that gap. A wrapper element inside `<ul>`, `<table>` or `<select>`
+    # is invalid markup, and it would be Herb's own markup tripping the structural rules this exists
+    # to run. An unstamped element is a worse answer that stays true. A wrong one would not.
+    #
+    # An element whose tag name is built at runtime, as in `<<%= tag %>>`, is not an element in the
+    # tree, so it is stamped no more than an unresolved helper is. Dynamic attributes are a different
+    # thing, and `<div <%= attrs %>>` is a `<div>` that gets stamped like any other.
+    #
+    # A partial that `InlineRender::Visitor` brought into this template is stamped with the file it
+    # was written in, not the file it was inlined into.
+    #
+    # The stamp is markup Herb added, so a consumer is expected to strip it before reporting
+    # positions back, and to leave the visitor out of anything but a development build.
+    class SourceAttributionVisitor < Herb::Visitor
+      include Herb::Visitor::ContextAware
+
+      ATTRIBUTE: String
+
+      # : (?attribute: String) -> void
+      def initialize: (?attribute: String) -> void
+
+      # : (Herb::AST::HTMLElementNode) -> void
+      def visit_html_element_node: (Herb::AST::HTMLElementNode) -> void
+
+      # : (Herb::AST::Node) -> void
+      def visit_child_nodes: (Herb::AST::Node) -> void
+
+      # : () -> String
+      def inspect: () -> String
+
+      private
+
+      # : () -> String
+      def current_file: () -> String
+
+      # : (Herb::AST::Node?) -> void
+      def stamp: (Herb::AST::Node?) -> void
+
+      # : ((Herb::AST::HTMLOpenTagNode | Herb::AST::ERBOpenTagNode)) -> Herb::serialized_position?
+      def position_of: (Herb::AST::HTMLOpenTagNode | Herb::AST::ERBOpenTagNode) -> Herb::serialized_position?
+
+      # : ((Herb::AST::HTMLOpenTagNode | Herb::AST::ERBOpenTagNode)) -> bool
+      def stamped?: (Herb::AST::HTMLOpenTagNode | Herb::AST::ERBOpenTagNode) -> bool
+
+      # : (Herb::AST::HTMLAttributeNode) -> String?
+      def attribute_name: (Herb::AST::HTMLAttributeNode) -> String?
+
+      # : (String, String) -> Herb::AST::HTMLAttributeNode
+      def attribute_node: (String, String) -> Herb::AST::HTMLAttributeNode
+    end
+  end
+end

--- a/test/engine/visitors/source_attribution_test.rb
+++ b/test/engine/visitors/source_attribution_test.rb
@@ -1,0 +1,255 @@
+# frozen_string_literal: true
+
+require_relative "../../test_helper"
+require_relative "../../snapshot_utils"
+require_relative "../../../lib/herb/engine"
+require_relative "../../../lib/herb/engine/visitors/source_attribution_visitor"
+require_relative "../../../lib/herb/engine/inline_render/visitor"
+require_relative "../../../lib/herb/engine/visitors/optimize_visitor"
+
+module Engine
+  class SourceAttributionTest < Minitest::Spec
+    include SnapshotUtils
+
+    FILENAME = "app/views/posts/_card.html.erb"
+    PROJECT_PATH = "test/fixtures/render_inliner"
+
+    def attribution_options(**overrides)
+      {
+        escape: false,
+        visitors: [Herb::Engine::SourceAttributionVisitor.new],
+      }.merge(overrides)
+    end
+
+    test "visitor is not loaded when only requiring herb" do
+      load_path = $LOAD_PATH.map { |path| "-I#{path}" }.join(" ")
+      output = `#{Gem.ruby} #{load_path} -e 'require "herb"; print defined?(Herb::Engine::SourceAttributionVisitor).inspect' 2>&1`
+
+      assert_equal "nil", output
+    end
+
+    describe "what it stamps" do
+      test "a single element" do
+        assert_evaluated_snapshot("<div>Hello</div>", {}, attribution_options, filename: FILENAME)
+      end
+
+      test "each element with its own position" do
+        template = <<~ERB
+          <div class="card">
+            <h1>Title</h1>
+            <p>Body</p>
+          </div>
+        ERB
+
+        assert_evaluated_snapshot(template, {}, attribution_options, filename: FILENAME)
+      end
+
+      test "a void element" do
+        assert_evaluated_snapshot(%(<img src="a.png">), {}, attribution_options, filename: FILENAME)
+      end
+
+      test "an element that already carries attributes" do
+        assert_evaluated_snapshot(%(<a href="/" class="link">Home</a>), {}, attribution_options, filename: FILENAME)
+      end
+
+      test "an element with a dynamic attribute" do
+        assert_evaluated_snapshot(%(<div class="<%= level %>">x</div>), { level: "high" }, attribution_options, filename: FILENAME)
+      end
+
+      test "an element carrying a whole attribute list from ERB" do
+        assert_evaluated_snapshot("<div <%= attributes %>>x</div>", { attributes: %(id="one") }, attribution_options, filename: FILENAME)
+      end
+
+      test "an element inside a conditional" do
+        assert_evaluated_snapshot("<% if visible %><span>x</span><% end %>", { visible: true }, attribution_options, filename: FILENAME)
+      end
+
+      test "the template it was written in when no filename is given" do
+        assert_evaluated_snapshot("<div>x</div>", {}, attribution_options)
+      end
+    end
+
+    describe "a tag helper the parser resolved" do
+      test "is stamped at the position of the tag that asked for it" do
+        assert_evaluated_snapshot(%(<%= link_to "Home", "/" %>), {}, attribution_options, filename: FILENAME)
+      end
+
+      test "keeps the attributes the helper was given" do
+        assert_evaluated_snapshot(%(<%= link_to "Home", "/", class: "nav" %>), {}, attribution_options, filename: FILENAME)
+      end
+
+      test "is stamped when an attribute is only known at render time" do
+        assert_evaluated_snapshot(%(<%= content_tag :div, "x", class: level %>), { level: "high" }, attribution_options, filename: FILENAME)
+      end
+
+      test "is stamped in its block form" do
+        assert_evaluated_snapshot(%(<%= link_to "/" do %>body<% end %>), {}, attribution_options, filename: FILENAME)
+      end
+
+      test "is stamped inside surrounding markup, which keeps its own position" do
+        template = <<~ERB
+          <nav>
+            <%= link_to "Home", "/" %>
+          </nav>
+        ERB
+
+        assert_evaluated_snapshot(template, {}, attribution_options, filename: FILENAME)
+      end
+
+      test "is left alone when the host turns the recommendation down" do
+        options = attribution_options(parser_options: { action_view_helpers: false, track_locations: true })
+
+        assert_compiled_snapshot(%(<div><%= link_to "Home", "/" %></div>), options, filename: FILENAME)
+      end
+
+      test "is stamped without the caller asking, once a visitor that requires the option is in the stack" do
+        options = attribution_options(
+          visitors: [
+            Herb::Engine::OptimizeVisitor.new,
+            Herb::Engine::SourceAttributionVisitor.new
+          ]
+        )
+
+        assert_evaluated_snapshot(%(<nav><%= link_to "Home", "/" %></nav>), {}, options, filename: FILENAME)
+      end
+    end
+
+    describe "a helper the parser cannot resolve to a tag" do
+      test "is left alone, and the markup around it keeps its stamp" do
+        template = <<~ERB
+          <div>
+            <%= form_with url: "/" do |form| %>
+              inner
+            <% end %>
+          </div>
+        ERB
+
+        assert_compiled_snapshot(template, attribution_options, filename: FILENAME)
+      end
+    end
+
+    describe "what it leaves alone" do
+      test "markup that arrives from Ruby, the way a helper builds it" do
+        template = <<~ERB
+          <div>
+            <%= button %>
+          </div>
+        ERB
+
+        assert_evaluated_snapshot(template, { button: %(<button type="submit">Go</button>) }, attribution_options, filename: FILENAME)
+      end
+
+      test "an element whose tag name is built at runtime" do
+        assert_evaluated_snapshot("<<%= tag_name %>>x</<%= tag_name %>>", { tag_name: "div" }, attribution_options, filename: FILENAME)
+      end
+
+      test "an element that is already stamped" do
+        options = attribution_options(
+          visitors: [
+            Herb::Engine::SourceAttributionVisitor.new,
+            Herb::Engine::SourceAttributionVisitor.new
+          ]
+        )
+
+        assert_evaluated_snapshot("<div>x</div>", {}, options, filename: FILENAME)
+      end
+    end
+
+    describe "an element that renders more than once" do
+      test "carries the line it was written at, not the line it rendered at" do
+        template = <<~ERB
+          <ul>
+            <% items.each do |item| %>
+              <li><%= item %></li>
+            <% end %>
+          </ul>
+        ERB
+
+        assert_evaluated_snapshot(template, { items: ["a", "b", "c"] }, attribution_options, filename: FILENAME)
+      end
+    end
+
+    describe "a partial brought in by the inliner" do
+      def inlined_options
+        {
+          escape: false,
+          project_path: PROJECT_PATH,
+          visitors: [
+            Herb::Engine::InlineRender::Visitor.new,
+            Herb::Engine::SourceAttributionVisitor.new
+          ],
+        }
+      end
+
+      test "is stamped with the file it was written in" do
+        assert_evaluated_snapshot(
+          %(<main><%= render "shared/header" %></main>),
+          {},
+          inlined_options,
+          filename: "app/views/posts/index.html.erb"
+        )
+      end
+
+      test "hands the surrounding template back after the partial ends" do
+        assert_evaluated_snapshot(
+          %(<main><%= render "shared/header" %><footer>end</footer></main>),
+          {},
+          inlined_options,
+          filename: "app/views/posts/index.html.erb"
+        )
+      end
+    end
+
+    describe "the attribute" do
+      test "can be named by the caller" do
+        options = attribution_options(
+          visitors: [Herb::Engine::SourceAttributionVisitor.new(attribute: "data-origin")]
+        )
+
+        assert_evaluated_snapshot("<div>x</div>", {}, options, filename: FILENAME)
+      end
+
+      test "escapes a value that would close it" do
+        assert_evaluated_snapshot("<div>x</div>", {}, attribution_options, filename: %(a"b.html.erb))
+      end
+    end
+
+    describe "inspect" do
+      test "names the visitor" do
+        assert_equal "#<Herb::Engine::SourceAttributionVisitor>", Herb::Engine::SourceAttributionVisitor.new.inspect
+      end
+
+      test "names a custom attribute" do
+        visitor = Herb::Engine::SourceAttributionVisitor.new(attribute: "data-origin")
+
+        assert_equal %(#<Herb::Engine::SourceAttributionVisitor attribute="data-origin">), visitor.inspect
+      end
+    end
+
+    describe "parser options" do
+      test "requires locations to be tracked" do
+        assert_equal({ track_locations: true }, Herb::Engine::SourceAttributionVisitor.required_parser_options)
+      end
+
+      test "recommends that the parser understands tag helpers" do
+        assert_equal({ action_view_helpers: true }, Herb::Engine::SourceAttributionVisitor.recommended_parser_options)
+      end
+
+      test "warns, without raising, when a compile turns tag helpers off" do
+        _, stderr = capture_io do
+          Herb::Engine.new("<div>x</div>", parser_options: { action_view_helpers: false }, visitors: [Herb::Engine::SourceAttributionVisitor.new])
+        end
+
+        assert_equal "[Herb] Herb::Engine::SourceAttributionVisitor recommends the `action_view_helpers` parser option to be true, but it is set to false\n", stderr
+      end
+
+      test "conflicts with a compile that turns location tracking off" do
+        error = assert_raises(ArgumentError) do
+          Herb::Engine.new("<div>x</div>", parser_options: { track_locations: false }, visitors: [Herb::Engine::SourceAttributionVisitor.new])
+        end
+
+        assert_equal "Herb::Engine::SourceAttributionVisitor requires the `track_locations` parser option to be true, but it is set to false", error.message
+      end
+    end
+  end
+end

--- a/test/snapshot_utils.rb
+++ b/test/snapshot_utils.rb
@@ -289,13 +289,13 @@ module SnapshotUtils
   end
 
   def should_compare_with_erubi?
-    return false if class_name.include?("DebugMode")
+    return false if class_name.include?("DebugMode") || class_name.include?("SourceAttribution")
 
     !ENV["COMPARE_WITH_ERUBI"].nil?
   end
 
   def should_compare_with_actionview_erubi?
-    return false if class_name.include?("DebugMode")
+    return false if class_name.include?("DebugMode") || class_name.include?("SourceAttribution")
 
     !ENV["COMPARE_WITH_ACTIONVIEW_ERUBI"].nil?
   end

--- a/test/snapshots/engine/source_attribution_test/a_helper_the_parser_cannot_resolve_to_a_tag/test_0001_is_left_alone,_and_the_markup_around_it_keeps_its_stamp_043c182cb411bbd2dbeac4bf214ee5ac.txt
+++ b/test/snapshots/engine/source_attribution_test/a_helper_the_parser_cannot_resolve_to_a_tag/test_0001_is_left_alone,_and_the_markup_around_it_keeps_its_stamp_043c182cb411bbd2dbeac4bf214ee5ac.txt
@@ -1,0 +1,11 @@
+---
+source: "Engine::SourceAttributionTest::a helper the parser cannot resolve to a tag#test_0001_is left alone, and the markup around it keeps its stamp"
+input: "{source: \"<div>\\n  <%= form_with url: \\\"/\\\" do |form| %>\\n    inner\\n  <% end %>\\n</div>\\n\", options: {escape: false, visitors: [#<Herb::Engine::SourceAttributionVisitor>], filename: \"app/views/posts/_card.html.erb\"}}"
+---
+_buf = ::String.new; _buf << '<div data-herb-source="app/views/posts/_card.html.erb:1:1">
+  '.freeze; _buf << (form_with url: "/" do |form|; _buf << '
+    inner
+'.freeze;   end )
+ _buf << '</div>
+'.freeze;
+_buf.to_s

--- a/test/snapshots/engine/source_attribution_test/a_partial_brought_in_by_the_inliner/test_0001_is_stamped_with_the_file_it_was_written_in_c2e46b4926330e867a0d35716a805fb1.txt
+++ b/test/snapshots/engine/source_attribution_test/a_partial_brought_in_by_the_inliner/test_0001_is_stamped_with_the_file_it_was_written_in_c2e46b4926330e867a0d35716a805fb1.txt
@@ -1,0 +1,6 @@
+---
+source: "Engine::SourceAttributionTest::a partial brought in by the inliner#test_0001_is stamped with the file it was written in"
+input: "{source: \"<main><%= render \\\"shared/header\\\" %></main>\", locals: {}, options: {escape: false, project_path: \"test/fixtures/render_inliner\", visitors: [#<Herb::Engine::InlineRender::Visitor>, #<Herb::Engine::SourceAttributionVisitor>], filename: \"app/views/posts/index.html.erb\"}}"
+---
+<main data-herb-source="app/views/posts/index.html.erb:1:1"><header data-herb-source="app/views/shared/_header.html.erb:1:1">Hello</header>
+</main>

--- a/test/snapshots/engine/source_attribution_test/a_partial_brought_in_by_the_inliner/test_0002_hands_the_surrounding_template_back_after_the_partial_ends_7dae45b7f31111c3eb5f22e68e4587a7.txt
+++ b/test/snapshots/engine/source_attribution_test/a_partial_brought_in_by_the_inliner/test_0002_hands_the_surrounding_template_back_after_the_partial_ends_7dae45b7f31111c3eb5f22e68e4587a7.txt
@@ -1,0 +1,6 @@
+---
+source: "Engine::SourceAttributionTest::a partial brought in by the inliner#test_0002_hands the surrounding template back after the partial ends"
+input: "{source: \"<main><%= render \\\"shared/header\\\" %><footer>end</footer></main>\", locals: {}, options: {escape: false, project_path: \"test/fixtures/render_inliner\", visitors: [#<Herb::Engine::InlineRender::Visitor>, #<Herb::Engine::SourceAttributionVisitor>], filename: \"app/views/posts/index.html.erb\"}}"
+---
+<main data-herb-source="app/views/posts/index.html.erb:1:1"><header data-herb-source="app/views/shared/_header.html.erb:1:1">Hello</header>
+<footer data-herb-source="app/views/posts/index.html.erb:1:36">end</footer></main>

--- a/test/snapshots/engine/source_attribution_test/a_tag_helper_the_parser_resolved/test_0001_is_stamped_at_the_position_of_the_tag_that_asked_for_it_5ed266b7876d3470699409f0beca00f4.txt
+++ b/test/snapshots/engine/source_attribution_test/a_tag_helper_the_parser_resolved/test_0001_is_stamped_at_the_position_of_the_tag_that_asked_for_it_5ed266b7876d3470699409f0beca00f4.txt
@@ -1,0 +1,5 @@
+---
+source: "Engine::SourceAttributionTest::a tag helper the parser resolved#test_0001_is stamped at the position of the tag that asked for it"
+input: "{source: \"<%= link_to \\\"Home\\\", \\\"/\\\" %>\", locals: {}, options: {escape: false, visitors: [#<Herb::Engine::SourceAttributionVisitor>], filename: \"app/views/posts/_card.html.erb\"}}"
+---
+<a href="/" data-herb-source="app/views/posts/_card.html.erb:1:1">Home</a>

--- a/test/snapshots/engine/source_attribution_test/a_tag_helper_the_parser_resolved/test_0002_keeps_the_attributes_the_helper_was_given_1cafa01e7109a2f9ef45bb03fc488b6d.txt
+++ b/test/snapshots/engine/source_attribution_test/a_tag_helper_the_parser_resolved/test_0002_keeps_the_attributes_the_helper_was_given_1cafa01e7109a2f9ef45bb03fc488b6d.txt
@@ -1,0 +1,5 @@
+---
+source: "Engine::SourceAttributionTest::a tag helper the parser resolved#test_0002_keeps the attributes the helper was given"
+input: "{source: \"<%= link_to \\\"Home\\\", \\\"/\\\", class: \\\"nav\\\" %>\", locals: {}, options: {escape: false, visitors: [#<Herb::Engine::SourceAttributionVisitor>], filename: \"app/views/posts/_card.html.erb\"}}"
+---
+<a class="nav" href="/" data-herb-source="app/views/posts/_card.html.erb:1:1">Home</a>

--- a/test/snapshots/engine/source_attribution_test/a_tag_helper_the_parser_resolved/test_0003_is_stamped_when_an_attribute_is_only_known_at_render_time_4642705aadd8d66dd915fd4181f23e31.txt
+++ b/test/snapshots/engine/source_attribution_test/a_tag_helper_the_parser_resolved/test_0003_is_stamped_when_an_attribute_is_only_known_at_render_time_4642705aadd8d66dd915fd4181f23e31.txt
@@ -1,0 +1,5 @@
+---
+source: "Engine::SourceAttributionTest::a tag helper the parser resolved#test_0003_is stamped when an attribute is only known at render time"
+input: "{source: \"<%= content_tag :div, \\\"x\\\", class: level %>\", locals: {level: \"high\"}, options: {escape: false, visitors: [#<Herb::Engine::SourceAttributionVisitor>], filename: \"app/views/posts/_card.html.erb\"}}"
+---
+<div class="high" data-herb-source="app/views/posts/_card.html.erb:1:1">x</div>

--- a/test/snapshots/engine/source_attribution_test/a_tag_helper_the_parser_resolved/test_0004_is_stamped_in_its_block_form_4acadb65bcd0484a3777e25708bb4710.txt
+++ b/test/snapshots/engine/source_attribution_test/a_tag_helper_the_parser_resolved/test_0004_is_stamped_in_its_block_form_4acadb65bcd0484a3777e25708bb4710.txt
@@ -1,0 +1,5 @@
+---
+source: "Engine::SourceAttributionTest::a tag helper the parser resolved#test_0004_is stamped in its block form"
+input: "{source: \"<%= link_to \\\"/\\\" do %>body<% end %>\", locals: {}, options: {escape: false, visitors: [#<Herb::Engine::SourceAttributionVisitor>], filename: \"app/views/posts/_card.html.erb\"}}"
+---
+<a href="/" data-herb-source="app/views/posts/_card.html.erb:1:1">body</a>

--- a/test/snapshots/engine/source_attribution_test/a_tag_helper_the_parser_resolved/test_0005_is_stamped_inside_surrounding_markup,_which_keeps_its_own_position_9eaee5970a7ac7e4bcb68c05aa16df86.txt
+++ b/test/snapshots/engine/source_attribution_test/a_tag_helper_the_parser_resolved/test_0005_is_stamped_inside_surrounding_markup,_which_keeps_its_own_position_9eaee5970a7ac7e4bcb68c05aa16df86.txt
@@ -1,0 +1,7 @@
+---
+source: "Engine::SourceAttributionTest::a tag helper the parser resolved#test_0005_is stamped inside surrounding markup, which keeps its own position"
+input: "{source: \"<nav>\\n  <%= link_to \\\"Home\\\", \\\"/\\\" %>\\n</nav>\\n\", locals: {}, options: {escape: false, visitors: [#<Herb::Engine::SourceAttributionVisitor>], filename: \"app/views/posts/_card.html.erb\"}}"
+---
+<nav data-herb-source="app/views/posts/_card.html.erb:1:1">
+  <a href="/" data-herb-source="app/views/posts/_card.html.erb:2:3">Home</a>
+</nav>

--- a/test/snapshots/engine/source_attribution_test/a_tag_helper_the_parser_resolved/test_0006_is_left_alone_when_the_host_turns_the_recommendation_down_669dbf802ca04e58056d251db5589c9c.txt
+++ b/test/snapshots/engine/source_attribution_test/a_tag_helper_the_parser_resolved/test_0006_is_left_alone_when_the_host_turns_the_recommendation_down_669dbf802ca04e58056d251db5589c9c.txt
@@ -1,0 +1,6 @@
+---
+source: "Engine::SourceAttributionTest::a tag helper the parser resolved#test_0006_is left alone when the host turns the recommendation down"
+input: "{source: \"<div><%= link_to \\\"Home\\\", \\\"/\\\" %></div>\", options: {escape: false, visitors: [#<Herb::Engine::SourceAttributionVisitor>], parser_options: {action_view_helpers: false, track_locations: true}, filename: \"app/views/posts/_card.html.erb\"}}"
+---
+_buf = ::String.new; _buf << '<div data-herb-source="app/views/posts/_card.html.erb:1:1">'.freeze; _buf << (link_to "Home", "/").to_s; _buf << '</div>'.freeze;
+_buf.to_s

--- a/test/snapshots/engine/source_attribution_test/a_tag_helper_the_parser_resolved/test_0007_is_stamped_without_the_caller_asking,_once_a_visitor_that_requires_the_option_is_in_the_stack_bfe20051abafb2c89e008c627d0090f1.txt
+++ b/test/snapshots/engine/source_attribution_test/a_tag_helper_the_parser_resolved/test_0007_is_stamped_without_the_caller_asking,_once_a_visitor_that_requires_the_option_is_in_the_stack_bfe20051abafb2c89e008c627d0090f1.txt
@@ -1,0 +1,5 @@
+---
+source: "Engine::SourceAttributionTest::a tag helper the parser resolved#test_0007_is stamped without the caller asking, once a visitor that requires the option is in the stack"
+input: "{source: \"<nav><%= link_to \\\"Home\\\", \\\"/\\\" %></nav>\", locals: {}, options: {escape: false, visitors: [#<Herb::Engine::OptimizeVisitor>, #<Herb::Engine::SourceAttributionVisitor>], filename: \"app/views/posts/_card.html.erb\"}}"
+---
+<nav data-herb-source="app/views/posts/_card.html.erb:1:1"><a href="/" data-herb-source="app/views/posts/_card.html.erb:1:6">Home</a></nav>

--- a/test/snapshots/engine/source_attribution_test/an_element_that_renders_more_than_once/test_0001_carries_the_line_it_was_written_at,_not_the_line_it_rendered_at_a7456f9d9a1cbd85c119e7ee7dad5cf8.txt
+++ b/test/snapshots/engine/source_attribution_test/an_element_that_renders_more_than_once/test_0001_carries_the_line_it_was_written_at,_not_the_line_it_rendered_at_a7456f9d9a1cbd85c119e7ee7dad5cf8.txt
@@ -1,0 +1,9 @@
+---
+source: "Engine::SourceAttributionTest::an element that renders more than once#test_0001_carries the line it was written at, not the line it rendered at"
+input: "{source: \"<ul>\\n  <% items.each do |item| %>\\n    <li><%= item %></li>\\n  <% end %>\\n</ul>\\n\", locals: {items: [\"a\", \"b\", \"c\"]}, options: {escape: false, visitors: [#<Herb::Engine::SourceAttributionVisitor>], filename: \"app/views/posts/_card.html.erb\"}}"
+---
+<ul data-herb-source="app/views/posts/_card.html.erb:1:1">
+    <li data-herb-source="app/views/posts/_card.html.erb:3:5">a</li>
+    <li data-herb-source="app/views/posts/_card.html.erb:3:5">b</li>
+    <li data-herb-source="app/views/posts/_card.html.erb:3:5">c</li>
+</ul>

--- a/test/snapshots/engine/source_attribution_test/the_attribute/test_0001_can_be_named_by_the_caller_107ba35b6c370867109f5155c5c598d6.txt
+++ b/test/snapshots/engine/source_attribution_test/the_attribute/test_0001_can_be_named_by_the_caller_107ba35b6c370867109f5155c5c598d6.txt
@@ -1,0 +1,5 @@
+---
+source: "Engine::SourceAttributionTest::the attribute#test_0001_can be named by the caller"
+input: "{source: \"<div>x</div>\", locals: {}, options: {escape: false, visitors: [#<Herb::Engine::SourceAttributionVisitor attribute=\"data-origin\">], filename: \"app/views/posts/_card.html.erb\"}}"
+---
+<div data-origin="app/views/posts/_card.html.erb:1:1">x</div>

--- a/test/snapshots/engine/source_attribution_test/the_attribute/test_0002_escapes_a_value_that_would_close_it_6d1abcdfd38441c362be4a24b479c3a8.txt
+++ b/test/snapshots/engine/source_attribution_test/the_attribute/test_0002_escapes_a_value_that_would_close_it_6d1abcdfd38441c362be4a24b479c3a8.txt
@@ -1,0 +1,5 @@
+---
+source: "Engine::SourceAttributionTest::the attribute#test_0002_escapes a value that would close it"
+input: "{source: \"<div>x</div>\", locals: {}, options: {escape: false, visitors: [#<Herb::Engine::SourceAttributionVisitor>], filename: \"a\\\"b.html.erb\"}}"
+---
+<div data-herb-source="a&quot;b.html.erb:1:1">x</div>

--- a/test/snapshots/engine/source_attribution_test/what_it_leaves_alone/test_0001_markup_that_arrives_from_Ruby,_the_way_a_helper_builds_it_e198ff50fb8ad1d7a5184a58701cf23d.txt
+++ b/test/snapshots/engine/source_attribution_test/what_it_leaves_alone/test_0001_markup_that_arrives_from_Ruby,_the_way_a_helper_builds_it_e198ff50fb8ad1d7a5184a58701cf23d.txt
@@ -1,0 +1,7 @@
+---
+source: "Engine::SourceAttributionTest::what it leaves alone#test_0001_markup that arrives from Ruby, the way a helper builds it"
+input: "{source: \"<div>\\n  <%= button %>\\n</div>\\n\", locals: {button: \"<button type=\\\"submit\\\">Go</button>\"}, options: {escape: false, visitors: [#<Herb::Engine::SourceAttributionVisitor>], filename: \"app/views/posts/_card.html.erb\"}}"
+---
+<div data-herb-source="app/views/posts/_card.html.erb:1:1">
+  <button type="submit">Go</button>
+</div>

--- a/test/snapshots/engine/source_attribution_test/what_it_leaves_alone/test_0002_an_element_whose_tag_name_is_built_at_runtime_934c7fd87b60f69a0ac6affb3cdd2b7c.txt
+++ b/test/snapshots/engine/source_attribution_test/what_it_leaves_alone/test_0002_an_element_whose_tag_name_is_built_at_runtime_934c7fd87b60f69a0ac6affb3cdd2b7c.txt
@@ -1,0 +1,5 @@
+---
+source: "Engine::SourceAttributionTest::what it leaves alone#test_0002_an element whose tag name is built at runtime"
+input: "{source: \"<<%= tag_name %>>x</<%= tag_name %>>\", locals: {tag_name: \"div\"}, options: {escape: false, visitors: [#<Herb::Engine::SourceAttributionVisitor>], filename: \"app/views/posts/_card.html.erb\"}}"
+---
+<div>x</div>

--- a/test/snapshots/engine/source_attribution_test/what_it_leaves_alone/test_0003_an_element_that_is_already_stamped_a038069491c185a79e547a6b64ae450f.txt
+++ b/test/snapshots/engine/source_attribution_test/what_it_leaves_alone/test_0003_an_element_that_is_already_stamped_a038069491c185a79e547a6b64ae450f.txt
@@ -1,0 +1,5 @@
+---
+source: "Engine::SourceAttributionTest::what it leaves alone#test_0003_an element that is already stamped"
+input: "{source: \"<div>x</div>\", locals: {}, options: {escape: false, visitors: [#<Herb::Engine::SourceAttributionVisitor>, #<Herb::Engine::SourceAttributionVisitor>], filename: \"app/views/posts/_card.html.erb\"}}"
+---
+<div data-herb-source="app/views/posts/_card.html.erb:1:1">x</div>

--- a/test/snapshots/engine/source_attribution_test/what_it_stamps/test_0001_a_single_element_ce5538b785321c15d17a352ca4d1feab.txt
+++ b/test/snapshots/engine/source_attribution_test/what_it_stamps/test_0001_a_single_element_ce5538b785321c15d17a352ca4d1feab.txt
@@ -1,0 +1,5 @@
+---
+source: "Engine::SourceAttributionTest::what it stamps#test_0001_a single element"
+input: "{source: \"<div>Hello</div>\", locals: {}, options: {escape: false, visitors: [#<Herb::Engine::SourceAttributionVisitor>], filename: \"app/views/posts/_card.html.erb\"}}"
+---
+<div data-herb-source="app/views/posts/_card.html.erb:1:1">Hello</div>

--- a/test/snapshots/engine/source_attribution_test/what_it_stamps/test_0002_each_element_with_its_own_position_523a072160c59bec19b7a3157dc82d42.txt
+++ b/test/snapshots/engine/source_attribution_test/what_it_stamps/test_0002_each_element_with_its_own_position_523a072160c59bec19b7a3157dc82d42.txt
@@ -1,0 +1,8 @@
+---
+source: "Engine::SourceAttributionTest::what it stamps#test_0002_each element with its own position"
+input: "{source: \"<div class=\\\"card\\\">\\n  <h1>Title</h1>\\n  <p>Body</p>\\n</div>\\n\", locals: {}, options: {escape: false, visitors: [#<Herb::Engine::SourceAttributionVisitor>], filename: \"app/views/posts/_card.html.erb\"}}"
+---
+<div class="card" data-herb-source="app/views/posts/_card.html.erb:1:1">
+  <h1 data-herb-source="app/views/posts/_card.html.erb:2:3">Title</h1>
+  <p data-herb-source="app/views/posts/_card.html.erb:3:3">Body</p>
+</div>

--- a/test/snapshots/engine/source_attribution_test/what_it_stamps/test_0003_a_void_element_6b1e308b62d5c6c985bd7aaa9bebf512.txt
+++ b/test/snapshots/engine/source_attribution_test/what_it_stamps/test_0003_a_void_element_6b1e308b62d5c6c985bd7aaa9bebf512.txt
@@ -1,0 +1,5 @@
+---
+source: "Engine::SourceAttributionTest::what it stamps#test_0003_a void element"
+input: "{source: \"<img src=\\\"a.png\\\">\", locals: {}, options: {escape: false, visitors: [#<Herb::Engine::SourceAttributionVisitor>], filename: \"app/views/posts/_card.html.erb\"}}"
+---
+<img src="a.png" data-herb-source="app/views/posts/_card.html.erb:1:1">

--- a/test/snapshots/engine/source_attribution_test/what_it_stamps/test_0004_an_element_that_already_carries_attributes_a86e78719519f13107b71a539b6acb6d.txt
+++ b/test/snapshots/engine/source_attribution_test/what_it_stamps/test_0004_an_element_that_already_carries_attributes_a86e78719519f13107b71a539b6acb6d.txt
@@ -1,0 +1,5 @@
+---
+source: "Engine::SourceAttributionTest::what it stamps#test_0004_an element that already carries attributes"
+input: "{source: \"<a href=\\\"/\\\" class=\\\"link\\\">Home</a>\", locals: {}, options: {escape: false, visitors: [#<Herb::Engine::SourceAttributionVisitor>], filename: \"app/views/posts/_card.html.erb\"}}"
+---
+<a href="/" class="link" data-herb-source="app/views/posts/_card.html.erb:1:1">Home</a>

--- a/test/snapshots/engine/source_attribution_test/what_it_stamps/test_0005_an_element_with_a_dynamic_attribute_d4204a2e66b02246252746a490ae470f.txt
+++ b/test/snapshots/engine/source_attribution_test/what_it_stamps/test_0005_an_element_with_a_dynamic_attribute_d4204a2e66b02246252746a490ae470f.txt
@@ -1,0 +1,5 @@
+---
+source: "Engine::SourceAttributionTest::what it stamps#test_0005_an element with a dynamic attribute"
+input: "{source: \"<div class=\\\"<%= level %>\\\">x</div>\", locals: {level: \"high\"}, options: {escape: false, visitors: [#<Herb::Engine::SourceAttributionVisitor>], filename: \"app/views/posts/_card.html.erb\"}}"
+---
+<div class="high" data-herb-source="app/views/posts/_card.html.erb:1:1">x</div>

--- a/test/snapshots/engine/source_attribution_test/what_it_stamps/test_0006_an_element_carrying_a_whole_attribute_list_from_ERB_cb5168afd6694694dcf01b80a80f1dfc.txt
+++ b/test/snapshots/engine/source_attribution_test/what_it_stamps/test_0006_an_element_carrying_a_whole_attribute_list_from_ERB_cb5168afd6694694dcf01b80a80f1dfc.txt
@@ -1,0 +1,5 @@
+---
+source: "Engine::SourceAttributionTest::what it stamps#test_0006_an element carrying a whole attribute list from ERB"
+input: "{source: \"<div <%= attributes %>>x</div>\", locals: {attributes: \"id=\\\"one\\\"\"}, options: {escape: false, visitors: [#<Herb::Engine::SourceAttributionVisitor>], filename: \"app/views/posts/_card.html.erb\"}}"
+---
+<div id="one" data-herb-source="app/views/posts/_card.html.erb:1:1">x</div>

--- a/test/snapshots/engine/source_attribution_test/what_it_stamps/test_0007_an_element_inside_a_conditional_a109999c807de97842a35e88d126b099.txt
+++ b/test/snapshots/engine/source_attribution_test/what_it_stamps/test_0007_an_element_inside_a_conditional_a109999c807de97842a35e88d126b099.txt
@@ -1,0 +1,5 @@
+---
+source: "Engine::SourceAttributionTest::what it stamps#test_0007_an element inside a conditional"
+input: "{source: \"<% if visible %><span>x</span><% end %>\", locals: {visible: true}, options: {escape: false, visitors: [#<Herb::Engine::SourceAttributionVisitor>], filename: \"app/views/posts/_card.html.erb\"}}"
+---
+<span data-herb-source="app/views/posts/_card.html.erb:1:17">x</span>

--- a/test/snapshots/engine/source_attribution_test/what_it_stamps/test_0008_the_template_it_was_written_in_when_no_filename_is_given_1fd5797ea5894b79fde4895aa979906a.txt
+++ b/test/snapshots/engine/source_attribution_test/what_it_stamps/test_0008_the_template_it_was_written_in_when_no_filename_is_given_1fd5797ea5894b79fde4895aa979906a.txt
@@ -1,0 +1,5 @@
+---
+source: "Engine::SourceAttributionTest::what it stamps#test_0008_the template it was written in when no filename is given"
+input: "{source: \"<div>x</div>\", locals: {}, options: {escape: false, visitors: [#<Herb::Engine::SourceAttributionVisitor>]}}"
+---
+<div data-herb-source="unknown:1:1">x</div>


### PR DESCRIPTION
This pull request introduces `Herb::Engine::SourceAttributionVisitor`, a compile pass that stamps every element with the template and the position it was written at, so that something found on the rendered page can be pointed back at the line that produced it.

#### Motivation

Some things are only visible once a page is rendered. Two partials can each be valid on their own and still collide on an `id`, a heading order only exists once a layout and everything it renders are composed, and a `<form>` inside another `<form>` is usually two templates that never see each other. Linting a template one file at a time cannot answer any of those. Linting the response can.

The problem with linting the response is that the positions come back as offsets into the response, and that is not a place anyone can go and fix anything. An offence on line 412 of a rendered page means nothing to the person who has to change a partial. This visitor is what turns those positions back into a file and a line.

#### What it emits

```html+erb
<div class="card">
  <h1>Title</h1>
  <p>Body</p>
</div>
```

```html
<div class="card" data-herb-source="app/views/posts/_card.html.erb:1:1">
  <h1 data-herb-source="app/views/posts/_card.html.erb:2:3">Title</h1>
  <p data-herb-source="app/views/posts/_card.html.erb:3:3">Body</p>
</div>
```

An element that renders many times carries the line it was written at, not the line it rendered at, which is exactly the diagnosis a duplicate `id` needs.

```html
<ul data-herb-source="app/views/posts/_card.html.erb:1:1">
    <li data-herb-source="app/views/posts/_card.html.erb:3:5">a</li>
    <li data-herb-source="app/views/posts/_card.html.erb:3:5">b</li>
    <li data-herb-source="app/views/posts/_card.html.erb:3:5">c</li>
</ul>
```

#### Tag helpers

A tag helper is stamped too. The `action_view_helpers` parser option turns `<%= link_to "Home", "/" %>` into an `<a>` that the compiler writes out as markup, and that `<a>` is stamped at the position of the `<%=` that asked for it.

```html+erb
<nav>
  <%= link_to "Home", "/" %>
</nav>
```

```html
<nav data-herb-source="app/views/posts/_card.html.erb:1:1">
  <a href="/" data-herb-source="app/views/posts/_card.html.erb:2:3">Home</a>
</nav>
```

An attribute known only at render time keeps its interpolation and still takes the stamp.

```erb
<%= content_tag :div, "x", class: level %>
```

```ruby
_buf << '<div class="'.freeze
_buf << ::Herb::Engine.attr((level))
_buf << '" data-herb-source="app/views/posts/_card.html.erb:1:1">x</div>'.freeze
```

#### Inlined partials

A partial that `InlineRender::Visitor` brought into the template is stamped with the file it was written in, not the file it was inlined into. The current file is swapped while descending into a subtree that `Visitor::Context::Origin` recorded, the same way `InstrumentationVisitor` does it.

```html
<main data-herb-source="app/views/posts/index.html.erb:1:1"><header data-herb-source="app/views/shared/_header.html.erb:1:1">Hello</header>
<footer data-herb-source="app/views/posts/index.html.erb:1:36">end</footer></main>
```

#### Ruby API

```ruby
require "herb/engine/visitors/source_attribution_visitor"

Herb::Engine.new(source, filename: path, visitors: [
  Herb::Engine::SourceAttributionVisitor.new
])
```