### PR TITLE
Client: Generate state kinds and comparison operators from one definition

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -107,6 +107,8 @@ java/org/herb/ast/HelperType.java
 java/org/herb/ast/Nodes.java
 java/org/herb/ast/NodeVisitor.java
 java/org/herb/ast/Visitor.java
+javascript/packages/client/src/state-kinds.ts
+javascript/packages/client/src/state-operators.ts
 javascript/packages/core/src/action-view-helpers.ts
 javascript/packages/core/src/config.ts
 javascript/packages/core/src/errors.ts
@@ -119,6 +121,8 @@ javascript/packages/node/extension/error_helpers.h
 javascript/packages/node/extension/nodes.cpp
 javascript/packages/node/extension/nodes.h
 lib/herb/action_view/helper_registry.rb
+lib/herb/engine/slots/state_kinds.rb
+lib/herb/engine/slots/state_operators.rb
 lib/herb/ast/nodes.rb
 lib/herb/errors.rb
 lib/herb/visitor.rb
@@ -146,6 +150,7 @@ src/diff/herb_diff_nodes.c
 src/diff/herb_hash_tree.c
 src/errors.c
 src/include/analyze/action_view/helper_registry.h
+src/include/analyze/herb_directive_kinds.h
 src/include/ast/ast_nodes.h
 src/include/ast/ast_pretty_print.h
 src/include/errors.h

--- a/config/state/kind.yml
+++ b/config/state/kind.yml
@@ -1,0 +1,59 @@
+---
+kinds:
+  - name: "boolean"
+    article: "a Boolean"
+    prism_nodes: ["TrueNode", "FalseNode"]
+    literal: true
+    value: true
+    falsy: true
+
+  - name: "integer"
+    article: "an Integer"
+    prism_nodes: ["IntegerNode"]
+    literal: true
+    value: true
+
+  - name: "float"
+    article: "a Float"
+    prism_nodes: ["FloatNode"]
+
+  - name: "string"
+    article: "a String"
+    prism_nodes: ["StringNode"]
+    literal: true
+    value: true
+
+  - name: "symbol"
+    article: "a Symbol"
+    prism_nodes: ["SymbolNode"]
+    literal: true
+    value: true
+
+  - name: "nil"
+    article: "a Nil"
+    prism_nodes: ["NilNode"]
+    literal: true
+    value: true
+    falsy: true
+
+  - name: "array"
+    article: "an Array"
+    prism_nodes: ["ArrayNode"]
+
+  - name: "hash"
+    article: "a Hash"
+    prism_nodes: ["HashNode", "KeywordHashNode"]
+
+  - name: "bare"
+    article: "a value"
+    prism_nodes: ["LocalVariableReadNode"]
+    unknown: true
+
+  - name: "seeded"
+    article: "a value"
+    value: true
+    unknown: true
+    falsy: true
+
+  - name: "missing"
+    article: "a value"

--- a/config/state/operators.yml
+++ b/config/state/operators.yml
@@ -1,0 +1,27 @@
+---
+comparisons:
+  - operator: "=="
+    negated: "!="
+
+  - operator: "!="
+    negated: "=="
+
+  - operator: ">"
+    mirrored: "<"
+    negated: "<="
+    ordered: true
+
+  - operator: ">="
+    mirrored: "<="
+    negated: "<"
+    ordered: true
+
+  - operator: "<"
+    mirrored: ">"
+    negated: ">="
+    ordered: true
+
+  - operator: "<="
+    mirrored: ">="
+    negated: ">"
+    ordered: true

