### PR TITLE
Client: Support predicates, transforms and negation in `herb:state` reads

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -109,6 +109,8 @@ java/org/herb/ast/NodeVisitor.java
 java/org/herb/ast/Visitor.java
 javascript/packages/client/src/state-kinds.ts
 javascript/packages/client/src/state-operators.ts
+javascript/packages/client/src/state-predicates.ts
+javascript/packages/client/src/state-transforms.ts
 javascript/packages/core/src/action-view-helpers.ts
 javascript/packages/core/src/config.ts
 javascript/packages/core/src/errors.ts
@@ -123,6 +125,8 @@ javascript/packages/node/extension/nodes.h
 lib/herb/action_view/helper_registry.rb
 lib/herb/engine/slots/state_kinds.rb
 lib/herb/engine/slots/state_operators.rb
+lib/herb/engine/slots/state_predicates.rb
+lib/herb/engine/slots/state_transforms.rb
 lib/herb/ast/nodes.rb
 lib/herb/errors.rb
 lib/herb/visitor.rb

--- a/config/state/predicates.yml
+++ b/config/state/predicates.yml
@@ -1,0 +1,39 @@
+---
+predicates:
+  - name: "nil?"
+    comparand: "nil"
+    only: "every state"
+
+  - name: "zero?"
+    comparand: "0"
+    kinds: ["integer"]
+    only: "an Integer state"
+
+  - name: "one?"
+    comparand: "1"
+    kinds: ["integer"]
+    only: "an Integer state"
+    rewrite: "== 1"
+
+  - name: "positive?"
+    comparand: "0"
+    operator: ">"
+    kinds: ["integer"]
+    only: "an Integer state"
+
+  - name: "empty?"
+    comparand: '""'
+    kinds: ["string", "symbol"]
+    only: "a String or a Symbol state"
+
+  - name: "blank?"
+    operator: "blank"
+    negated: "present"
+    kinds: ["boolean", "string", "nil"]
+    only: "a Boolean, a String or a Nil state"
+
+  - name: "present?"
+    operator: "present"
+    negated: "blank"
+    kinds: ["boolean", "string", "nil"]
+    only: "a Boolean, a String or a Nil state"

--- a/config/state/transforms.yml
+++ b/config/state/transforms.yml
@@ -1,0 +1,18 @@
+---
+transforms:
+  - name: "length"
+    operation: "length"
+    kinds: ["string", "symbol"]
+    returns: "integer"
+    only: "a String or a Symbol state"
+
+  - name: "size"
+    operation: "length"
+    kinds: ["string", "symbol"]
+    returns: "integer"
+    only: "a String or a Symbol state"
+
+  - name: "to_s"
+    operation: "to_s"
+    returns: "string"
+    only: "every state"

--- a/javascript/packages/client/src/directives.ts
+++ b/javascript/packages/client/src/directives.ts
@@ -9,17 +9,23 @@
  */
 
 export { ACTION_SCHEMA, ACTION_NAMES, HERB_ATTRIBUTES } from "./grammar/attributes"
-export { clauses, names, balancedQuotes, splitOutsideQuotes, unquote } from "./grammar/parsing"
-
-export { STATE_DEFAULT_KINDS, LITERAL_STATE_KINDS, UNKNOWN_STATE_KINDS, FALSY_STATE_KINDS, PRISM_LITERAL_KINDS, stateKindArticle } from "./state-kinds"
+export { STATE_PREDICATES, STATE_PREDICATE_NAMES } from "./state-predicates"
+export { STATE_TRANSFORMS, STATE_TRANSFORM_NAMES } from "./state-transforms"
 export { MIRRORED_COMPARISONS, NEGATED_COMPARISONS, ORDERED_COMPARISONS, COMPARISON_OPERATORS } from "./state-operators"
+export { STATE_DEFAULT_KINDS, LITERAL_STATE_KINDS, UNKNOWN_STATE_KINDS, FALSY_STATE_KINDS, PRISM_LITERAL_KINDS, stateKindArticle } from "./state-kinds"
+
+export { clauses, names, balancedQuotes, splitOutsideQuotes, unquote } from "./grammar/parsing"
 
 export type { Clause } from "./grammar/parsing"
 export type { ActionName, ActionSchema, HerbAttribute } from "./grammar/attributes"
+export type { StatePredicate } from "./state-predicates"
+export type { StateTransform } from "./state-transforms"
 export type { StateDefaultKind, StateValueKind } from "./state-kinds"
 
-import { LITERAL_STATE_KINDS } from "./state-kinds"
-import { MIRRORED_COMPARISONS } from "./state-operators"
+import { STATE_PREDICATES } from "./state-predicates"
+import { STATE_TRANSFORMS } from "./state-transforms"
+import { MIRRORED_COMPARISONS, NEGATED_COMPARISONS } from "./state-operators"
+import { LITERAL_STATE_KINDS, UNKNOWN_STATE_KINDS } from "./state-kinds"
 
 import type { StateDefaultKind } from "./state-kinds"
 
@@ -189,6 +195,7 @@ export type DerivedComparand = string | null | { state: string }
 export type DerivedCondition =
   | [string, DerivedComparand]
   | [string, DerivedComparand, string]
