### PR TITLE
Engine: Narrow `<style scoped>` with Lightning CSS by default

### DIFF
--- a/Steepfile
+++ b/Steepfile
@@ -13,6 +13,7 @@ target :lib do
   library "tempfile"
   library "yaml"
   library "prism"
+  library "lightningcss"
 
   ignore "lib/herb/cli.rb"
   ignore "lib/herb/project.rb"

--- a/docs/docs/projects/engine.md
+++ b/docs/docs/projects/engine.md
@@ -897,7 +897,13 @@ into this:
 
 Every element the file wrote carries the scope, and every rule is narrowed by that attribute. Markup the file rendered carries a scope of its own or none, so a scoped block reaches what the file wrote and nothing else, whatever is nested inside it. That holds without the file having to know whether it renders anything.
 
-The visitor does not rewrite the CSS itself. It passes the CSS to a `transform`, and the [`lightningcss`](https://github.com/marcoroth/lightningcss-ruby) gem is one. Give the visitor a `LightningCSS::Transformer`, and each rule in the block is narrowed to the scope.
+The visitor does not rewrite the CSS itself. It passes the CSS to a `transform`, and the [`lightningcss`](https://github.com/marcoroth/lightningcss-ruby) gem is the one it reaches for unless something else is given, so each rule in a block is narrowed to the scope without anything being said:
+
+```ruby
+Herb::Engine::ScopedStyle::Visitor.new
+```
+
+Herb does not depend on `lightningcss`, so a machine without it gets a block left as it was written and a diagnostic saying so. Pass a `transform` to narrow the CSS some other way.
 
 ```ruby
 require "herb/engine/scoped_style/visitor"
@@ -910,7 +916,7 @@ Herb::Engine.new(source, filename: path, visitors: [
 
 The `herb compile --scoped-styles` and `herb render --scoped-styles` commands wire the same thing up from the command line, installing `lightningcss` the first time if it is not already there.
 
-Given no `transform`, the block is left as it was written and a diagnostic reports it, because scoping the markup while leaving the CSS untouched would turn a scoped block into a global one. The same holds for a block built with ERB, which has no CSS to read at compile time, and for a template compiled without a `filename`, which has no stable scope to derive. A `transform` that raises is treated the same way, so CSS nobody can read costs the block it was written in and not the whole template.
+With no `transform` at all, the block is left as it was written and a diagnostic reports it, because scoping the markup while leaving the CSS untouched would turn a scoped block into a global one. The same holds for a block built with ERB, which has no CSS to read at compile time, and for a template compiled without a `filename`, which has no stable scope to derive. A `transform` that raises is treated the same way, so CSS nobody can read costs the block it was written in and not the whole template.
 
 `deliver` says where the narrowed CSS goes.
 

--- a/lib/herb/cli.rb
+++ b/lib/herb/cli.rb
@@ -1125,7 +1125,7 @@ class Herb::CLI
     require_relative "engine/scoped_style/visitor"
     Herb.ensure_installed("lightningcss")
 
-    Herb::Engine::ScopedStyle::Visitor.new(transform: LightningCSS::Transformer.new)
+    Herb::Engine::ScopedStyle::Visitor.new
   end
 
   def compile_template

--- a/lib/herb/engine/scoped_style/visitor.rb
+++ b/lib/herb/engine/scoped_style/visitor.rb
@@ -54,7 +54,9 @@ module Herb
       # `scope` is the selector each rule has to be narrowed by, appended to what the rule already
       # matches.
       #
-      # Without one, a block is left exactly as it was written and reported. Scoping the markup while
+      # Lightning CSS is what narrows a block unless something else is given, so `transform` is for
+      # narrowing it some other way. Without one at all, which is a machine with no `lightningcss` on
+      # it, a block is left exactly as it was written and reported. Scoping the markup while
       # leaving the CSS alone would turn a scoped block into a global one. A `transform` that raises
       # is treated the same way, so CSS nobody can read costs the block it was written in and not the
       # whole template.
@@ -94,7 +96,7 @@ module Herb
           raise ArgumentError, "`deliver: #{deliver.inspect}` is not a delivery. Pass one of #{DELIVERIES.map(&:inspect).join(", ")}." unless DELIVERIES.include?(deliver)
 
           @deliver = deliver
-          @transform = transform
+          @transform = transform || default_transform
           @scopes = {} #: Hash[String, String]
           @styles = {} #: Hash[String, String]
           @elements = {} #: Hash[String, Integer]
@@ -385,11 +387,24 @@ module Herb
 
         #: (Herb::AST::HTMLElementNode) -> void
         def untransformed_style(node)
+          reason = @unavailable ? " Loading `lightningcss` failed with `#{@unavailable}`." : ""
+
           warning(
-            "A `<style scoped>` block was found, and #{self.class.name} was given no `transform` to narrow its selectors with, so it was left as it was written and still applies to the whole page.",
+            "A `<style scoped>` block was found, and there is no `transform` to narrow its selectors with, so it was left as it was written and still applies to the whole page.#{reason} Install `lightningcss`, or give #{self.class.name} a `transform` of its own.",
             node.location,
             code: "scoped-style-without-a-transform"
           )
+
+          nil
+        end
+
+        #: () -> untyped
+        def default_transform
+          require "lightningcss"
+
+          ::LightningCSS::Transformer.new
+        rescue LoadError => e
+          @unavailable = e.message
 
           nil
         end

--- a/sig/herb/engine/scoped_style/visitor.rbs
+++ b/sig/herb/engine/scoped_style/visitor.rbs
@@ -44,7 +44,9 @@ module Herb
       # `scope` is the selector each rule has to be narrowed by, appended to what the rule already
       # matches.
       #
-      # Without one, a block is left exactly as it was written and reported. Scoping the markup while
+      # Lightning CSS is what narrows a block unless something else is given, so `transform` is for
+      # narrowing it some other way. Without one at all, which is a machine with no `lightningcss` on
+      # it, a block is left exactly as it was written and reported. Scoping the markup while
       # leaving the CSS alone would turn a scoped block into a global one. A `transform` that raises
       # is treated the same way, so CSS nobody can read costs the block it was written in and not the
       # whole template.
@@ -171,6 +173,9 @@ module Herb
 
         # : (Herb::AST::HTMLElementNode) -> void
         def untransformed_style: (Herb::AST::HTMLElementNode) -> void
+
+        # : () -> untyped
+        def default_transform: () -> untyped
 
         # : (Herb::AST::HTMLElementNode, StandardError) -> nil
         def untransformable_style: (Herb::AST::HTMLElementNode, StandardError) -> nil

--- a/sorbet/rbi/lightningcss.rbi
+++ b/sorbet/rbi/lightningcss.rbi
@@ -1,0 +1,8 @@
+# typed: false
+
+module LightningCSS
+  class Transformer
+    def initialize(minify: nil); end
+    def call(css, scope:); end
+  end
+end

--- a/test/engine/scoped_style/visitor_test.rb
+++ b/test/engine/scoped_style/visitor_test.rb
@@ -72,6 +72,14 @@ module Engine
       end
     end
 
+    class Untransformable < Herb::Engine::ScopedStyle::Visitor
+      private
+
+      def require(*)
+        raise LoadError, "cannot load such file -- lightningcss"
+      end
+    end
+
     def options(transform: Transform.new, filename: TEMPLATE, visitors: [], deliver: :inline, **overrides)
       visitor = Herb::Engine::ScopedStyle::Visitor.new(transform: transform, deliver: deliver)
 
@@ -160,11 +168,12 @@ module Engine
       assert_empty visitor.styles
     end
 
-    test "leaves a block alone when it was given no transform to narrow it with" do
-      _, visitor = compile(%(<style scoped>.title { color: red; }</style><h1>Hi</h1>), transform: nil)
+    test "narrows with Lightning CSS when it was given no transform of its own" do
+      _, visitor = compile(%(<style scoped>.title { color: red; }</style><h1 class="title">Hi</h1>), transform: nil)
 
-      assert_equal ["scoped-style-without-a-transform"], visitor.diagnostics.map(&:code)
-      assert_empty visitor.styles
+      assert_empty visitor.diagnostics
+      assert_equal 1, visitor.styles.length
+      assert_includes visitor.styles.values.first, "[data-herb-scope-"
     end
 
     test "refuses a template compiled without a path, because a scope would not be stable" do
@@ -349,6 +358,20 @@ module Engine
       output = `#{Gem.ruby} #{load_path} -e 'require "herb"; print defined?(Herb::Engine::ScopedStyle::Visitor).inspect' 2>&1`
 
       assert_equal "nil", output
+    end
+    test "leaves a block alone when there is no transform to narrow it with" do
+      visitor = Untransformable.new
+      Herb::Engine.new(%(<style scoped>.title { color: red; }</style><h1>Hi</h1>), filename: TEMPLATE, escape: false, visitors: [visitor])
+
+      assert_equal ["scoped-style-without-a-transform"], visitor.diagnostics.map(&:code)
+      assert_empty visitor.styles
+    end
+
+    test "says why there is no transform, so that a broken install is not read as a missing one" do
+      visitor = Untransformable.new
+      Herb::Engine.new(%(<style scoped>.title { color: red; }</style><h1>Hi</h1>), filename: TEMPLATE, escape: false, visitors: [visitor])
+
+      assert_includes visitor.diagnostics.first.message, "cannot load such file -- lightningcss"
     end
   end
 end


### PR DESCRIPTION
This pull request gives `ScopedStyle::Visitor` a `transform` when it was not given one.

```ruby
Herb::Engine.new(source, filename: path, visitors: [
  Herb::Engine::ScopedStyle::Visitor.new
])
```

```html
<style>.title[data-herb-scope-2940ba8a] { color: red; }</style>
<h1 class="title" data-herb-scope-2940ba8a>Hi</h1>
```

#### Why

Narrowing the CSS is the whole of what the visitor does. Without a `transform` it scoped the markup, left the CSS exactly as it was written, and reported it, because scoping markup while leaving its CSS alone turns a scoped block into a global one. That is a safe thing to do about a missing `transform`, and it is not a useful default: putting the visitor in a stack is already the sentence "narrow these blocks", and having to say it twice is a `<style scoped>` block that silently still applies to the whole page.

Lightning CSS was already the one everybody passed, and the one the CLI installed on demand. It is the default now, and `transform` is for narrowing some other way.

#### When it cannot be loaded

Herb does not depend on `lightningcss`, so the default is built if the gem loads and skipped if it does not. A machine without it gets the behavior a visitor with no `transform` has always had, the block left as it was written, and a diagnostic saying so.

`LoadError` means two things, though: the gem is not installed, or it is and something it needs did not load. Reporting only the first would send somebody to install what they already have, so the reason is carried into the diagnostic:

```
A `<style scoped>` block was found, and there is no `transform` to narrow its selectors
with, so it was left as it was written and still applies to the whole page. Loading
`lightningcss` failed with `cannot load such file -- lightningcss`. Install
`lightningcss`, or give Herb::Engine::ScopedStyle::Visitor a `transform` of its own.
```

The code stays `scoped-style-without-a-transform`.