### PR TITLE
Client: Settle a shown branch from its slot, not from the DOM

### DIFF
--- a/javascript/packages/client/src/state/state.ts
+++ b/javascript/packages/client/src/state/state.ts
@@ -878,23 +878,14 @@ export class State implements ElementObserverDelegate, SlotsDelegate, SeedsDeleg
       return
     }
 
-    const element = hostOf(slot.anchor)
-
-    if (!element) {
-      return
-    }
+    const at = scopeOf(region, slot.item)
 
     for (const [name, reads] of Object.entries(manifest.reads)) {
       if (reads.length === 0) {
         continue
       }
 
-      const scope = this.scopeFor(element, name)
-
-      if (!scope) {
-        continue
-      }
-
+      const scope = this.scopeFor(at, name) ?? at
       const value = this.getState(name, { scope })
 
       if (value === undefined) {
@@ -902,12 +893,6 @@ export class State implements ElementObserverDelegate, SlotsDelegate, SeedsDeleg
       }
 
       this.writeValueSlots(manifest, scope, name, value)
-    }
-
-    const at = this.scopeFor(element)
-
-    if (!at) {
-      return
     }
 
     const declared = manifest.declarations.map((declaration) => declaration.name)

--- a/javascript/packages/client/test/branch-value-staleness.test.ts
+++ b/javascript/packages/client/test/branch-value-staleness.test.ts
@@ -1,0 +1,105 @@
+import { describe, test, expect, beforeEach, afterEach } from "vitest"
+
+import { Actions } from "../src/actions/actions"
+import { Slots } from "../src/slots/slots"
+import { State } from "../src/state/state"
+
+const FILE = "app/views/chat/show.html.erb"
+const VERSION = "8cb7a499"
+
+const MANIFEST = {
+  state: {},
+  states: {
+    [FILE]: {
+      version: VERSION,
+      declarations: [
+        { name: "draft", kind: "string", default: '""', derived: null, scope: "region", value: "" },
+      ],
+      reads: { draft: [1] },
+      conditionals: {
+        0: { arms: [{ branch: 0, condition: ["draft", { value: "hello" }] }], else: null },
+      },
+      presence: {},
+    },
+  },
+}
+
+const PAGE =
+  `<!--herb-region:${FILE}:${VERSION}:0-->\n` +
+  `<input data-herb-set="input->draft=$value">\n` +
+  `<!--herb-slot:0:conditional--><!--/herb-slot:0-->\n` +
+  `<!--/herb-region:${FILE}--><template data-herb-region="${FILE}:${VERSION}"><!--herb-branch:0:0-->\n` +
+  `  <!--herb-slot:1--><!--/herb-slot:1-->\n` +
+  `</template>` +
+  `<template data-herb-dependencies>${JSON.stringify(MANIFEST)}</template>`
+
+let slots: Slots
+let state: State
+let actions: Actions
+
+function input(): HTMLInputElement {
+  return document.querySelector("input")!
+}
+
+function type(text: string): void {
+  input().value = text
+  input().dispatchEvent(new Event("input", { bubbles: true }))
+}
+
+function shown(): string {
+  const slot = slots.slot(FILE, 1)
+
+  return slot ? slots.rangeOf(slot).toString() : "<not placed>"
+}
+
+beforeEach(() => {
+  document.body.innerHTML = PAGE
+
+  slots = new Slots()
+  slots.scan(document.body)
+
+  state = new State(slots, {})
+  state.adopt()
+
+  actions = new Actions(state)
+  actions.start(document.body)
+})
+
+afterEach(() => actions.stop())
+
+describe("a value slot inside a branch driven by the same state", () => {
+  test("shows the current value the first time the branch is taken", () => {
+    type("hell")
+
+    expect(slots.slot(FILE, 0)?.branch).toBeNull()
+
+    type("hello")
+
+    expect(slots.slot(FILE, 0)?.branch).toBe(0)
+    expect(shown()).toBe("hello")
+  })
+
+  test("shows the current value when the branch is taken again", () => {
+    type("hello")
+
+    expect(shown()).toBe("hello")
+
+    type("hell")
+
+    expect(slots.slot(FILE, 0)?.branch).toBeNull()
+
+    type("hello")
+
+    expect(slots.slot(FILE, 0)?.branch).toBe(0)
+    expect(shown()).toBe("hello")
+  })
+
+  test("shows the current value when the state changes while the branch is hidden", () => {
+    type("hello")
+    type("hell")
+    type("hello!")
+    type("hello")
+
+    expect(shown()).toBe("hello")
+  })
+})


### PR DESCRIPTION
This pull request fixes a value slot inside a conditional branch keeping a stale value the first time the branch is shown.

```erb
<%# herb:slots client %>
<%# herb:state (draft: "") %>

<input data-herb-set="input->draft=$value">

<% if draft == "hello" %>
  <%= draft %>
<% end %>
```

Typing towards `hello` shows the branch with the value from an earlier keystroke instead of the current one.

`State#settleBranch` resolved its scope with `this.scopeFor(hostOf(slot.anchor))`. `hostOf` returns the anchor comment's parent element, and when the conditional sits at the top level of a template that parent is the layout's wrapper, which contains the region instead of sitting inside it. `scopeFor` returns null, every read is skipped, and the branch is never settled after it is swapped in.

It now derives the scope from the region the slot already resolved two lines earlier, which is what `settleItem` directly below it has always done.