### PR TITLE
Dev Server: Make server output work in non-interactive terminals

### DIFF
--- a/lib/herb/dev/runner.rb
+++ b/lib/herb/dev/runner.rb
@@ -30,6 +30,8 @@ module Herb
       end
 
       def run
+        $stdout.sync = true
+
         require_cruise
         require_relative "server"
 
@@ -44,8 +46,8 @@ module Herb
         check_existing_server(expanded_path)
         port = find_port
 
-        print CLEAR_SCREEN
-        print HIDE_CURSOR
+        terminal(CLEAR_SCREEN)
+        terminal(HIDE_CURSOR)
         print_header(config, expanded_path)
 
         file_states = index_files(config, @path)
@@ -61,13 +63,13 @@ module Herb
         watch_files(config, expanded_path, websocket, file_states)
       rescue Interrupt
         websocket&.stop
-        print SHOW_CURSOR
+        terminal(SHOW_CURSOR)
         puts
         puts "Stopped."
         exit(0)
       ensure
         websocket&.stop
-        print SHOW_CURSOR
+        terminal(SHOW_CURSOR)
       end
 
       def stop
@@ -113,6 +115,14 @@ module Herb
       end
 
       private
+
+      def interactive?
+        $stdout.tty?
+      end
+
+      def terminal(sequence)
+        print sequence if interactive?
+      end
 
       def pluralize(count, word)
         "#{count} #{word}#{"s" unless count == 1}"
@@ -176,7 +186,7 @@ module Herb
       end
 
       def index_files(config, path)
-        puts "  #{fg("Indexing files...", 241)}"
+        puts "  #{fg("Indexing files...", 241)}" if interactive?
 
         file_states = {}
         initial_files = config.find_files(path)
@@ -187,7 +197,7 @@ module Herb
           # skip files that can't be read
         end
 
-        print "\e[1A\e[2K"
+        terminal("\e[1A\e[2K")
         puts "  #{fg("Files:".ljust(11), 245)}#{fg("#{file_states.size} templates indexed", 250)}"
 
         file_states
@@ -214,7 +224,7 @@ module Herb
           next unless config.path_included?(relative_path, include_patterns)
 
           if first_change
-            print "\e[2A\e[J"
+            terminal("\e[2A\e[J")
             puts "  #{fg("Recent changes:", 245)}"
             puts
             first_change = false

--- a/sig/herb/dev/runner.rbs
+++ b/sig/herb/dev/runner.rbs
@@ -27,6 +27,10 @@ module Herb
 
       private
 
+      def interactive?: () -> untyped
+
+      def terminal: (untyped sequence) -> untyped
+
       def pluralize: (untyped count, untyped word) -> untyped
 
       def require_cruise: () -> untyped

--- a/test/dev/runner_test.rb
+++ b/test/dev/runner_test.rb
@@ -2,6 +2,8 @@
 
 require_relative "../test_helper"
 require_relative "../../lib/herb/dev/runner"
+require "fileutils"
+require "tmpdir"
 
 module Dev
   class RunnerTest < Minitest::Spec
@@ -144,6 +146,23 @@ module Dev
       diff_result = Herb.diff('<div class="old">Hello</div>', '<div class="new">Hello</div><span>New</span>')
 
       refute Herb::Dev::Runner.can_patch?(diff_result.operations)
+    end
+
+    test "indexing writes no cursor escapes when stdout is not a terminal" do
+      directory = Dir.mktmpdir("herb_dev_runner_test")
+
+      File.write(File.join(directory, "index.html.erb"), "<div>Hello</div>\n")
+
+      config = Herb::Configuration.load(directory)
+
+      output, = capture_io do
+        Herb::Dev::Runner.new(path: directory).send(:index_files, config, directory)
+      end
+
+      assert_equal "  Files:     1 templates indexed\n", output
+    ensure
+      FileUtils.rm_rf(directory)
+      Herb.reset_configuration!
     end
   end
 end


### PR DESCRIPTION
This pull request updates the Herb Dev Server so that its output survives being piped, which it currently does not when the server runs under a process manager like `foreman`.

Ruby line-buffers `$stdout` only when it is a TTY. Foreman hands each child process a pipe, so Ruby switches to block buffering and the dev server prints nothing at all until the buffer fills or the process exits. An entire session's worth of logging then arrives at once, after `Ctrl-C`:

```
^C01:53:33 system | SIGINT received, starting shutdown
01:53:33 web.1  | - Gracefully stopping, waiting for requests to finish
01:53:33 web.1  | Exiting
01:53:33 herb.1 |
01:53:33 herb.1 |  🌿 Herb Dev Server
01:53:33 herb.1 |
01:53:33 herb.1 |   Herb:      0.10.3
01:53:33 herb.1 |   Config:    .herb.yml
                    Files:     8 templates indexed
01:53:33 herb.1 |   WebSocket: ws://localhost:8592
01:53:33 herb.1 |
01:53:33 herb.1 |   Ready! Watching for changes...
```

The runner also wrote terminal control sequences unconditionally. There is the clear-screen and cursor hide on startup, the `\e[1A\e[2K` that overwrites the transient `Indexing files...` placeholder, and the `\e[2A\e[J` that erases the `Ready!` block before the first change is logged. Under `foreman` those sequences move the cursor over output the runner does not own, which is what strips the `01:53:33 herb.1 |` prefix from the `Files:` line above.

With both fixed, lines arrive when the events actually happen. 