### PR TITLE
Dev Server: Use `Herb::Diagnostic::Formatter` to log errors

### DIFF
--- a/lib/herb/dev/runner.rb
+++ b/lib/herb/dev/runner.rb
@@ -3,6 +3,8 @@
 
 require_relative "../colors"
 require_relative "../configuration"
+require_relative "../diagnostic"
+require_relative "../diagnostic/formatter"
 
 module Herb
   module Dev
@@ -122,6 +124,18 @@ module Herb
 
       def terminal(sequence)
         print sequence if interactive?
+      end
+
+      def print_diagnostics(source, diagnostics, filename)
+        return if diagnostics.empty?
+
+        formatter = Herb::Diagnostic::Formatter.new(source, diagnostics, filename: filename)
+
+        formatter.format_all(highlight: enabled?).each_line do |line|
+          stripped = line.chomp
+
+          puts stripped.empty? ? "" : "  #{stripped}"
+        end
       end
 
       def pluralize(count, word)
@@ -257,12 +271,12 @@ module Herb
           return
         end
 
-        return if previous_content == current_content && !errored_files.include?(file_path)
+        return if previous_content == current_content
 
         current_parse = Herb.parse(current_content, strict: true, analyze: true)
 
         if current_parse.errors.any?
-          broadcast_errors(file_path, relative_path, current_parse, current_content, previous_content, errored_files, websocket, timestamp, display_path)
+          broadcast_errors(file_path, relative_path, current_parse, current_content, previous_content, file_states, errored_files, websocket, timestamp)
           return
         end
 
@@ -274,7 +288,7 @@ module Herb
         handle_diff(file_path, relative_path, current_content, previous_content, file_states, websocket, timestamp, display_path)
       end
 
-      def broadcast_errors(file_path, relative_path, current_parse, current_content, previous_content, errored_files, websocket, timestamp, display_path)
+      def broadcast_errors(file_path, relative_path, current_parse, current_content, previous_content, file_states, errored_files, websocket, timestamp)
         current_errors = current_parse.errors
 
         previous_parse = Herb.parse(previous_content, strict: true, analyze: true)
@@ -286,15 +300,12 @@ module Herb
           }
         }
 
-        badge = bold(fg("\u{2717} error  ", 196))
-        puts "    #{timestamp} #{badge} #{display_path} #{fg("(#{pluralize(current_errors.size, "error")})", 241)}"
+        badge = bold(fg("\u{2717} error", 196))
+        print "    #{timestamp} #{badge}"
 
-        new_errors.each do |error|
-          location = fg("#{relative_path}:#{error.location.start.line}:#{error.location.start.column}", 241)
-          puts "                        #{fg(error.error_name, 196)} #{location}"
-          puts "                        #{fg(error.message, 250)}" if error.message && !error.message.empty?
-        end
+        print_diagnostics(current_content, Herb::Diagnostic.from_errors(new_errors, template: relative_path), relative_path)
 
+        file_states[file_path] = current_content
         errored_files.add(file_path)
 
         if websocket.client_count.positive?

--- a/sig/herb/dev/runner.rbs
+++ b/sig/herb/dev/runner.rbs
@@ -31,6 +31,8 @@ module Herb
 
       def terminal: (untyped sequence) -> untyped
 
+      def print_diagnostics: (untyped source, untyped diagnostics, untyped filename) -> untyped
+
       def pluralize: (untyped count, untyped word) -> untyped
 
       def require_cruise: () -> untyped
@@ -47,7 +49,7 @@ module Herb
 
       def handle_file_change: (untyped file_path, untyped relative_path, untyped file_states, untyped errored_files, untyped websocket, untyped timestamp, untyped display_path) -> untyped
 
-      def broadcast_errors: (untyped file_path, untyped relative_path, untyped current_parse, untyped current_content, untyped previous_content, untyped errored_files, untyped websocket, untyped timestamp, untyped display_path) -> untyped
+      def broadcast_errors: (untyped file_path, untyped relative_path, untyped current_parse, untyped current_content, untyped previous_content, untyped file_states, untyped errored_files, untyped websocket, untyped timestamp) -> untyped
 
       def broadcast_fixed: (untyped file_path, untyped relative_path, untyped current_content, untyped file_states, untyped websocket, untyped timestamp, untyped display_path) -> untyped
 

--- a/test/dev/runner_test.rb
+++ b/test/dev/runner_test.rb
@@ -37,10 +37,10 @@ module Dev
           parse,
           current_content,
           previous_content,
+          {},
           Set.new,
           websocket,
-          "12:00:00",
-          "index.html.erb"
+          "12:00:00"
         )
       end
 