--- a/javascript/packages/client/project.json
+++ b/javascript/packages/client/project.json
@@ -8,7 +8,8 @@
       "executor": "nx:run-script",
       "options": {
         "script": "build"
-      }
+      },
+      "dependsOn": ["templates:generate"]
     },
     "test": {
       "executor": "nx:run-script",

--- a/javascript/packages/client/src/directives.ts
+++ b/javascript/packages/client/src/directives.ts
@@ -11,8 +11,17 @@
 export { ACTION_SCHEMA, ACTION_NAMES, HERB_ATTRIBUTES } from "./grammar/attributes"
 export { clauses, names, balancedQuotes, splitOutsideQuotes, unquote } from "./grammar/parsing"
 
+export { STATE_DEFAULT_KINDS, LITERAL_STATE_KINDS, UNKNOWN_STATE_KINDS, FALSY_STATE_KINDS, PRISM_LITERAL_KINDS, stateKindArticle } from "./state-kinds"
+export { MIRRORED_COMPARISONS, NEGATED_COMPARISONS, ORDERED_COMPARISONS, COMPARISON_OPERATORS } from "./state-operators"
+
 export type { Clause } from "./grammar/parsing"
 export type { ActionName, ActionSchema, HerbAttribute } from "./grammar/attributes"
+export type { StateDefaultKind, StateValueKind } from "./state-kinds"
+
+import { LITERAL_STATE_KINDS } from "./state-kinds"
+import { MIRRORED_COMPARISONS } from "./state-operators"
+
+import type { StateDefaultKind } from "./state-kinds"
 
 const SLOTS_MODE = /\b(server|client)\b/
 const SLOTS_DIRECTIVE = /^\s*herb:slots\b(.*)$/s
@@ -20,19 +29,6 @@ const STATE_DIRECTIVE_PRESENCE = /^\s*herb:state\b/
 const STATE_DIRECTIVE_PATTERN = /^\s*herb:state\s*(\(.*\))\s*$/s
 const BARE_IDENTIFIER = /^[a-z_][a-zA-Z0-9_]*$/
 const KEYWORD_SEGMENT = /^(\s*)([a-z_][a-zA-Z0-9_]*):(.*)$/s
-
-export type StateDefaultKind =
-  | "boolean"
-  | "integer"
-  | "string"
-  | "symbol"
-  | "nil"
-  | "float"
-  | "array"
-  | "hash"
-  | "bare"
-  | "seeded"
-  | "missing"
 
 export interface StateDeclaration {
   name: string
@@ -201,8 +197,6 @@ export interface DerivedDefault {
   sources: string[]
 }
 
-const MIRRORED_COMPARISONS: Record<string, string> = { ">": "<", ">=": "<=", "<": ">", "<=": ">=" }
-const LITERAL_DEFAULT_KINDS = new Set(["boolean", "integer", "string", "symbol", "nil"])
 
 export function classifyDerivedDefault(source: string, declared: ReadonlyMap<string, string>): DerivedDefault | "mixed" | null {
   const parsed = parseDerivedCondition(source.trim(), declared)
@@ -261,7 +255,7 @@ function parseDerivedCondition(source: string, declared: ReadonlyMap<string, str
 
     const literal = (leftState ? right : left).trim()
 
-    if (!LITERAL_DEFAULT_KINDS.has(classifyDefault(literal))) {
+    if (!LITERAL_STATE_KINDS.has(classifyDefault(literal))) {
       return null
     }
 
@@ -294,7 +288,7 @@ function parseDerivedCondition(source: string, declared: ReadonlyMap<string, str
       : "mixed"
   }
 
-  const resolved = LITERAL_DEFAULT_KINDS.has(kind) ? kind as DerivedDefault["kind"] : "seeded"
+  const resolved = LITERAL_STATE_KINDS.has(kind) ? kind as DerivedDefault["kind"] : "seeded"
 
   return { kind: resolved, condition: [bare, null], sources: [bare] }
 }

--- a/javascript/packages/client/src/state/values.ts
+++ b/javascript/packages/client/src/state/values.ts
@@ -1,5 +1,7 @@
 export type StateValue = string | number | boolean | null
-export type StateKind = "boolean" | "integer" | "string" | "symbol" | "nil" | "seeded"
+import type { StateValueKind } from "../state-kinds"
+
+export type StateKind = StateValueKind
 
 export function printValue(value: StateValue): string {
   if (value === null) {

--- a/javascript/packages/language-service/src/hover_provider.ts
+++ b/javascript/packages/language-service/src/hover_provider.ts
@@ -9,6 +9,7 @@ import { ParserService } from "./parser_service"
 import { lspPosition, isPositionInRange, rangeSize, hasSourceLocation, nodeToRange } from "./range_utils"
 import { RubyLocalsIndex } from "./ruby_locals_index"
 import { collectStateDirectives } from "./herb_attribute_links"
+import { LITERAL_STATE_KINDS } from "@herb-tools/client/directives"
 
 import type { DocumentNode } from "@herb-tools/core"
 
@@ -136,7 +137,7 @@ function blockParameter(scope: Node): string | null {
 }
 
 function declaredStateKind(kind: string): string {
-  return ["boolean", "integer", "string", "symbol", "nil"].includes(kind) ? kind : "seeded"
+  return LITERAL_STATE_KINDS.has(kind) ? kind : "seeded"
 }
 
 function stateUsageLines(name: string, kind: string, defaultSource: string, derived = false): string[] {

--- a/javascript/packages/linter/src/rules/herb-state-valid-reads.ts
+++ b/javascript/packages/linter/src/rules/herb-state-valid-reads.ts
@@ -1,7 +1,7 @@
 import { BaseRuleVisitor } from "../utils/rule-utils.js"
 import { ParserRule } from "../types.js"
 import { StateScopeMap, declaredKind, kindWithArticle } from "../utils/state-directives-utils.js"
-import { bareReadName, classifyDerivedDefault, mentionsAnyState } from "@herb-tools/client/directives"
+import { COMPARISON_OPERATORS, PRISM_LITERAL_KINDS, bareReadName, classifyDerivedDefault, mentionsAnyState } from "@herb-tools/client/directives"
 
 import { isBooleanAttribute, locationFromByteOffset, substringFromByteOffset } from "@herb-tools/core"
 import { getAttributeName, getAttributeValueNodes, isERBContentNode } from "@herb-tools/core"
@@ -9,15 +9,6 @@ import { getAttributeName, getAttributeValueNodes, isERBContentNode } from "@her
 import type { UnboundLintOffense, LintContext, FullRuleConfig } from "../types.js"
 import type { ParseResult, ParserOptions, Location, PrismNode, ERBBlockNode, ERBContentNode, ERBIfNode, ERBUnlessNode, ERBCaseNode, HTMLAttributeNode, RubyLiteralNode } from "@herb-tools/core"
 import type { StateDeclaration } from "@herb-tools/client/directives"
-
-const LITERAL_KINDS: Record<string, string> = {
-  TrueNode: "boolean",
-  FalseNode: "boolean",
-  IntegerNode: "integer",
-  StringNode: "string",
-  SymbolNode: "symbol",
-  NilNode: "nil",
-}
 
 interface BareRead {
   name: string
@@ -42,8 +33,6 @@ function prismBareRead(node: PrismNode | null | undefined): BareRead | null {
 
   return { name: predicate ? spelled.slice(0, -1) : spelled, predicate }
 }
-
-const COMPARISON_OPERATORS = new Set(["==", "!=", ">", ">=", "<", "<="])
 
 function equalitySides(node: PrismNode): [PrismNode, PrismNode, string] | null {
   if (prismType(node) !== "CallNode") return null
@@ -324,7 +313,7 @@ class StateValidReadsVisitor extends BaseRuleVisitor {
 
       if (declaration) {
         const comparand = leftDeclaration ? right : left
-        const comparandKind = LITERAL_KINDS[prismType(comparand)]
+        const comparandKind = PRISM_LITERAL_KINDS[prismType(comparand)]
         const kind = declaredKind(declaration)
 
         if (!comparandKind) {
@@ -420,7 +409,7 @@ class StateValidReadsVisitor extends BaseRuleVisitor {
       const list = (when.conditions ?? []).map((condition: PrismNode) => this.sliceOf(condition)).join(", ")
 
       for (const condition of when.conditions ?? []) {
-        const comparandKind = LITERAL_KINDS[prismType(condition)]
+        const comparandKind = PRISM_LITERAL_KINDS[prismType(condition)]
 
         if (!comparandKind) {
           this.addOffense(

--- a/javascript/packages/linter/src/utils/state-directives-utils.ts
+++ b/javascript/packages/linter/src/utils/state-directives-utils.ts
@@ -65,11 +65,7 @@ export function declaredKind(declaration: StateDeclaration): "boolean" | "intege
   }
 }
 
-export function kindWithArticle(kind: string): string {
-  const capitalized = kind.charAt(0).toUpperCase() + kind.slice(1)
-
-  return kind === "integer" ? `an ${capitalized}` : `a ${capitalized}`
-}
+export { stateKindArticle as kindWithArticle } from "@herb-tools/client/directives"
 
 export class StateScopeMap {
   #scopes = new Map<unknown, Map<string, StateDeclaration>>()

--- a/javascript/packages/linter/test/state-kind-parity.test.ts
+++ b/javascript/packages/linter/test/state-kind-parity.test.ts
@@ -1,0 +1,81 @@
+import { describe, test, expect, beforeAll } from "vitest"
+
+import { Herb } from "@herb-tools/node-wasm"
+import { classifyDefault, STATE_DEFAULT_KINDS } from "@herb-tools/client/directives"
+
+import type { Node } from "@herb-tools/core"
+
+const DEFAULTS = [
+  "true",
+  "false",
+  "0",
+  "-12",
+  "0xff",
+  "1.5",
+  "1e3",
+  '""',
+  '"hello"',
+  "'single'",
+  ":name",
+  ":\"quoted\"",
+  "nil",
+  "[1, 2]",
+  "{ a: 1 }",
+  "total",
+  "user.name",
+  "current_user.admin?",
+  "params[:sort]",
+]
+
+function directiveKinds(source: string): Record<string, string> {
+  const result = Herb.parse(source, { herb_directives: true })
+  const found: Record<string, string> = {}
+
+  const walk = (node: Node | null): void => {
+    if (!node) return
+
+    for (const state of ((node as never as { states?: { name?: { value: string }, kind: string }[] }).states) ?? []) {
+      if (state.name) found[state.name.value] = state.kind
+    }
+
+    for (const child of ((node as never as { children?: Node[] }).children) ?? []) walk(child)
+  }
+
+  walk(result.value)
+
+  return found
+}
+
+describe("the state kind vocabulary", () => {
+  beforeAll(async () => {
+    await Herb.load()
+  })
+
+  test("the parser only ever reports a kind the shared definition knows", () => {
+    const source = `<%# herb:state (${DEFAULTS.map((value, index) => `state${index}: ${value}`).join(", ")}) %>`
+    const kinds = Object.values(directiveKinds(source))
+
+    expect(kinds).toHaveLength(DEFAULTS.length)
+
+    for (const kind of kinds) {
+      expect(STATE_DEFAULT_KINDS).toContain(kind)
+    }
+  })
+
+  test("the TypeScript classifier agrees with the parser on every default", () => {
+    const source = `<%# herb:state (${DEFAULTS.map((value, index) => `state${index}: ${value}`).join(", ")}) %>`
+    const kinds = directiveKinds(source)
+
+    const parsed = DEFAULTS.map((value, index) => [value, kinds[`state${index}`]])
+    const classified = DEFAULTS.map((value) => [value, classifyDefault(value)])
+
+    expect(classified).toEqual(parsed)
+  })
+
+  test("a missing default reports the kind the shared definition names for it", () => {
+    const kinds = directiveKinds("<%# herb:state (open:) %>")
+
+    expect(kinds).toEqual({ open: "missing" })
+    expect(classifyDefault("")).toBe("missing")
+  })
+})

--- a/lib/herb/engine/slots/state_compiler.rb
+++ b/lib/herb/engine/slots/state_compiler.rb
@@ -705,7 +705,7 @@ module Herb
 
           return nil unless read.is_a?(StateDirectives::Read) || read.is_a?(StateDirectives::Combo)
 
-          if read.is_a?(StateDirectives::Read) && read.comparand.nil? && read.against.nil? && ![:boolean, :nil, :seeded].include?(read.kind)
+          if read.is_a?(StateDirectives::Read) && read.comparand.nil? && read.against.nil? && !StateKinds::FALSY.include?(read.kind)
             return @visitor.slot_error("`#{slot.attribute}=\"<%= #{expression} %>\"` reads the #{read.kind.to_s.capitalize} state `#{read.name}` as a presence. Only `nil` and `false` are falsy in Ruby, so the attribute could never turn off. Compare the state to a literal, or declare it as a boolean.", node.location, :read)
           end
 

--- a/lib/herb/engine/slots/state_directives.rb
+++ b/lib/herb/engine/slots/state_directives.rb
@@ -3,6 +3,9 @@
 
 require "prism"
 
+require_relative "state_kinds"
+require_relative "state_operators"
+
 module Herb
   class Engine
     module Slots
@@ -12,22 +15,9 @@ module Herb
       class StateDirectives
         BARE = /\A[a-z_][a-zA-Z0-9_]*\z/ #: Regexp
 
-        KINDS = {
-          "Prism::TrueNode" => :boolean,
-          "Prism::FalseNode" => :boolean,
-          "Prism::IntegerNode" => :integer,
-          "Prism::StringNode" => :string,
-          "Prism::SymbolNode" => :symbol,
-          "Prism::NilNode" => :nil,
-        }.freeze #: Hash[String, Symbol]
+        KINDS = StateKinds::PRISM #: Hash[String, Symbol]
 
-        NODE_KINDS = {
-          "boolean" => :boolean,
-          "integer" => :integer,
-          "string" => :string,
-          "symbol" => :symbol,
-          "nil" => :nil,
-        }.freeze #: Hash[String, Symbol]
+        NODE_KINDS = StateKinds::NODE #: Hash[String, Symbol]
 
         Declaration = Data.define(
           :name,    #: String
@@ -56,8 +46,8 @@ module Herb
           :by    #: Integer
         )
 
-        ORDERED_OPERATORS = [:>, :>=, :<, :<=].freeze #: Array[Symbol]
-        MIRRORED_OPERATORS = { ">" => "<", ">=" => "<=", "<" => ">", "<=" => ">=" }.freeze #: Hash[String, String]
+        ORDERED_OPERATORS = StateOperators::ORDERED #: Array[Symbol]
+        MIRRORED_OPERATORS = StateOperators::MIRRORED #: Hash[String, String]
 
         Parsing = Data.define(
           :locals,    #: Hash[String, Symbol]
@@ -324,6 +314,10 @@ module Herb
 
           #: ((Symbol | String)?) -> String
           def kind_article(kind)
+            known = StateKinds::ARTICLES[kind.to_s]
+
+            return known if known
+
             spelled = kind.to_s.capitalize
 
             return "a value" if spelled.empty?

--- a/sig/herb/engine/slots/state_kinds.rbs
+++ b/sig/herb/engine/slots/state_kinds.rbs
@@ -1,0 +1,22 @@
+# Generated from lib/herb/engine/slots/state_kinds.rb with RBS::Inline
+
+module Herb
+  class Engine
+    module Slots
+      # The kinds a `herb:state` default can have, and what each one means to the compiler.
+      module StateKinds
+        PRISM: Hash[String, Symbol]
+
+        NODE: Hash[String, Symbol]
+
+        LITERAL: Array[Symbol]
+
+        UNKNOWN: Array[Symbol]
+
+        FALSY: Array[Symbol]
+
+        ARTICLES: Hash[String, String]
+      end
+    end
+  end
+end

--- a/sig/herb/engine/slots/state_operators.rbs
+++ b/sig/herb/engine/slots/state_operators.rbs
@@ -1,0 +1,19 @@
+# Generated from lib/herb/engine/slots/state_operators.rb with RBS::Inline
+
+module Herb
+  class Engine
+    module Slots
+      # The comparison operators a `herb:state` read may use, and what swapping or negating one
+      # turns it into.
+      module StateOperators
+        MIRRORED: Hash[String, String]
+
+        NEGATED: Hash[String, String]
+
+        ORDERED: Array[Symbol]
+
+        COMPARISONS: Array[String]
+      end
+    end
+  end
+end

--- a/src/analyze/herb_directives.c
+++ b/src/analyze/herb_directives.c
@@ -2,6 +2,7 @@
 #include "../include/analyze/action_view/tag_helper_node_builders.h"
 #include "../include/analyze/action_view/tag_helpers.h"
 #include "../include/analyze/analyze.h"
+#include "../include/analyze/herb_directive_kinds.h"
 #include "../include/ast/ast_nodes.h"
 #include "../include/errors.h"
 #include "../include/lexer/token.h"
@@ -135,29 +136,17 @@ static size_t find_signature_close(const directive_content_T* content, const siz
 static hb_string_T directive_kind_for_prism_node(const pm_node_t* node) {
   if (!node) { return hb_string("missing"); }
 
-  switch (node->type) {
-    case PM_TRUE_NODE:
-    case PM_FALSE_NODE: return hb_string("boolean");
-    case PM_INTEGER_NODE: return hb_string("integer");
-    case PM_FLOAT_NODE: return hb_string("float");
-    case PM_STRING_NODE: return hb_string("string");
-    case PM_SYMBOL_NODE: return hb_string("symbol");
-    case PM_NIL_NODE: return hb_string("nil");
-    case PM_ARRAY_NODE: return hb_string("array");
-    case PM_HASH_NODE:
-    case PM_KEYWORD_HASH_NODE: return hb_string("hash");
-    case PM_LOCAL_VARIABLE_READ_NODE: return hb_string("bare");
+  const char* mapped = herb_directive_kind_for_prism_type(node->type);
 
-    case PM_CALL_NODE: {
-      const pm_call_node_t* call = (const pm_call_node_t*) node;
+  if (mapped) { return hb_string(mapped); }
 
-      if (!call->receiver && !call->arguments && !call->block) { return hb_string("bare"); }
+  if (node->type == PM_CALL_NODE) {
+    const pm_call_node_t* call = (const pm_call_node_t*) node;
 
-      return hb_string("seeded");
-    }
-
-    default: return hb_string("seeded");
+    if (!call->receiver && !call->arguments && !call->block) { return hb_string("bare"); }
   }
+
+  return hb_string("seeded");
 }
 
 typedef struct {

--- a/templates/javascript/packages/client/src/state-kinds.ts.erb
+++ b/templates/javascript/packages/client/src/state-kinds.ts.erb
@@ -1,0 +1,47 @@
+export type StateDefaultKind =
+<%- state_kinds.each do |kind| -%>
+  | <%= kind.name.inspect %>
+<%- end -%>
+
+export type StateValueKind =
+<%- state_kinds.select(&:value?).each do |kind| -%>
+  | <%= kind.name.inspect %>
+<%- end -%>
+
+export const STATE_DEFAULT_KINDS: readonly StateDefaultKind[] = [<%= state_kinds.map { |kind| kind.name.inspect }.join(", ") %>]
+
+export const LITERAL_STATE_KINDS: ReadonlySet<string> = new Set([<%= state_kinds.select(&:literal?).map { |kind| kind.name.inspect }.join(", ") %>])
+
+export const UNKNOWN_STATE_KINDS: ReadonlySet<string> = new Set([<%= state_kinds.select(&:unknown?).map { |kind| kind.name.inspect }.join(", ") %>])
+
+export const FALSY_STATE_KINDS: ReadonlySet<string> = new Set([<%= state_kinds.select(&:falsy?).map { |kind| kind.name.inspect }.join(", ") %>])
+
+export const PRISM_LITERAL_KINDS: Record<string, StateDefaultKind> = {
+<%- state_kinds.select(&:literal?).each do |kind| -%>
+<%- kind.prism_nodes.each do |node| -%>
+  <%= node.inspect %>: <%= kind.name.inspect %>,
+<%- end -%>
+<%- end -%>
+}
+
+const STATE_KIND_ARTICLES: Record<string, string> = {
+<%- state_kinds.each do |kind| -%>
+  <%= kind.name.inspect %>: <%= kind.article.inspect %>,
+<%- end -%>
+}
+
+export function stateKindArticle(kind: string): string {
+  const known = STATE_KIND_ARTICLES[kind]
+
+  if (known) {
+    return known
+  }
+
+  const spelled = kind.charAt(0).toUpperCase() + kind.slice(1)
+
+  if (spelled === "") {
+    return "a value"
+  }
+
+  return /^[AEIOU]/.test(spelled) ? `an ${spelled}` : `a ${spelled}`
+}

--- a/templates/javascript/packages/client/src/state-operators.ts.erb
+++ b/templates/javascript/packages/client/src/state-operators.ts.erb
@@ -1,0 +1,15 @@
+export const MIRRORED_COMPARISONS: Record<string, string> = {
+<%- state_operators.select(&:mirrored).each do |operator| -%>
+  <%= operator.operator.inspect %>: <%= operator.mirrored.inspect %>,
+<%- end -%>
+}
+
+export const NEGATED_COMPARISONS: Record<string, string> = {
+<%- state_operators.each do |operator| -%>
+  <%= operator.operator.inspect %>: <%= operator.negated.inspect %>,
+<%- end -%>
+}
+
+export const ORDERED_COMPARISONS: ReadonlySet<string> = new Set([<%= state_operators.select(&:ordered?).map { |operator| operator.operator.inspect }.join(", ") %>])
+
+export const COMPARISON_OPERATORS: ReadonlySet<string> = new Set([<%= state_operators.map { |operator| operator.operator.inspect }.join(", ") %>])

--- a/templates/lib/herb/engine/slots/state_kinds.rb.erb
+++ b/templates/lib/herb/engine/slots/state_kinds.rb.erb
@@ -1,0 +1,35 @@
+module Herb
+  class Engine
+    module Slots
+      # The kinds a `herb:state` default can have, and what each one means to the compiler.
+      #
+      module StateKinds
+        PRISM = {
+<%- state_kinds.select(&:literal?).each do |kind| -%>
+<%- kind.prism_nodes.each do |node| -%>
+          "Prism::<%= node %>" => :<%= kind.name %>,
+<%- end -%>
+<%- end -%>
+        }.freeze #: Hash[String, Symbol]
+
+        NODE = {
+<%- state_kinds.select(&:literal?).each do |kind| -%>
+          <%= kind.name.inspect %> => :<%= kind.name %>,
+<%- end -%>
+        }.freeze #: Hash[String, Symbol]
+
+        LITERAL = [<%= state_kinds.select(&:literal?).map { |kind| ":#{kind.name}" }.join(", ") %>].freeze #: Array[Symbol]
+
+        UNKNOWN = [<%= state_kinds.select(&:unknown?).map { |kind| ":#{kind.name}" }.join(", ") %>].freeze #: Array[Symbol]
+
+        FALSY = [<%= state_kinds.select(&:falsy?).map { |kind| ":#{kind.name}" }.join(", ") %>].freeze #: Array[Symbol]
+
+        ARTICLES = {
+<%- state_kinds.each do |kind| -%>
+          <%= kind.name.inspect %> => <%= kind.article.inspect %>,
+<%- end -%>
+        }.freeze #: Hash[String, String]
+      end
+    end
+  end
+end

--- a/templates/lib/herb/engine/slots/state_operators.rb.erb
+++ b/templates/lib/herb/engine/slots/state_operators.rb.erb
@@ -1,0 +1,26 @@
+module Herb
+  class Engine
+    module Slots
+      # The comparison operators a `herb:state` read may use, and what swapping or negating one
+      # turns it into.
+      #
+      module StateOperators
+        MIRRORED = {
+<%- state_operators.select(&:mirrored).each do |operator| -%>
+          <%= operator.operator.inspect %> => <%= operator.mirrored.inspect %>,
+<%- end -%>
+        }.freeze #: Hash[String, String]
+
+        NEGATED = {
+<%- state_operators.each do |operator| -%>
+          <%= operator.operator.inspect %> => <%= operator.negated.inspect %>,
+<%- end -%>
+        }.freeze #: Hash[String, String]
+
+        ORDERED = [<%= state_operators.select(&:ordered?).map { |operator| ":#{operator.operator}" }.join(", ") %>].freeze #: Array[Symbol]
+
+        COMPARISONS = [<%= state_operators.map { |operator| operator.operator.inspect }.join(", ") %>].freeze #: Array[String]
+      end
+    end
+  end
+end

--- a/templates/src/include/analyze/herb_directive_kinds.h.erb
+++ b/templates/src/include/analyze/herb_directive_kinds.h.erb
@@ -1,0 +1,25 @@
+#ifndef HERB_DIRECTIVE_KINDS_H
+#define HERB_DIRECTIVE_KINDS_H
+
+#include <prism.h>
+
+/**
+ * The kind a `herb:state` default gets from the Prism node it parsed into.
+ *
+ * Returns NULL for a node type that has no plain mapping. The caller decides what those become,
+ * since a call node is a bare read or a seed depending on its shape.
+ */
+static inline const char* herb_directive_kind_for_prism_type(pm_node_type_t type) {
+  switch (type) {
+<%- state_kinds.reject { |kind| kind.prism_nodes.empty? }.each do |kind| -%>
+<%- kind.prism_constants[0..-2].each do |constant| -%>
+    case <%= constant %>:
+<%- end -%>
+    case <%= kind.prism_constants.last %>: return "<%= kind.name %>";
+
+<%- end -%>
+    default: return NULL;
+  }
+}
+
+#endif

--- a/templates/template.rb
+++ b/templates/template.rb
@@ -681,6 +681,55 @@ module Herb
       end
     end
 
+    class StateKind
+      attr_reader :name, :article, :prism_nodes
+
+      def initialize(config)
+        @name = config.fetch("name")
+        @article = config.fetch("article")
+        @prism_nodes = config.fetch("prism_nodes", [])
+        @literal = config.fetch("literal", false)
+        @value = config.fetch("value", false)
+        @unknown = config.fetch("unknown", false)
+        @falsy = config.fetch("falsy", false)
+      end
+
+      def literal?
+        @literal
+      end
+
+      def value?
+        @value
+      end
+
+      def unknown?
+        @unknown
+      end
+
+      def falsy?
+        @falsy
+      end
+
+      def prism_constants
+        prism_nodes.map { |node| "PM_#{Template.underscore(node).upcase}" }
+      end
+    end
+
+    class StateOperator
+      attr_reader :operator, :mirrored, :negated
+
+      def initialize(config)
+        @operator = config.fetch("operator")
+        @mirrored = config.fetch("mirrored", nil)
+        @negated = config.fetch("negated")
+        @ordered = config.fetch("ordered", false)
+      end
+
+      def ordered?
+        @ordered
+      end
+    end
+
     class HelperType
       attr_reader :name, :source, :gem, :output, :visibility, :receiver, :supports_block,
                   :supported, :description, :signature, :documentation_url, :tag,
@@ -951,7 +1000,7 @@ module Herb
                       end
 
       rendered_template = read_template(template_path.to_s).result_with_hash(
-        { nodes: nodes, errors: errors, union_kinds: union_kinds, helpers: helpers, prism_nodes: prism_nodes, prism_flags: prism_flags }
+        { nodes: nodes, errors: errors, union_kinds: union_kinds, helpers: helpers, prism_nodes: prism_nodes, prism_flags: prism_flags, state_kinds: state_kinds, state_operators: state_operators }
       )
       content = heading_for(name, template_file) + rendered_template
 
@@ -1019,6 +1068,18 @@ module Herb
       Dir.glob("config/action_view_helpers/**/*.yml").map do |file|
         HelperType.new(YAML.load_file(file))
       end
+    end
+
+    def self.state_kinds
+      config = YAML.load_file("config/state/kind.yml")
+
+      (config["kinds"] || []).map { |kind| StateKind.new(kind) }
+    end
+
+    def self.state_operators
+      config = YAML.load_file("config/state/operators.yml")
+
+      (config["comparisons"] || []).map { |operator| StateOperator.new(operator) }
     end
 
     def self.config


### PR DESCRIPTION
This pull request moves the state kind vocabulary and the comparison operator table into `config/state/`, so the C parser, the Ruby engine, the client, the linter and the language service are all generated from one source. There is no behavior change; the test suites pass unchanged.

* `config/state/kind.yml` carries the Prism node types, `literal`, `value`, `unknown`, `falsy` and the article prose per kind. 
* `config/state/operators.yml` carries `mirrored`, `negated` and `ordered` per comparison operator, replacing the hand-mirrored `MIRRORED_OPERATORS` and `MIRRORED_COMPARISONS` pair.