### PR TITLE
Herb: Add `locate` on nodes and parse results

### DIFF
--- a/docs/docs/bindings/javascript/reference.md
+++ b/docs/docs/bindings/javascript/reference.md
@@ -295,7 +295,7 @@ Columns are 0-based character offsets into their line, which is what the parser 
 import { locate, Position, isHTMLElementNode } from "@herb-tools/core"
 
 const result = Herb.parse("<div><span>hi</span></div>")
-const found = locate(result.value, Position.from(1, 12))
+const found = result.locate(Position.from(1, 12))
 
 found.node
 // => HTMLTextNode
@@ -313,7 +313,7 @@ found.path.map((node) => node.constructor.name)
 
 `innermost` takes a predicate and starts with the node itself, so it answers with the node when the node already matches. Passing a type guard such as `isHTMLElementNode` narrows the result. `path` reads the other way around, outermost first, and ends with the node that was found. A position that belongs to no node answers `null`.
 
-A parse result answers for the document it parsed, so the result a caller already has can be handed over directly. ``locatable`` asks the same question without walking, and answers whether a position falls anywhere inside a node or what it holds.
+Every node answers too, so a walk can start from the node a caller already holds. `result.locate(position)` and `node.locate(position)` are the same walk from different starting points, and the `locate` function takes either. `locatable` asks the same question without walking, and answers whether a position falls anywhere inside a node or what it holds.
 
 The walk goes by how much source a node and everything it holds cover together, which is not the same as the node's own location. A branch of an `if` holds the branch after it, and each branch is positioned where it was written, so the node holding the chain ends before what it holds. Walking by a node's own location would leave every branch but the first unreachable. `ancestors` is therefore the walk that was taken, whether or not each node along it covers the position itself, and a caller that wants only the nodes the position is really inside filters on `location.contains`.
 