@@ -163,6 +163,96 @@ module Dev
     ensure
       FileUtils.rm_rf(directory)
       Herb.reset_configuration!
+    end
+
+    test "prints the diagnostic with its source context and suggestion" do
+      output, = capture_io do
+        Herb::Dev::Runner.new.send(
+          :broadcast_errors,
+          "/app/views/posts/index.html.erb",
+          "app/views/posts/index.html.erb",
+          Herb.parse(BROKEN, strict: true, analyze: true),
+          BROKEN,
+          "",
+          {},
+          Set.new,
+          FakeWebSocket.new,
+          "12:00:00"
+        )
+      end
+
+      expected = [
+        "    12:00:00 \u2717 error  \u2718 [MissingClosingTagError] Opening tag `<form>` at (2:3) doesn't have a matching closing tag `</form>` in the same scope.",
+        "",
+        "      app/views/posts/index.html.erb:2:3:",
+        "        2 \u2502   <form>",
+        "          \u2575   ~~~~~~",
+        "",
+        "    Add the closing tag, or make it self-closing.",
+        "",
+        ""
+      ].join("\n")
+
+      assert_equal expected, output
+    end
+
+    test "a repeated event for unchanged content reports the error only once" do
+      runner = Herb::Dev::Runner.new
+      websocket = FakeWebSocket.new
+      file_states = { "/app/views/posts/index.html.erb" => "<div>\n</div>\n" }
+      errored_files = Set.new
+      directory = Dir.mktmpdir("herb_dev_runner_test")
+      path = File.join(directory, "index.html.erb")
+
+      File.write(path, BROKEN)
+      file_states[path] = "<div>\n</div>\n"
+
+      first, = capture_io do
+        runner.send(:handle_file_change, path, "index.html.erb", file_states, errored_files, websocket, "12:00:00", "index.html.erb")
+      end
+
+      second, = capture_io do
+        runner.send(:handle_file_change, path, "index.html.erb", file_states, errored_files, websocket, "12:00:01", "index.html.erb")
+      end
+
+      refute_equal "", first
+      assert_equal "", second
+    ensure
+      FileUtils.rm_rf(directory)
+    end
+
+    test "an error already reported is not repeated when a new one joins it" do
+      broken_once = "<div>\n  <form>\n</div>\n"
+      broken_twice = "<div>\n  <form>\n  <span>\n</div>\n"
+
+      output, = capture_io do
+        Herb::Dev::Runner.new.send(
+          :broadcast_errors,
+          "/app/views/posts/index.html.erb",
+          "app/views/posts/index.html.erb",
+          Herb.parse(broken_twice, strict: true, analyze: true),
+          broken_twice,
+          broken_once,
+          {},
+          Set.new,
+          FakeWebSocket.new,
+          "12:00:00"
+        )
+      end
+
+      expected = [
+        "    12:00:00 \u2717 error  \u2718 [MissingClosingTagError] Opening tag `<span>` at (3:3) doesn't have a matching closing tag `</span>` in the same scope.",
+        "",
+        "      app/views/posts/index.html.erb:3:3:",
+        "        3 \u2502   <span>",
+        "          \u2575   ~~~~~~",
+        "",
+        "    Add the closing tag, or make it self-closing.",
+        "",
+        ""
+      ].join("\n")
+
+      assert_equal expected, output
     end
   end
 end


### PR DESCRIPTION
This pull request updates the Herb Dev Server to render parse errors through `Herb::Diagnostic::Formatter` instead of hand-rolling its own name, location, and message lines, and fixes a bug that made it report the same error twice on every save.

The runner already built diagnostics for every parse error, since the websocket payload needs `code`, `origin`, `suggestion`, and `message`. The terminal output was assembled separately and showed strictly less, so the browser panel had the source context and the suggestion while the terminal did not.

**Before**

```
    01:56:18.792 ✗ error   app/views/posts/index.html.erb (1 error)
                        MissingClosingTagError app/views/posts/index.html.erb:2:3
                        Opening tag `<form>` at (2:3) doesn't have a matching closing tag `</form>` in the same scope.
```

**After**

```
    01:56:18.792 ✗ error  ✘ [MissingClosingTagError] Opening tag `<form>` at (2:3) doesn't have a matching closing tag `</form>` in the same scope.

      app/views/posts/index.html.erb:2:3:
        2 │   <form>
          ╵   ~~~~~~

    Add the closing tag, or make it self-closing.
```