+  | [string, DerivedComparand, string | null, string]
   | { all?: DerivedCondition[]; any?: DerivedCondition[] }
 
 export interface DerivedDefault {
@@ -197,6 +204,69 @@ export interface DerivedDefault {
   sources: string[]
 }
 
+
+export interface PredicateRead {
+  name: string
+  predicate: string
+}
+
+const PREDICATE_READ = /^([a-z_][a-zA-Z0-9_]*)\.([a-z_]+\?)$/
+const TRANSFORM_READ = /^([a-z_][a-zA-Z0-9_]*)\.([a-z_]+)$/
+
+export interface TransformRead {
+  name: string
+  transform: string
+}
+
+export function transformReadName(expression: string): TransformRead | null {
+  const match = TRANSFORM_READ.exec(expression.trim())
+
+  if (!match || !(match[2] in STATE_TRANSFORMS)) {
+    return null
+  }
+
+  return { name: match[1], transform: match[2] }
+}
+
+export function transformApplies(transform: string, kind: string): boolean {
+  const spec = STATE_TRANSFORMS[transform]
+
+  if (!spec || spec.kinds === null || UNKNOWN_STATE_KINDS.has(kind)) {
+    return true
+  }
+
+  return spec.kinds.includes(kind)
+}
+
+export function predicateReadName(expression: string): PredicateRead | null {
+  const match = PREDICATE_READ.exec(expression.trim())
+
+  if (!match || !(match[2] in STATE_PREDICATES)) {
+    return null
+  }
+
+  return { name: match[1], predicate: match[2] }
+}
+
+export function predicateAnswers(predicate: string, kind: string): boolean {
+  const spec = STATE_PREDICATES[predicate]
+
+  if (!spec || spec.kinds === null || UNKNOWN_STATE_KINDS.has(kind)) {
+    return true
+  }
+
+  return spec.kinds.includes(kind)
+}
+
+export function predicateCondition(read: PredicateRead): DerivedCondition {
+  const spec = STATE_PREDICATES[read.predicate]
+
+  if (spec.comparand === undefined) {
+    return [read.name, null, spec.operator as string]
+  }
+
+  return spec.operator ? [read.name, spec.comparand, spec.operator] : [read.name, spec.comparand]
+}
 
 export function classifyDerivedDefault(source: string, declared: ReadonlyMap<string, string>): DerivedDefault | "mixed" | null {
   const parsed = parseDerivedCondition(source.trim(), declared)
@@ -233,6 +303,18 @@ function parseDerivedCondition(source: string, declared: ReadonlyMap<string, str
     }
   }
 
+  if (trimmed.startsWith("!")) {
+    const inner = parseDerivedCondition(unwrapParentheses(trimmed.slice(1).trim()), declared)
+
+    if (inner === null || inner === "mixed") {
+      return inner
+    }
+
+    const negated = negateCondition(inner.condition)
+
+    return negated === null ? "mixed" : { kind: "boolean", condition: negated, sources: inner.sources }
+  }
+
   const comparison = splitTopLevelComparison(trimmed)
 
   if (comparison) {
@@ -241,15 +323,19 @@ function parseDerivedCondition(source: string, declared: ReadonlyMap<string, str
     const rightState = derivedStateSide(right, declared)
 
     if (leftState && rightState) {
-      const spelled = operator === "==" ? undefined : operator
-      const condition: DerivedCondition = spelled ? [leftState, { state: rightState }, spelled] : [leftState, { state: rightState }]
+      if (leftState.transform || rightState.transform) {
+        return "mixed"
+      }
 
-      return { kind: "boolean", condition, sources: [...new Set([leftState, rightState])] }
+      const spelled = operator === "==" ? undefined : operator
+      const condition: DerivedCondition = spelled ? [leftState.state, { state: rightState.state }, spelled] : [leftState.state, { state: rightState.state }]
+
+      return { kind: "boolean", condition, sources: [...new Set([leftState.state, rightState.state])] }
     }
 
-    const state = leftState ?? rightState
+    const side = leftState ?? rightState
 
-    if (!state) {
+    if (!side) {
       return null
     }
 
@@ -265,9 +351,45 @@ function parseDerivedCondition(source: string, declared: ReadonlyMap<string, str
       spelled = MIRRORED_COMPARISONS[spelled]
     }
 
-    const condition: DerivedCondition = spelled ? [state, literal, spelled] : [state, literal]
+    if (side.transform) {
+      return { kind: "boolean", condition: [side.state, literal, spelled ?? "==", side.transform], sources: [side.state] }
+    }
 
-    return { kind: "boolean", condition, sources: [state] }
+    const condition: DerivedCondition = spelled ? [side.state, literal, spelled] : [side.state, literal]
+
+    return { kind: "boolean", condition, sources: [side.state] }
+  }
+
+  const transform = transformReadName(trimmed)
+
+  if (transform) {
+    const kind = declared.get(transform.name)
+
+    if (kind === undefined) {
+      return null
+    }
+
+    if (!transformApplies(transform.transform, kind)) {
+      return "mixed"
+    }
+
+    const spec = STATE_TRANSFORMS[transform.transform]
+
+    return { kind: spec.returns as DerivedDefault["kind"], condition: [transform.name, null, null, spec.operation], sources: [transform.name] }
+  }
+
+  const predicate = predicateReadName(trimmed)
+
+  if (predicate) {
+    const kind = declared.get(predicate.name)
+
+    if (kind === undefined) {
+      return null
+    }
+
+    return predicateAnswers(predicate.predicate, kind)
+      ? { kind: "boolean", condition: predicateCondition(predicate), sources: [predicate.name] }
+      : "mixed"
   }
 
   const bare = bareReadName(trimmed)
@@ -283,9 +405,7 @@ function parseDerivedCondition(source: string, declared: ReadonlyMap<string, str
   }
 
   if (trimmed.endsWith("?")) {
-    return kind === "boolean" || kind === "seeded" || kind === "bare"
-      ? { kind: "boolean", condition: [bare, null], sources: [bare] }
-      : "mixed"
+    return { kind: "boolean", condition: [bare, null], sources: [bare] }
   }
 
   const resolved = LITERAL_STATE_KINDS.has(kind) ? kind as DerivedDefault["kind"] : "seeded"
@@ -293,14 +413,72 @@ function parseDerivedCondition(source: string, declared: ReadonlyMap<string, str
   return { kind: resolved, condition: [bare, null], sources: [bare] }
 }
 
-function derivedStateSide(side: string, declared: ReadonlyMap<string, string>): string | null {
-  const bare = bareReadName(side.trim())
+interface DerivedSide {
+  state: string
+  transform: string | null
+}
 
-  if (bare === null || !declared.has(bare)) {
+const NEGATED_UNARY: Record<string, string> = { blank: "present", present: "blank" }
+
+function negateCondition(condition: DerivedCondition): DerivedCondition | null {
+  if (!Array.isArray(condition)) {
+    const parts = condition.all ?? condition.any
+
+    if (!parts) {
+      return null
+    }
+
+    const negated = parts.map((part) => negateCondition(part))
+
+    if (negated.some((part) => part === null)) {
+      return null
+    }
+
+    return condition.all ? { any: negated as DerivedCondition[] } : { all: negated as DerivedCondition[] }
+  }
+
+  const [name, comparand, operator, transform] = condition
+  const spelled = typeof operator === "string" ? operator : null
+
+  const flipped =
+    spelled === null
+      ? (comparand === null ? "falsy" : "!=")
+      : spelled === "falsy"
+        ? null
+        : (NEGATED_UNARY[spelled] ?? NEGATED_COMPARISONS[spelled] ?? null)
+
+  if (spelled !== null && spelled !== "falsy" && flipped === null) {
     return null
   }
 
-  return bare
+  if (typeof transform === "string") {
+    return [name, comparand, flipped, transform]
+  }
+
+  return flipped === null ? [name, comparand] : [name, comparand, flipped]
+}
+
+function derivedStateSide(side: string, declared: ReadonlyMap<string, string>): DerivedSide | null {
+  const source = side.trim()
+  const bare = bareReadName(source)
+
+  if (bare !== null && declared.has(bare)) {
+    return { state: bare, transform: null }
+  }
+
+  const transform = transformReadName(source)
+
+  if (transform === null) {
+    return null
+  }
+
+  const kind = declared.get(transform.name)
+
+  if (kind === undefined || !transformApplies(transform.transform, kind)) {
+    return null
+  }
+
+  return { state: transform.name, transform: STATE_TRANSFORMS[transform.transform].operation }
 }
 
 function unwrapParentheses(source: string): string {

--- a/javascript/packages/client/src/state/conditions.ts
+++ b/javascript/packages/client/src/state/conditions.ts
@@ -29,8 +29,20 @@ export function matches(condition: StateCondition, valueOf: ValueOf): boolean {
     return parts(condition).some((part) => matches(part, valueOf))
   }
 
-  const [name, comparand, operator] = condition
-  const value = valueOf(name)
+  const [name, comparand, operator, transform] = condition
+  const value = typeof transform === "string" ? transformed(transform, valueOf(name)) : valueOf(name)
+
+  if (operator === "blank") {
+    return blank(value)
+  }
+
+  if (operator === "present") {
+    return !blank(value)
+  }
+
+  if (operator === "falsy") {
+    return !truthy(value)
+  }
 
   if (comparand === null) {
     return truthy(value)
@@ -103,6 +115,42 @@ export function statesIn(condition: StateCondition): string[] {
 
 export function truthy(value: ConditionValue): boolean {
   return value !== false && value !== null
+}
+
+export function transformed(operation: string, value: ConditionValue): ConditionValue {
+  if (operation === "to_s") {
+    return value === null ? "" : String(value)
+  }
+
+  if (operation !== "length") {
+    return value
+  }
+
+  if (typeof value !== "string") {
+    return 0
+  }
+
+  return [...value].length
+}
+
+export function evaluate(condition: StateCondition, valueOf: ValueOf): ConditionValue {
+  if (Array.isArray(condition)) {
+    const [name, comparand, operator, transform] = condition
+
+    if (typeof transform === "string" && comparand === null && !operator) {
+      return transformed(transform, valueOf(name))
+    }
+  }
+
+  return matches(condition, valueOf)
+}
+
+export function blank(value: ConditionValue): boolean {
+  if (value === null || value === false) {
+    return true
+  }
+
+  return typeof value === "string" && /^\s*$/.test(value)
 }
 
 export function literal(source: string): ConditionValue | undefined {

--- a/javascript/packages/client/src/state/state.ts
+++ b/javascript/packages/client/src/state/state.ts
@@ -10,7 +10,7 @@ import { ElementObserver } from "../shared/element-observer"
 import { report } from "../shared/report"
 import { printValue } from "./values"
 import { elementOf, hostOf } from "../markup/anchors"
-import { armOf, matches, mentions } from "./conditions"
+import { armOf, evaluate, matches, mentions } from "./conditions"
 import { collectionIn, scopeOf, scoped } from "./scopes"
 import { declarationSpot, declared, declaredValue } from "./declarations"
 
@@ -393,6 +393,7 @@ export class State implements ElementObserverDelegate, SlotsDelegate, SeedsDeleg
 
       this.writeConditionals(manifest, scope, changed)
       this.writePresence(manifest, scope, changed)
+      this.writeComputed(manifest, scope, changed)
     }
 
     const recounted: string[] = []
@@ -411,6 +412,7 @@ export class State implements ElementObserverDelegate, SlotsDelegate, SeedsDeleg
     if (recounted.length > 0) {
       this.writeConditionals(manifest, regionScope, recounted)
       this.writePresence(manifest, regionScope, recounted)
+      this.writeComputed(manifest, regionScope, recounted)
     }
 
     for (const [name, value] of Object.entries(values)) {
@@ -699,8 +701,13 @@ export class State implements ElementObserverDelegate, SlotsDelegate, SeedsDeleg
 
   private writeValueSlots(manifest: StateManifest, scope: StateScope, name: string, value: StateValue): void {
     const text = printValue(value)
+    const computed = manifest.computed ?? {}
 
     for (const index of manifest.reads[name] ?? []) {
+      if (computed[String(index)]) {
+        continue
+      }
+
       for (const slot of this.scopedSlots(scope, index)) {
         if (slot.type === "boolean_attribute") {
           continue
@@ -722,6 +729,19 @@ export class State implements ElementObserverDelegate, SlotsDelegate, SeedsDeleg
         const present = matches(entry, (name) => this.valueAt(name, placed.scope))
 
         this.slots.setBooleanAttribute(placed.slot, present)
+        this.slots.claim(placed.slot)
+      }
+    }
+  }
+
+  private writeComputed(manifest: StateManifest, scope: StateScope, changed: string[]): void {
+    for (const [indexKey, entry] of Object.entries(manifest.computed ?? {})) {
+      if (!mentions(entry, changed)) {
+        continue
+      }
+
+      for (const placed of this.placedSlots(scope, Number(indexKey))) {
+        this.write(placed.slot, printValue(evaluate(entry, (name) => this.valueAt(name, placed.scope))))
         this.slots.claim(placed.slot)
       }
     }
@@ -782,6 +802,7 @@ export class State implements ElementObserverDelegate, SlotsDelegate, SeedsDeleg
 
     this.writeConditionals(manifest, scope, names)
     this.writePresence(manifest, scope, names)
+    this.writeComputed(manifest, scope, names)
 
     for (const entry of changes) {
       this.announceState(scope, entry.name, entry.value, entry.previous)
@@ -898,6 +919,7 @@ export class State implements ElementObserverDelegate, SlotsDelegate, SeedsDeleg
     const declared = manifest.declarations.map((declaration) => declaration.name)
 
     this.writePresence(manifest, at, declared)
+    this.writeComputed(manifest, at, declared)
     this.writeConditionals(manifest, at, declared)
   }
 
@@ -929,7 +951,7 @@ export class State implements ElementObserverDelegate, SlotsDelegate, SeedsDeleg
       for (const index of indices) {
         const slot = item.slots.get(index)
 
-        if (!slot || slot.type === "boolean_attribute") {
+        if (!slot || slot.type === "boolean_attribute" || manifest.computed?.[String(index)]) {
           continue
         }
 
@@ -946,6 +968,17 @@ export class State implements ElementObserverDelegate, SlotsDelegate, SeedsDeleg
       }
 
       this.slots.setBooleanAttribute(slot, matches(entry, (name) => this.valueAt(name, at)))
+      this.slots.claim(slot)
+    }
+
+    for (const [indexKey, entry] of Object.entries(manifest.computed ?? {})) {
+      const slot = item.slots.get(Number(indexKey))
+
+      if (!slot) {
+        continue
+      }
+
+      this.write(slot, printValue(evaluate(entry, (name) => this.valueAt(name, at))))
       this.slots.claim(slot)
     }
   }

--- a/javascript/packages/client/src/state/types.ts
+++ b/javascript/packages/client/src/state/types.ts
@@ -1,7 +1,7 @@
 export type ConditionValue = string | number | boolean | null
 export type ConditionalArm = Arm | ComboArm | [string, StateComparand, number | null] | [string, StateComparand, number | null, string]
 export type StateComparand = null | { state: string } | { value: ConditionValue } | string
-export type StateCondition = [string, StateComparand] | [string, StateComparand, string] | ComboCondition
+export type StateCondition = [string, StateComparand] | [string, StateComparand, string] | [string, StateComparand, string | null, string] | ComboCondition
 export type ValueOf = (name: string) => ConditionValue
 
 export interface ComboCondition {
@@ -36,6 +36,7 @@ export type SerializedState = Record<string, string>
 export type StateIndices = Record<string, number[]>
 export type ConditionalMap = Record<string, Conditional>
 export type PresenceMap = Record<string, StateCondition>
+export type ComputedMap = Record<string, StateCondition>
 export type ResolvedStateOptions = Required<Omit<StateOptions, "transport">> & { transport: StateTransport }
 
 export type StateBucket = Map<string, StateValue>
@@ -66,6 +67,7 @@ export interface StateManifest {
   bound?: StateIndices
   conditionals: ConditionalMap
   presence?: PresenceMap
+  computed?: ComputedMap
 }
 
 export interface StateScope {

--- a/javascript/packages/client/test/branch-value-staleness.test.ts
+++ b/javascript/packages/client/test/branch-value-staleness.test.ts
@@ -20,6 +20,7 @@ const MANIFEST = {
         0: { arms: [{ branch: 0, condition: ["draft", { value: "hello" }] }], else: null },
       },
       presence: {},
+      computed: {},
     },
   },
 }

--- a/javascript/packages/client/test/conditions.test.ts
+++ b/javascript/packages/client/test/conditions.test.ts
@@ -1,6 +1,6 @@
 import { describe, test, expect } from "vitest"
 
-import { armOf, matches, mentions, statesIn } from "../src/state/conditions"
+import { armOf, evaluate, matches, mentions, statesIn } from "../src/state/conditions"
 
 import type { ConditionalArm, StateCondition, ConditionValue } from "../src/state/types"
 
@@ -10,6 +10,9 @@ const VALUES: Record<string, ConditionValue> = {
   attempts: 4,
   limit: 3,
   sort: "name",
+  draft: "",
+  spaced: "   ",
+  note: null,
 }
 
 function valueOf(name: string): ConditionValue {
@@ -37,6 +40,69 @@ describe("a condition the compiler wrote", () => {
   test("compares a state against another state", () => {
     expect(matches(["attempts", { state: "limit" }, ">"], valueOf)).toBe(true)
     expect(matches(["limit", { state: "attempts" }, ">"], valueOf)).toBe(false)
+  })
+
+  test("reads a state for blankness the way ActiveSupport does", () => {
+    expect(matches(["draft", null, "blank"], valueOf)).toBe(true)
+    expect(matches(["spaced", null, "blank"], valueOf)).toBe(true)
+    expect(matches(["sort", null, "blank"], valueOf)).toBe(false)
+    expect(matches(["note", null, "blank"], valueOf)).toBe(true)
+    expect(matches(["failed", null, "blank"], valueOf)).toBe(true)
+    expect(matches(["pending", null, "blank"], valueOf)).toBe(false)
+    expect(matches(["attempts", null, "blank"], valueOf)).toBe(false)
+  })
+
+  test("reads a state for presence as the opposite of blankness", () => {
+    expect(matches(["draft", null, "present"], valueOf)).toBe(false)
+    expect(matches(["spaced", null, "present"], valueOf)).toBe(false)
+    expect(matches(["sort", null, "present"], valueOf)).toBe(true)
+    expect(matches(["note", null, "present"], valueOf)).toBe(false)
+  })
+
+  test("compares a transformed read against a number", () => {
+    expect(matches(["sort", { value: 4 }, "==", "length"], valueOf)).toBe(true)
+    expect(matches(["sort", { value: 3 }, ">", "length"], valueOf)).toBe(true)
+    expect(matches(["sort", { value: 4 }, ">", "length"], valueOf)).toBe(false)
+    expect(matches(["draft", { value: 0 }, "==", "length"], valueOf)).toBe(true)
+  })
+
+  test("counts length the way Ruby does, by codepoint", () => {
+    const emoji = (name: string): ConditionValue => (name === "wave" ? "\u{1F44B}a" : "\u{1F468}\u{200D}\u{1F469}\u{200D}\u{1F467}")
+
+    expect(evaluate(["wave", null, null, "length"], emoji)).toBe(2)
+    expect(evaluate(["family", null, null, "length"], emoji)).toBe(5)
+  })
+
+  test("resolves a bare transformed read to its value, not to a boolean", () => {
+    expect(evaluate(["sort", null, null, "length"], valueOf)).toBe(4)
+    expect(evaluate(["spaced", null, null, "length"], valueOf)).toBe(3)
+    expect(evaluate(["sort", { value: 4 }, "==", "length"], valueOf)).toBe(true)
+    expect(evaluate(["sort", { value: "name" }], valueOf)).toBe(true)
+  })
+
+  test("stringifies a read the way Ruby's to_s does", () => {
+    const kinds = (name: string): ConditionValue => ({ yes: true, no: false, none: null, word: "hi", blank: "", num: -5 })[name] ?? null
+
+    expect(evaluate(["yes", null, null, "to_s"], kinds)).toBe("true")
+    expect(evaluate(["no", null, null, "to_s"], kinds)).toBe("false")
+    expect(evaluate(["none", null, null, "to_s"], kinds)).toBe("")
+    expect(evaluate(["word", null, null, "to_s"], kinds)).toBe("hi")
+    expect(evaluate(["blank", null, null, "to_s"], kinds)).toBe("")
+    expect(evaluate(["num", null, null, "to_s"], kinds)).toBe("-5")
+    expect(matches(["num", { value: "-5" }, "==", "to_s"], kinds)).toBe(true)
+  })
+
+  test("compares a transformed read against another state", () => {
+    expect(matches(["attempts", { state: "limit" }, ">"], valueOf)).toBe(true)
+    expect(matches(["sort", { state: "draft" }, "==", "to_s"], valueOf)).toBe(false)
+  })
+
+  test("negates a read the way `!` does", () => {
+    expect(matches(["pending", null, "falsy"], valueOf)).toBe(false)
+    expect(matches(["failed", null, "falsy"], valueOf)).toBe(true)
+    expect(matches(["note", null, "falsy"], valueOf)).toBe(true)
+    expect(matches(["draft", null, "falsy"], valueOf)).toBe(false)
+    expect(matches(["attempts", null, "falsy"], valueOf)).toBe(false)
   })
 
   test("joins conditions", () => {

--- a/javascript/packages/client/test/directives.test.ts
+++ b/javascript/packages/client/test/directives.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect } from "vitest"
-import { classifyDefault, mentionsAnyState } from "../src/directives"
+import { classifyDefault, classifyDerivedDefault, mentionsAnyState } from "../src/directives"
 
 describe("mentionsAnyState", () => {
   test("a bare read mentions the state", () => {
@@ -57,5 +57,59 @@ describe("classifyDefault", () => {
     expect(classifyDefault("[]")).toBe("array")
     expect(classifyDefault("{ a: 1 }")).toBe("hash")
     expect(classifyDefault("open_initially")).toBe("bare")
+  })
+})
+
+describe("classifyDerivedDefault", () => {
+  const declared = new Map([["draft", "string"], ["count", "integer"], ["open", "boolean"]])
+
+  test("derives a boolean from a predicate the state kind answers", () => {
+    expect(classifyDerivedDefault("draft.blank?", declared)).toEqual({ kind: "boolean", condition: ["draft", null, "blank"], sources: ["draft"] })
+    expect(classifyDerivedDefault("draft.present?", declared)).toEqual({ kind: "boolean", condition: ["draft", null, "present"], sources: ["draft"] })
+    expect(classifyDerivedDefault("draft.empty?", declared)).toEqual({ kind: "boolean", condition: ["draft", '""'], sources: ["draft"] })
+    expect(classifyDerivedDefault("count.zero?", declared)).toEqual({ kind: "boolean", condition: ["count", "0"], sources: ["count"] })
+    expect(classifyDerivedDefault("count.one?", declared)).toEqual({ kind: "boolean", condition: ["count", "1"], sources: ["count"] })
+    expect(classifyDerivedDefault("open.nil?", declared)).toEqual({ kind: "boolean", condition: ["open", "nil"], sources: ["open"] })
+  })
+
+  test("refuses a predicate the state kind cannot answer", () => {
+    expect(classifyDerivedDefault("count.empty?", declared)).toBe("mixed")
+    expect(classifyDerivedDefault("count.blank?", declared)).toBe("mixed")
+    expect(classifyDerivedDefault("draft.zero?", declared)).toBe("mixed")
+  })
+
+  test("negates the condition it wraps", () => {
+    expect(classifyDerivedDefault("!open", declared)).toEqual({ kind: "boolean", condition: ["open", null, "falsy"], sources: ["open"] })
+    expect(classifyDerivedDefault("!open?", declared)).toEqual({ kind: "boolean", condition: ["open", null, "falsy"], sources: ["open"] })
+    expect(classifyDerivedDefault("!!open", declared)).toEqual({ kind: "boolean", condition: ["open", null], sources: ["open"] })
+    expect(classifyDerivedDefault("!draft.blank?", declared)).toEqual({ kind: "boolean", condition: ["draft", null, "present"], sources: ["draft"] })
+    expect(classifyDerivedDefault("!count.zero?", declared)).toEqual({ kind: "boolean", condition: ["count", "0", "!="], sources: ["count"] })
+    expect(classifyDerivedDefault('!(draft == "hi")', declared)).toEqual({ kind: "boolean", condition: ["draft", '"hi"', "!="], sources: ["draft"] })
+    expect(classifyDerivedDefault("!(count > 3)", declared)).toEqual({ kind: "boolean", condition: ["count", "3", "<="], sources: ["count"] })
+  })
+
+  test("distributes a negated combination over its parts", () => {
+    expect(classifyDerivedDefault("!(open && draft.blank?)", declared)).toEqual({
+      kind: "boolean",
+      condition: { any: [["open", null, "falsy"], ["draft", null, "present"]] },
+      sources: ["open", "draft"],
+    })
+
+    expect(classifyDerivedDefault("!(open || count.zero?)", declared)).toEqual({
+      kind: "boolean",
+      condition: { all: [["open", null, "falsy"], ["count", "0", "!="]] },
+      sources: ["open", "count"],
+    })
+  })
+
+  test("reads to_s on a state of any kind", () => {
+    expect(classifyDerivedDefault("count.to_s", declared)).toEqual({ kind: "string", condition: ["count", null, null, "to_s"], sources: ["count"] })
+    expect(classifyDerivedDefault("open.to_s", declared)).toEqual({ kind: "string", condition: ["open", null, null, "to_s"], sources: ["open"] })
+    expect(classifyDerivedDefault('count.to_s == "3"', declared)).toEqual({ kind: "boolean", condition: ["count", '"3"', "==", "to_s"], sources: ["count"] })
+  })
+
+  test("stays out of expressions that are not predicates", () => {
+    expect(classifyDerivedDefault("draft.upcase", declared)).toBe("mixed")
+    expect(classifyDerivedDefault("other.blank?", declared)).toBeNull()
   })
 })

--- a/javascript/packages/client/test/fixtures/contract/a-boolean-attribute-inside-a-block.json
+++ b/javascript/packages/client/test/fixtures/contract/a-boolean-attribute-inside-a-block.json
@@ -67,7 +67,8 @@
           "sending",
           null
         ]
-      }
+      },
+      "computed": {}
     }
   },
   "dependencies": {

--- a/javascript/packages/client/test/fixtures/contract/a-keyed-collection-with-declared-item-state.json
+++ b/javascript/packages/client/test/fixtures/contract/a-keyed-collection-with-declared-item-state.json
@@ -131,7 +131,8 @@
             ]
           ]
         }
-      }
+      },
+      "computed": {}
     }
   },
   "dependencies": {

--- a/javascript/packages/client/test/negation-parity.test.ts
+++ b/javascript/packages/client/test/negation-parity.test.ts
@@ -1,0 +1,51 @@
+import { describe, test, expect } from "vitest"
+
+import { matches } from "../src/state/conditions"
+
+import type { ConditionValue, StateCondition } from "../src/state/types"
+
+/**
+ * The condition the compiler writes for
+ *
+ *   <% if !((message.length > count) && !(message == "abc" || count == 0)) %>
+ *
+ * with `(message: "", count: 0)` declared. Every row below is the answer Ruby gives for the
+ * original expression, so this pins De Morgan against the language rather than against itself.
+ */
+const CONDITION: StateCondition = {
+  any: [
+    ["message", { state: "count" }, "<=", "length"],
+    { any: [["message", { value: "abc" }, "=="], ["count", { value: 0 }, "=="]] },
+  ],
+}
+
+const RUBY_ANSWERS: [string, number, boolean][] = [
+  ["", 0, true],
+  ["", 1, true],
+  ["", 3, true],
+  ["", 5, true],
+  ["abc", 0, true],
+  ["abc", 1, true],
+  ["abc", 3, true],
+  ["abc", 5, true],
+  ["hello", 0, true],
+  ["hello", 1, false],
+  ["hello", 3, false],
+  ["hello", 5, true],
+  ["hi", 0, true],
+  ["hi", 1, false],
+  ["hi", 3, true],
+  ["hi", 5, true],
+]
+
+describe("a negated combination the compiler rewrote with De Morgan", () => {
+  test("answers what Ruby answers for the original expression", () => {
+    const answers = RUBY_ANSWERS.map(([message, count]) => {
+      const valueOf = (name: string): ConditionValue => (name === "message" ? message : count)
+
+      return [message, count, matches(CONDITION, valueOf)] as [string, number, boolean]
+    })
+
+    expect(answers).toEqual(RUBY_ANSWERS)
+  })
+})

--- a/javascript/packages/client/test/state-predicates.test.ts
+++ b/javascript/packages/client/test/state-predicates.test.ts
@@ -1,0 +1,112 @@
+import { describe, test, expect, beforeEach } from "vitest"
+
+import { Slots } from "../src/slots/slots"
+import { State } from "../src/state/state"
+
+const FILE = "app/views/chat/show.html.erb"
+const VERSION = "aaaaaaaa"
+
+const MANIFEST = {
+  state: {},
+  states: {
+    [FILE]: {
+      version: VERSION,
+      declarations: [
+        { name: "draft", kind: "string", default: '""', value: "", scope: "region" },
+        { name: "count", kind: "integer", default: "0", value: 0, scope: "region" },
+      ],
+      reads: { draft: [1, 2, 3], count: [4] },
+      conditionals: {
+        0: { arms: [{ branch: 0, condition: ["draft", { value: "hello" }] }], else: null },
+      },
+      presence: { 3: ["draft", null, "blank"] },
+      computed: { 1: ["draft", { value: "hello" }], 4: ["count", { value: 1 }] },
+    },
+  },
+}
+
+const PAGE =
+  `<!--herb-region:${FILE}:${VERSION}:0-->` +
+  `<div><!--herb-slot:0:conditional--><!--/herb-slot:0--></div>` +
+  `<p><!--herb-slot:1-->false<!--/herb-slot:1--></p>` +
+  `<button data-herb-slot="3:boolean_attribute:disabled" disabled>Send</button>` +
+  `<em><!--herb-slot:4-->false<!--/herb-slot:4--></em>` +
+  `<!--/herb-region:${FILE}-->` +
+  `<template data-herb-region="${FILE}:${VERSION}">` +
+  `<!--herb-branch:0:0-->\n  <!--herb-slot:2--><!--/herb-slot:2-->\n` +
+  `</template>` +
+  `<template data-herb-dependencies>${JSON.stringify(MANIFEST)}</template>`
+
+let slots: Slots
+let state: State
+
+beforeEach(() => {
+  document.body.innerHTML = PAGE
+
+  slots = new Slots()
+  slots.scan(document.body)
+
+  state = new State(slots, {})
+  state.adopt()
+})
+
+function text(index: number): string {
+  return slots.rangeOf(slots.slot(FILE, index)!).toString()
+}
+
+describe("a slot whose value the compiler resolved into a condition", () => {
+  test("prints the condition's answer instead of the state", () => {
+    expect(text(1)).toBe("false")
+
+    state.setState({ draft: "hello" })
+
+    expect(text(1)).toBe("true")
+
+    state.setState({ draft: "hell" })
+
+    expect(text(1)).toBe("false")
+  })
+
+  test("prints a count comparison the same way", () => {
+    state.setState({ count: 1 })
+
+    expect(text(4)).toBe("true")
+
+    state.setState({ count: 2 })
+
+    expect(text(4)).toBe("false")
+  })
+
+  test("leaves the state's own text alone", () => {
+    state.setState({ draft: "hello" })
+
+    expect(text(2)).toBe("hello")
+  })
+})
+
+describe("a boolean attribute the compiler resolved into a blank check", () => {
+  test("turns off once the state holds more than whitespace", () => {
+    const button = document.querySelector("button")!
+
+    expect(button.hasAttribute("disabled")).toBe(true)
+
+    state.setState({ draft: "   " })
+
+    expect(button.hasAttribute("disabled")).toBe(true)
+
+    state.setState({ draft: "hi" })
+
+    expect(button.hasAttribute("disabled")).toBe(false)
+  })
+})
+
+describe("a value slot inside a branch that was never in the document", () => {
+  test("shows the value the state holds now, not the one it was parked with", () => {
+    state.setState({ draft: "hell" })
+    state.setState({ draft: "hello" })
+
+    expect(slots.slot(FILE, 0)?.branch).toBe(0)
+    expect(text(2)).toBe("hello")
+  })
+
+})

--- a/javascript/packages/linter/docs/rules/herb-state-valid-reads.md
+++ b/javascript/packages/linter/docs/rules/herb-state-valid-reads.md
@@ -4,11 +4,39 @@
 
 ## Description
 
-Validates every read of a declared state. A state is read bare (`<%= attempts %>`, `<% if pending %>`, `<% unless pending %>`), as a predicate on a boolean (`pending?`), compared to a literal of its own type (`sort == "name"`, `sort != "date"`), ordered against an Integer literal when it is an Integer (`attempts > 3`), or compared with another state of the same kind (`counter1 > counter2`), or switched over with literal `when` arms. Those conditions also combine with `&&` and `||` (`pending? || failed?`), as long as every side reads a state. A boolean attribute accepts the same read shapes, since its presence is a two-arm conditional (`disabled="<%= draft == "" %>"`). Anything else, a computed expression, a predicate on a non-boolean, a comparison against a non-literal or a mismatched literal, or a combination that mixes a state with server Ruby, is flagged.
+Validates every read of a declared state. A state is read bare (`<%= attempts %>`, `<% if pending %>`, `<% unless pending %>`), with a `?` on the end (`pending?`), compared to a literal of its own type (`sort == "name"`, `sort != "date"`), ordered against an Integer literal when it is an Integer (`attempts > 3`), or compared with another state of the same kind (`counter1 > counter2`), or switched over with literal `when` arms. Those conditions also combine with `&&` and `||` (`pending? || failed?`), as long as every side reads a state. A boolean attribute accepts the same read shapes, since its presence is a two-arm conditional (`disabled="<%= draft == "" %>"`). Anything else, a computed expression, a comparison against a non-literal or a mismatched literal, or a combination that mixes a state with server Ruby, is flagged.
+
+`!` negates any of these. It flips a comparison (`!(count > 3)` becomes `count <= 3`), swaps `blank?` and `present?`, and turns a plain read into a falsy check. Negating a whole `&&` or `||` distributes over its parts by De Morgan, so `!(a && b)` compiles as `!a || !b` and nests to any depth. `not` reads the same way.
+
+The `?` spelling reads a state for its truth, exactly as the bare name does, and the compiler drops the `?` from the source it hands the server. It carries no extra meaning on a state that is not a boolean, so `<% if draft? %>` asks the same question as `<% if draft %>`. For "does this string hold anything", reach for `draft.present?`.
+
+Six Ruby predicates are read as the comparison they stand for, each on the state kinds that answer it.
+
+| Predicate  | Reads                              | Resolves as                                  |
+|------------|------------------------------------|----------------------------------------------|
+| `nil?`     | every state                        | `state == nil`                               |
+| `positive?` | an Integer state | `state > 0` |
+| `zero?`    | an Integer state                   | `state == 0`                                 |
+| `one?`     | an Integer state                   | `state == 1`                                 |
+| `empty?`   | a String or a Symbol state         | `state == ""`                                |
+| `blank?`   | a Boolean, a String or a Nil state | ActiveSupport blankness, whitespace included |
+| `present?` | a Boolean, a String or a Nil state | the opposite of `blank?`                     |
+
+An expression the client can resolve also stands on its own as an output, so `<%= draft == "" %>` and `<%= draft.blank? %>` print `true` or `false` and stay current as the state changes.
+
+`to_s` reads a state of any kind as a String, matching Ruby down to `nil.to_s` being `""`. `length` and `size` read the character count of a String or a Symbol state, either compared to an Integer literal (`draft.length > 3`) or printed on its own (`<%= draft.length %>`). Both spell the same thing, so `size` compiles exactly like `length`.
+
+A transform compares against a literal or against another declared state, so `draft.to_s == filter` works. Only one side of a comparison may carry a transform.
+
+`count` is not supported. Unlike `Array#count`, `String#count` takes a character set (`"hello".count("a-z")`) and raises without one, so there is nothing to resolve on the client.
 
 ## Rationale
 
 The client resolves state reads itself, without the server. That works because every allowed shape is a lookup or a comparison both languages compute identically, and a `&&`/`||` combination of those shapes is resolved one condition at a time. A computed read (`attempts + 1`, `attempts * 2 > 3`) would need a Ruby evaluator in JavaScript, so the engine rejects it at compile time. A combination like `pending? && current_user.admin?` has the same problem on its server side, since the client holds no value for it. An `unless` reads like an `if` with its arms inverted, so every `if` shape works there too.
+
+`length` on an Integer is flagged too, and `size` especially. `Integer#size` is the machine byte width, so `count.size` answers `8` rather than a length, which is the kind of quiet wrong answer worth refusing outright. On the client the count is taken by codepoint, matching Ruby, so an emoji counts as one character rather than the two UTF-16 units JavaScript's own `String#length` would report.
+
+A predicate on a state kind that cannot answer it is flagged the same way. `count.empty?` raises `NoMethodError` on an Integer, and `count.blank?` answers `false` for every Integer, so both are mistakes worth catching before the page renders. `one?` is the one predicate the compiler rewrites, since Ruby defines `one?` on Enumerable and not on Integer, so `count.one?` reaches the server as `count == 1`.
 
 The engine raises all of these as compile errors when the template renders. This rule reports the same findings in the editor first.
 
@@ -28,10 +56,32 @@ The engine raises all of these as compile errors when the template renders. This
 
 <% if pending? || attempts > 3 %>Hold on<% else %>Ready<% end %>
 
+<% if !pending %>Idle<% end %>
+
+<% if !(attempts > 3) %>Room to retry<% end %>
+
+<% if !(pending && attempts > 3) %>Fine<% end %>
+
 <% case sort %>
 <% when "name" %>By name
 <% when "date" %>By date
 <% end %>
+```
+
+```erb
+<%# herb:slots client %>
+<%# herb:state (draft: "", count: 0) %>
+
+<% if draft.blank? %>Nothing to send<% end %>
+
+<% if count.zero? %>No messages<% elsif count.one? %>One message<% end %>
+
+<% if count.positive? %>Some messages<% end %>
+
+<% if draft.length > 280 %>Too long<% end %>
+
+<p><%= draft == "" %></p>
+<p><%= draft.length %></p>
 ```
 
 ```erb
@@ -52,11 +102,17 @@ The engine raises all of these as compile errors when the template renders. This
 
 <% if pending? && current_user.admin? %>Retry as admin<% end %>
 
-<% if attempts? %>Tried<% end %>
-
 <% if sort == params[:sort] %>Current<% end %>
 
 <% if sort == 3 %>Odd<% end %>
+
+<% if attempts.empty? %>None<% end %>
+
+<% if attempts.blank? %>None<% end %>
+
+<% if attempts.length > 3 %>Many<% end %>
+
+<% if sort.count("a") > 1 %>Twice<% end %>
 ```
 
 ## Limits

--- a/javascript/packages/linter/src/rules/herb-state-valid-reads.ts
+++ b/javascript/packages/linter/src/rules/herb-state-valid-reads.ts
@@ -1,18 +1,58 @@
-import { BaseRuleVisitor } from "../utils/rule-utils.js"
 import { ParserRule } from "../types.js"
-import { StateScopeMap, declaredKind, kindWithArticle } from "../utils/state-directives-utils.js"
-import { COMPARISON_OPERATORS, PRISM_LITERAL_KINDS, bareReadName, classifyDerivedDefault, mentionsAnyState } from "@herb-tools/client/directives"
+import { BaseRuleVisitor } from "../utils/rule-utils.js"
+import { StateScopeMap } from "../utils/state-directives-utils.js"
 
+import { COMPARISON_OPERATORS, PRISM_LITERAL_KINDS, STATE_PREDICATES, STATE_TRANSFORMS } from "@herb-tools/client/directives"
+
+import { declaredKind, kindWithArticle } from "../utils/state-directives-utils.js"
+import { bareReadName, classifyDerivedDefault, mentionsAnyState, predicateAnswers, transformApplies } from "@herb-tools/client/directives"
 import { isBooleanAttribute, locationFromByteOffset, substringFromByteOffset } from "@herb-tools/core"
 import { getAttributeName, getAttributeValueNodes, isERBContentNode } from "@herb-tools/core"
 
+import type { StateDeclaration } from "@herb-tools/client/directives"
 import type { UnboundLintOffense, LintContext, FullRuleConfig } from "../types.js"
 import type { ParseResult, ParserOptions, Location, PrismNode, ERBBlockNode, ERBContentNode, ERBIfNode, ERBUnlessNode, ERBCaseNode, HTMLAttributeNode, RubyLiteralNode } from "@herb-tools/core"
-import type { StateDeclaration } from "@herb-tools/client/directives"
 
 interface BareRead {
   name: string
   predicate: boolean
+}
+
+interface PredicateCall {
+  name: string
+  predicate: string
+}
+
+interface TransformCall {
+  name: string
+  transform: string
+}
+
+type ReadContext = "branch" | "value"
+
+function prismNegation(node: PrismNode | null | undefined): PrismNode | null {
+  if (prismType(node) !== "CallNode") return null
+  if (String(node.name) !== "!") return null
+  if (!node.receiver || node.block) return null
+  if (node.arguments_?.arguments_?.length) return null
+
+  const inner = node.receiver
+
+  return prismType(inner) === "ParenthesesNode" && inner.body?.body?.length === 1 ? inner.body.body[0] : inner
+}
+
+function prismTransformRead(node: PrismNode | null | undefined): TransformCall | null {
+  if (prismType(node) !== "CallNode") return null
+  if (!node.receiver || node.block) return null
+  if (node.arguments_?.arguments_?.length) return null
+
+  const transform = String(node.name)
+  if (!(transform in STATE_TRANSFORMS)) return null
+
+  const receiver = prismBareRead(node.receiver)
+  if (!receiver || receiver.predicate) return null
+
+  return { name: receiver.name, transform }
 }
 
 function prismType(node: PrismNode | null | undefined): string {
@@ -32,6 +72,26 @@ function prismBareRead(node: PrismNode | null | undefined): BareRead | null {
   const predicate = spelled.endsWith("?")
 
   return { name: predicate ? spelled.slice(0, -1) : spelled, predicate }
+}
+
+function prismPredicateRead(node: PrismNode | null | undefined): PredicateCall | null {
+  if (prismType(node) !== "CallNode") return null
+  if (!node.receiver || node.block) return null
+  if (node.arguments_?.arguments_?.length) return null
+
+  const predicate = String(node.name)
+
+  if (!(predicate in STATE_PREDICATES)) {
+    return null
+  }
+
+  const receiver = prismBareRead(node.receiver)
+
+  if (!receiver || receiver.predicate) {
+    return null
+  }
+
+  return { name: receiver.name, predicate }
 }
 
 function equalitySides(node: PrismNode): [PrismNode, PrismNode, string] | null {
@@ -120,12 +180,13 @@ class StateValidReadsVisitor extends BaseRuleVisitor {
 
     if (bare && this.resolve(bare)) return
 
+    const prism = node.prismNode
+
+    if (prism && this.classifyPredicate(prism, names, "value") !== "other") return
+
     const name = names.find(candidate => mentionsAnyState(expression, [candidate])) ?? names[0]
 
-    this.addOffense(
-      `\`${expression}\` computes with the state \`${name}\`, and the client cannot run Ruby to keep the result current. Show the value with \`<%= ${name} %>\`, or declare a second state for the computed answer and set it from app code.`,
-      node.location,
-    )
+    this.addOffense(this.computedValueOffense(expression, name), node.location)
   }
 
   visitRubyLiteralNode(node: RubyLiteralNode): void {
@@ -143,14 +204,15 @@ class StateValidReadsVisitor extends BaseRuleVisitor {
       const bare = bareReadName(expression)
 
       if (bare && this.resolve(bare)) return
+
+      const declared = new Map(names.map((name) => [name, declaredKind(this.resolve(name)!)]))
+
+      if (classifyDerivedDefault(expression, declared) !== "mixed") return
     }
 
     const name = names.find(candidate => mentionsAnyState(expression, [candidate])) ?? names[0]
 
-    this.addOffense(
-      `\`${expression}\` computes with the state \`${name}\`, and the client cannot run Ruby to keep the result current. Show the value with \`<%= ${name} %>\`, or declare a second state for the computed answer and set it from app code.`,
-      node.location,
-    )
+    this.addOffense(this.computedValueOffense(expression, name), node.location)
   }
 
   visitERBUnlessNode(node: ERBUnlessNode): void {
@@ -219,22 +281,28 @@ class StateValidReadsVisitor extends BaseRuleVisitor {
     }
   }
 
-  private classifyPredicate(predicate: PrismNode, names: readonly string[]): "state" | "other" | "reported" {
+  private classifyPredicate(predicate: PrismNode, names: readonly string[], context: ReadContext = "branch"): "state" | "other" | "reported" {
     const type = prismType(predicate)
 
     if (type === "ParenthesesNode") {
       const statements = predicate.body?.body
 
       if (Array.isArray(statements) && statements.length === 1) {
-        return this.classifyPredicate(statements[0], names)
+        return this.classifyPredicate(statements[0], names, context)
       }
     }
 
+    const negated = prismNegation(predicate)
+
+    if (negated) {
+      return this.classifyPredicate(negated, names, context)
+    }
+
     if ((type === "AndNode" || type === "OrNode") && predicate.left && predicate.right) {
-      const left = this.classifyPredicate(predicate.left, names)
+      const left = this.classifyPredicate(predicate.left, names, context)
       if (left === "reported") return "reported"
 
-      const right = this.classifyPredicate(predicate.right, names)
+      const right = this.classifyPredicate(predicate.right, names, context)
       if (right === "reported") return "reported"
       if (left === "state" && right === "state") return "state"
 
@@ -258,17 +326,45 @@ class StateValidReadsVisitor extends BaseRuleVisitor {
       const declaration = this.resolve(bare.name)
       if (!declaration) return "other"
 
-      if (bare.predicate) {
-        const kind = declaredKind(declaration)
+      return "state"
+    }
 
-        if (kind !== "boolean" && kind !== "seeded") {
-          this.addOffense(
-            `\`${this.sliceOf(predicate)}\` reads the ${capitalize(kind)} state \`${bare.name}\` as a predicate. Write \`${bare.name}\` bare, or declare a boolean flag. Only a boolean state reads with a \`?\`.`,
-            this.locationOf(predicate),
-          )
+    const transformCall = prismTransformRead(predicate)
 
-          return "reported"
-        }
+    if (transformCall) {
+      const declaration = this.resolve(transformCall.name)
+
+      if (!declaration) return "other"
+
+      const kind = declaredKind(declaration)
+
+      if (!transformApplies(transformCall.transform, kind)) {
+        this.addOffense(
+          `\`${this.sliceOf(predicate)}\` reads the ${capitalize(kind)} state \`${transformCall.name}\` with \`${transformCall.transform}\`. Only ${STATE_TRANSFORMS[transformCall.transform].only} can be read with \`${transformCall.transform}\`, so compare \`${transformCall.name}\` itself instead.`,
+          this.locationOf(predicate),
+        )
+
+        return "reported"
+      }
+
+      return "state"
+    }
+
+    const call = prismPredicateRead(predicate)
+
+    if (call) {
+      const declaration = this.resolve(call.name)
+      if (!declaration) return "other"
+
+      const kind = declaredKind(declaration)
+
+      if (!predicateAnswers(call.predicate, kind)) {
+        this.addOffense(
+          `\`${this.sliceOf(predicate)}\` reads the ${capitalize(kind)} state \`${call.name}\` with \`${call.predicate}\`. Only ${STATE_PREDICATES[call.predicate].only} can be read with \`${call.predicate}\`, so compare \`${call.name}\` to a literal instead.`,
+          this.locationOf(predicate),
+        )
+
+        return "reported"
       }
 
       return "state"
@@ -278,6 +374,84 @@ class StateValidReadsVisitor extends BaseRuleVisitor {
 
     if (sides) {
       const [left, right, operator] = sides
+
+      const leftTransform = prismTransformRead(left)
+      const rightTransform = prismTransformRead(right)
+
+      for (const [side, call] of [[left, leftTransform], [right, rightTransform]] as [PrismNode, TransformCall | null][]) {
+        if (!call) continue
+
+        const declaration = this.resolve(call.name)
+
+        if (!declaration) continue
+
+        const kind = declaredKind(declaration)
+
+        if (!transformApplies(call.transform, kind)) {
+          this.addOffense(
+            `\`${this.sliceOf(side)}\` reads the ${capitalize(kind)} state \`${call.name}\` with \`${call.transform}\`. Only ${STATE_TRANSFORMS[call.transform].only} can be read with \`${call.transform}\`, so compare \`${call.name}\` itself instead.`,
+            this.locationOf(side),
+          )
+
+          return "reported"
+        }
+      }
+
+      if (leftTransform && rightTransform) {
+        this.addOffense(
+          `\`${this.sliceOf(predicate)}\` compares the ${leftTransform.transform} of the state \`${leftTransform.name}\` against the ${rightTransform.transform} of the state \`${rightTransform.name}\`. One condition carries one transform, so declare a state for one of the two sides and compare that.`,
+          this.locationOf(predicate),
+        )
+
+        return "reported"
+      }
+
+      const transformed = leftTransform ?? rightTransform
+
+      if (transformed) {
+        const returns = STATE_TRANSFORMS[transformed.transform].returns
+        const other = leftTransform ? right : left
+        const otherTransform = prismBareRead(other)
+        const otherDeclaration = otherTransform ? this.resolve(otherTransform.name) : undefined
+
+        if (otherDeclaration) {
+          const otherKind = declaredKind(otherDeclaration)
+
+          if (otherKind !== "seeded" && otherKind !== returns) {
+            this.addOffense(
+              `\`${this.sliceOf(predicate)}\` compares the ${transformed.transform} of the state \`${transformed.name}\` with the ${capitalize(otherKind)} state \`${otherTransform!.name}\`, so it can never match. Compare values of the same kind.`,
+              this.locationOf(predicate),
+            )
+
+            return "reported"
+          }
+
+          return "state"
+        }
+
+        const otherKind = PRISM_LITERAL_KINDS[prismType(other)]
+
+        if (!otherKind) {
+          this.addOffense(
+            `\`${this.sliceOf(predicate)}\` compares the ${transformed.transform} of the state \`${transformed.name}\` against something that is not a literal or another declared state. Compare against a literal, since the client resolves a comparison by lookup.`,
+            this.locationOf(predicate),
+          )
+
+          return "reported"
+        }
+
+        if (otherKind !== returns) {
+          this.addOffense(
+            `\`${this.sliceOf(predicate)}\` compares the ${transformed.transform} of the state \`${transformed.name}\` against ${kindWithArticle(otherKind)} literal, so it can never match. Compare it against ${kindWithArticle(returns)} literal instead.`,
+            this.locationOf(predicate),
+          )
+
+          return "reported"
+        }
+
+        return "state"
+      }
+
       const leftRead = prismBareRead(left)
       const rightRead = prismBareRead(right)
       const leftDeclaration = leftRead ? this.resolve(leftRead.name) : undefined
@@ -366,7 +540,7 @@ class StateValidReadsVisitor extends BaseRuleVisitor {
       const name = names.find(candidate => mentionsAnyState(this.sliceOf(predicate), [candidate])) ?? names[0]
 
       this.addOffense(
-        `\`${this.sliceOf(predicate)}\` computes with the state \`${name}\`, and the client cannot run Ruby to pick the branch. ${this.conditionAdvice(name)}`,
+        context === "value" ? this.computedValueOffense(this.sliceOf(predicate), name) : `\`${this.sliceOf(predicate)}\` computes with the state \`${name}\`, and the client cannot run Ruby to pick the branch. ${this.conditionAdvice(name)}`,
         this.locationOf(predicate),
       )
 
@@ -374,6 +548,10 @@ class StateValidReadsVisitor extends BaseRuleVisitor {
     }
 
     return "other"
+  }
+
+  private computedValueOffense(expression: string, name: string): string {
+    return `\`${expression}\` computes with the state \`${name}\`, and the client cannot run Ruby to keep the result current. Show the value with \`<%= ${name} %>\`, or declare a second state for the computed answer and set it from app code.`
   }
 
   private checkCase(prism: PrismNode): void {

--- a/javascript/packages/linter/test/rules/herb-state-valid-reads.test.ts
+++ b/javascript/packages/linter/test/rules/herb-state-valid-reads.test.ts
@@ -35,11 +35,11 @@ describe("HerbStateValidReadsRule", () => {
   })
 
   test("still flags a state read beside an action attribute", () => {
-    expectError("`count.to_s` computes with the state `count`, and the client cannot run Ruby to keep the result current. Show the value with `<%= count %>`, or declare a second state for the computed answer and set it from app code.")
+    expectError("`count + 1` computes with the state `count`, and the client cannot run Ruby to keep the result current. Show the value with `<%= count %>`, or declare a second state for the computed answer and set it from app code.")
 
     assertOffenses(dedent`
       <%# herb:state (count: 0) %>
-      <%= tag.button "More", data: { herb_increment: "count" }, title: count.to_s %>
+      <%= tag.button "More", data: { herb_increment: "count" }, title: count + 1 %>
     `)
   })
 
@@ -65,15 +65,6 @@ describe("HerbStateValidReadsRule", () => {
     assertOffenses(dedent`
       <%# herb:state (status: "") %>
       <div class="row-<%= status %>-<%= @kind %>">x</div>
-    `)
-  })
-
-  test("flags a negated condition the way it flags not", () => {
-    expectError("`!open` computes with the state `open`, and the client cannot run Ruby to pick the branch. Read it bare, `<% if open %>`, or as `open?`.")
-
-    assertOffenses(dedent`
-      <%# herb:state (open: false) %>
-      <% if !open %>Closed<% end %>
     `)
   })
 
@@ -170,12 +161,13 @@ describe("HerbStateValidReadsRule", () => {
     `)
   })
 
-  test("flags a predicate on a non-boolean state", () => {
-    expectError("`attempts?` reads the Integer state `attempts` as a predicate. Write `attempts` bare, or declare a boolean flag. Only a boolean state reads with a `?`.")
-
-    assertOffenses(dedent`
-      <%# herb:state (attempts: 0) %>
+  test("allows the `?` spelling on a state of any kind", () => {
+    expectNoOffenses(dedent`
+      <%# herb:state (attempts: 0, draft: "", tab: :first, shown: draft?) %>
       <% if attempts? %>Tried<% end %>
+      <% if draft? %>Drafted<% end %>
+      <% if tab? %>Tabbed<% end %>
+      <% if shown %>Shown<% end %>
     `)
   })
 
@@ -250,11 +242,11 @@ describe("HerbStateValidReadsRule", () => {
   })
 
   test("flags the invalid condition inside a combo once", () => {
-    expectError("`attempts?` reads the Integer state `attempts` as a predicate. Write `attempts` bare, or declare a boolean flag. Only a boolean state reads with a `?`.")
+    expectError("`attempts.empty?` reads the Integer state `attempts` with `empty?`. Only a String or a Symbol state can be read with `empty?`, so compare `attempts` to a literal instead.")
 
     assertOffenses(dedent`
       <%# herb:state (pending: false, attempts: 0) %>
-      <% if pending? && attempts? %>x<% end %>
+      <% if pending? && attempts.empty? %>x<% end %>
     `)
   })
 
@@ -362,22 +354,218 @@ describe("HerbStateValidReadsRule", () => {
   })
 
   test("flags a computed read in a boolean attribute", () => {
-    expectError('`draft.empty?` computes with the state `draft`, and the client cannot run Ruby to pick the branch. Read it bare, `<% if draft %>`, or compare it to a literal, `draft == ""`.')
+    expectError('`draft.upcase` computes with the state `draft`, and the client cannot run Ruby to pick the branch. Read it bare, `<% if draft %>`, or compare it to a literal, `draft == ""`.')
 
     assertOffenses(dedent`
+      <%# herb:state (draft: "") %>
+      <p><%= draft %></p>
+      <button disabled="<%= draft.upcase %>">Send</button>
+    `)
+  })
+
+  test("allows a predicate read in a boolean attribute", () => {
+    expectNoOffenses(dedent`
       <%# herb:state (draft: "") %>
       <p><%= draft %></p>
       <button disabled="<%= draft.empty? %>">Send</button>
     `)
   })
 
-  test("still flags equality in an attribute that is not boolean", () => {
-    expectError('`draft == ""` computes with the state `draft`, and the client cannot run Ruby to keep the result current. Show the value with `<%= draft %>`, or declare a second state for the computed answer and set it from app code.')
-
-    assertOffenses(dedent`
+  test("allows equality in an attribute that is not boolean", () => {
+    expectNoOffenses(dedent`
       <%# herb:state (draft: "") %>
       <p><%= draft %></p>
       <button title="<%= draft == "" %>">Send</button>
+    `)
+  })
+
+  test("allows a comparison as an output", () => {
+    expectNoOffenses(dedent`
+      <%# herb:state (draft: "") %>
+      <p><%= draft == "hello" %></p>
+    `)
+  })
+
+  test("allows a negated read", () => {
+    expectNoOffenses(dedent`
+      <%# herb:state (sending: false, draft: "", count: 0, idle: !sending) %>
+      <% if !sending %>a<% end %>
+      <% if !sending? %>b<% end %>
+      <% if not sending %>c<% end %>
+      <% if !draft.blank? %>d<% end %>
+      <% if !(count > 3) %>e<% end %>
+      <% if !count.zero? %>f<% end %>
+      <% if !sending && count.zero? %>g<% end %>
+      <% if idle %>h<% end %>
+      <button disabled="<%= !sending %>">Send</button>
+      <p><%= !sending %></p>
+    `)
+  })
+
+  test("allows a negated combination", () => {
+    expectNoOffenses(dedent`
+      <%# herb:state (sending: false, draft: "", count: 0) %>
+      <% if !(sending && draft == "hi") %>a<% end %>
+      <% if !(sending || draft == "hi") %>b<% end %>
+      <% if !((draft.length > count) && !(draft == "abc" || count == 0)) %>c<% end %>
+    `)
+  })
+
+  test("allows a predicate combined with a comparison", () => {
+    expectNoOffenses(dedent`
+      <%# herb:state (sending: false, draft: "", count: 0) %>
+      <% if sending? && draft == "hello" %>a<% end %>
+      <% if sending? || draft.blank? %>b<% end %>
+      <% if sending? && draft.present? && count.zero? %>c<% end %>
+      <% if sending? && (draft == "hello" || count.one?) %>d<% end %>
+      <button disabled="<%= sending? && draft == "hello" %>">Send</button>
+      <p><%= sending? && draft == "hello" %></p>
+    `)
+  })
+
+  test("allows a default derived from a predicate combined with a comparison", () => {
+    expectNoOffenses(dedent`
+      <%# herb:state (sending: false, draft: "", ready: sending? && draft == "hello") %>
+      <% if ready %>Ready<% end %>
+    `)
+  })
+
+  test("allows to_s on a state of any kind", () => {
+    expectNoOffenses(dedent`
+      <%# herb:state (draft: 3, filter: "all", open: false, note: nil, tab: :first, text: draft.to_s) %>
+      <% if draft.to_s == filter %>a<% end %>
+      <% if filter == draft.to_s %>b<% end %>
+      <% if open.to_s == "true" %>c<% end %>
+      <% if note.to_s == "" %>d<% end %>
+      <% if tab.to_s == "first" %>e<% end %>
+      <p><%= draft.to_s %></p>
+      <p><%= text %></p>
+    `)
+  })
+
+  test("allows a transform compared against another state", () => {
+    expectNoOffenses(dedent`
+      <%# herb:state (draft: "", count: 0) %>
+      <% if draft.length > count %>a<% end %>
+      <% if count < draft.length %>b<% end %>
+    `)
+  })
+
+  test("flags a transform on both sides of a comparison", () => {
+    expectError("`draft.length > other.length` compares the length of the state `draft` against the length of the state `other`. One condition carries one transform, so declare a state for one of the two sides and compare that.")
+
+    assertOffenses(dedent`
+      <%# herb:state (draft: "", other: "") %>
+      <% if draft.length > other.length %>a<% end %>
+    `)
+  })
+
+  test("flags a transform compared against a state of another kind", () => {
+    expectError("`draft.length > filter` compares the length of the state `draft` with the String state `filter`, so it can never match. Compare values of the same kind.")
+
+    assertOffenses(dedent`
+      <%# herb:state (draft: "", filter: "all") %>
+      <% if draft.length > filter %>a<% end %>
+    `)
+  })
+
+  test("allows length and size compared against an Integer", () => {
+    expectNoOffenses(dedent`
+      <%# herb:state (draft: "", tab: :first, count: 0, width: draft.length) %>
+      <% if draft.length > 3 %>a<% end %>
+      <% if draft.size == 0 %>b<% end %>
+      <% if 3 < draft.length %>c<% end %>
+      <% if tab.length > 2 %>d<% end %>
+      <% if draft.length > 3 && count.zero? %>e<% end %>
+      <p><%= draft.length %></p>
+      <p><%= width %></p>
+      <button disabled="<%= draft.length > 3 %>">Send</button>
+    `)
+  })
+
+  test("flags length on a state that is not a String or a Symbol", () => {
+    expectError("`count.length` reads the Integer state `count` with `length`. Only a String or a Symbol state can be read with `length`, so compare `count` itself instead.")
+
+    assertOffenses(dedent`
+      <%# herb:state (count: 0) %>
+      <% if count.length > 3 %>a<% end %>
+    `)
+  })
+
+  test("flags a length compared against a literal of another type", () => {
+    expectError('`draft.length == "x"` compares the length of the state `draft` against a String literal, so it can never match. Compare it against an Integer literal instead.')
+
+    assertOffenses(dedent`
+      <%# herb:state (draft: "") %>
+      <% if draft.length == "x" %>a<% end %>
+    `)
+  })
+
+  test("allows every supported predicate on a state of its kind", () => {
+    expectNoOffenses(dedent`
+      <%# herb:state (draft: "", count: 0, open: false, note: nil) %>
+      <% if count.positive? %>Some<% end %>
+      <% if draft.blank? %>Blank<% end %>
+      <% if draft.present? %>Present<% end %>
+      <% if draft.empty? %>Empty<% end %>
+      <% if count.zero? %>None<% end %>
+      <% if count.one? %>One<% end %>
+      <% if open.nil? %>Unset<% end %>
+      <% if note.blank? %>No note<% end %>
+    `)
+  })
+
+  test("flags zero? on a state that is not an Integer", () => {
+    expectError("`draft.zero?` reads the String state `draft` with `zero?`. Only an Integer state can be read with `zero?`, so compare `draft` to a literal instead.")
+
+    assertOffenses(dedent`
+      <%# herb:state (draft: "") %>
+      <% if draft.zero? %>None<% end %>
+    `)
+  })
+
+  test("flags one? on a state that is not an Integer", () => {
+    expectError("`draft.one?` reads the String state `draft` with `one?`. Only an Integer state can be read with `one?`, so compare `draft` to a literal instead.")
+
+    assertOffenses(dedent`
+      <%# herb:state (draft: "") %>
+      <% if draft.one? %>One<% end %>
+    `)
+  })
+
+  test("flags empty? on a state that is not a String or a Symbol", () => {
+    expectError("`count.empty?` reads the Integer state `count` with `empty?`. Only a String or a Symbol state can be read with `empty?`, so compare `count` to a literal instead.")
+
+    assertOffenses(dedent`
+      <%# herb:state (count: 0) %>
+      <% if count.empty? %>None<% end %>
+    `)
+  })
+
+  test("flags blank? on a state that is never blank", () => {
+    expectError("`count.blank?` reads the Integer state `count` with `blank?`. Only a Boolean, a String or a Nil state can be read with `blank?`, so compare `count` to a literal instead.")
+
+    assertOffenses(dedent`
+      <%# herb:state (count: 0) %>
+      <% if count.blank? %>None<% end %>
+    `)
+  })
+
+  test("flags present? on a state that is always present", () => {
+    expectError("`tab.present?` reads the Symbol state `tab` with `present?`. Only a Boolean, a String or a Nil state can be read with `present?`, so compare `tab` to a literal instead.")
+
+    assertOffenses(dedent`
+      <%# herb:state (tab: :first) %>
+      <% if tab.present? %>Tab<% end %>
+    `)
+  })
+
+  test("flags a method that is not a supported predicate", () => {
+    expectError("`draft.upcase?` computes with the state `draft`, and the client cannot run Ruby to pick the branch. Read it bare, `<% if draft %>`, or compare it to a literal, `draft == \"\"`.")
+
+    assertOffenses(dedent`
+      <%# herb:state (draft: "") %>
+      <% if draft.upcase? %>Loud<% end %>
     `)
   })
 

--- a/javascript/packages/linter/test/rules/html-boolean-attributes-no-value.test.ts
+++ b/javascript/packages/linter/test/rules/html-boolean-attributes-no-value.test.ts
@@ -89,6 +89,10 @@ describe("html-boolean-attributes-no-value", () => {
     expectNoOffenses('<%# herb:state (draft: "") %>\n<p><%= draft %></p>\n<button disabled="<%= draft == \'\' %>">Send</button>')
   })
 
+  test("allows a boolean attribute reading a declared state with a predicate", () => {
+    expectNoOffenses('<%# herb:state (draft: "") %>\n<p><%= draft %></p>\n<button disabled="<%= draft.blank? %>">Send</button>')
+  })
+
   test("fails for a state read outside the loop that declares it", () => {
     expectError('Boolean attribute `muted` should not have a value. Use `muted` instead of `muted="<%= starred %>"`.')
 

--- a/lib/herb/engine/slots/state_compiler.rb
+++ b/lib/herb/engine/slots/state_compiler.rb
@@ -21,6 +21,8 @@ module Herb
 
         attr_reader :state_presence #: Hash[Integer, untyped]
 
+        attr_reader :state_values #: Hash[Integer, untyped]
+
         #: (untyped) -> void
         def initialize(visitor)
           @visitor = visitor
@@ -35,6 +37,7 @@ module Herb
           @state_signatures = state_signatures.compare_by_identity
           @state_counts = [] #: Array[Hash[Symbol, untyped]]
           @state_presence = {} #: Hash[Integer, untyped]
+          @state_values = {} #: Hash[Integer, untyped]
         end
 
         #: () -> bool
@@ -80,6 +83,13 @@ module Herb
             StateDirectives.read_names(read).each { |name| (reads[name] ||= []) << index }
           end
 
+          computed = {} #: Hash[String, untyped]
+
+          state_values.each do |index, read|
+            computed[index.to_s] = StateDirectives.condition_entry(read)
+            StateDirectives.read_names(read).each { |name| (reads[name] ||= []) << index }
+          end
+
           conditionals = {} #: Hash[String, Hash[String, untyped]]
 
           state_conditional_entries.each do |index, info|
@@ -100,6 +110,7 @@ module Herb
             "reads" => reads,
             "conditionals" => conditionals,
             "presence" => presence,
+            "computed" => computed,
           }
         end
 
@@ -318,7 +329,7 @@ module Herb
 
           if declaration.derived
             StateDirectives.read_names(declaration.derived).each do |name|
-              source = source.gsub(/(?<![\w?!])#{Regexp.escape(name)}\?(?![\w?!])/) { name }
+              source = StateDirectives.rewrite_reads(source, name)
             end
           end
 
@@ -369,7 +380,7 @@ module Herb
             return nil if read == :reported
 
             if read == :computed
-              return @visitor.slot_error("`#{expression}` computes with a state. The client cannot evaluate Ruby, so read the state bare, as a predicate, or compared to a literal.", arm.location, :read)
+              return @visitor.slot_error("`#{expression}` computes with a state. The client cannot evaluate Ruby, so read the state bare, read it with a predicate, or compare it to a literal.", arm.location, :read)
             end
 
             unless read.is_a?(StateDirectives::Read) || read.is_a?(StateDirectives::Combo)
@@ -407,7 +418,7 @@ module Herb
           return nil if read.nil? || read == :reported
 
           if read == :computed
-            return @visitor.slot_error("`unless #{expression}` computes with a state. The client cannot evaluate Ruby, so read the state bare, as a predicate, or compared to a literal.", node.location, :read)
+            return @visitor.slot_error("`unless #{expression}` computes with a state. The client cannot evaluate Ruby, so read the state bare, read it with a predicate, or compare it to a literal.", node.location, :read)
           end
 
           return nil unless read.is_a?(StateDirectives::Read) || read.is_a?(StateDirectives::Combo)
@@ -431,7 +442,7 @@ module Herb
 
           return nil if read.nil? || read == :reported
 
-          unless read.is_a?(StateDirectives::Read) && read.comparand.nil?
+          unless read.is_a?(StateDirectives::Read) && read.comparand.nil? && read.operator.nil? && read.transform.nil?
             return @visitor.slot_error("`case #{subject_source}` switches on something other than a bare state read. The client resolves a `case` by looking the state up, so switch on the state itself.", node.location, :conditional)
           end
 
@@ -607,7 +618,7 @@ module Herb
 
           return unless token
 
-          token.value.gsub!(/(?<![\w?!])#{Regexp.escape(name)}\?(?![\w?!])/) { name }
+          token.value.replace(StateDirectives.rewrite_reads(token.value, name))
         rescue FrozenError
           nil
         end
@@ -625,7 +636,7 @@ module Herb
           return nil unless position
 
           literal = children.fetch(position) #: untyped
-          rewritten = literal.content.to_s.gsub(/(?<![\w?!])#{Regexp.escape(name)}\?(?![\w?!])/) { name }
+          rewritten = StateDirectives.rewrite_reads(literal.content.to_s, name)
           replacement = Herb::AST::RubyLiteralNode.build(content: rewritten, location: literal.location)
 
           children[position] = replacement
@@ -686,14 +697,29 @@ module Herb
 
             next if convert_boolean_attribute(node, index, slot, expression, states)
 
-            bare = states.key?(expression) || states.key?(expression.delete_suffix("?"))
+            if states.key?(expression) || states.key?(expression.delete_suffix("?"))
+              rewrite_predicate(node, expression.delete_suffix("?")) if expression.end_with?("?")
 
-            unless bare
-              next @visitor.slot_error("`#{expression}` computes with a state. The client cannot evaluate Ruby, so read the state bare, or compare it to a literal in a conditional or a boolean attribute.", node.location, :read)
+              next
             end
 
-            rewrite_predicate(node, expression.delete_suffix("?")) if expression.end_with?("?")
+            register_state_value(node, index, slot, expression, states)
           end
+        end
+
+        #: (untyped, Integer, untyped, String, Hash[String, StateDirectives::Declaration]) -> void
+        def register_state_value(node, index, slot, expression, states)
+          read = slot.valued? ? StateDirectives.condition_read(expression, states, @visitor, node.location) : nil
+
+          return if read == :reported
+
+          unless read.is_a?(StateDirectives::Read) || read.is_a?(StateDirectives::Combo)
+            return @visitor.slot_error("`#{expression}` computes with a state. The client cannot evaluate Ruby, so read the state bare, read it with a predicate, or compare it to a literal.", node.location, :read)
+          end
+
+          StateDirectives.read_names(read).each { |name| rewrite_predicate(node, name) }
+
+          @state_values[index] = read
         end
 
         #: (untyped, Integer, untyped, String, Hash[String, StateDirectives::Declaration]) -> untyped
@@ -705,8 +731,8 @@ module Herb
 
           return nil unless read.is_a?(StateDirectives::Read) || read.is_a?(StateDirectives::Combo)
 
-          if read.is_a?(StateDirectives::Read) && read.comparand.nil? && read.against.nil? && !StateKinds::FALSY.include?(read.kind)
-            return @visitor.slot_error("`#{slot.attribute}=\"<%= #{expression} %>\"` reads the #{read.kind.to_s.capitalize} state `#{read.name}` as a presence. Only `nil` and `false` are falsy in Ruby, so the attribute could never turn off. Compare the state to a literal, or declare it as a boolean.", node.location, :read)
+          if read.is_a?(StateDirectives::Read) && read.comparand.nil? && read.against.nil? && read.operator.nil? && !StateKinds::FALSY.include?(read.kind)
+            return @visitor.slot_error("`#{slot.attribute}=\"<%= #{expression} %>\"` reads #{StateDirectives.subject_phrase(read)} as a presence. Only `nil` and `false` are falsy in Ruby, so the attribute could never turn off. Compare the state to a literal, or declare it as a boolean.", node.location, :read)
           end
 
           open_tag = @visitor.open_tag_for(node)

--- a/lib/herb/engine/slots/state_directives.rb
+++ b/lib/herb/engine/slots/state_directives.rb
@@ -5,6 +5,8 @@ require "prism"
 
 require_relative "state_kinds"
 require_relative "state_operators"
+require_relative "state_predicates"
+require_relative "state_transforms"
 
 module Herb
   class Engine
@@ -33,7 +35,8 @@ module Herb
           :comparand, #: String?
           :kind,      #: Symbol?
           :operator,  #: String?
-          :against    #: String?
+          :against,   #: String?
+          :transform  #: String?
         )
 
         Combo = Data.define(
@@ -48,6 +51,19 @@ module Herb
 
         ORDERED_OPERATORS = StateOperators::ORDERED #: Array[Symbol]
         MIRRORED_OPERATORS = StateOperators::MIRRORED #: Hash[String, String]
+        NEGATED_OPERATORS = StateOperators::NEGATED #: Hash[String, String]
+
+        FALSY_OPERATOR = "falsy" #: String
+
+        PREDICATES = StatePredicates::TABLE #: Hash[String, Hash[Symbol, untyped]]
+
+        UNARY_OPERATORS = StatePredicates::UNARY #: Hash[String, String]
+
+        NEGATED_UNARY = StatePredicates::NEGATED #: Hash[String, String]
+
+        TRANSFORMS = StateTransforms::TABLE #: Hash[String, Hash[Symbol, untyped]]
+
+        TRANSFORM_SPELLINGS = StateTransforms::SPELLINGS #: Hash[String, String]
 
         Parsing = Data.define(
           :locals,    #: Hash[String, Symbol]
@@ -119,6 +135,15 @@ module Herb
             read = bare_read(node, states, visitor, location)
             return read if read
 
+            predicate = predicate_read(node, states, visitor, location)
+            return predicate if predicate
+
+            transform = transform_read(node, states, visitor, location)
+            return transform if transform
+
+            negated = negated_read(node, states, visitor, location)
+            return negated if negated
+
             equality = equality_read(node, states, visitor, location)
             return equality if equality
 
@@ -172,6 +197,10 @@ module Herb
 
             comparand = comparand_entry(read)
 
+            if read.transform
+              return [read.name, comparand, read.operator || (comparand ? "==" : nil), read.transform]
+            end
+
             read.operator ? [read.name, comparand, read.operator] : [read.name, comparand]
           end
 
@@ -206,9 +235,14 @@ module Herb
           #: (Read | Combo) -> String
           def condition_source(read)
             if read.is_a?(Read)
-              return read.name if read.comparand.nil? && read.against.nil?
+              spelled = UNARY_OPERATORS[read.operator.to_s]
+              subject = read.transform ? "#{read.name}.#{TRANSFORM_SPELLINGS.fetch(read.transform)}" : read.name
 
-              "#{read.name} #{read.operator || "=="} #{read.against || read.comparand}"
+              return "#{subject}.#{spelled}" if spelled
+              return "!#{subject}" if read.operator == FALSY_OPERATOR
+              return subject if read.comparand.nil? && read.against.nil?
+
+              "#{subject} #{read.operator || "=="} #{read.against || read.comparand}"
             else
               joiner = read.op == "all" ? " && " : " || "
 
@@ -312,6 +346,13 @@ module Herb
             node.nil? || !KINDS.key?(node.class.name)
           end
 
+          #: (Read) -> String
+          def subject_phrase(read)
+            return "the #{TRANSFORM_SPELLINGS.fetch(read.transform)} of the state `#{read.name}`" if read.transform
+
+            "the #{read.kind.to_s.capitalize} state `#{read.name}`"
+          end
+
           #: ((Symbol | String)?) -> String
           def kind_article(kind)
             known = StateKinds::ARTICLES[kind.to_s]
@@ -323,6 +364,21 @@ module Herb
             return "a value" if spelled.empty?
 
             spelled.start_with?("A", "E", "I", "O", "U") ? "an #{spelled}" : "a #{spelled}"
+          end
+
+          #: (String, String) -> String
+          def rewrite_reads(source, name)
+            rewritten = source
+
+            PREDICATES.each do |spelled, predicate|
+              rewrite = predicate[:rewrite]
+
+              next unless rewrite
+
+              rewritten = rewritten.gsub(/(?<![\w?!])#{Regexp.escape(name)}\.#{Regexp.escape(spelled)}(?![\w?!])/) { "(#{name} #{rewrite})" }
+            end
+
+            rewritten.gsub(/(?<![\w?!])#{Regexp.escape(name)}\?(?![\w?!])/) { name }
           end
 
           #: (String, Hash[String, Declaration]) -> bool
@@ -415,7 +471,7 @@ module Herb
 
           #: (Read | Combo) -> Symbol
           def derived_kind(read)
-            return read.kind || :seeded if read.is_a?(Read) && read.comparand.nil? && read.against.nil?
+            return read.kind || :seeded if read.is_a?(Read) && read.comparand.nil? && read.against.nil? && read.operator.nil?
 
             :boolean
           end
@@ -453,13 +509,13 @@ module Herb
           end
 
           #: (untyped, Hash[String, Declaration], untyped, Herb::Location?) -> Read?
-          def bare_read(node, states, visitor, location)
+          def bare_read(node, states, _visitor, _location)
             if node.is_a?(Prism::LocalVariableReadNode)
               declaration = states[node.name.to_s]
 
               return nil unless declaration
 
-              return Read.new(name: node.name.to_s, comparand: nil, kind: declaration.kind, operator: nil, against: nil)
+              return Read.new(name: node.name.to_s, comparand: nil, kind: declaration.kind, operator: nil, against: nil, transform: nil)
             end
 
             return nil unless node.is_a?(Prism::CallNode) && node.receiver.nil? && node.arguments.nil? && node.block.nil?
@@ -471,11 +527,87 @@ module Herb
 
             return nil unless declaration
 
-            if predicate && declaration.kind != :boolean && declaration.kind != :seeded
-              return visitor.slot_error("`#{spelled}` reads the #{declaration.kind.to_s.capitalize} state `#{name}` as a predicate. Only a boolean state can be read with a `?`, so drop the `?` or declare `#{name}` as a boolean.", location, :read)
+            Read.new(name: name, comparand: nil, kind: declaration.kind, operator: nil, against: nil, transform: nil)
+          end
+
+          #: (untyped, Hash[String, Declaration], untyped, Herb::Location?) -> Read?
+          def operand_read(node, states, visitor, location)
+            bare_read(node, states, visitor, location) || transform_read(node, states, visitor, location)
+          end
+
+          #: (untyped, Hash[String, Declaration], untyped, Herb::Location?) -> Read?
+          def transform_read(node, states, visitor, location)
+            return nil unless node.is_a?(Prism::CallNode)
+
+            transform = TRANSFORMS[node.name.to_s]
+
+            return nil unless transform
+            return nil unless node.arguments.nil? && node.block.nil?
+
+            receiver = node.receiver
+
+            return nil unless receiver
+
+            read = bare_read(receiver, states, visitor, location)
+
+            return nil unless read.is_a?(Read)
+
+            kinds = transform.fetch(:kinds)
+
+            if kinds && read.kind != :seeded && !kinds.include?(read.kind)
+              return visitor.slot_error("`#{node.slice}` reads the #{read.kind.to_s.capitalize} state `#{read.name}` with `#{node.name}`. Only #{transform.fetch(:only)} can be read with `#{node.name}`, so compare `#{read.name}` itself instead.", location, :read)
             end
 
-            Read.new(name: name, comparand: nil, kind: declaration.kind, operator: nil, against: nil)
+            Read.new(name: read.name, comparand: nil, kind: transform.fetch(:returns), operator: nil, against: nil, transform: transform.fetch(:operation))
+          end
+
+          #: (untyped, Hash[String, Declaration], untyped, Herb::Location?) -> Read?
+          def predicate_read(node, states, visitor, location)
+            return nil unless node.is_a?(Prism::CallNode)
+
+            predicate = PREDICATES[node.name.to_s]
+
+            return nil unless predicate
+            return nil unless node.arguments.nil? && node.block.nil?
+
+            receiver = node.receiver
+
+            return nil unless receiver
+
+            read = bare_read(receiver, states, visitor, location)
+
+            return nil unless read.is_a?(Read)
+
+            kinds = predicate[:kinds]
+
+            if kinds && read.kind != :seeded && !kinds.include?(read.kind)
+              return visitor.slot_error("`#{node.slice}` reads the #{read.kind.to_s.capitalize} state `#{read.name}` with `#{node.name}`. Only #{predicate.fetch(:only)} can be read with `#{node.name}`, so compare `#{read.name}` to a literal instead.", location, :read)
+            end
+
+            Read.new(name: read.name, comparand: predicate[:comparand], kind: read.kind, operator: predicate[:operator], against: nil, transform: nil)
+          end
+
+          #: (untyped, Hash[String, Declaration], untyped, Herb::Location?) -> (Read | Combo)?
+          def negated_read(node, states, visitor, location)
+            return nil unless node.is_a?(Prism::CallNode) && node.name == :!
+            return nil unless node.receiver && node.arguments.nil? && node.block.nil?
+
+            inner = tree_read(unwrap_parentheses(node.receiver), states, visitor, location)
+
+            return nil unless inner.is_a?(Read) || inner.is_a?(Combo)
+
+            negate(inner)
+          end
+
+          #: (Read | Combo) -> (Read | Combo)
+          def negate(read)
+            return Combo.new(op: read.op == "all" ? "any" : "all", parts: read.parts.map { |part| negate(part) }) if read.is_a?(Combo)
+
+            return read.with(operator: NEGATED_UNARY.fetch(read.operator), kind: :boolean) if NEGATED_UNARY.key?(read.operator.to_s)
+            return read.with(operator: nil, kind: :boolean) if read.operator == FALSY_OPERATOR
+            return read.with(operator: FALSY_OPERATOR, kind: :boolean) if read.operator.nil? && read.comparand.nil? && read.against.nil?
+
+            read.with(operator: NEGATED_OPERATORS.fetch(read.operator || "=="), kind: :boolean)
           end
 
           #: (untyped, Hash[String, Declaration], untyped, Herb::Location?) -> Read?
@@ -488,8 +620,8 @@ module Herb
 
             return nil unless left && right && node.arguments&.arguments&.one?
 
-            left_read = bare_read(left, states, visitor, location)
-            right_read = bare_read(right, states, visitor, location)
+            left_read = operand_read(left, states, visitor, location)
+            right_read = operand_read(right, states, visitor, location)
             read = left_read || right_read
 
             return nil unless read
@@ -506,11 +638,11 @@ module Herb
             end
 
             operator = node.name == :== ? nil : node.name.to_s
-            operator = MIRRORED_OPERATORS.fetch(operator) if operator && operator != "!=" && bare_read(right, states, visitor, location)
+            operator = MIRRORED_OPERATORS.fetch(operator) if operator && operator != "!=" && right_read
             ordered = operator && operator != "!="
 
             if ordered && read.kind != :integer && read.kind != :seeded
-              return visitor.slot_error("`#{node.slice}` orders the #{read.kind.to_s.capitalize} state `#{read.name}`. Ordering compares numbers, so declare `#{read.name}` as an Integer or compare it with `==` instead.", location, :compare)
+              return visitor.slot_error("`#{node.slice}` orders #{subject_phrase(read)}. Ordering compares numbers, so declare `#{read.name}` as an Integer or compare it with `==` instead.", location, :compare)
             end
 
             if ordered && kind != :integer
@@ -518,26 +650,36 @@ module Herb
             end
 
             unless ordered || kind == read.kind || kind == :nil || read.kind == :seeded
-              return visitor.slot_error("`#{node.slice}` compares the #{read.kind.to_s.capitalize} state `#{read.name}` against #{kind_article(kind)} literal, so it can never match. Compare it against #{kind_article(read.kind)} literal instead.", location, :compare)
+              return visitor.slot_error("`#{node.slice}` compares #{subject_phrase(read)} against #{kind_article(kind)} literal, so it can never match. Compare it against #{kind_article(read.kind)} literal instead.", location, :compare)
             end
 
-            Read.new(name: read.name, comparand: literal.slice, kind: read.kind, operator: operator, against: nil)
+            Read.new(name: read.name, comparand: literal.slice, kind: read.kind, operator: operator, against: nil, transform: read.transform)
           end
 
           #: (untyped, Read, Read, untyped, Herb::Location?) -> Read?
           def state_pair_read(node, left, right, visitor, location)
+            if left.transform && right.transform
+              return visitor.slot_error("`#{node.slice}` compares #{subject_phrase(left)} against #{subject_phrase(right)}. One condition carries one transform, so declare a state for one of the two sides and compare that.", location, :compare)
+            end
+
             operator = node.name == :== ? nil : node.name.to_s
+
+            if right.transform
+              left, right = right, left
+              operator = MIRRORED_OPERATORS.fetch(operator) if operator && operator != "!="
+            end
+
             ordered = operator && operator != "!="
 
             if ordered && (left.kind != :integer || right.kind != :integer) && left.kind != :seeded && right.kind != :seeded
-              return visitor.slot_error("`#{node.slice}` orders the states `#{left.name}` and `#{right.name}`. Ordering compares numbers, so declare both as Integers.", location, :compare)
+              return visitor.slot_error("`#{node.slice}` orders #{subject_phrase(left)} against #{subject_phrase(right)}. Ordering compares numbers, so both sides have to be Integers.", location, :compare)
             end
 
             if !ordered && left.kind != right.kind && left.kind != :seeded && right.kind != :seeded
-              return visitor.slot_error("`#{node.slice}` compares the #{left.kind.to_s.capitalize} state `#{left.name}` with the #{right.kind.to_s.capitalize} state `#{right.name}`, so it can never match. Compare states of the same kind.", location, :compare)
+              return visitor.slot_error("`#{node.slice}` compares #{subject_phrase(left)} with #{subject_phrase(right)}, so it can never match. Compare values of the same kind.", location, :compare)
             end
 
-            Read.new(name: left.name, comparand: nil, kind: left.kind, operator: operator, against: right.name)
+            Read.new(name: left.name, comparand: nil, kind: left.kind, operator: operator, against: right.name, transform: left.transform)
           end
         end
       end

--- a/lib/herb/engine/slots/visitor.rb
+++ b/lib/herb/engine/slots/visitor.rb
@@ -227,6 +227,11 @@ module Herb
           @states.state_presence
         end
 
+        #: () -> Hash[Integer, untyped]
+        def state_values
+          @states.state_values
+        end
+
         #: () -> Array[String]
         def seeded_region_states
           @states.seeded_region_states

--- a/sig/herb/engine/slots/state_compiler.rbs
+++ b/sig/herb/engine/slots/state_compiler.rbs
@@ -16,6 +16,8 @@ module Herb
 
         attr_reader state_presence: Hash[Integer, untyped]
 
+        attr_reader state_values: Hash[Integer, untyped]
+
         # : (untyped) -> void
         def initialize: (untyped) -> void
 
@@ -123,6 +125,9 @@ module Herb
 
         # : () -> void
         def check_state_value_reads: () -> void
+
+        # : (untyped, Integer, untyped, String, Hash[String, StateDirectives::Declaration]) -> void
+        def register_state_value: (untyped, Integer, untyped, String, Hash[String, StateDirectives::Declaration]) -> void
 
         # : (untyped, Integer, untyped, String, Hash[String, StateDirectives::Declaration]) -> untyped
         def convert_boolean_attribute: (untyped, Integer, untyped, String, Hash[String, StateDirectives::Declaration]) -> untyped

--- a/sig/herb/engine/slots/state_directives.rbs
+++ b/sig/herb/engine/slots/state_directives.rbs
@@ -44,12 +44,14 @@ module Herb
 
           attr_reader against(): String?
 
-          def self.new: (String name, String? comparand, Symbol? kind, String? operator, String? against) -> instance
-                      | (name: String, comparand: String?, kind: Symbol?, operator: String?, against: String?) -> instance
+          attr_reader transform(): String?
 
-          def self.members: () -> [ :name, :comparand, :kind, :operator, :against ]
+          def self.new: (String name, String? comparand, Symbol? kind, String? operator, String? against, String? transform) -> instance
+                      | (name: String, comparand: String?, kind: Symbol?, operator: String?, against: String?, transform: String?) -> instance
 
-          def members: () -> [ :name, :comparand, :kind, :operator, :against ]
+          def self.members: () -> [ :name, :comparand, :kind, :operator, :against, :transform ]
+
+          def members: () -> [ :name, :comparand, :kind, :operator, :against, :transform ]
         end
 
         class Combo < Data
@@ -81,6 +83,20 @@ module Herb
         ORDERED_OPERATORS: Array[Symbol]
 
         MIRRORED_OPERATORS: Hash[String, String]
+
+        NEGATED_OPERATORS: Hash[String, String]
+
+        FALSY_OPERATOR: String
+
+        PREDICATES: Hash[String, Hash[Symbol, untyped]]
+
+        UNARY_OPERATORS: Hash[String, String]
+
+        NEGATED_UNARY: Hash[String, String]
+
+        TRANSFORMS: Hash[String, Hash[Symbol, untyped]]
+
+        TRANSFORM_SPELLINGS: Hash[String, String]
 
         class Parsing < Data
           attr_reader locals(): Hash[String, Symbol]
@@ -159,8 +175,14 @@ module Herb
         # : (Declaration) -> bool
         def self.seeded?: (Declaration) -> bool
 
+        # : (Read) -> String
+        def self.subject_phrase: (Read) -> String
+
         # : ((Symbol | String)?) -> String
         def self.kind_article: ((Symbol | String)?) -> String
+
+        # : (String, String) -> String
+        def self.rewrite_reads: (String, String) -> String
 
         # : (String, Hash[String, Declaration]) -> bool
         def self.mentions_any?: (String, Hash[String, Declaration]) -> bool
@@ -188,6 +210,21 @@ module Herb
 
         # : (untyped, Hash[String, Declaration], untyped, Herb::Location?) -> Read?
         private def self.bare_read: (untyped, Hash[String, Declaration], untyped, Herb::Location?) -> Read?
+
+        # : (untyped, Hash[String, Declaration], untyped, Herb::Location?) -> Read?
+        private def self.operand_read: (untyped, Hash[String, Declaration], untyped, Herb::Location?) -> Read?
+
+        # : (untyped, Hash[String, Declaration], untyped, Herb::Location?) -> Read?
+        private def self.transform_read: (untyped, Hash[String, Declaration], untyped, Herb::Location?) -> Read?
+
+        # : (untyped, Hash[String, Declaration], untyped, Herb::Location?) -> Read?
+        private def self.predicate_read: (untyped, Hash[String, Declaration], untyped, Herb::Location?) -> Read?
+
+        # : (untyped, Hash[String, Declaration], untyped, Herb::Location?) -> (Read | Combo)?
+        private def self.negated_read: (untyped, Hash[String, Declaration], untyped, Herb::Location?) -> (Read | Combo)?
+
+        # : (Read | Combo) -> (Read | Combo)
+        private def self.negate: (Read | Combo) -> (Read | Combo)
 
         # : (untyped, Hash[String, Declaration], untyped, Herb::Location?) -> Read?
         private def self.equality_read: (untyped, Hash[String, Declaration], untyped, Herb::Location?) -> Read?

--- a/sig/herb/engine/slots/state_predicates.rbs
+++ b/sig/herb/engine/slots/state_predicates.rbs
@@ -1,0 +1,16 @@
+# Generated from lib/herb/engine/slots/state_predicates.rb with RBS::Inline
+
+module Herb
+  class Engine
+    module Slots
+      # The Ruby predicates a `herb:state` read may use, and the condition each one resolves into.
+      module StatePredicates
+        TABLE: Hash[String, Hash[Symbol, untyped]]
+
+        NEGATED: Hash[String, String]
+
+        UNARY: Hash[String, String]
+      end
+    end
+  end
+end

--- a/sig/herb/engine/slots/state_transforms.rbs
+++ b/sig/herb/engine/slots/state_transforms.rbs
@@ -1,0 +1,15 @@
+# Generated from lib/herb/engine/slots/state_transforms.rb with RBS::Inline
+
+module Herb
+  class Engine
+    module Slots
+      # The Ruby methods a `herb:state` read may call to transform a state's value before comparing
+      # it, and the operation each one becomes on the wire.
+      module StateTransforms
+        TABLE: Hash[String, Hash[Symbol, untyped]]
+
+        SPELLINGS: Hash[String, String]
+      end
+    end
+  end
+end

--- a/sig/herb/engine/slots/visitor.rbs
+++ b/sig/herb/engine/slots/visitor.rbs
@@ -152,6 +152,9 @@ module Herb
         # : () -> Hash[Integer, untyped]
         def state_presence: () -> Hash[Integer, untyped]
 
+        # : () -> Hash[Integer, untyped]
+        def state_values: () -> Hash[Integer, untyped]
+
         # : () -> Array[String]
         def seeded_region_states: () -> Array[String]
 

--- a/templates/javascript/packages/client/src/state-predicates.ts.erb
+++ b/templates/javascript/packages/client/src/state-predicates.ts.erb
@@ -1,0 +1,27 @@
+export interface StatePredicate {
+  readonly comparand?: string
+  readonly operator?: string
+  readonly kinds: string[] | null
+  readonly only: string
+  readonly rewrite?: string
+}
+
+export const STATE_PREDICATES: Record<string, StatePredicate> = {
+<%- state_predicates.each do |predicate| -%>
+  <%= predicate.literal(predicate.name) %>: {
+<%- if predicate.comparand -%>
+    comparand: <%= predicate.literal(predicate.comparand) %>,
+<%- end -%>
+<%- if predicate.operator -%>
+    operator: <%= predicate.literal(predicate.operator) %>,
+<%- end -%>
+    kinds: <%= predicate.typescript_kinds %>,
+    only: <%= predicate.literal(predicate.only) %>,
+<%- if predicate.rewrite -%>
+    rewrite: <%= predicate.literal(predicate.rewrite) %>,
+<%- end -%>
+  },
+<%- end -%>
+}
+
+export const STATE_PREDICATE_NAMES = Object.keys(STATE_PREDICATES)

--- a/templates/javascript/packages/client/src/state-transforms.ts.erb
+++ b/templates/javascript/packages/client/src/state-transforms.ts.erb
@@ -1,0 +1,19 @@
+export interface StateTransform {
+  readonly operation: string
+  readonly kinds: string[] | null
+  readonly returns: string
+  readonly only: string
+}
+
+export const STATE_TRANSFORMS: Record<string, StateTransform> = {
+<%- state_transforms.each do |transform| -%>
+  <%= transform.name.inspect %>: {
+    operation: <%= transform.operation.inspect %>,
+    kinds: <%= transform.typescript_kinds %>,
+    returns: <%= transform.returns.inspect %>,
+    only: <%= transform.only.inspect %>,
+  },
+<%- end -%>
+}
+
+export const STATE_TRANSFORM_NAMES = Object.keys(STATE_TRANSFORMS)

--- a/templates/lib/herb/engine/slots/state_predicates.rb.erb
+++ b/templates/lib/herb/engine/slots/state_predicates.rb.erb
@@ -1,0 +1,39 @@
+module Herb
+  class Engine
+    module Slots
+      # The Ruby predicates a `herb:state` read may use, and the condition each one resolves into.
+      #
+      module StatePredicates
+        TABLE = {
+<%- state_predicates.each do |predicate| -%>
+          <%= predicate.name.inspect %> => {
+<%- if predicate.comparand -%>
+            comparand: <%= predicate.comparand.inspect %>,
+<%- end -%>
+<%- if predicate.operator -%>
+            operator: <%= predicate.operator.inspect %>,
+<%- end -%>
+            kinds: <%= predicate.ruby_kinds %>,
+            only: <%= predicate.only.inspect %>,
+<%- if predicate.rewrite -%>
+            rewrite: <%= predicate.rewrite.inspect %>,
+<%- end -%>
+          },
+<%- end -%>
+        }.freeze #: Hash[String, Hash[Symbol, untyped]]
+
+        NEGATED = {
+<%- state_predicates.select { |predicate| predicate.unary? && predicate.negated }.each do |predicate| -%>
+          <%= predicate.operator.inspect %> => <%= predicate.negated.inspect %>,
+<%- end -%>
+        }.freeze #: Hash[String, String]
+
+        UNARY = {
+<%- state_predicates.select(&:unary?).each do |predicate| -%>
+          <%= predicate.operator.inspect %> => <%= predicate.name.inspect %>,
+<%- end -%>
+        }.freeze #: Hash[String, String]
+      end
+    end
+  end
+end

--- a/templates/lib/herb/engine/slots/state_transforms.rb.erb
+++ b/templates/lib/herb/engine/slots/state_transforms.rb.erb
@@ -1,0 +1,27 @@
+module Herb
+  class Engine
+    module Slots
+      # The Ruby methods a `herb:state` read may call to transform a state's value before comparing
+      # it, and the operation each one becomes on the wire.
+      #
+      module StateTransforms
+        TABLE = {
+<%- state_transforms.each do |transform| -%>
+          <%= transform.name.inspect %> => {
+            operation: <%= transform.operation.inspect %>,
+            kinds: <%= transform.ruby_kinds %>,
+            returns: :<%= transform.returns %>,
+            only: <%= transform.only.inspect %>,
+          },
+<%- end -%>
+        }.freeze #: Hash[String, Hash[Symbol, untyped]]
+
+        SPELLINGS = {
+<%- state_transforms.group_by(&:operation).each do |operation, transforms| -%>
+          <%= operation.inspect %> => <%= transforms.first.name.inspect %>,
+<%- end -%>
+        }.freeze #: Hash[String, String]
+      end
+    end
+  end
+end

--- a/templates/template.rb
+++ b/templates/template.rb
@@ -730,6 +730,56 @@ module Herb
       end
     end
 
+    class StateTransform
+      attr_reader :name, :operation, :kinds, :returns, :only
+
+      def initialize(config)
+        @name = config.fetch("name")
+        @operation = config.fetch("operation")
+        @kinds = config.fetch("kinds", nil)
+        @returns = config.fetch("returns")
+        @only = config.fetch("only")
+      end
+
+      def ruby_kinds
+        kinds ? "[#{kinds.map { |kind| ":#{kind}" }.join(", ")}]" : "nil"
+      end
+
+      def typescript_kinds
+        kinds ? "[#{kinds.map(&:inspect).join(", ")}]" : "null"
+      end
+    end
+
+    class StatePredicate
+      attr_reader :name, :comparand, :operator, :kinds, :only, :rewrite, :negated
+
+      def initialize(config)
+        @name = config.fetch("name")
+        @comparand = config.fetch("comparand", nil)
+        @operator = config.fetch("operator", nil)
+        @kinds = config.fetch("kinds", nil)
+        @only = config.fetch("only")
+        @rewrite = config.fetch("rewrite", nil)
+        @negated = config.fetch("negated", nil)
+      end
+
+      def unary?
+        !operator.nil? && comparand.nil?
+      end
+
+      def ruby_kinds
+        kinds ? "[#{kinds.map { |kind| ":#{kind}" }.join(", ")}]" : "nil"
+      end
+
+      def typescript_kinds
+        kinds ? "[#{kinds.map(&:inspect).join(", ")}]" : "null"
+      end
+
+      def literal(value)
+        value.inspect
+      end
+    end
+
     class HelperType
       attr_reader :name, :source, :gem, :output, :visibility, :receiver, :supports_block,
                   :supported, :description, :signature, :documentation_url, :tag,
@@ -1000,7 +1050,7 @@ module Herb
                       end
 
       rendered_template = read_template(template_path.to_s).result_with_hash(
-        { nodes: nodes, errors: errors, union_kinds: union_kinds, helpers: helpers, prism_nodes: prism_nodes, prism_flags: prism_flags, state_kinds: state_kinds, state_operators: state_operators }
+        { nodes: nodes, errors: errors, union_kinds: union_kinds, helpers: helpers, prism_nodes: prism_nodes, prism_flags: prism_flags, state_predicates: state_predicates, state_kinds: state_kinds, state_transforms: state_transforms, state_operators: state_operators }
       )
       content = heading_for(name, template_file) + rendered_template
 
@@ -1070,10 +1120,22 @@ module Herb
       end
     end
 
+    def self.state_predicates
+      config = YAML.load_file("config/state/predicates.yml")
+
+      (config["predicates"] || []).map { |predicate| StatePredicate.new(predicate) }
+    end
+
     def self.state_kinds
       config = YAML.load_file("config/state/kind.yml")
 
       (config["kinds"] || []).map { |kind| StateKind.new(kind) }
+    end
+
+    def self.state_transforms
+      config = YAML.load_file("config/state/transforms.yml")
+
+      (config["transforms"] || []).map { |transform| StateTransform.new(transform) }
     end
 
     def self.state_operators

--- a/test/engine/slots/states_test.rb
+++ b/test/engine/slots/states_test.rb
@@ -201,17 +201,12 @@ module Engine
 
         refuse(
           "<%# herb:state (attempts: 0) %><p><%= attempts + 1 %></p>",
-          "`attempts + 1` computes with a state. The client cannot evaluate Ruby, so read the state bare, or compare it to a literal in a conditional or a boolean attribute."
+          "`attempts + 1` computes with a state. The client cannot evaluate Ruby, so read the state bare, read it with a predicate, or compare it to a literal."
         )
 
         refuse(
           "<%# herb:state (sort: \"name\") %><div><% if sort == 3 %>a<% end %></div>",
           "`sort == 3` compares the String state `sort` against an Integer literal, so it can never match. Compare it against a String literal instead."
-        )
-
-        refuse(
-          "<%# herb:state (attempts: 0) %><div><% if attempts? %>a<% end %></div>",
-          "`attempts?` reads the Integer state `attempts` as a predicate. Only a boolean state can be read with a `?`, so drop the `?` or declare `attempts` as a boolean."
         )
 
         refuse(
@@ -280,13 +275,288 @@ module Engine
         assert_includes rendered, "false</textarea>"
       end
 
+      test "the `?` spelling reads any state for its truth, the way the bare name does" do
+        {
+          %(<%# herb:state (message: "hi") %><div><% if message? %>x<% end %></div>) => ["message", nil],
+          %(<%# herb:state (attempts: 0) %><div><% if attempts? %>x<% end %></div>) => ["attempts", nil],
+          %(<%# herb:state (tab: :first) %><div><% if tab? %>x<% end %></div>) => ["tab", nil],
+        }.each do |template, condition|
+          visitor, = compile(template)
+
+          assert_equal({ arms: [arm(0, condition)], else: nil }, visitor.state_conditional_entries.fetch(0))
+        end
+      end
+
+      test "the `?` spelling drops off the source the server runs" do
+        rendered = render(%(<%# herb:state (message: "hi") %><div><% if message? %>Present<% else %>None<% end %></div>))
+
+        assert_includes rendered, "Present"
+      end
+
+      test "a predicate compiles into the comparison it stands for" do
+        {
+          %(<%# herb:state (draft: "") %><div><% if draft.empty? %>x<% end %></div>) => ["draft", { "value" => "" }],
+          %(<%# herb:state (draft: "") %><div><% if draft.nil? %>x<% end %></div>) => ["draft", { "value" => nil }],
+          %(<%# herb:state (count: 0) %><div><% if count.zero? %>x<% end %></div>) => ["count", { "value" => 0 }],
+          %(<%# herb:state (count: 0) %><div><% if count.one? %>x<% end %></div>) => ["count", { "value" => 1 }],
+          %(<%# herb:state (count: 0) %><div><% if count.positive? %>x<% end %></div>) => ["count", { "value" => 0 }, ">"],
+        }.each do |template, condition|
+          visitor, = compile(template)
+
+          assert_equal({ arms: [arm(0, condition)], else: nil }, visitor.state_conditional_entries.fetch(0))
+        end
+      end
+
+      test "blank? and present? compile into operators the client resolves" do
+        visitor, = compile(%(<%# herb:state (draft: "") %><div><% if draft.blank? %>x<% end %></div>))
+
+        assert_equal({ arms: [arm(0, ["draft", nil, "blank"])], else: nil }, visitor.state_conditional_entries.fetch(0))
+
+        visitor, = compile(%(<%# herb:state (draft: "") %><div><% if draft.present? %>x<% end %></div>))
+
+        assert_equal({ arms: [arm(0, ["draft", nil, "present"])], else: nil }, visitor.state_conditional_entries.fetch(0))
+      end
+
+      test "one? rewrites for the server, since Ruby defines it on Enumerable" do
+        rendered = render(%(<%# herb:state (count: 1) %><div><% if count.one? %>one<% else %>many<% end %></div>))
+
+        assert_includes rendered, "one"
+      end
+
+      test "a predicate on a state of another kind is refused" do
+        refuse(
+          %(<%# herb:state (draft: "") %><div><% if draft.zero? %>x<% end %></div>),
+          "`draft.zero?` reads the String state `draft` with `zero?`. Only an Integer state can be read with `zero?`, so compare `draft` to a literal instead."
+        )
+
+        refuse(
+          %(<%# herb:state (count: 0) %><div><% if count.empty? %>x<% end %></div>),
+          "`count.empty?` reads the Integer state `count` with `empty?`. Only a String or a Symbol state can be read with `empty?`, so compare `count` to a literal instead."
+        )
+
+        refuse(
+          %(<%# herb:state (count: 0) %><div><% if count.blank? %>x<% end %></div>),
+          "`count.blank?` reads the Integer state `count` with `blank?`. Only a Boolean, a String or a Nil state can be read with `blank?`, so compare `count` to a literal instead."
+        )
+
+        refuse(
+          %(<%# herb:state (draft: "") %><div><% if draft.positive? %>x<% end %></div>),
+          "`draft.positive?` reads the String state `draft` with `positive?`. Only an Integer state can be read with `positive?`, so compare `draft` to a literal instead."
+        )
+
+        refuse(
+          %(<%# herb:state (tab: :first) %><div><% if tab.present? %>x<% end %></div>),
+          "`tab.present?` reads the Symbol state `tab` with `present?`. Only a Boolean, a String or a Nil state can be read with `present?`, so compare `tab` to a literal instead."
+        )
+      end
+
+      test "length and size compile into one transform on the read" do
+        {
+          %(<%# herb:state (draft: "") %><div><% if draft.length > 3 %>x<% end %></div>) => ["draft", { "value" => 3 }, ">", "length"],
+          %(<%# herb:state (draft: "") %><div><% if draft.size > 3 %>x<% end %></div>) => ["draft", { "value" => 3 }, ">", "length"],
+          %(<%# herb:state (draft: "") %><div><% if 3 < draft.length %>x<% end %></div>) => ["draft", { "value" => 3 }, ">", "length"],
+          %(<%# herb:state (draft: "") %><div><% if draft.length == 0 %>x<% end %></div>) => ["draft", { "value" => 0 }, "==", "length"],
+        }.each do |template, condition|
+          visitor, = compile(template)
+
+          assert_equal({ arms: [arm(0, condition)], else: nil }, visitor.state_conditional_entries.fetch(0))
+        end
+      end
+
+      test "to_s reads a state of any kind as a String" do
+        {
+          %(<%# herb:state (draft: 3) %><div><% if draft.to_s == "3" %>x<% end %></div>) => ["draft", { "value" => "3" }, "==", "to_s"],
+          %(<%# herb:state (open: false) %><div><% if open.to_s == "false" %>x<% end %></div>) => ["open", { "value" => "false" }, "==", "to_s"],
+          %(<%# herb:state (note: nil) %><div><% if note.to_s == "" %>x<% end %></div>) => ["note", { "value" => "" }, "==", "to_s"],
+          %(<%# herb:state (draft: "hi") %><div><% if draft.to_s == "hi" %>x<% end %></div>) => ["draft", { "value" => "hi" }, "==", "to_s"],
+          %(<%# herb:state (tab: :first) %><div><% if tab.to_s == "first" %>x<% end %></div>) => ["tab", { "value" => "first" }, "==", "to_s"],
+        }.each do |template, condition|
+          visitor, = compile(template)
+
+          assert_equal({ arms: [arm(0, condition)], else: nil }, visitor.state_conditional_entries.fetch(0))
+        end
+      end
+
+      test "to_s renders what Ruby renders, for every kind" do
+        {
+          %(<%# herb:state (flag: true) %><p><%= flag.to_s %></p>) => ">true<",
+          %(<%# herb:state (flag: false) %><p><%= flag.to_s %></p>) => ">false<",
+          %(<%# herb:state (note: nil) %><p>[<%= note.to_s %>]</p>) => ">[<",
+          %(<%# herb:state (draft: "hi") %><p><%= draft.to_s %></p>) => ">hi<",
+          %(<%# herb:state (count: -5) %><p><%= count.to_s %></p>) => ">-5<",
+          %(<%# herb:state (tab: :first) %><p><%= tab.to_s %></p>) => ">first<",
+        }.each do |template, expected|
+          assert_includes render(template), expected
+        end
+      end
+
+      test "a transform compares against another state when only one side carries it" do
+        visitor, = compile(%(<%# herb:state (draft: 3, filter: "all") %><div><% if draft.to_s == filter %>x<% end %></div>))
+
+        assert_equal({ arms: [arm(0, ["draft", { "state" => "filter" }, "==", "to_s"])], else: nil }, visitor.state_conditional_entries.fetch(0))
+
+        visitor, = compile(%(<%# herb:state (draft: 3, filter: "all") %><div><% if filter == draft.to_s %>x<% end %></div>))
+
+        assert_equal({ arms: [arm(0, ["draft", { "state" => "filter" }, "==", "to_s"])], else: nil }, visitor.state_conditional_entries.fetch(0))
+
+        visitor, = compile(%(<%# herb:state (draft: "", count: 0) %><div><% if count < draft.length %>x<% end %></div>))
+
+        assert_equal({ arms: [arm(0, ["draft", { "state" => "count" }, ">", "length"])], else: nil }, visitor.state_conditional_entries.fetch(0))
+      end
+
+      test "a length read stands alone as a computed value slot" do
+        visitor, = compile(%(<%# herb:state (draft: "") %><p><%= draft.length %></p>))
+
+        assert_equal ["draft", nil, nil, "length"], encoded(visitor.state_values.fetch(0))
+      end
+
+      test "a length read derives an Integer state" do
+        visitor, = compile(%(<%# herb:state (draft: "", width: draft.length) %><p><%= width %></p>))
+        entries = visitor.state_entries.to_h { |entry| [entry[:name], entry] }
+
+        assert_equal :integer, entries.fetch("width")[:kind]
+        assert_equal ["draft", nil, nil, "length"], encoded(entries.fetch("width")[:derived])
+      end
+
+      test "length renders the server's answer" do
+        rendered = render(%(<%# herb:state (draft: "hello") %><p><%= draft.length %></p>))
+
+        assert_includes rendered, ">5<"
+      end
+
+      test "length on a state of another kind is refused" do
+        refuse(
+          %(<%# herb:state (count: 0) %><div><% if count.length > 3 %>x<% end %></div>),
+          "`count.length` reads the Integer state `count` with `length`. Only a String or a Symbol state can be read with `length`, so compare `count` itself instead."
+        )
+
+        refuse(
+          %(<%# herb:state (count: 0) %><div><% if count.size > 3 %>x<% end %></div>),
+          "`count.size` reads the Integer state `count` with `size`. Only a String or a Symbol state can be read with `size`, so compare `count` itself instead."
+        )
+      end
+
+      test "a transform on both sides of a comparison is refused" do
+        refuse(
+          %(<%# herb:state (draft: "", other: "") %><div><% if draft.length > other.length %>x<% end %></div>),
+          "`draft.length > other.length` compares the length of the state `draft` against the length of the state `other`. One condition carries one transform, so declare a state for one of the two sides and compare that."
+        )
+
+        refuse(
+          %(<%# herb:state (draft: "", filter: "all") %><div><% if draft.length > filter %>x<% end %></div>),
+          "`draft.length > filter` orders the length of the state `draft` against the String state `filter`. Ordering compares numbers, so both sides have to be Integers."
+        )
+      end
+
+      test "`!` negates the read it wraps" do
+        {
+          %(<%# herb:state (open: false) %><div><% if !open %>x<% end %></div>) => ["open", nil, "falsy"],
+          %(<%# herb:state (open: false) %><div><% if not open %>x<% end %></div>) => ["open", nil, "falsy"],
+          %(<%# herb:state (open: false) %><div><% if !open? %>x<% end %></div>) => ["open", nil, "falsy"],
+          %(<%# herb:state (open: false) %><div><% if !!open %>x<% end %></div>) => ["open", nil],
+          %(<%# herb:state (draft: "") %><div><% if !(draft == "hi") %>x<% end %></div>) => ["draft", { "value" => "hi" }, "!="],
+          %(<%# herb:state (count: 0) %><div><% if !(count > 3) %>x<% end %></div>) => ["count", { "value" => 3 }, "<="],
+          %(<%# herb:state (draft: "") %><div><% if !draft.blank? %>x<% end %></div>) => ["draft", nil, "present"],
+          %(<%# herb:state (draft: "") %><div><% if !draft.present? %>x<% end %></div>) => ["draft", nil, "blank"],
+          %(<%# herb:state (count: 0) %><div><% if !count.zero? %>x<% end %></div>) => ["count", { "value" => 0 }, "!="],
+          %(<%# herb:state (draft: "") %><div><% if !(draft.length > 3) %>x<% end %></div>) => ["draft", { "value" => 3 }, "<=", "length"],
+        }.each do |template, condition|
+          visitor, = compile(template)
+
+          assert_equal({ arms: [arm(0, condition)], else: nil }, visitor.state_conditional_entries.fetch(0))
+        end
+      end
+
+      test "a negated read renders for the server" do
+        rendered = render(%(<%# herb:state (open: false) %><button disabled="<%= !open %>">Send</button>))
+
+        assert_includes rendered, "<button disabled"
+      end
+
+      test "a negated combination distributes over its parts" do
+        visitor, = compile(%(<%# herb:state (open: false, draft: "") %><div><% if !(open && draft == "hi") %>x<% end %></div>))
+
+        assert_equal(
+          { arms: [arm(0, { "any" => [["open", nil, "falsy"], ["draft", { "value" => "hi" }, "!="]] })], else: nil },
+          visitor.state_conditional_entries.fetch(0)
+        )
+
+        visitor, = compile(%(<%# herb:state (open: false, draft: "") %><div><% if !(open || draft == "hi") %>x<% end %></div>))
+
+        assert_equal(
+          { arms: [arm(0, { "all" => [["open", nil, "falsy"], ["draft", { "value" => "hi" }, "!="]] })], else: nil },
+          visitor.state_conditional_entries.fetch(0)
+        )
+      end
+
+      test "a negation nests through a combination" do
+        visitor, = compile(%(<%# herb:state (message: "", count: 0) %><div><% if !((message.length > count) && !(message == "abc" || count == 0)) %>x<% end %></div>))
+
+        assert_equal(
+          {
+            arms: [arm(0, {
+              "any" => [
+                ["message", { "state" => "count" }, "<=", "length"],
+                { "any" => [["message", { "value" => "abc" }, "=="], ["count", { "value" => 0 }, "=="]] }
+              ],
+            })],
+            else: nil,
+          },
+          visitor.state_conditional_entries.fetch(0)
+        )
+      end
+
+      test "a predicate combines with a comparison in one condition" do
+        visitor, = compile(%(<%# herb:state (sending: false, draft: "") %><div><% if sending? && draft == "hello" %>x<% end %></div>))
+
+        assert_equal(
+          { arms: [arm(0, { "all" => [["sending", nil], ["draft", { "value" => "hello" }]] })], else: nil },
+          visitor.state_conditional_entries.fetch(0)
+        )
+      end
+
+      test "a combo of predicates derives a state" do
+        visitor, = compile(%(<%# herb:state (sending: false, draft: "", ready: sending? && draft.present?) %><div><% if ready %>x<% end %></div>))
+        entries = visitor.state_entries.to_h { |entry| [entry[:name], entry] }
+
+        assert_equal :boolean, entries.fetch("ready")[:kind]
+        assert_equal({ "all" => [["sending", nil], ["draft", nil, "present"]] }, encoded(entries.fetch("ready")[:derived]))
+      end
+
+      test "a predicate derives a state from the one it reads" do
+        visitor, = compile(%(<%# herb:state (draft: "", empty: draft.blank?) %><div><% if empty %>x<% end %></div>))
+        entries = visitor.state_entries.to_h { |entry| [entry[:name], entry] }
+
+        assert_equal :boolean, entries.fetch("empty")[:kind]
+        assert_equal ["draft", nil, "blank"], encoded(entries.fetch("empty")[:derived])
+      end
+
+      test "a predicate in a boolean attribute becomes a presence" do
+        visitor, = compile(%(<%# herb:state (draft: "") %><button disabled="<%= draft.blank? %>">Send</button>))
+
+        assert_equal :boolean_attribute, visitor.slots.fetch(0).type
+        assert_equal ["draft", nil, "blank"], encoded(visitor.state_presence.fetch(0))
+      end
+
+      test "a comparison in an output becomes a computed value slot" do
+        visitor, = compile(%(<%# herb:state (draft: "") %><p><%= draft == "hello" %></p>))
+
+        assert_equal ["draft", { "value" => "hello" }], encoded(visitor.state_values.fetch(0))
+      end
+
+      test "a computed value slot renders the answer the server computed" do
+        rendered = render(%(<%# herb:state (draft: "") %><p><%= draft == "" %></p>))
+
+        assert_includes rendered, ">true<"
+      end
+
       test "a computed read in a textarea still raises" do
         error = assert_raises(Herb::Engine::CompilationError) do
           compile(%(<%# herb:state (draft: "") %><textarea><%= draft.upcase %></textarea>))
         end
 
         assert_equal(
-          ["`draft.upcase` computes with a state. The client cannot evaluate Ruby, so read the state bare, or compare it to a literal in a conditional or a boolean attribute."],
+          ["`draft.upcase` computes with a state. The client cannot evaluate Ruby, so read the state bare, read it with a predicate, or compare it to a literal."],
           compiler_findings(error)
         )
       end
@@ -378,12 +648,12 @@ module Engine
       test "a state pair keeps its kinds compatible" do
         refuse(
           "<%# herb:state (sort: \"name\", attempts: 0) %><div><% if sort == attempts %>x<% end %></div>",
-          "`sort == attempts` compares the String state `sort` with the Integer state `attempts`, so it can never match. Compare states of the same kind."
+          "`sort == attempts` compares the String state `sort` with the Integer state `attempts`, so it can never match. Compare values of the same kind."
         )
 
         refuse(
           "<%# herb:state (sort: \"name\", other: \"x\") %><div><% if sort > other %>x<% end %></div>",
-          "`sort > other` orders the states `sort` and `other`. Ordering compares numbers, so declare both as Integers."
+          "`sort > other` orders the String state `sort` against the String state `other`. Ordering compares numbers, so both sides have to be Integers."
         )
       end
 
@@ -453,7 +723,7 @@ module Engine
       test "a combo mixing a state with server code raises" do
         refuse(
           "<%# herb:state (pending: false) %><div><% if pending? && current_user.admin? %>x<% else %>y<% end %></div>",
-          "`pending? && current_user.admin?` computes with a state. The client cannot evaluate Ruby, so read the state bare, as a predicate, or compared to a literal."
+          "`pending? && current_user.admin?` computes with a state. The client cannot evaluate Ruby, so read the state bare, read it with a predicate, or compare it to a literal."
         )
       end
 
@@ -735,7 +1005,7 @@ module Engine
       test "a computed tag helper attribute raises" do
         refuse(
           %(<%# herb:slots client %><%# herb:state (draft: "") %><%= tag.input value: draft.upcase %>),
-          "`draft.upcase` computes with a state. The client cannot evaluate Ruby, so read the state bare, or compare it to a literal in a conditional or a boolean attribute."
+          "`draft.upcase` computes with a state. The client cannot evaluate Ruby, so read the state bare, read it with a predicate, or compare it to a literal."
         )
       end
 
@@ -842,18 +1112,7 @@ module Engine
         end
 
         assert_equal(
-          ["`unless attempts * 2 > 3` computes with a state. The client cannot evaluate Ruby, so read the state bare, as a predicate, or compared to a literal."],
-          compiler_findings(error)
-        )
-      end
-
-      test "a negated state read in a conditional is refused" do
-        error = assert_raises(Herb::Engine::CompilationError) do
-          compile(%(<%# herb:state (open: false) %><% if !open %>x<% end %>))
-        end
-
-        assert_equal(
-          ["`!open` computes with a state. The client cannot evaluate Ruby, so read the state bare, as a predicate, or compared to a literal."],
+          ["`unless attempts * 2 > 3` computes with a state. The client cannot evaluate Ruby, so read the state bare, read it with a predicate, or compare it to a literal."],
           compiler_findings(error)
         )
       end
@@ -933,7 +1192,7 @@ module Engine
         error = assert_raises(Herb::Engine::CompilationError) do
           compile(<<~ERB)
             <%# herb:state (draft: "") %>
-            <button disabled="<%= draft.empty? %>">Send</button>
+            <button disabled="<%= draft.upcase %>">Send</button>
           ERB
         end
 


### PR DESCRIPTION
This pull request widens what a `herb:state` read can do. Until now a state could be read bare, compared to a literal of its own kind, compared to another state, or switched over with literal `when` arms. Anything else was refused with `computes with a state`.

```erb
<%# herb:slots client %>
<%# herb:state (draft: "", count: 0) %>

<% if draft.blank? %>Nothing to send<% end %>
<% if count.zero? %>No messages<% elsif count.one? %>One message<% end %>
<% if draft.length > 280 %>Too long<% end %>
<% if !draft.present? %>Empty<% end %>

<p><%= draft == "" %></p>
```

Every line above was a compile error before this change.

#### Predicates

These Ruby predicates now resolve into the comparison they stand for:

| Predicate | Reads | Resolves as |
| --- | --- | --- |
| `nil?` | every state | `state == nil` |
| `zero?` | an Integer state | `state == 0` |
| `one?` | an Integer state | `state == 1` |
| `positive?` | an Integer state | `state > 0` |
| `empty?` | a String or a Symbol state | `state == ""` |
| `blank?` | a Boolean, a String or a Nil state | ActiveSupport blankness, whitespace included |
| `present?` | a Boolean, a String or a Nil state | the opposite of `blank?` |

`blank?` and `present?` cannot be expressed as an `==` comparison, since `"   ".blank?` is true, so they compile to unary operators the client implements itself.

`one?` is the one predicate whose source has to change. Ruby defines `one?` on `Enumerable` and not on `Integer`, so `<% if count.one? %>` would raise `NoMethodError` when the server renders. The compiler rewrites it to `count == 1` in the source it emits, reusing the machinery that already turns `flag?` into `flag`.

A predicate a kind cannot answer is refused, and for two different reasons that the messages distinguish. `count.empty?` raises `NoMethodError` on an Integer, while `count.blank?` merely answers `false` for every Integer that will ever exist.

#### Transforms

`length`, `size` and `to_s` read a state through a method before comparing or printing it.

```erb
<% if draft.length > 3 %>Long enough<% end %>
<p><%= count.to_s %></p>
<% if draft.to_s == filter %>Selected<% end %>
```

These carry a fourth element on the wire, so `draft.length > 3` becomes `["draft", {"value": 3}, ">", "length"]`. A transform may sit on one side of a comparison, including against another declared state. Both sides carrying one is refused, since a condition carries a single transform.

Two details decide the client implementation:

- Ruby's `String#length` counts codepoints and JavaScript's `String#length` counts UTF-16 code units, so `"👋a"` is `2` in Ruby and `3` in JavaScript. The client counts with `[...value].length`, which agrees with Ruby including on ZWJ sequences.
- `nil.to_s` is `""` while `String(null)` is `"null"`, so `null` is special-cased.

`size` needs its kind gate for a less obvious reason. `Integer#size` is the machine byte width, so `count.size` would quietly answer `8`.

`String#count` is deliberately absent. `Array#count` and `Hash#count` with no argument are size aliases, which is where the intuition comes from, but `String#count` takes a character set (`"hello".count("a-z")`) and raises without one. A state is always a scalar, so the receiver is never the `Enumerable` version.

#### The `?` spelling

`pending?` used to be boolean-only, so `<% if draft %>` compiled while `<% if draft? %>` was refused, even though both ask the same question and the compiler already strips the `?` before the server sees it. The `?` spelling now works on every kind. It carries no extra meaning on a state that is not a boolean, and the rule docs point at `draft.present?` for "does this hold anything".

#### Negation

`!` was the one boolean idiom with no answer at all. Across the ERB corpus it outnumbers `unless` by roughly ninety to one.

It flips a comparison, swaps the `blank?` and `present?` pair, and turns a plain read into a falsy check. Negating a combination distributes by De Morgan and nests to any depth.

```erb
<% if !open %>Closed<% end %>
<% if !(count > 3) %>Room to retry<% end %>
<% if !((message.length > count) && !(message == "abc" || count == 0)) %>Fine<% end %>
```

`!x` cannot be encoded as `x == false`, because a Nil state would answer wrongly, so a `falsy` operator means `!truthy(value)` and matches Ruby for every kind. Because a rewrite like this is easy to get plausibly wrong, `negation-parity.test.ts` computes the answer for that third expression in Ruby across sixteen combinations of `message` and `count` and asserts the compiled condition agrees on every row.

#### Computed value slots

An expression the client can resolve now stands on its own as an output.

```erb
<p><%= draft == "" %></p>
<p><%= draft.blank? %></p>
<p><%= draft.length %></p>
```

These compile into a `computed` section of the manifest, and the client prints the answer and keeps it current as the state changes. A bare transform read resolves to its value, so `<%= draft.length %>` prints a number and not `true`.