### PR TITLE
Client: Carry a transform on each side of a `herb:state` comparison

### DIFF
--- a/javascript/packages/client/src/directives.ts
+++ b/javascript/packages/client/src/directives.ts
@@ -190,7 +190,7 @@ export function classifyDefault(source: string): StateDefaultKind {
   return "seeded"
 }
 
-export type DerivedComparand = string | null | { state: string }
+export type DerivedComparand = string | null | { state: string, transform?: string }
 
 export type DerivedCondition =
   | [string, DerivedComparand]
@@ -323,14 +323,26 @@ function parseDerivedCondition(source: string, declared: ReadonlyMap<string, str
     const rightState = derivedStateSide(right, declared)
 
     if (leftState && rightState) {
-      if (leftState.transform || rightState.transform) {
-        return "mixed"
+      let left = leftState
+      let right = rightState
+      let mirrored = operator === "==" ? undefined : operator
+
+      if (right.transform && !left.transform) {
+        [left, right] = [right, left]
+
+        if (mirrored && mirrored !== "!=") {
+          mirrored = MIRRORED_COMPARISONS[mirrored]
+        }
       }
 
-      const spelled = operator === "==" ? undefined : operator
-      const condition: DerivedCondition = spelled ? [leftState.state, { state: rightState.state }, spelled] : [leftState.state, { state: rightState.state }]
+      const comparand: DerivedComparand = right.transform ? { state: right.state, transform: right.transform } : { state: right.state }
+      const sources = [...new Set([left.state, right.state])]
 
-      return { kind: "boolean", condition, sources: [...new Set([leftState.state, rightState.state])] }
+      if (left.transform) {
+        return { kind: "boolean", condition: [left.state, comparand, mirrored ?? "==", left.transform], sources }
+      }
+
+      return { kind: "boolean", condition: mirrored ? [left.state, comparand, mirrored] : [left.state, comparand], sources }
     }
 
     const side = leftState ?? rightState

--- a/javascript/packages/client/src/state/conditions.ts
+++ b/javascript/packages/client/src/state/conditions.ts
@@ -189,7 +189,9 @@ function comparandValue(comparand: Exclude<StateComparand, null>, valueOf: Value
   }
 
   if ("state" in comparand) {
-    return valueOf(comparand.state)
+    const value = valueOf(comparand.state)
+
+    return comparand.transform ? transformed(comparand.transform, value) : value
   }
 
   return comparand.value

--- a/javascript/packages/client/src/state/types.ts
+++ b/javascript/packages/client/src/state/types.ts
@@ -1,6 +1,6 @@
 export type ConditionValue = string | number | boolean | null
 export type ConditionalArm = Arm | ComboArm | [string, StateComparand, number | null] | [string, StateComparand, number | null, string]
-export type StateComparand = null | { state: string } | { value: ConditionValue } | string
+export type StateComparand = null | { state: string, transform?: string } | { value: ConditionValue } | string
 export type StateCondition = [string, StateComparand] | [string, StateComparand, string] | [string, StateComparand, string | null, string] | ComboCondition
 export type ValueOf = (name: string) => ConditionValue
 

--- a/javascript/packages/client/test/conditions.test.ts
+++ b/javascript/packages/client/test/conditions.test.ts
@@ -97,6 +97,24 @@ describe("a condition the compiler wrote", () => {
     expect(matches(["sort", { state: "draft" }, "==", "to_s"], valueOf)).toBe(false)
   })
 
+  test("transforms both sides of a comparison, matching Ruby", () => {
+    const rows: [string, string, boolean, boolean][] = [
+      ["", "", false, true],
+      ["abc", "ab", true, false],
+      ["ab", "abc", false, false],
+      ["ab", "ab", false, true],
+      ["\u{1F44B}a", "abc", false, false],
+      ["\u{1F44B}\u{1F44B}", "ab", false, true],
+    ]
+
+    for (const [draft, filter, ordered, equal] of rows) {
+      const sides = (name: string): ConditionValue => (name === "draft" ? draft : filter)
+
+      expect(matches(["draft", { state: "filter", transform: "length" }, ">", "length"], sides)).toBe(ordered)
+      expect(matches(["draft", { state: "filter", transform: "length" }, "==", "length"], sides)).toBe(equal)
+    }
+  })
+
   test("negates a read the way `!` does", () => {
     expect(matches(["pending", null, "falsy"], valueOf)).toBe(false)
     expect(matches(["failed", null, "falsy"], valueOf)).toBe(true)

--- a/javascript/packages/client/test/directives.test.ts
+++ b/javascript/packages/client/test/directives.test.ts
@@ -108,6 +108,20 @@ describe("classifyDerivedDefault", () => {
     expect(classifyDerivedDefault('count.to_s == "3"', declared)).toEqual({ kind: "boolean", condition: ["count", '"3"', "==", "to_s"], sources: ["count"] })
   })
 
+  test("carries a transform on each side of a comparison", () => {
+    expect(classifyDerivedDefault("draft.length > count", declared)).toEqual({
+      kind: "boolean",
+      condition: ["draft", { state: "count" }, ">", "length"],
+      sources: ["draft", "count"],
+    })
+
+    expect(classifyDerivedDefault("count < draft.length", declared)).toEqual({
+      kind: "boolean",
+      condition: ["draft", { state: "count" }, ">", "length"],
+      sources: ["draft", "count"],
+    })
+  })
+
   test("stays out of expressions that are not predicates", () => {
     expect(classifyDerivedDefault("draft.upcase", declared)).toBe("mixed")
     expect(classifyDerivedDefault("other.blank?", declared)).toBeNull()

--- a/javascript/packages/linter/docs/rules/herb-state-valid-reads.md
+++ b/javascript/packages/linter/docs/rules/herb-state-valid-reads.md
@@ -26,7 +26,7 @@ An expression the client can resolve also stands on its own as an output, so `<%
 
 `to_s` reads a state of any kind as a String, matching Ruby down to `nil.to_s` being `""`. `length` and `size` read the character count of a String or a Symbol state, either compared to an Integer literal (`draft.length > 3`) or printed on its own (`<%= draft.length %>`). Both spell the same thing, so `size` compiles exactly like `length`.
 
-A transform compares against a literal or against another declared state, so `draft.to_s == filter` works. Only one side of a comparison may carry a transform.
+A transform compares against a literal or against another declared state, so `draft.to_s == filter` and `draft.length > filter.length` both work. Each side carries its own transform, and the two have to end up the same kind.
 
 `count` is not supported. Unlike `Array#count`, `String#count` takes a character set (`"hello".count("a-z")`) and raises without one, so there is nothing to resolve on the client.
 

--- a/javascript/packages/linter/src/rules/herb-state-valid-reads.ts
+++ b/javascript/packages/linter/src/rules/herb-state-valid-reads.ts
@@ -398,12 +398,29 @@ class StateValidReadsVisitor extends BaseRuleVisitor {
       }
 
       if (leftTransform && rightTransform) {
-        this.addOffense(
-          `\`${this.sliceOf(predicate)}\` compares the ${leftTransform.transform} of the state \`${leftTransform.name}\` against the ${rightTransform.transform} of the state \`${rightTransform.name}\`. One condition carries one transform, so declare a state for one of the two sides and compare that.`,
-          this.locationOf(predicate),
-        )
+        const leftReturns = STATE_TRANSFORMS[leftTransform.transform].returns
+        const rightReturns = STATE_TRANSFORMS[rightTransform.transform].returns
+        const ordered = operator !== "==" && operator !== "!="
 
-        return "reported"
+        if (ordered && (leftReturns !== "integer" || rightReturns !== "integer")) {
+          this.addOffense(
+            `\`${this.sliceOf(predicate)}\` orders the ${leftTransform.transform} of the state \`${leftTransform.name}\` against the ${rightTransform.transform} of the state \`${rightTransform.name}\`. Ordering compares numbers, so both sides have to be Integers.`,
+            this.locationOf(predicate),
+          )
+
+          return "reported"
+        }
+
+        if (!ordered && leftReturns !== rightReturns) {
+          this.addOffense(
+            `\`${this.sliceOf(predicate)}\` compares the ${leftTransform.transform} of the state \`${leftTransform.name}\` with the ${rightTransform.transform} of the state \`${rightTransform.name}\`, so it can never match. Compare values of the same kind.`,
+            this.locationOf(predicate),
+          )
+
+          return "reported"
+        }
+
+        return "state"
       }
 
       const transformed = leftTransform ?? rightTransform

--- a/javascript/packages/linter/test/rules/herb-state-valid-reads.test.ts
+++ b/javascript/packages/linter/test/rules/herb-state-valid-reads.test.ts
@@ -451,12 +451,23 @@ describe("HerbStateValidReadsRule", () => {
     `)
   })
 
-  test("flags a transform on both sides of a comparison", () => {
-    expectError("`draft.length > other.length` compares the length of the state `draft` against the length of the state `other`. One condition carries one transform, so declare a state for one of the two sides and compare that.")
+  test("allows a transform on both sides of a comparison", () => {
+    expectNoOffenses(dedent`
+      <%# herb:state (draft: "", other: "", longer: draft.length > other.length) %>
+      <% if draft.length > other.length %>a<% end %>
+      <% if draft.to_s == other.to_s %>b<% end %>
+      <% if !(draft.length > other.length) %>c<% end %>
+      <% if longer %>d<% end %>
+      <p><%= draft.length > other.length %></p>
+    `)
+  })
+
+  test("flags two transformed sides whose kinds disagree", () => {
+    expectError("`draft.length > other.to_s` orders the length of the state `draft` against the to_s of the state `other`. Ordering compares numbers, so both sides have to be Integers.")
 
     assertOffenses(dedent`
       <%# herb:state (draft: "", other: "") %>
-      <% if draft.length > other.length %>a<% end %>
+      <% if draft.length > other.to_s %>a<% end %>
     `)
   })
 

--- a/lib/herb/engine/slots/state_directives.rb
+++ b/lib/herb/engine/slots/state_directives.rb
@@ -31,12 +31,13 @@ module Herb
         )
 
         Read = Data.define(
-          :name,      #: String
-          :comparand, #: String?
-          :kind,      #: Symbol?
-          :operator,  #: String?
-          :against,   #: String?
-          :transform  #: String?
+          :name,             #: String
+          :comparand,        #: String?
+          :kind,             #: Symbol?
+          :operator,         #: String?
+          :against,          #: String?
+          :transform,        #: String?
+          :against_transform #: String?
         )
 
         Combo = Data.define(
@@ -206,7 +207,13 @@ module Herb
 
           #: (Read) -> untyped
           def comparand_entry(read)
-            return { "state" => read.against } if read.against
+            if read.against
+              entry = { "state" => read.against } #: Hash[String, untyped]
+              entry["transform"] = read.against_transform if read.against_transform
+
+              return entry
+            end
+
             return nil unless read.comparand
 
             { "value" => literal_value(read.comparand) }
@@ -242,7 +249,9 @@ module Herb
               return "!#{subject}" if read.operator == FALSY_OPERATOR
               return subject if read.comparand.nil? && read.against.nil?
 
-              "#{subject} #{read.operator || "=="} #{read.against || read.comparand}"
+              against = read.against && read.against_transform ? "#{read.against}.#{TRANSFORM_SPELLINGS.fetch(read.against_transform)}" : read.against
+
+              "#{subject} #{read.operator || "=="} #{against || read.comparand}"
             else
               joiner = read.op == "all" ? " && " : " || "
 
@@ -515,7 +524,7 @@ module Herb
 
               return nil unless declaration
 
-              return Read.new(name: node.name.to_s, comparand: nil, kind: declaration.kind, operator: nil, against: nil, transform: nil)
+              return Read.new(name: node.name.to_s, comparand: nil, kind: declaration.kind, operator: nil, against: nil, transform: nil, against_transform: nil)
             end
 
             return nil unless node.is_a?(Prism::CallNode) && node.receiver.nil? && node.arguments.nil? && node.block.nil?
@@ -527,7 +536,7 @@ module Herb
 
             return nil unless declaration
 
-            Read.new(name: name, comparand: nil, kind: declaration.kind, operator: nil, against: nil, transform: nil)
+            Read.new(name: name, comparand: nil, kind: declaration.kind, operator: nil, against: nil, transform: nil, against_transform: nil)
           end
 
           #: (untyped, Hash[String, Declaration], untyped, Herb::Location?) -> Read?
@@ -558,7 +567,7 @@ module Herb
               return visitor.slot_error("`#{node.slice}` reads the #{read.kind.to_s.capitalize} state `#{read.name}` with `#{node.name}`. Only #{transform.fetch(:only)} can be read with `#{node.name}`, so compare `#{read.name}` itself instead.", location, :read)
             end
 
-            Read.new(name: read.name, comparand: nil, kind: transform.fetch(:returns), operator: nil, against: nil, transform: transform.fetch(:operation))
+            Read.new(name: read.name, comparand: nil, kind: transform.fetch(:returns), operator: nil, against: nil, transform: transform.fetch(:operation), against_transform: nil)
           end
 
           #: (untyped, Hash[String, Declaration], untyped, Herb::Location?) -> Read?
@@ -584,7 +593,7 @@ module Herb
               return visitor.slot_error("`#{node.slice}` reads the #{read.kind.to_s.capitalize} state `#{read.name}` with `#{node.name}`. Only #{predicate.fetch(:only)} can be read with `#{node.name}`, so compare `#{read.name}` to a literal instead.", location, :read)
             end
 
-            Read.new(name: read.name, comparand: predicate[:comparand], kind: read.kind, operator: predicate[:operator], against: nil, transform: nil)
+            Read.new(name: read.name, comparand: predicate[:comparand], kind: read.kind, operator: predicate[:operator], against: nil, transform: nil, against_transform: nil)
           end
 
           #: (untyped, Hash[String, Declaration], untyped, Herb::Location?) -> (Read | Combo)?
@@ -653,18 +662,14 @@ module Herb
               return visitor.slot_error("`#{node.slice}` compares #{subject_phrase(read)} against #{kind_article(kind)} literal, so it can never match. Compare it against #{kind_article(read.kind)} literal instead.", location, :compare)
             end
 
-            Read.new(name: read.name, comparand: literal.slice, kind: read.kind, operator: operator, against: nil, transform: read.transform)
+            Read.new(name: read.name, comparand: literal.slice, kind: read.kind, operator: operator, against: nil, transform: read.transform, against_transform: nil)
           end
 
           #: (untyped, Read, Read, untyped, Herb::Location?) -> Read?
           def state_pair_read(node, left, right, visitor, location)
-            if left.transform && right.transform
-              return visitor.slot_error("`#{node.slice}` compares #{subject_phrase(left)} against #{subject_phrase(right)}. One condition carries one transform, so declare a state for one of the two sides and compare that.", location, :compare)
-            end
-
             operator = node.name == :== ? nil : node.name.to_s
 
-            if right.transform
+            if right.transform && !left.transform
               left, right = right, left
               operator = MIRRORED_OPERATORS.fetch(operator) if operator && operator != "!="
             end
@@ -679,7 +684,7 @@ module Herb
               return visitor.slot_error("`#{node.slice}` compares #{subject_phrase(left)} with #{subject_phrase(right)}, so it can never match. Compare values of the same kind.", location, :compare)
             end
 
-            Read.new(name: left.name, comparand: nil, kind: left.kind, operator: operator, against: right.name, transform: left.transform)
+            Read.new(name: left.name, comparand: nil, kind: left.kind, operator: operator, against: right.name, transform: left.transform, against_transform: right.transform)
           end
         end
       end

--- a/sig/herb/engine/slots/state_directives.rbs
+++ b/sig/herb/engine/slots/state_directives.rbs
@@ -46,12 +46,14 @@ module Herb
 
           attr_reader transform(): String?
 
-          def self.new: (String name, String? comparand, Symbol? kind, String? operator, String? against, String? transform) -> instance
-                      | (name: String, comparand: String?, kind: Symbol?, operator: String?, against: String?, transform: String?) -> instance
+          attr_reader against_transform(): String?
 
-          def self.members: () -> [ :name, :comparand, :kind, :operator, :against, :transform ]
+          def self.new: (String name, String? comparand, Symbol? kind, String? operator, String? against, String? transform, String? against_transform) -> instance
+                      | (name: String, comparand: String?, kind: Symbol?, operator: String?, against: String?, transform: String?, against_transform: String?) -> instance
 
-          def members: () -> [ :name, :comparand, :kind, :operator, :against, :transform ]
+          def self.members: () -> [ :name, :comparand, :kind, :operator, :against, :transform, :against_transform ]
+
+          def members: () -> [ :name, :comparand, :kind, :operator, :against, :transform, :against_transform ]
         end
 
         class Combo < Data

--- a/test/engine/slots/states_test.rb
+++ b/test/engine/slots/states_test.rb
@@ -436,12 +436,36 @@ module Engine
         )
       end
 
-      test "a transform on both sides of a comparison is refused" do
-        refuse(
-          %(<%# herb:state (draft: "", other: "") %><div><% if draft.length > other.length %>x<% end %></div>),
-          "`draft.length > other.length` compares the length of the state `draft` against the length of the state `other`. One condition carries one transform, so declare a state for one of the two sides and compare that."
+      test "a transform on both sides carries one on the comparand" do
+        visitor, = compile(%(<%# herb:state (draft: "", other: "") %><div><% if draft.length > other.length %>x<% end %></div>))
+
+        assert_equal(
+          { arms: [arm(0, ["draft", { "state" => "other", "transform" => "length" }, ">", "length"])], else: nil },
+          visitor.state_conditional_entries.fetch(0)
         )
 
+        visitor, = compile(%(<%# herb:state (draft: "", other: "") %><div><% if draft.to_s == other.to_s %>x<% end %></div>))
+
+        assert_equal(
+          { arms: [arm(0, ["draft", { "state" => "other", "transform" => "to_s" }, "==", "to_s"])], else: nil },
+          visitor.state_conditional_entries.fetch(0)
+        )
+      end
+
+      test "two transformed sides render for the server" do
+        rendered = render(%(<%# herb:state (draft: "abc", other: "ab") %><div><% if draft.length > other.length %>longer<% end %></div>))
+
+        assert_includes rendered, "longer"
+      end
+
+      test "two transformed sides keep their kinds compatible" do
+        refuse(
+          %(<%# herb:state (draft: "", other: "") %><div><% if draft.length > other.to_s %>x<% end %></div>),
+          "`draft.length > other.to_s` orders the length of the state `draft` against the to_s of the state `other`. Ordering compares numbers, so both sides have to be Integers."
+        )
+      end
+
+      test "a transform compared against a state of another kind is refused" do
         refuse(
           %(<%# herb:state (draft: "", filter: "all") %><div><% if draft.length > filter %>x<% end %></div>),
           "`draft.length > filter` orders the length of the state `draft` against the String state `filter`. Ordering compares numbers, so both sides have to be Integers."


### PR DESCRIPTION
Follow up on #2450, which added `length`, `size` and `to_s` as transforms on a `herb:state` read. That pull request let a transform sit on one side of a comparison and refused two, on the grounds that the wire format carried a single transform slot.

That reasoning was wrong. The comparand is already an object, so it has room for a transform of its own.

```erb
<%# herb:slots client %>
<%# herb:state (draft: "", filter: "all") %>

<% if draft.length > filter.length %>Longer<% end %>
<% if draft.to_s == filter.to_s %>Same<% end %>
```

Both of those were a `slots-compare` error before this change.

#### How it works

The left transform rides in the fourth element as it already did, and the right one rides on the comparand.

```json
["draft", { "state": "filter", "transform": "length" }, ">", "length"]
```

Nothing about the existing shapes changes, so a comparison with a transform on one side only, or with a literal comparand, compiles exactly as before. When only the right side carries a transform the operands swap and the operator mirrors, so `count < draft.length` and `draft.length > count` produce the same condition.

This works in every position a condition appears: conditionals, boolean attributes, outputs, derived defaults, inside `&&` and `||`, and under `!`, which flips the operator while keeping both transforms.

```erb
<button disabled="<%= draft.length > filter.length %>">Send</button>
<p><%= draft.length > filter.length %></p>

<%# herb:state (draft: "", filter: "all", longer: draft.length > filter.length) %>
```

The kind check now compares what each side returns rather than what each state is declared as, so ordering still requires two Integers.

```erb
<% if draft.length > filter.to_s %>Long<% end %>
```

> `draft.length > filter.to_s` orders the length of the state `draft` against the to_s of the state `filter`. Ordering compares numbers, so both sides have to be Integers.