--- a/docs/docs/bindings/ruby/reference.md
+++ b/docs/docs/bindings/ruby/reference.md
@@ -251,7 +251,7 @@ Columns are 0-based character offsets into their line, which is what the parser 
 :::code-group
 ```ruby
 result = Herb.parse("<div><span>hi</span></div>")
-found = Herb::Locate.call(result.value, Herb::Position[1, 12])
+found = result.locate(Herb::Position[1, 12])
 
 found.node
 # => #<Herb::AST::HTMLTextNode>
@@ -269,7 +269,7 @@ found.path.map(&:class)
 
 `innermost` starts with the node itself, so it answers with the node when the node is already of that kind. `path` reads the other way around, outermost first, and ends with the node that was found. A position that belongs to no node answers `nil`.
 
-A parse result answers for the document it parsed, so the result a caller already has can be handed over directly. ``Herb::Locate.locatable?`` asks the same question without walking, and answers whether a position falls anywhere inside a node or what it holds.
+Every node answers too, so a walk can start from the node a caller already holds. `result.locate(position)` and `node.locate(position)` are the same walk from different starting points. `locatable?` asks the same question without walking, and answers whether a position falls anywhere inside a node or what it holds.
 
 The walk goes by how much source a node and everything it holds cover together, which is not the same as the node's own location. A branch of an `if` holds the branch after it, and each branch is positioned where it was written, so the node holding the chain ends before what it holds. Walking by a node's own location would leave every branch but the first unreachable. `ancestors` is therefore the walk that was taken, whether or not each node along it covers the position itself, and a caller that wants only the nodes the position is really inside filters on `location.contains?`.
 

--- a/docs/docs/bindings/rust/reference.md
+++ b/docs/docs/bindings/rust/reference.md
@@ -395,7 +395,7 @@ use herb::locate::locate;
 use herb::position::Position;
 
 let result = herb::parse("<div><span>hi</span></div>").unwrap();
-let found = locate(&result.value, Position::new(1, 12)).unwrap();
+let found = result.locate(Position::new(1, 12)).unwrap();
 
 found.node.node_type();
 // => "AST_HTML_TEXT_NODE"
@@ -412,7 +412,7 @@ found.path();
 
 `innermost` starts with the node itself, so it answers with the node when the node already matches the predicate. A position that belongs to no node answers `None`.
 
-A parse result answers for the document it parsed, so the result a caller already has can be handed over directly. ``herb::locatable`` asks the same question without walking, and answers whether a position falls anywhere inside a node or what it holds.
+Every node answers too through the `NodeLocate` trait, so a walk can start from the node a caller already holds. `result.locate(position)` and `node.locate(position)` are the same walk from different starting points, and `herb::locate` takes either. `locatable` asks the same question without walking, and answers whether a position falls anywhere inside a node or what it holds.
 
 The walk goes by how much source a node and everything it holds cover together, which is not the same as the node's own location. A branch of an `if` holds the branch after it, and each branch is positioned where it was written, so the node holding the chain ends before what it holds. Walking by a node's own location would leave every branch but the first unreachable. `ancestors` is therefore the walk that was taken, whether or not each node along it covers the position itself, and a caller that wants only the nodes the position is really inside filters on `node.location().contains(position)`.
 

--- a/javascript/packages/core/src/parse-result.ts
+++ b/javascript/packages/core/src/parse-result.ts
@@ -1,10 +1,13 @@
-import { Result } from "./result.js"
+import { locate, locatable } from "./locate.js"
 
-import { DocumentNode } from "./nodes.js"
+import { Result } from "./result.js"
 import { HerbError } from "./errors.js"
+import { DocumentNode } from "./nodes.js"
 import { HerbWarning } from "./warning.js"
 import { ParserOptions } from "./parser-options.js"
 
+import type { Position } from "./position.js"
+import type { LocateResult } from "./locate.js"
 import type { SerializedHerbError } from "./errors.js"
 import type { SerializedHerbWarning } from "./warning.js"
 import type { SerializedDocumentNode } from "./nodes.js"
@@ -141,6 +144,16 @@ export class ParseResult extends Result {
    */
   inspect(): string {
     return this.value.inspect()
+  }
+
+  /** The most specific node at a position, and the nodes it sits inside. */
+  locate(position: Position): LocateResult | null {
+    return locate(this, position)
+  }
+
+  /** Whether a position falls anywhere inside the document this parsed. */
+  locatable(position: Position): boolean {
+    return locatable(this, position)
   }
 
   /**

--- a/javascript/packages/core/test/locate.test.ts
+++ b/javascript/packages/core/test/locate.test.ts
@@ -1,5 +1,6 @@
 import { describe, test, expect } from "vitest"
 import { locate, locatable } from "../src/locate.js"
+import { ParseResult } from "../src/parse-result.js"
 
 import { Location } from "../src/location.js"
 import { Position } from "../src/position.js"
@@ -296,6 +297,49 @@ describe("locate", () => {
       })
 
       expect(locatable(holder, Position.from(1, 20))).toBe(true)
+    })
+  })
+
+  describe("a parse result answering for itself", () => {
+    test("delegates to locate", () => {
+      const { document, text } = tree()
+      const result = { value: document, locate: undefined } as any
+
+      result.locate = ParseResult.prototype.locate
+      result.locatable = ParseResult.prototype.locatable
+
+      expect(result.locate(Position.from(1, 12)).node).toBe(text)
+      expect(result.locatable(Position.from(1, 12))).toBe(true)
+      expect(result.locatable(Position.from(1, 999))).toBe(false)
+    })
+  })
+
+  describe("a node answering for itself", () => {
+    test("finds the most specific node at a position", () => {
+      const { document, text } = tree()
+
+      expect(document.locate(Position.from(1, 12))!.node).toBe(text)
+    })
+
+    test("answers the same way the free function does", () => {
+      const { document } = tree()
+      const position = Position.from(1, 12)
+
+      expect(document.locate(position)!.node).toBe(locate(document, position)!.node)
+    })
+
+    test("works on a node reached through a walk", () => {
+      const { document, text } = tree()
+      const span = document.locate(Position.from(1, 12))!.ancestors[0]
+
+      expect(span.locate(Position.from(1, 12))!.node).toBe(text)
+    })
+
+    test("says whether a position falls inside it at all", () => {
+      const { document } = tree()
+
+      expect(document.locatable(Position.from(1, 12))).toBe(true)
+      expect(document.locatable(Position.from(1, 999))).toBe(false)
     })
   })
 })

--- a/lib/herb/ast/node.rb
+++ b/lib/herb/ast/node.rb
@@ -115,6 +115,16 @@ module Herb
         child_nodes.compact
       end
 
+      #: (Herb::Position) -> Herb::Locate::Result?
+      def locate(position)
+        Herb::Locate.call(self, position)
+      end
+
+      #: (Herb::Position) -> bool
+      def locatable?(position)
+        Herb::Locate.locatable?(self, position)
+      end
+
       #: () -> Array[Herb::Errors::Error]
       def recursive_errors
         accumulator = [] #: Array[Herb::Errors::Error]

--- a/lib/herb/locate.rb
+++ b/lib/herb/locate.rb
@@ -4,10 +4,14 @@
 module Herb
   # Finds the most specific node at a position, and the nodes it sits inside.
   #
-  #     result = Herb::Locate.call(document, Herb::Position[2, 7])
+  #     result = document.locate(Herb::Position.from(2, 7))
   #
   #     result.node      #=> the innermost node whose location contains the position
   #     result.ancestors #=> every node it sits inside, nearest first
+  #
+  # A node and a parse result both answer, so a walk starts from whichever one a caller already
+  # holds. `Herb::AST::Node#locate` and `Herb::ParseResult#locate` are the same walk from different
+  # starting points.
   #
   # Everything that reads a position back from a rendered page, an editor, or a diagnostic needs
   # this, and every caller was writing its own descent. A finding at `2:7` is a node before it is
@@ -20,7 +24,7 @@ module Herb
   #
   # A node's location contains its start and stops short of its end, so two nodes sitting next to
   # each other never both answer for the character between them. A position past the end of the
-  # source belongs to no node, and `call` answers `nil`.
+  # source belongs to no node, and the answer is `nil`.
   #
   # Columns are 0-based character offsets into their line, which is what the parser reports.
   # `Herb::Position#to_one_based` is what turns one into what an editor shows.

--- a/lib/herb/parse_result.rb
+++ b/lib/herb/parse_result.rb
@@ -36,6 +36,16 @@ module Herb
       JSON.pretty_generate(errors)
     end
 
+    #: (Herb::Position) -> Herb::Locate::Result?
+    def locate(position)
+      Locate.call(self, position)
+    end
+
+    #: (Herb::Position) -> bool
+    def locatable?(position)
+      Locate.locatable?(self, position)
+    end
+
     #: (Visitor) -> void
     def visit(visitor)
       value.accept(visitor)

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -21,7 +21,7 @@ pub mod visitor;
 pub(crate) mod style;
 
 pub use lex_result::LexResult;
-pub use locate::{locatable, locate, LocateResult, LocateSource};
+pub use locate::{locatable, locate, LocateResult, LocateSource, NodeLocate};
 pub use location::Location;
 pub use nodes::{AnyNode, ERBNode, Node};
 pub use parse_result::ParseResult;

--- a/rust/src/locate.rs
+++ b/rust/src/locate.rs
@@ -15,7 +15,7 @@ impl<T: Node> LocateSource for T {
   }
 }
 
-impl LocateSource for dyn Node {
+impl<'n> LocateSource for dyn Node + 'n {
   fn locate_root(&self) -> &dyn Node {
     self
   }
@@ -131,5 +131,31 @@ pub fn locate<S: LocateSource + ?Sized>(source: &S, position: Position) -> Optio
         });
       }
     }
+  }
+}
+
+pub trait NodeLocate {
+  fn locate(&self, position: Position) -> Option<LocateResult<'_>>;
+
+  fn locatable(&self, position: Position) -> bool;
+}
+
+impl<T: Node> NodeLocate for T {
+  fn locate(&self, position: Position) -> Option<LocateResult<'_>> {
+    locate(self, position)
+  }
+
+  fn locatable(&self, position: Position) -> bool {
+    locatable(self, position)
+  }
+}
+
+impl<'n> NodeLocate for dyn Node + 'n {
+  fn locate(&self, position: Position) -> Option<LocateResult<'_>> {
+    locate(self, position)
+  }
+
+  fn locatable(&self, position: Position) -> bool {
+    locatable(self, position)
   }
 }

--- a/rust/src/parse_result.rs
+++ b/rust/src/parse_result.rs
@@ -1,6 +1,8 @@
 use crate::errors::{AnyError, ErrorNode};
 use crate::herb::ParserOptions;
+use crate::locate::{locatable, locate, LocateResult};
 use crate::nodes::{DocumentNode, Node};
+use crate::position::Position;
 use std::fmt;
 
 pub struct ParseResult {
@@ -14,6 +16,14 @@ pub struct ParseResult {
 impl ParseResult {
   pub fn new(value: DocumentNode, source: String, errors: Vec<AnyError>, options: &ParserOptions) -> Self {
     Self::with_error_count(value, source, errors, options, None)
+  }
+
+  pub fn locate(&self, position: Position) -> Option<LocateResult<'_>> {
+    locate(self, position)
+  }
+
+  pub fn locatable(&self, position: Position) -> bool {
+    locatable(self, position)
   }
 
   pub fn with_error_count(value: DocumentNode, source: String, errors: Vec<AnyError>, options: &ParserOptions, error_count: Option<u32>) -> Self {

--- a/rust/tests/locate_test.rs
+++ b/rust/tests/locate_test.rs
@@ -225,3 +225,36 @@ fn test_locatable_answers_for_a_position_only_a_branch_covers() {
 
   assert!(locatable(&result.value, Position::new(1, 35)));
 }
+
+#[test]
+fn test_a_parse_result_answers_for_itself() {
+  let result = parse(SOURCE).unwrap();
+
+  assert_eq!(result.locate(Position::new(1, 12)).unwrap().node.node_type(), "AST_HTML_TEXT_NODE");
+
+  assert!(result.locatable(Position::new(1, 12)));
+  assert!(!result.locatable(Position::new(1, 999)));
+}
+
+#[test]
+fn test_a_node_answers_for_itself() {
+  use herb::locate::NodeLocate;
+
+  let result = parse(SOURCE).unwrap();
+
+  assert_eq!(result.value.locate(Position::new(1, 12)).unwrap().node.node_type(), "AST_HTML_TEXT_NODE");
+
+  assert!(result.value.locatable(Position::new(1, 12)));
+  assert!(!result.value.locatable(Position::new(1, 999)));
+}
+
+#[test]
+fn test_a_node_reached_through_a_walk_answers_for_itself_too() {
+  use herb::locate::NodeLocate;
+
+  let result = parse(SOURCE).unwrap();
+  let found = result.value.locate(Position::new(1, 12)).unwrap();
+  let span = found.innermost(|node| node.node_type() == "AST_HTML_ELEMENT_NODE").unwrap();
+
+  assert_eq!(span.locate(Position::new(1, 12)).unwrap().node.node_type(), "AST_HTML_TEXT_NODE");
+}

--- a/sig/herb/ast/node.rbs
+++ b/sig/herb/ast/node.rbs
@@ -61,6 +61,12 @@ module Herb
       # : () -> Array[Herb::AST::Node]
       def compact_child_nodes: () -> Array[Herb::AST::Node]
 
+      # : (Herb::Position) -> Herb::Locate::Result?
+      def locate: (Herb::Position) -> Herb::Locate::Result?
+
+      # : (Herb::Position) -> bool
+      def locatable?: (Herb::Position) -> bool
+
       # : () -> Array[Herb::Errors::Error]
       def recursive_errors: () -> Array[Herb::Errors::Error]
 

--- a/sig/herb/locate.rbs
+++ b/sig/herb/locate.rbs
@@ -3,10 +3,14 @@
 module Herb
   # Finds the most specific node at a position, and the nodes it sits inside.
   #
-  #     result = Herb::Locate.call(document, Herb::Position[2, 7])
+  #     result = document.locate(Herb::Position.from(2, 7))
   #
   #     result.node      #=> the innermost node whose location contains the position
   #     result.ancestors #=> every node it sits inside, nearest first
+  #
+  # A node and a parse result both answer, so a walk starts from whichever one a caller already
+  # holds. `Herb::AST::Node#locate` and `Herb::ParseResult#locate` are the same walk from different
+  # starting points.
   #
   # Everything that reads a position back from a rendered page, an editor, or a diagnostic needs
   # this, and every caller was writing its own descent. A finding at `2:7` is a node before it is
@@ -19,7 +23,7 @@ module Herb
   #
   # A node's location contains its start and stops short of its end, so two nodes sitting next to
   # each other never both answer for the character between them. A position past the end of the
-  # source belongs to no node, and `call` answers `nil`.
+  # source belongs to no node, and the answer is `nil`.
   #
   # Columns are 0-based character offsets into their line, which is what the parser reports.
   # `Herb::Position#to_one_based` is what turns one into what an editor shows.

--- a/sig/herb/parse_result.rbs
+++ b/sig/herb/parse_result.rbs
@@ -17,6 +17,12 @@ module Herb
     # : () -> String
     def pretty_errors: () -> String
 
+    # : (Herb::Position) -> Herb::Locate::Result?
+    def locate: (Herb::Position) -> Herb::Locate::Result?
+
+    # : (Herb::Position) -> bool
+    def locatable?: (Herb::Position) -> bool
+
     # : (Visitor) -> void
     def visit: (Visitor) -> void
   end

--- a/templates/javascript/packages/core/src/nodes.ts.erb
+++ b/templates/javascript/packages/core/src/nodes.ts.erb
@@ -1,4 +1,5 @@
 import { Location } from "./location.js"
+import { locate, locatable } from "./locate.js"
 import { Token, SerializedToken } from "./token.js"
 import { HerbError } from "./errors.js"
 import { deserializePrismNode, inspectPrismSerialized } from "./prism/index.js"
@@ -7,6 +8,8 @@ import type { PrismNode } from "./prism/index.js"
 import type { SerializedLocation } from "./location.js"
 import type { SerializedHerbError } from "./errors.js"
 import type { Visitor } from "./visitor.js"
+import type { Position } from "./position.js"
+import type { LocateResult } from "./locate.js"
 
 export type SerializedNodeType = string
 
@@ -40,6 +43,14 @@ export abstract class Node implements BaseNodeProps {
     this.type = type
     this.location = location
     this.errors = errors
+  }
+
+  locate(position: Position): LocateResult | null {
+    return locate(this, position)
+  }
+
+  locatable(position: Position): boolean {
+    return locatable(this, position)
   }
 
   setSource(source: string): void {

--- a/test/locate_test.rb
+++ b/test/locate_test.rb
@@ -4,7 +4,7 @@ require_relative "test_helper"
 
 class LocateTest < Minitest::Spec
   def locate(source, line, column)
-    Herb::Locate.call(Herb.parse(source).value, Herb::Position[line, column])
+    Herb.parse(source).value.locate(Herb::Position.from(line, column))
   end
 
   def types(nodes)
@@ -67,7 +67,7 @@ class LocateTest < Minitest::Spec
     test "are empty when the node the walk started from is the answer" do
       document = Herb.parse("x").value
       text = document.children.first
-      result = Herb::Locate.call(text, Herb::Position[1, 0])
+      result = text.locate(Herb::Position[1, 0])
 
       assert_equal [], result.ancestors
       assert_same text, result.node
@@ -140,7 +140,7 @@ class LocateTest < Minitest::Spec
       node = Herb::AST::HTMLTextNode.build(content: +"x")
 
       assert_predicate node.location, :empty?
-      assert_nil Herb::Locate.call(node, Herb::Position[0, 0])
+      assert_nil node.locate(Herb::Position[0, 0])
     end
   end
 
@@ -148,7 +148,7 @@ class LocateTest < Minitest::Spec
     test "starts the walk at whatever node it is given" do
       document = Herb.parse("<div><span>hi</span></div>").value
       element = document.children.first
-      result = Herb::Locate.call(element, Herb::Position[1, 12])
+      result = element.locate(Herb::Position[1, 12])
 
       assert_equal ["HTMLElementNode", "HTMLElementNode"], types(result.ancestors)
     end
@@ -157,7 +157,7 @@ class LocateTest < Minitest::Spec
       document = Herb.parse("<b>one</b><i>two</i>").value
       first = document.children.first
 
-      assert_nil Herb::Locate.call(first, Herb::Position[1, 15])
+      assert_nil first.locate(Herb::Position[1, 15])
     end
   end
 
@@ -189,30 +189,37 @@ class LocateTest < Minitest::Spec
 
   describe "a parse result" do
     test "answers for the document it parsed" do
-      result = Herb::Locate.call(Herb.parse("<div>x</div>"), Herb::Position[1, 2])
+      result = Herb.parse("<div><span>hi</span></div>").locate(Herb::Position[1, 12])
 
-      assert_equal "HTMLOpenTagNode", types([result.node]).first
+      assert_equal "HTMLTextNode", types([result.node]).first
     end
 
-    test "answers the same way the document does" do
+    test "answers the same way the document it holds does" do
       parsed = Herb.parse("<div><span>hi</span></div>")
       position = Herb::Position[1, 12]
 
-      assert_same Herb::Locate.call(parsed, position).node, Herb::Locate.call(parsed.value, position).node
+      assert_same parsed.locate(position).node, parsed.value.locate(position).node
+    end
+
+    test "says whether a position falls inside it at all" do
+      parsed = Herb.parse("<div>x</div>")
+
+      assert parsed.locatable?(Herb::Position[1, 2])
+      refute parsed.locatable?(Herb::Position[1, 999])
     end
   end
 
-  describe ".locatable?" do
+  describe "#locatable?" do
     test "answers for a position the node covers" do
-      assert Herb::Locate.locatable?(Herb.parse("<div>x</div>"), Herb::Position[1, 2])
+      assert Herb.parse("<div>x</div>").value.locatable?(Herb::Position[1, 2])
     end
 
     test "does not answer for a position past the end" do
-      refute Herb::Locate.locatable?(Herb.parse("<div>x</div>"), Herb::Position[1, 999])
+      refute Herb.parse("<div>x</div>").value.locatable?(Herb::Position[1, 999])
     end
 
     test "answers for a position only a branch covers" do
-      assert Herb::Locate.locatable?(Herb.parse("<% if a %>A<% else %>C<% end %>").value, Herb::Position[1, 21])
+      assert Herb.parse("<% if a %>A<% else %>C<% end %>").value.locatable?(Herb::Position[1, 21])
     end
   end
 end


### PR DESCRIPTION
Follow up on #2452, which introduced `Locate` but reached it only through `Herb::Locate.call(node, position)` in Ruby and a free function in JavaScript and Rust. A walk almost always starts from a node or a parse result a caller already holds:

```ruby
document.locate(Herb::Position.from(2, 7))
result.locate(Herb::Position.from(2, 7))
```

```js
document.locate(Position.from(2, 7))
result.locate(Position.from(2, 7))
```

```rust
document.locate(Position::new(2, 7));
result.locate(Position::new(2, 7));
```

`locatable` comes along the same way, and asks whether a position falls anywhere inside a node or what it holds without doing the walk. Both are the same walk from different starting points, so a node reached through one result can start another.

The free function stays in every binding. `Herb::Locate.call` remains the implementation in Ruby, and `locate(source, position)` remains exported from `@herb-tools/core` and `herb` in Rust.