### PR TITLE
Engine: Point `herb:state` diagnostics at the part that is wrong

### DIFF
--- a/javascript/packages/linter/src/rules/herb-state-no-server-writes.ts
+++ b/javascript/packages/linter/src/rules/herb-state-no-server-writes.ts
@@ -155,7 +155,7 @@ class StateNoServerWritesVisitor extends BaseRuleVisitor {
     const content = (node.content?.value ?? "").trim()
 
     this.addOffense(
-      `\`${tag} ${content} %>\` assigns the state \`${assigned[0]}\`, and the client never sees a server-side write. Seed the initial value in the declaration, derive it from other states, count items with \`${assigned[0]} += 1\` behind a state condition in a keyed loop, or write it at runtime with \`data-herb-set\` or \`state.set\`.`,
+      `\`${tag} ${content} %>\` assigns the state \`${assigned[0]}\`. The client never sees a server-side write, so the value it holds would drift from the one the server rendered. Seed the initial value in the declaration, derive it from other states, count items with \`${assigned[0]} += 1\` behind a state condition in a keyed loop, or write it at runtime with \`data-herb-set\` or \`state.set\`.`,
       node.location,
     )
   }
@@ -169,7 +169,7 @@ class StateNoServerWritesVisitor extends BaseRuleVisitor {
 
         if (read.order < foldOrder) {
           this.addOffense(
-            `\`${fold.name}\` is read before its count is complete. The server renders this read mid-count and the client cannot keep it current here, so move it after the loop.`,
+            `\`${fold.name}\` is read before its count is complete. The server renders that read mid-count and the client cannot keep it current. Move the read below the loop that counts \`${fold.name}\`.`,
             read.location,
           )
 
@@ -178,7 +178,7 @@ class StateNoServerWritesVisitor extends BaseRuleVisitor {
 
         if (read.blocks.includes(fold.block)) {
           this.addOffense(
-            `\`${fold.name}\` is read inside the loop that counts it. The count is complete only after the loop, so move this read below it.`,
+            `\`${fold.name}\` is read inside the loop that counts it. The count is complete only after the loop. Move the read below the loop.`,
             read.location,
           )
         }
@@ -196,7 +196,7 @@ class StateNoServerWritesVisitor extends BaseRuleVisitor {
 
     if (!region) {
       this.addOffense(
-        `\`${spelled}\` counts into \`${fold.name}\`, which is an item state. A count lives once per region, so declare \`${fold.name}\` at the top of the template.`,
+        `\`${spelled}\` counts into \`${fold.name}\`, which is an item state. A count lives once per region, not once per item. Declare \`${fold.name}\` at the top of the template, outside the loop.`,
         fold.assignment.location,
       )
 
@@ -205,7 +205,7 @@ class StateNoServerWritesVisitor extends BaseRuleVisitor {
 
     if (isDerived(region)) {
       this.addOffense(
-        `\`${spelled}\` counts into \`${fold.name}\`, which is derived from \`${region.defaultSource}\`. A state is either derived or counted, so drop one of the two.`,
+        `\`${spelled}\` counts into \`${fold.name}\`, which is derived from \`${region.defaultSource}\`. A state is either derived or counted, never both. Drop the derivation from \`${fold.name}\`, or count into a second state.`,
         fold.assignment.location,
       )
 
@@ -216,7 +216,7 @@ class StateNoServerWritesVisitor extends BaseRuleVisitor {
 
     if (kind !== "integer") {
       this.addOffense(
-        `\`${spelled}\` counts into the ${kind.charAt(0).toUpperCase() + kind.slice(1)} state \`${fold.name}\`. A count is a number, so declare it as an Integer, like \`(${fold.name}: 0)\`.`,
+        `\`${spelled}\` counts into the ${kind.charAt(0).toUpperCase() + kind.slice(1)} state \`${fold.name}\`. A count is a number. Declare \`${fold.name}\` as an Integer, like \`(${fold.name}: 0)\`.`,
         fold.assignment.location,
       )
 
@@ -225,7 +225,7 @@ class StateNoServerWritesVisitor extends BaseRuleVisitor {
 
     if (this.folds.some((other) => other !== fold && other.name === fold.name && (this.foldOrders.get(other) ?? Infinity) < (this.foldOrders.get(fold) ?? 0))) {
       this.addOffense(
-        `\`${fold.name}\` is counted twice. One state holds one count, so declare a second state for the second count.`,
+        `\`${fold.name}\` is counted twice. One state holds one count. Declare a second state for the second count.`,
         fold.assignment.location,
       )
     }

--- a/javascript/packages/linter/src/rules/herb-state-valid-declaration.ts
+++ b/javascript/packages/linter/src/rules/herb-state-valid-declaration.ts
@@ -79,7 +79,7 @@ class StateValidDeclarationVisitor extends BaseRuleVisitor {
 
     if (declaration.derived === "mixed") {
       this.addOffense(
-        `The state \`${declaration.name}\` defaults to \`${declaration.defaultSource}\`, which mixes state reads with other Ruby. A derived state reads only other states, and a seed reads none, so split the two apart.`,
+        `The state \`${declaration.name}\` defaults to \`${declaration.defaultSource}\`, which mixes state reads with other Ruby. A derived state reads only other states and a seed reads none. Split the two apart, so \`${declaration.name}\` derives from states only.`,
         defaultLocation,
       )
 
@@ -88,7 +88,7 @@ class StateValidDeclarationVisitor extends BaseRuleVisitor {
 
     if (declaration.derived === "forward") {
       this.addOffense(
-        `The state \`${declaration.name}\` reads a state that is declared after it. Reorder the signature, since a derived state reads only states declared before it.`,
+        `The state \`${declaration.name}\` reads a state that is declared after it. A derived state reads only states declared before it. Move \`${declaration.name}\` after the states it reads.`,
         defaultLocation,
       )
 
@@ -98,21 +98,21 @@ class StateValidDeclarationVisitor extends BaseRuleVisitor {
     switch (declaration.kind) {
       case "missing":
         this.addOffense(
-          `The state \`${declaration.name}\` has no default. Add one, like \`${declaration.name}: false\`. The server renders a state as its default, so a state always has a value.`,
+          `The state \`${declaration.name}\` has no default. The server renders a value for every state, so there is nothing to render or to seed the client with. Give it a default, like \`${declaration.name}: false\`.`,
           nameLocation,
         )
 
         return
       case "float":
         this.addOffense(
-          `The state \`${declaration.name}\` has a Float default. Use an Integer or a String instead, since Ruby and JavaScript print floats differently.`,
+          `The state \`${declaration.name}\` has a Float default. Ruby and JavaScript disagree on how to print a float, so the server and the client would render different text. Declare it as an Integer or a String instead.`,
           defaultLocation,
         )
 
         return
       case "array":
         this.addOffense(
-          `The state \`${declaration.name}\` has an Array default. Declare a per-row boolean inside the loop instead, like \`${declaration.name}: false\`. A list on the page is a collection of items, not a state.`,
+          `The state \`${declaration.name}\` has an Array default. A list on the page is a collection of items, not one state holding many values. Declare an item-scoped state inside the loop instead, like \`${declaration.name}: false\`.`,
           defaultLocation,
         )
 
@@ -129,7 +129,7 @@ class StateValidDeclarationVisitor extends BaseRuleVisitor {
 
         if (this.scopes.some((outer) => outer !== this.scopes[this.scopes.length - 1] && outer.has(declaration.defaultSource))) {
           this.addOffense(
-            `The state \`${declaration.name}\` reads \`${declaration.defaultSource}\` from an enclosing scope. Declare it beside its sources, since a derived state reads states declared in its own signature.`,
+            `The state \`${declaration.name}\` reads \`${declaration.defaultSource}\` from an enclosing scope. A derived state reads only states from its own signature. Declare \`${declaration.name}\` beside the states it reads.`,
             defaultLocation,
           )
 
@@ -148,7 +148,7 @@ class StateValidDeclarationVisitor extends BaseRuleVisitor {
 
     if (this.locals.has(declaration.name)) {
       this.addOffense(
-        `\`${declaration.name}\` is both a strict local and a state. Rename one of them. A local comes from the caller and a state is client-owned, so one name cannot be both.`,
+        `\`${declaration.name}\` is both a strict local and a state. A local comes from the caller and a state is owned by the client, so the name has two owners. Rename one of the two.`,
         nameLocation,
       )
 
@@ -159,7 +159,7 @@ class StateValidDeclarationVisitor extends BaseRuleVisitor {
 
     if (scope.has(declaration.name)) {
       this.addOffense(
-        `The state \`${declaration.name}\` is declared twice in the same scope. Remove one of the declarations.`,
+        `The state \`${declaration.name}\` is declared twice in the same scope. Remove one of the two declarations.`,
         nameLocation,
       )
 
@@ -173,7 +173,7 @@ class StateValidDeclarationVisitor extends BaseRuleVisitor {
 
     if (shadowed) {
       this.addOffense(
-        `The state \`${declaration.name}\` is declared in both an item and its region. Rename one of them, since a read of \`${declaration.name}\` could mean either.`,
+        `The state \`${declaration.name}\` is declared in both an item and its region, so a later read could mean either one. Give them different names, like \`item_${declaration.name}\` for the one inside the loop.`,
         nameLocation,
       )
 

--- a/javascript/packages/linter/src/rules/herb-state-valid-reads.ts
+++ b/javascript/packages/linter/src/rules/herb-state-valid-reads.ts
@@ -2,7 +2,7 @@ import { ParserRule } from "../types.js"
 import { BaseRuleVisitor } from "../utils/rule-utils.js"
 import { StateScopeMap } from "../utils/state-directives-utils.js"
 
-import { COMPARISON_OPERATORS, PRISM_LITERAL_KINDS, STATE_PREDICATES, STATE_TRANSFORMS } from "@herb-tools/client/directives"
+import { COMPARISON_OPERATORS, FALSY_STATE_KINDS, PRISM_LITERAL_KINDS, STATE_PREDICATES, STATE_TRANSFORMS } from "@herb-tools/client/directives"
 
 import { declaredKind, kindWithArticle } from "../utils/state-directives-utils.js"
 import { bareReadName, classifyDerivedDefault, mentionsAnyState, predicateAnswers, transformApplies } from "@herb-tools/client/directives"
@@ -111,6 +111,7 @@ class StateValidReadsVisitor extends BaseRuleVisitor {
   private source: string
   private stack: (ERBBlockNode | null)[] = [null]
   private booleanAttribute = false
+  private attributeName: string | null = null
 
   constructor(ruleName: string, states: StateScopeMap, source: string, context?: Partial<LintContext>) {
     super(ruleName, context)
@@ -130,14 +131,17 @@ class StateValidReadsVisitor extends BaseRuleVisitor {
   visitHTMLAttributeNode(node: HTMLAttributeNode): void {
     const name = getAttributeName(node)
     const previous = this.booleanAttribute
+    const previousName = this.attributeName
 
     this.booleanAttribute = name !== null && isBooleanAttribute(name)
+    this.attributeName = name
 
     this.checkMixedInterpolation(node)
 
     super.visitHTMLAttributeNode(node)
 
     this.booleanAttribute = previous
+    this.attributeName = previousName
   }
 
   private checkMixedInterpolation(node: HTMLAttributeNode): void {
@@ -154,7 +158,7 @@ class StateValidReadsVisitor extends BaseRuleVisitor {
     if (!read) return
 
     this.addOffense(
-      `\`${read}\` reads a state inside an interpolated attribute that mixes other dynamic parts. Give the state its own attribute or its own output, since a state write cannot supply the other values.`,
+      `\`${read}\` reads a state inside an interpolated attribute that mixes other dynamic parts. A state write cannot supply the other values. Give the state its own attribute, or its own output outside this one.`,
       node.location,
     )
   }
@@ -170,6 +174,8 @@ class StateValidReadsVisitor extends BaseRuleVisitor {
 
     if (this.booleanAttribute) {
       const prism = node.prismNode
+
+      if (this.checkPresenceRead(expression, node)) return
 
       if (prism) this.classifyPredicate(prism, names)
 
@@ -272,7 +278,7 @@ class StateValidReadsVisitor extends BaseRuleVisitor {
 
       if (stateDriven) {
         this.addOffense(
-          `\`${this.sliceOf(predicate)}\` sits in a state-driven conditional but reads no state. Move it into its own conditional, or read a state in this arm, since the client resolves every arm itself.`,
+          `\`${this.sliceOf(predicate)}\` sits in a state-driven conditional but reads no state. The client resolves every arm, so an arm it cannot answer would never be chosen. Read a state in this arm, or move this branch into its own conditional.`,
           this.locationOf(predicate),
         )
       }
@@ -308,10 +314,15 @@ class StateValidReadsVisitor extends BaseRuleVisitor {
 
       if (left === "state" || right === "state") {
         const server = left === "state" ? predicate.right : predicate.left
+        const reader = left === "state" ? predicate.left : predicate.right
+        const read = names.find(candidate => mentionsAnyState(this.sliceOf(reader), [candidate]))
+        const reads = read ? `the state \`${read}\`` : "a state"
+        const joiner = type === "AndNode" ? "&&" : "||"
+        const offending = this.sliceOf(server)
 
         this.addOffense(
-          `\`${this.sliceOf(predicate)}\` combines a state with \`${this.sliceOf(server)}\`, which the client cannot evaluate. Split the server condition into its own conditional, or compute it into a second state set from app code.`,
-          this.locationOf(predicate),
+          `\`${offending}\` is server Ruby inside a condition that also reads ${reads}. The client resolves each side of \`${joiner}\` itself and has no value for this one. Move \`${offending}\` into its own conditional around this one, or declare a state for it and set it from app code.`,
+          this.locationOf(server),
         )
 
         return "reported"
@@ -340,7 +351,7 @@ class StateValidReadsVisitor extends BaseRuleVisitor {
 
       if (!transformApplies(transformCall.transform, kind)) {
         this.addOffense(
-          `\`${this.sliceOf(predicate)}\` reads the ${capitalize(kind)} state \`${transformCall.name}\` with \`${transformCall.transform}\`. Only ${STATE_TRANSFORMS[transformCall.transform].only} can be read with \`${transformCall.transform}\`, so compare \`${transformCall.name}\` itself instead.`,
+          `\`${this.sliceOf(predicate)}\` reads the ${capitalize(kind)} state \`${transformCall.name}\` with \`${transformCall.transform}\`. Only ${STATE_TRANSFORMS[transformCall.transform].only} can be read with \`${transformCall.transform}\`. Compare \`${transformCall.name}\` itself instead, like \`${transformCall.name} == ${declaration.defaultSource}\`.`,
           this.locationOf(predicate),
         )
 
@@ -360,7 +371,7 @@ class StateValidReadsVisitor extends BaseRuleVisitor {
 
       if (!predicateAnswers(call.predicate, kind)) {
         this.addOffense(
-          `\`${this.sliceOf(predicate)}\` reads the ${capitalize(kind)} state \`${call.name}\` with \`${call.predicate}\`. Only ${STATE_PREDICATES[call.predicate].only} can be read with \`${call.predicate}\`, so compare \`${call.name}\` to a literal instead.`,
+          `\`${this.sliceOf(predicate)}\` reads the ${capitalize(kind)} state \`${call.name}\` with \`${call.predicate}\`. Only ${STATE_PREDICATES[call.predicate].only} can be read with \`${call.predicate}\`. Compare \`${call.name}\` to a literal instead, or declare it as ${kindWithArticle(STATE_PREDICATES[call.predicate].kinds?.[0] ?? "seeded")} state.`,
           this.locationOf(predicate),
         )
 
@@ -389,7 +400,7 @@ class StateValidReadsVisitor extends BaseRuleVisitor {
 
         if (!transformApplies(call.transform, kind)) {
           this.addOffense(
-            `\`${this.sliceOf(side)}\` reads the ${capitalize(kind)} state \`${call.name}\` with \`${call.transform}\`. Only ${STATE_TRANSFORMS[call.transform].only} can be read with \`${call.transform}\`, so compare \`${call.name}\` itself instead.`,
+            `\`${this.sliceOf(side)}\` reads the ${capitalize(kind)} state \`${call.name}\` with \`${call.transform}\`. Only ${STATE_TRANSFORMS[call.transform].only} can be read with \`${call.transform}\`. Compare \`${call.name}\` itself instead, like \`${call.name} == ${declaration.defaultSource}\`.`,
             this.locationOf(side),
           )
 
@@ -404,7 +415,7 @@ class StateValidReadsVisitor extends BaseRuleVisitor {
 
         if (ordered && (leftReturns !== "integer" || rightReturns !== "integer")) {
           this.addOffense(
-            `\`${this.sliceOf(predicate)}\` orders the ${leftTransform.transform} of the state \`${leftTransform.name}\` against the ${rightTransform.transform} of the state \`${rightTransform.name}\`. Ordering compares numbers, so both sides have to be Integers.`,
+            `\`${this.sliceOf(predicate)}\` orders the ${leftTransform.transform} of the state \`${leftTransform.name}\` against the ${rightTransform.transform} of the state \`${rightTransform.name}\`. Ordering compares numbers. Make both sides Integers, or compare them with \`==\` instead.`,
             this.locationOf(predicate),
           )
 
@@ -413,7 +424,7 @@ class StateValidReadsVisitor extends BaseRuleVisitor {
 
         if (!ordered && leftReturns !== rightReturns) {
           this.addOffense(
-            `\`${this.sliceOf(predicate)}\` compares the ${leftTransform.transform} of the state \`${leftTransform.name}\` with the ${rightTransform.transform} of the state \`${rightTransform.name}\`, so it can never match. Compare values of the same kind.`,
+            `\`${this.sliceOf(predicate)}\` compares the ${leftTransform.transform} of the state \`${leftTransform.name}\` with the ${rightTransform.transform} of the state \`${rightTransform.name}\`, so it can never match. Compare values of the same kind, or redeclare one of the two states.`,
             this.locationOf(predicate),
           )
 
@@ -436,7 +447,7 @@ class StateValidReadsVisitor extends BaseRuleVisitor {
 
           if (otherKind !== "seeded" && otherKind !== returns) {
             this.addOffense(
-              `\`${this.sliceOf(predicate)}\` compares the ${transformed.transform} of the state \`${transformed.name}\` with the ${capitalize(otherKind)} state \`${otherTransform!.name}\`, so it can never match. Compare values of the same kind.`,
+              `\`${this.sliceOf(predicate)}\` compares the ${transformed.transform} of the state \`${transformed.name}\` with the ${capitalize(otherKind)} state \`${otherTransform!.name}\`, so it can never match. Compare values of the same kind, or redeclare one of the two states.`,
               this.locationOf(predicate),
             )
 
@@ -450,7 +461,7 @@ class StateValidReadsVisitor extends BaseRuleVisitor {
 
         if (!otherKind) {
           this.addOffense(
-            `\`${this.sliceOf(predicate)}\` compares the ${transformed.transform} of the state \`${transformed.name}\` against something that is not a literal or another declared state. Compare against a literal, since the client resolves a comparison by lookup.`,
+            `\`${this.sliceOf(predicate)}\` compares the ${transformed.transform} of the state \`${transformed.name}\` against \`${this.sliceOf(other)}\`, which is not a literal. The client resolves a comparison by looking the state up, so it has no value for the other side. Compare it to a literal instead, or declare a state for \`${this.sliceOf(other)}\` and set it from app code.`,
             this.locationOf(predicate),
           )
 
@@ -481,7 +492,7 @@ class StateValidReadsVisitor extends BaseRuleVisitor {
 
         if (ordered && leftKind !== "seeded" && rightKind !== "seeded" && (leftKind !== "integer" || rightKind !== "integer")) {
           this.addOffense(
-            `\`${this.sliceOf(predicate)}\` orders the states \`${leftRead.name}\` and \`${rightRead.name}\`. Ordering compares numbers, so both have to be Integer states.`,
+            `\`${this.sliceOf(predicate)}\` orders the ${capitalize(leftKind)} state \`${leftRead.name}\` against the ${capitalize(rightKind)} state \`${rightRead.name}\`. Ordering compares numbers. Make both sides Integers, or compare them with \`==\` instead.`,
             this.locationOf(predicate),
           )
 
@@ -490,7 +501,7 @@ class StateValidReadsVisitor extends BaseRuleVisitor {
 
         if (!ordered && leftKind !== "seeded" && rightKind !== "seeded" && leftKind !== rightKind) {
           this.addOffense(
-            `\`${this.sliceOf(predicate)}\` compares the ${capitalize(leftKind)} state \`${leftRead.name}\` with the ${capitalize(rightKind)} state \`${rightRead.name}\`, so it can never match. Compare states of one kind, or redeclare one.`,
+            `\`${this.sliceOf(predicate)}\` compares the ${capitalize(leftKind)} state \`${leftRead.name}\` with the ${capitalize(rightKind)} state \`${rightRead.name}\`, so it can never match. Compare values of the same kind, or redeclare one of the two states.`,
             this.locationOf(predicate),
           )
 
@@ -511,7 +522,7 @@ class StateValidReadsVisitor extends BaseRuleVisitor {
           const example = kind === "seeded" ? "" : `, like \`${declaration.name} == ${declaration.defaultSource}\``
 
           this.addOffense(
-            `\`${this.sliceOf(predicate)}\` compares the state \`${declaration.name}\` against something that is not a literal or another declared state. Compare against a literal${example}, since the client resolves a comparison by lookup.`,
+            `\`${this.sliceOf(predicate)}\` compares the state \`${declaration.name}\` against \`${this.sliceOf(comparand)}\`, which is not a literal. The client resolves a comparison by looking the state up, so it has no value for the other side. Compare \`${declaration.name}\` to a literal${example}, or declare a state for \`${this.sliceOf(comparand)}\` and set it from app code.`,
             this.locationOf(predicate),
           )
 
@@ -522,7 +533,7 @@ class StateValidReadsVisitor extends BaseRuleVisitor {
 
         if (ordered && kind !== "seeded" && kind !== "integer") {
           this.addOffense(
-            `\`${this.sliceOf(predicate)}\` orders the ${capitalize(kind)} state \`${declaration.name}\`. Ordering compares numbers, so only an Integer state takes \`${operator}\`.`,
+            `\`${this.sliceOf(predicate)}\` orders the ${capitalize(kind)} state \`${declaration.name}\`. Ordering compares numbers. Declare \`${declaration.name}\` as an Integer, like \`(${declaration.name}: 0)\`, or compare it with \`==\` instead.`,
             this.locationOf(predicate),
           )
 
@@ -531,7 +542,7 @@ class StateValidReadsVisitor extends BaseRuleVisitor {
 
         if (ordered && comparandKind !== "integer") {
           this.addOffense(
-            `\`${this.sliceOf(predicate)}\` orders the state \`${declaration.name}\` against ${kindWithArticle(comparandKind)} literal. Ordering compares numbers, so the comparand has to be an Integer.`,
+            `\`${this.sliceOf(predicate)}\` orders the state \`${declaration.name}\` against ${kindWithArticle(comparandKind)} literal. Ordering compares numbers. Compare \`${declaration.name}\` against an Integer literal, like \`${declaration.name} > 0\`.`,
             this.locationOf(predicate),
           )
 
@@ -542,7 +553,7 @@ class StateValidReadsVisitor extends BaseRuleVisitor {
           const consequence = operator === "==" ? "so it can never match" : "so it always matches"
 
           this.addOffense(
-            `\`${this.sliceOf(predicate)}\` compares the ${capitalize(kind)} state \`${declaration.name}\` against ${kindWithArticle(comparandKind)} literal, ${consequence}. Compare against a ${capitalize(kind)}, or redeclare the state.`,
+            `\`${this.sliceOf(predicate)}\` compares the ${capitalize(kind)} state \`${declaration.name}\` against ${kindWithArticle(comparandKind)} literal, ${consequence}. Compare it against ${kindWithArticle(kind)} literal, like \`${declaration.name} == ${declaration.defaultSource}\`.`,
             this.locationOf(predicate),
           )
 
@@ -557,7 +568,7 @@ class StateValidReadsVisitor extends BaseRuleVisitor {
       const name = names.find(candidate => mentionsAnyState(this.sliceOf(predicate), [candidate])) ?? names[0]
 
       this.addOffense(
-        context === "value" ? this.computedValueOffense(this.sliceOf(predicate), name) : `\`${this.sliceOf(predicate)}\` computes with the state \`${name}\`, and the client cannot run Ruby to pick the branch. ${this.conditionAdvice(name)}`,
+        context === "value" ? this.computedValueOffense(this.sliceOf(predicate), name) : `\`${this.sliceOf(predicate)}\` computes with the state \`${name}\`. The client resolves each condition itself and cannot run Ruby to pick a branch. ${this.conditionAdvice(name)}`,
         this.locationOf(predicate),
       )
 
@@ -567,8 +578,26 @@ class StateValidReadsVisitor extends BaseRuleVisitor {
     return "other"
   }
 
+  private checkPresenceRead(expression: string, node: ERBContentNode): boolean {
+    const bare = bareReadName(expression)
+    const declaration = bare ? this.resolve(bare) : null
+
+    if (!declaration) return false
+
+    const kind = declaredKind(declaration)
+
+    if (FALSY_STATE_KINDS.has(kind)) return false
+
+    this.addOffense(
+      `\`${this.attributeName}="<%= ${expression} %>"\` reads the ${capitalize(kind)} state \`${bare}\` as a presence. Only \`nil\` and \`false\` are falsy in Ruby, so the attribute could never turn off. Compare \`${bare}\` to a literal, like \`${bare} == ${declaration.defaultSource}\`, or declare it as a boolean.`,
+      node.location,
+    )
+
+    return true
+  }
+
   private computedValueOffense(expression: string, name: string): string {
-    return `\`${expression}\` computes with the state \`${name}\`, and the client cannot run Ruby to keep the result current. Show the value with \`<%= ${name} %>\`, or declare a second state for the computed answer and set it from app code.`
+    return `\`${expression}\` computes with the state \`${name}\`. The client cannot run Ruby to keep the result current. Show the value with \`<%= ${name} %>\`, or declare a second state for the computed answer and set it from app code.`
   }
 
   private checkCase(prism: PrismNode): void {
@@ -586,10 +615,11 @@ class StateValidReadsVisitor extends BaseRuleVisitor {
     const declaration = bare && !bare.predicate ? this.resolve(bare.name) : null
 
     if (!declaration) {
-      const example = bare ? `, like \`case ${bare.name}\`` : ""
+      const mentioned = bare?.name ?? names.find(candidate => mentionsAnyState(subjectText, [candidate]))
+      const example = mentioned ? `, like \`case ${mentioned}\`` : ""
 
       this.addOffense(
-        `\`case ${subjectText}\` does not switch on a bare state read. Write the state alone${example}, or compute the value into its own state.`,
+        `\`case ${subjectText}\` switches on something other than a bare state read. The client resolves a \`case\` by looking the state up. Switch on the state itself${example}.`,
         this.locationOf(subject),
       )
 
@@ -608,7 +638,7 @@ class StateValidReadsVisitor extends BaseRuleVisitor {
 
         if (!comparandKind) {
           this.addOffense(
-            `\`when ${list}\` on the state \`${declaration.name}\` has a comparand that is not a literal. List literals, like \`when "name", "date"\`, since the client resolves a \`when\` by lookup.`,
+            `\`when ${list}\` on the state \`${declaration.name}\` has a comparand that is not a literal. The client resolves a \`when\` by lookup. List literals instead, like \`when ${declaration.defaultSource}\`.`,
             this.locationOf(condition),
           )
 
@@ -617,7 +647,7 @@ class StateValidReadsVisitor extends BaseRuleVisitor {
 
         if (kind !== "seeded" && comparandKind !== "nil" && comparandKind !== kind) {
           this.addOffense(
-            `\`when ${list}\` compares the ${capitalize(kind)} state \`${declaration.name}\` against a literal of another type, so it can never match. Use ${capitalize(kind)} literals in every arm.`,
+            `\`when ${list}\` compares the ${capitalize(kind)} state \`${declaration.name}\` against a literal of another type, so it can never match. Use ${kindWithArticle(kind)} literal in every arm, like \`when ${declaration.defaultSource}\`.`,
             this.locationOf(condition),
           )
 
@@ -631,15 +661,13 @@ class StateValidReadsVisitor extends BaseRuleVisitor {
     const declaration = this.resolve(name)
     const kind = declaration ? declaredKind(declaration) : "seeded"
 
+    if (!declaration) return "Read the state bare, or compare it to a literal."
+
     if (kind === "boolean") {
-      return `Read it bare, \`<% if ${name} %>\`, or as \`${name}?\`.`
+      return `Read \`${name}\` bare, like \`<% if ${name} %>\`, or as \`${name}?\`.`
     }
 
-    if ((kind === "string" || kind === "integer" || kind === "symbol") && declaration) {
-      return `Read it bare, \`<% if ${name} %>\`, or compare it to a literal, \`${name} == ${declaration.defaultSource}\`.`
-    }
-
-    return `Read it bare, \`<% if ${name} %>\`, or compare it to a literal.`
+    return `Read \`${name}\` bare, like \`<% if ${name} %>\`, or compare it to a literal, like \`${name} == ${declaration.defaultSource}\`.`
   }
 
   private resolve(name: string): StateDeclaration | undefined {

--- a/javascript/packages/linter/test/rules/herb-state-no-server-writes.test.ts
+++ b/javascript/packages/linter/test/rules/herb-state-no-server-writes.test.ts
@@ -38,7 +38,7 @@ describe("HerbStateNoServerWritesRule", () => {
   })
 
   test("flags a plain assignment to a state", () => {
-    expectError("`<% pending = true %>` assigns the state `pending`, and the client never sees a server-side write. Seed the initial value in the declaration, derive it from other states, count items with `pending += 1` behind a state condition in a keyed loop, or write it at runtime with `data-herb-set` or `state.set`.")
+    expectError("`<% pending = true %>` assigns the state `pending`. The client never sees a server-side write, so the value it holds would drift from the one the server rendered. Seed the initial value in the declaration, derive it from other states, count items with `pending += 1` behind a state condition in a keyed loop, or write it at runtime with `data-herb-set` or `state.set`.")
 
     assertOffenses(dedent`
       <%# herb:state (pending: false) %>
@@ -48,7 +48,7 @@ describe("HerbStateNoServerWritesRule", () => {
   })
 
   test("flags an increment gated by a server condition", () => {
-    expectError("`<% total += 1 %>` assigns the state `total`, and the client never sees a server-side write. Seed the initial value in the declaration, derive it from other states, count items with `total += 1` behind a state condition in a keyed loop, or write it at runtime with `data-herb-set` or `state.set`.")
+    expectError("`<% total += 1 %>` assigns the state `total`. The client never sees a server-side write, so the value it holds would drift from the one the server rendered. Seed the initial value in the declaration, derive it from other states, count items with `total += 1` behind a state condition in a keyed loop, or write it at runtime with `data-herb-set` or `state.set`.")
 
     assertOffenses(dedent`
       <%# herb:state (total: 0) %>
@@ -58,7 +58,7 @@ describe("HerbStateNoServerWritesRule", () => {
   })
 
   test("flags an assignment inside an output tag", () => {
-    expectError("`<%= draft = \"x\" %>` assigns the state `draft`, and the client never sees a server-side write. Seed the initial value in the declaration, derive it from other states, count items with `draft += 1` behind a state condition in a keyed loop, or write it at runtime with `data-herb-set` or `state.set`.")
+    expectError("`<%= draft = \"x\" %>` assigns the state `draft`. The client never sees a server-side write, so the value it holds would drift from the one the server rendered. Seed the initial value in the declaration, derive it from other states, count items with `draft += 1` behind a state condition in a keyed loop, or write it at runtime with `data-herb-set` or `state.set`.")
 
     assertOffenses(dedent`
       <%# herb:state (draft: "") %>
@@ -68,7 +68,7 @@ describe("HerbStateNoServerWritesRule", () => {
   })
 
   test("flags a fold into an item state", () => {
-    expectError("`mine += 1` counts into `mine`, which is an item state. A count lives once per region, so declare `mine` at the top of the template.")
+    expectError("`mine += 1` counts into `mine`, which is an item state. A count lives once per region, not once per item. Declare `mine` at the top of the template, outside the loop.")
 
     assertOffenses(dedent`
       <%# herb:slots client %>
@@ -77,7 +77,7 @@ describe("HerbStateNoServerWritesRule", () => {
   })
 
   test("flags a fold into a non-integer state", () => {
-    expectError("`label += 1` counts into the String state `label`. A count is a number, so declare it as an Integer, like `(label: 0)`.")
+    expectError("`label += 1` counts into the String state `label`. A count is a number. Declare `label` as an Integer, like `(label: 0)`.")
 
     assertOffenses(dedent`
       <%# herb:state (label: "x") %>
@@ -86,7 +86,7 @@ describe("HerbStateNoServerWritesRule", () => {
   })
 
   test("flags a fold into a derived state", () => {
-    expectError("`busy += 1` counts into `busy`, which is derived from `pending`. A state is either derived or counted, so drop one of the two.")
+    expectError("`busy += 1` counts into `busy`, which is derived from `pending`. A state is either derived or counted, never both. Drop the derivation from `busy`, or count into a second state.")
 
     assertOffenses(dedent`
       <%# herb:state (pending: false, busy: pending) %>
@@ -95,7 +95,7 @@ describe("HerbStateNoServerWritesRule", () => {
   })
 
   test("flags a state counted twice", () => {
-    expectError("`total` is counted twice. One state holds one count, so declare a second state for the second count.")
+    expectError("`total` is counted twice. One state holds one count. Declare a second state for the second count.")
 
     assertOffenses(dedent`
       <%# herb:state (total: 0) %>
@@ -105,7 +105,7 @@ describe("HerbStateNoServerWritesRule", () => {
   })
 
   test("flags a count read before its loop", () => {
-    expectError("`total` is read before its count is complete. The server renders this read mid-count and the client cannot keep it current here, so move it after the loop.")
+    expectError("`total` is read before its count is complete. The server renders that read mid-count and the client cannot keep it current. Move the read below the loop that counts `total`.")
 
     assertOffenses(dedent`
       <%# herb:state (total: 0) %>
@@ -115,7 +115,7 @@ describe("HerbStateNoServerWritesRule", () => {
   })
 
   test("flags a count read inside its loop", () => {
-    expectError("`total` is read inside the loop that counts it. The count is complete only after the loop, so move this read below it.")
+    expectError("`total` is read inside the loop that counts it. The count is complete only after the loop. Move the read below the loop.")
 
     assertOffenses(dedent`
       <%# herb:state (total: 0) %>

--- a/javascript/packages/linter/test/rules/herb-state-valid-declaration.test.ts
+++ b/javascript/packages/linter/test/rules/herb-state-valid-declaration.test.ts
@@ -42,7 +42,7 @@ describe("HerbStateValidDeclarationRule", () => {
   })
 
   test("flags a state with no default", () => {
-    expectError("The state `pending` has no default. Add one, like `pending: false`. The server renders a state as its default, so a state always has a value.", [1, 16])
+    expectError("The state `pending` has no default. The server renders a value for every state, so there is nothing to render or to seed the client with. Give it a default, like `pending: false`.", [1, 16])
 
     assertOffenses(dedent`
       <%# herb:state (pending:) %>
@@ -51,7 +51,7 @@ describe("HerbStateValidDeclarationRule", () => {
   })
 
   test("flags a Float default", () => {
-    expectError("The state `rate` has a Float default. Use an Integer or a String instead, since Ruby and JavaScript print floats differently.", [1, 22])
+    expectError("The state `rate` has a Float default. Ruby and JavaScript disagree on how to print a float, so the server and the client would render different text. Declare it as an Integer or a String instead.", [1, 22])
 
     assertOffenses(dedent`
       <%# herb:state (rate: 1.0) %>
@@ -60,7 +60,7 @@ describe("HerbStateValidDeclarationRule", () => {
   })
 
   test("flags a Float default written with an exponent", () => {
-    expectError("The state `rate` has a Float default. Use an Integer or a String instead, since Ruby and JavaScript print floats differently.", [1, 22])
+    expectError("The state `rate` has a Float default. Ruby and JavaScript disagree on how to print a float, so the server and the client would render different text. Declare it as an Integer or a String instead.", [1, 22])
 
     assertOffenses(dedent`
       <%# herb:state (rate: 1e3) %>
@@ -76,7 +76,7 @@ describe("HerbStateValidDeclarationRule", () => {
   })
 
   test("flags an Array default", () => {
-    expectError("The state `selected` has an Array default. Declare a per-row boolean inside the loop instead, like `selected: false`. A list on the page is a collection of items, not a state.")
+    expectError("The state `selected` has an Array default. A list on the page is a collection of items, not one state holding many values. Declare an item-scoped state inside the loop instead, like `selected: false`.")
 
     assertOffenses(dedent`
       <%# herb:state (selected: []) %>
@@ -103,7 +103,7 @@ describe("HerbStateValidDeclarationRule", () => {
   })
 
   test("flags a state colliding with a strict local", () => {
-    expectError("`open` is both a strict local and a state. Rename one of them. A local comes from the caller and a state is client-owned, so one name cannot be both.")
+    expectError("`open` is both a strict local and a state. A local comes from the caller and a state is owned by the client, so the name has two owners. Rename one of the two.")
 
     assertOffenses(dedent`
       <%# locals: (open: false) %>
@@ -113,7 +113,7 @@ describe("HerbStateValidDeclarationRule", () => {
   })
 
   test("flags a state declared twice in the same scope", () => {
-    expectError("The state `pending` is declared twice in the same scope. Remove one of the declarations.")
+    expectError("The state `pending` is declared twice in the same scope. Remove one of the two declarations.")
 
     assertOffenses(dedent`
       <%# herb:state (pending: false, pending: true) %>
@@ -122,7 +122,7 @@ describe("HerbStateValidDeclarationRule", () => {
   })
 
   test("flags a state declared twice across two directives in one scope", () => {
-    expectError("The state `pending` is declared twice in the same scope. Remove one of the declarations.")
+    expectError("The state `pending` is declared twice in the same scope. Remove one of the two declarations.")
 
     assertOffenses(dedent`
       <%# herb:state (pending: false) %>
@@ -132,7 +132,7 @@ describe("HerbStateValidDeclarationRule", () => {
   })
 
   test("flags an item state shadowing a region state", () => {
-    expectError("The state `open` is declared in both an item and its region. Rename one of them, since a read of `open` could mean either.")
+    expectError("The state `open` is declared in both an item and its region, so a later read could mean either one. Give them different names, like `item_open` for the one inside the loop.")
 
     assertOffenses(dedent`
       <%# herb:state (open: false) %>
@@ -144,7 +144,7 @@ describe("HerbStateValidDeclarationRule", () => {
   })
 
   test("flags a region state shadowing an earlier item state", () => {
-    expectError("The state `open` is declared in both an item and its region. Rename one of them, since a read of `open` could mean either.")
+    expectError("The state `open` is declared in both an item and its region, so a later read could mean either one. Give them different names, like `item_open` for the one inside the loop.")
 
     assertOffenses(dedent`
       <% @rows.each do |row| %>
@@ -211,7 +211,7 @@ describe("HerbStateValidDeclarationRule", () => {
   })
 
   test("flags a derived default mixing states with other Ruby", () => {
-    expectError("The state `busy` defaults to `pending || current_user.admin?`, which mixes state reads with other Ruby. A derived state reads only other states, and a seed reads none, so split the two apart.")
+    expectError("The state `busy` defaults to `pending || current_user.admin?`, which mixes state reads with other Ruby. A derived state reads only other states and a seed reads none. Split the two apart, so `busy` derives from states only.")
 
     assertOffenses(dedent`
       <%# herb:state (pending: false, busy: pending || current_user.admin?) %>
@@ -220,7 +220,7 @@ describe("HerbStateValidDeclarationRule", () => {
   })
 
   test("flags a derived state reading forward", () => {
-    expectError("The state `busy` reads a state that is declared after it. Reorder the signature, since a derived state reads only states declared before it.")
+    expectError("The state `busy` reads a state that is declared after it. A derived state reads only states declared before it. Move `busy` after the states it reads.")
 
     assertOffenses(dedent`
       <%# herb:state (busy: pending || failed, pending: false, failed: false) %>
@@ -229,7 +229,7 @@ describe("HerbStateValidDeclarationRule", () => {
   })
 
   test("flags an item state deriving from the region", () => {
-    expectError("The state `mirror` reads `open` from an enclosing scope. Declare it beside its sources, since a derived state reads states declared in its own signature.")
+    expectError("The state `mirror` reads `open` from an enclosing scope. A derived state reads only states from its own signature. Declare `mirror` beside the states it reads.")
 
     assertOffenses(dedent`
       <%# herb:state (open: false) %>

--- a/javascript/packages/linter/test/rules/herb-state-valid-reads.test.ts
+++ b/javascript/packages/linter/test/rules/herb-state-valid-reads.test.ts
@@ -35,7 +35,7 @@ describe("HerbStateValidReadsRule", () => {
   })
 
   test("still flags a state read beside an action attribute", () => {
-    expectError("`count + 1` computes with the state `count`, and the client cannot run Ruby to keep the result current. Show the value with `<%= count %>`, or declare a second state for the computed answer and set it from app code.")
+    expectError("`count + 1` computes with the state `count`. The client cannot run Ruby to keep the result current. Show the value with `<%= count %>`, or declare a second state for the computed answer and set it from app code.")
 
     assertOffenses(dedent`
       <%# herb:state (count: 0) %>
@@ -44,7 +44,7 @@ describe("HerbStateValidReadsRule", () => {
   })
 
   test("flags a computed value read", () => {
-    expectError("`attempts + 1` computes with the state `attempts`, and the client cannot run Ruby to keep the result current. Show the value with `<%= attempts %>`, or declare a second state for the computed answer and set it from app code.")
+    expectError("`attempts + 1` computes with the state `attempts`. The client cannot run Ruby to keep the result current. Show the value with `<%= attempts %>`, or declare a second state for the computed answer and set it from app code.")
 
     assertOffenses(dedent`
       <%# herb:state (attempts: 0) %>
@@ -60,7 +60,7 @@ describe("HerbStateValidReadsRule", () => {
   })
 
   test("flags a state mixed with other dynamics in an interpolated attribute", () => {
-    expectError("`status` reads a state inside an interpolated attribute that mixes other dynamic parts. Give the state its own attribute or its own output, since a state write cannot supply the other values.")
+    expectError("`status` reads a state inside an interpolated attribute that mixes other dynamic parts. A state write cannot supply the other values. Give the state its own attribute, or its own output outside this one.")
 
     assertOffenses(dedent`
       <%# herb:state (status: "") %>
@@ -85,7 +85,7 @@ describe("HerbStateValidReadsRule", () => {
   })
 
   test("flags comparing states of different kinds", () => {
-    expectError("`sort == attempts` compares the String state `sort` with the Integer state `attempts`, so it can never match. Compare states of one kind, or redeclare one.")
+    expectError("`sort == attempts` compares the String state `sort` with the Integer state `attempts`, so it can never match. Compare values of the same kind, or redeclare one of the two states.")
 
     assertOffenses(dedent`
       <%# herb:state (sort: "name", attempts: 0) %>
@@ -94,7 +94,7 @@ describe("HerbStateValidReadsRule", () => {
   })
 
   test("flags ordering non-integer states against each other", () => {
-    expectError("`sort > other` orders the states `sort` and `other`. Ordering compares numbers, so both have to be Integer states.")
+    expectError("`sort > other` orders the String state `sort` against the String state `other`. Ordering compares numbers. Make both sides Integers, or compare them with `==` instead.")
 
     assertOffenses(dedent`
       <%# herb:state (sort: "name", other: "x") %>
@@ -110,7 +110,7 @@ describe("HerbStateValidReadsRule", () => {
   })
 
   test("flags a negated equality against another kind", () => {
-    expectError('`sort != 3` compares the String state `sort` against an Integer literal, so it always matches. Compare against a String, or redeclare the state.')
+    expectError('`sort != 3` compares the String state `sort` against an Integer literal, so it always matches. Compare it against a String literal, like `sort == \"name\"`.')
 
     assertOffenses(dedent`
       <%# herb:state (sort: "name") %>
@@ -119,7 +119,7 @@ describe("HerbStateValidReadsRule", () => {
   })
 
   test("flags ordering a string state", () => {
-    expectError("`sort > \"a\"` orders the String state `sort`. Ordering compares numbers, so only an Integer state takes `>`.")
+    expectError("`sort > \"a\"` orders the String state `sort`. Ordering compares numbers. Declare `sort` as an Integer, like `(sort: 0)`, or compare it with `==` instead.")
 
     assertOffenses(dedent`
       <%# herb:state (sort: "name") %>
@@ -128,7 +128,7 @@ describe("HerbStateValidReadsRule", () => {
   })
 
   test("flags ordering against a non-integer literal", () => {
-    expectError("`attempts > \"a\"` orders the state `attempts` against a String literal. Ordering compares numbers, so the comparand has to be an Integer.")
+    expectError("`attempts > \"a\"` orders the state `attempts` against a String literal. Ordering compares numbers. Compare \`attempts\` against an Integer literal, like \`attempts > 0\`.")
 
     assertOffenses(dedent`
       <%# herb:state (attempts: 0) %>
@@ -137,7 +137,7 @@ describe("HerbStateValidReadsRule", () => {
   })
 
   test("flags a computed condition", () => {
-    expectError("`attempts * 2 > 3` computes with the state `attempts`, and the client cannot run Ruby to pick the branch. Read it bare, `<% if attempts %>`, or compare it to a literal, `attempts == 0`.")
+    expectError("`attempts * 2 > 3` computes with the state `attempts`. The client resolves each condition itself and cannot run Ruby to pick a branch. Read `attempts` bare, like `<% if attempts %>`, or compare it to a literal, like `attempts == 0`.")
 
     assertOffenses(dedent`
       <%# herb:state (attempts: 0) %>
@@ -153,7 +153,7 @@ describe("HerbStateValidReadsRule", () => {
   })
 
   test("flags a computed unless condition", () => {
-    expectError("`attempts * 2 > 3` computes with the state `attempts`, and the client cannot run Ruby to pick the branch. Read it bare, `<% if attempts %>`, or compare it to a literal, `attempts == 0`.")
+    expectError("`attempts * 2 > 3` computes with the state `attempts`. The client resolves each condition itself and cannot run Ruby to pick a branch. Read `attempts` bare, like `<% if attempts %>`, or compare it to a literal, like `attempts == 0`.")
 
     assertOffenses(dedent`
       <%# herb:state (attempts: 0) %>
@@ -172,7 +172,7 @@ describe("HerbStateValidReadsRule", () => {
   })
 
   test("flags a comparison against a non-literal", () => {
-    expectError('`sort == params[:sort]` compares the state `sort` against something that is not a literal or another declared state. Compare against a literal, like `sort == "name"`, since the client resolves a comparison by lookup.')
+    expectError('`sort == params[:sort]` compares the state `sort` against `params[:sort]`, which is not a literal. The client resolves a comparison by looking the state up, so it has no value for the other side. Compare `sort` to a literal, like `sort == "name"`, or declare a state for `params[:sort]` and set it from app code.')
 
     assertOffenses(dedent`
       <%# herb:state (sort: "name") %>
@@ -181,7 +181,7 @@ describe("HerbStateValidReadsRule", () => {
   })
 
   test("flags a comparison against a literal of another type", () => {
-    expectError("`sort == 3` compares the String state `sort` against an Integer literal, so it can never match. Compare against a String, or redeclare the state.")
+    expectError("`sort == 3` compares the String state `sort` against an Integer literal, so it can never match. Compare it against a String literal, like `sort == \"name\"`.")
 
     assertOffenses(dedent`
       <%# herb:state (sort: "name") %>
@@ -197,7 +197,7 @@ describe("HerbStateValidReadsRule", () => {
   })
 
   test("flags a symbol state compared against a string", () => {
-    expectError("`tab == \"profile\"` compares the Symbol state `tab` against a String literal, so it can never match. Compare against a Symbol, or redeclare the state.")
+    expectError("`tab == \"profile\"` compares the Symbol state `tab` against a String literal, so it can never match. Compare it against a Symbol literal, like `tab == :profile`.")
 
     assertOffenses(dedent`
       <%# herb:state (tab: :profile) %>
@@ -206,7 +206,7 @@ describe("HerbStateValidReadsRule", () => {
   })
 
   test("flags a stateless arm inside a state-driven conditional", () => {
-    expectError("`current_user.admin?` sits in a state-driven conditional but reads no state. Move it into its own conditional, or read a state in this arm, since the client resolves every arm itself.")
+    expectError("`current_user.admin?` sits in a state-driven conditional but reads no state. The client resolves every arm, so an arm it cannot answer would never be chosen. Read a state in this arm, or move this branch into its own conditional.")
 
     assertOffenses(dedent`
       <%# herb:state (pending: false) %>
@@ -233,7 +233,7 @@ describe("HerbStateValidReadsRule", () => {
   })
 
   test("flags a combo mixing a state with server code", () => {
-    expectError("`pending? && current_user.admin?` combines a state with `current_user.admin?`, which the client cannot evaluate. Split the server condition into its own conditional, or compute it into a second state set from app code.")
+    expectError("`current_user.admin?` is server Ruby inside a condition that also reads the state `pending`. The client resolves each side of `&&` itself and has no value for this one. Move `current_user.admin?` into its own conditional around this one, or declare a state for it and set it from app code.")
 
     assertOffenses(dedent`
       <%# herb:state (pending: false) %>
@@ -242,7 +242,7 @@ describe("HerbStateValidReadsRule", () => {
   })
 
   test("flags the invalid condition inside a combo once", () => {
-    expectError("`attempts.empty?` reads the Integer state `attempts` with `empty?`. Only a String or a Symbol state can be read with `empty?`, so compare `attempts` to a literal instead.")
+    expectError("`attempts.empty?` reads the Integer state `attempts` with `empty?`. Only a String or a Symbol state can be read with `empty?`. Compare `attempts` to a literal instead, or declare it as a String state.")
 
     assertOffenses(dedent`
       <%# herb:state (pending: false, attempts: 0) %>
@@ -266,7 +266,7 @@ describe("HerbStateValidReadsRule", () => {
   })
 
   test("flags a comparison against a derived state's inferred kind", () => {
-    expectError("`busy == 3` compares the Boolean state `busy` against an Integer literal, so it can never match. Compare against a Boolean, or redeclare the state.")
+    expectError("`busy == 3` compares the Boolean state `busy` against an Integer literal, so it can never match. Compare it against a Boolean literal, like `busy == pending || failed`.")
 
     assertOffenses(dedent`
       <%# herb:state (pending: false, failed: false, busy: pending || failed) %>
@@ -285,7 +285,7 @@ describe("HerbStateValidReadsRule", () => {
   })
 
   test("flags a computed tag helper attribute", () => {
-    expectError("`draft.upcase` computes with the state `draft`, and the client cannot run Ruby to keep the result current. Show the value with `<%= draft %>`, or declare a second state for the computed answer and set it from app code.")
+    expectError("`draft.upcase` computes with the state `draft`. The client cannot run Ruby to keep the result current. Show the value with `<%= draft %>`, or declare a second state for the computed answer and set it from app code.")
 
     assertOffenses(dedent`
       <%# herb:state (draft: "") %>
@@ -294,7 +294,7 @@ describe("HerbStateValidReadsRule", () => {
   })
 
   test("flags a case that does not switch on a bare state read", () => {
-    expectError("`case sort.downcase` does not switch on a bare state read. Write the state alone, or compute the value into its own state.")
+    expectError("`case sort.downcase` switches on something other than a bare state read. The client resolves a `case` by looking the state up. Switch on the state itself, like `case sort`.")
 
     assertOffenses(dedent`
       <%# herb:state (sort: "name") %>
@@ -305,7 +305,7 @@ describe("HerbStateValidReadsRule", () => {
   })
 
   test("flags a when comparand that is not a literal", () => {
-    expectError('`when other_sort` on the state `sort` has a comparand that is not a literal. List literals, like `when "name", "date"`, since the client resolves a `when` by lookup.')
+    expectError('`when other_sort` on the state `sort` has a comparand that is not a literal. The client resolves a `when` by lookup. List literals instead, like `when "name"`.')
 
     assertOffenses(dedent`
       <%# herb:state (sort: "name") %>
@@ -316,7 +316,7 @@ describe("HerbStateValidReadsRule", () => {
   })
 
   test("flags a when comparand of another type", () => {
-    expectError("`when 3` compares the String state `sort` against a literal of another type, so it can never match. Use String literals in every arm.")
+    expectError("`when 3` compares the String state `sort` against a literal of another type, so it can never match. Use a String literal in every arm, like `when \"name\"`.")
 
     assertOffenses(dedent`
       <%# herb:state (sort: "name") %>
@@ -344,7 +344,7 @@ describe("HerbStateValidReadsRule", () => {
   })
 
   test("flags a mismatched comparand in a boolean attribute", () => {
-    expectError("`draft == 3` compares the String state `draft` against an Integer literal, so it can never match. Compare against a String, or redeclare the state.")
+    expectError("`draft == 3` compares the String state `draft` against an Integer literal, so it can never match. Compare it against a String literal, like `draft == \"\"`.")
 
     assertOffenses(dedent`
       <%# herb:state (draft: "") %>
@@ -353,8 +353,28 @@ describe("HerbStateValidReadsRule", () => {
     `)
   })
 
+  test("flags a presence read of a state that is never falsy", () => {
+    expectError('`disabled="<%= draft %>"` reads the String state `draft` as a presence. Only `nil` and `false` are falsy in Ruby, so the attribute could never turn off. Compare `draft` to a literal, like `draft == ""`, or declare it as a boolean.')
+
+    assertOffenses(dedent`
+      <%# herb:state (draft: "") %>
+      <p><%= draft %></p>
+      <button disabled="<%= draft %>">Send</button>
+    `)
+  })
+
+  test("flags the predicate spelling of a presence read the same way", () => {
+    expectError('`disabled="<%= draft? %>"` reads the String state `draft` as a presence. Only `nil` and `false` are falsy in Ruby, so the attribute could never turn off. Compare `draft` to a literal, like `draft == ""`, or declare it as a boolean.')
+
+    assertOffenses(dedent`
+      <%# herb:state (draft: "") %>
+      <p><%= draft %></p>
+      <button disabled="<%= draft? %>">Send</button>
+    `)
+  })
+
   test("flags a computed read in a boolean attribute", () => {
-    expectError('`draft.upcase` computes with the state `draft`, and the client cannot run Ruby to pick the branch. Read it bare, `<% if draft %>`, or compare it to a literal, `draft == ""`.')
+    expectError('`draft.upcase` computes with the state `draft`. The client resolves each condition itself and cannot run Ruby to pick a branch. Read `draft` bare, like `<% if draft %>`, or compare it to a literal, like `draft == ""`.')
 
     assertOffenses(dedent`
       <%# herb:state (draft: "") %>
@@ -463,7 +483,7 @@ describe("HerbStateValidReadsRule", () => {
   })
 
   test("flags two transformed sides whose kinds disagree", () => {
-    expectError("`draft.length > other.to_s` orders the length of the state `draft` against the to_s of the state `other`. Ordering compares numbers, so both sides have to be Integers.")
+    expectError("`draft.length > other.to_s` orders the length of the state `draft` against the to_s of the state `other`. Ordering compares numbers. Make both sides Integers, or compare them with `==` instead.")
 
     assertOffenses(dedent`
       <%# herb:state (draft: "", other: "") %>
@@ -472,7 +492,7 @@ describe("HerbStateValidReadsRule", () => {
   })
 
   test("flags a transform compared against a state of another kind", () => {
-    expectError("`draft.length > filter` compares the length of the state `draft` with the String state `filter`, so it can never match. Compare values of the same kind.")
+    expectError("`draft.length > filter` compares the length of the state `draft` with the String state `filter`, so it can never match. Compare values of the same kind, or redeclare one of the two states.")
 
     assertOffenses(dedent`
       <%# herb:state (draft: "", filter: "all") %>
@@ -495,7 +515,7 @@ describe("HerbStateValidReadsRule", () => {
   })
 
   test("flags length on a state that is not a String or a Symbol", () => {
-    expectError("`count.length` reads the Integer state `count` with `length`. Only a String or a Symbol state can be read with `length`, so compare `count` itself instead.")
+    expectError("`count.length` reads the Integer state `count` with `length`. Only a String or a Symbol state can be read with `length`. Compare `count` itself instead, like `count == 0`.")
 
     assertOffenses(dedent`
       <%# herb:state (count: 0) %>
@@ -527,7 +547,7 @@ describe("HerbStateValidReadsRule", () => {
   })
 
   test("flags zero? on a state that is not an Integer", () => {
-    expectError("`draft.zero?` reads the String state `draft` with `zero?`. Only an Integer state can be read with `zero?`, so compare `draft` to a literal instead.")
+    expectError("`draft.zero?` reads the String state `draft` with `zero?`. Only an Integer state can be read with `zero?`. Compare `draft` to a literal instead, or declare it as an Integer state.")
 
     assertOffenses(dedent`
       <%# herb:state (draft: "") %>
@@ -536,7 +556,7 @@ describe("HerbStateValidReadsRule", () => {
   })
 
   test("flags one? on a state that is not an Integer", () => {
-    expectError("`draft.one?` reads the String state `draft` with `one?`. Only an Integer state can be read with `one?`, so compare `draft` to a literal instead.")
+    expectError("`draft.one?` reads the String state `draft` with `one?`. Only an Integer state can be read with `one?`. Compare `draft` to a literal instead, or declare it as an Integer state.")
 
     assertOffenses(dedent`
       <%# herb:state (draft: "") %>
@@ -545,7 +565,7 @@ describe("HerbStateValidReadsRule", () => {
   })
 
   test("flags empty? on a state that is not a String or a Symbol", () => {
-    expectError("`count.empty?` reads the Integer state `count` with `empty?`. Only a String or a Symbol state can be read with `empty?`, so compare `count` to a literal instead.")
+    expectError("`count.empty?` reads the Integer state `count` with `empty?`. Only a String or a Symbol state can be read with `empty?`. Compare `count` to a literal instead, or declare it as a String state.")
 
     assertOffenses(dedent`
       <%# herb:state (count: 0) %>
@@ -554,7 +574,7 @@ describe("HerbStateValidReadsRule", () => {
   })
 
   test("flags blank? on a state that is never blank", () => {
-    expectError("`count.blank?` reads the Integer state `count` with `blank?`. Only a Boolean, a String or a Nil state can be read with `blank?`, so compare `count` to a literal instead.")
+    expectError("`count.blank?` reads the Integer state `count` with `blank?`. Only a Boolean, a String or a Nil state can be read with `blank?`. Compare `count` to a literal instead, or declare it as a Boolean state.")
 
     assertOffenses(dedent`
       <%# herb:state (count: 0) %>
@@ -563,7 +583,7 @@ describe("HerbStateValidReadsRule", () => {
   })
 
   test("flags present? on a state that is always present", () => {
-    expectError("`tab.present?` reads the Symbol state `tab` with `present?`. Only a Boolean, a String or a Nil state can be read with `present?`, so compare `tab` to a literal instead.")
+    expectError("`tab.present?` reads the Symbol state `tab` with `present?`. Only a Boolean, a String or a Nil state can be read with `present?`. Compare `tab` to a literal instead, or declare it as a Boolean state.")
 
     assertOffenses(dedent`
       <%# herb:state (tab: :first) %>
@@ -572,7 +592,7 @@ describe("HerbStateValidReadsRule", () => {
   })
 
   test("flags a method that is not a supported predicate", () => {
-    expectError("`draft.upcase?` computes with the state `draft`, and the client cannot run Ruby to pick the branch. Read it bare, `<% if draft %>`, or compare it to a literal, `draft == \"\"`.")
+    expectError("`draft.upcase?` computes with the state `draft`. The client resolves each condition itself and cannot run Ruby to pick a branch. Read `draft` bare, like `<% if draft %>`, or compare it to a literal, like `draft == \"\"`.")
 
     assertOffenses(dedent`
       <%# herb:state (draft: "") %>

--- a/lib/herb/engine/slots/state_anchor.rb
+++ b/lib/herb/engine/slots/state_anchor.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+# typed: true
+
+module Herb
+  class Engine
+    module Slots
+      # Points a diagnostic at the part of an expression that is actually wrong.
+      #
+      # A condition reaches the state compiler as a string that was cut out of an ERB token, so a
+      # Prism node inside it knows only its own offset within that string. This carries the token
+      # the string came from and turns those offsets back into a location in the template. When it
+      # has nothing to work with it answers the whole node's location, which is what every
+      # diagnostic used before.
+      #
+      class StateAnchor
+        attr_reader :location #: Herb::Location?
+
+        #: (Herb::Location?, ?token: Herb::Token?, ?expression: String?, ?context: Symbol) -> void
+        def initialize(location, token: nil, expression: nil, context: :condition)
+          @location = location #: Herb::Location?
+          @token = token #: Herb::Token?
+          @expression = expression #: String?
+          @context = context #: Symbol
+        end
+
+        #: () -> bool
+        def condition?
+          @context == :condition
+        end
+
+        #: (::Prism::Node) -> Herb::Location?
+        def locate(node)
+          return location unless node.respond_to?(:location)
+
+          offset = character_offset(node)
+
+          return location unless offset
+
+          length = node.slice.to_s.length #: Integer
+
+          Herb::Location.new(advance(offset), advance(offset + length))
+        end
+
+        private
+
+        #: (::Prism::Node) -> Integer?
+        def character_offset(node)
+          token = @token
+          expression = @expression
+          start = @location&.start
+
+          return nil unless token && expression && start
+
+          source = token.value.to_s
+          within = source.index(expression)
+
+          return nil unless within
+
+          bytes = node.location.start_offset
+          prefix = expression.byteslice(0, bytes)
+
+          return nil unless prefix
+
+          within + prefix.length
+        end
+
+        #: (Integer) -> Herb::Position
+        def advance(offset)
+          anchored = location || Herb::Location.zero
+          line = anchored.start.line
+          column = anchored.start.column
+          consumed = @token&.value.to_s[0, offset].to_s #: String
+          breaks = consumed.count("\n") #: Integer
+
+          return Herb::Position.new(line, column + consumed.length) if breaks.zero?
+
+          Herb::Position.new(line + breaks, consumed.length - consumed.rindex("\n").to_i - 1)
+        end
+      end
+    end
+  end
+end

--- a/lib/herb/engine/slots/state_compiler.rb
+++ b/lib/herb/engine/slots/state_compiler.rb
@@ -237,17 +237,17 @@ module Herb
             spelled = declaration_location(declaration) || node.location
 
             if @strict_locals.key?(declaration.name)
-              next @visitor.slot_error("`#{declaration.name}` is both a strict local and a state. A local comes from the caller and a state is owned by the client, so rename one of the two.", spelled, :declaration)
+              next @visitor.slot_error("`#{declaration.name}` is both a strict local and a state. A local comes from the caller and a state is owned by the client, so the name has two owners.", spelled, :declaration, suggestion: "Rename one of the two.")
             end
 
             if bucket.key?(declaration.name)
-              next @visitor.slot_error("The state `#{declaration.name}` is declared twice in the same scope. Remove one of the two declarations.", spelled, :declaration)
+              next @visitor.slot_error("The state `#{declaration.name}` is declared twice in the same scope.", spelled, :declaration, suggestion: "Remove one of the two declarations.")
             end
 
             shadowed = scope ? @region_states.key?(declaration.name) : @item_states.values.any? { |declarations| declarations.key?(declaration.name) }
 
             if shadowed
-              next @visitor.slot_error("The state `#{declaration.name}` is declared in both an item and its region. A later read could mean either one, so give them different names.", spelled, :declaration)
+              next @visitor.slot_error("The state `#{declaration.name}` is declared in both an item and its region, so a later read could mean either one.", spelled, :declaration, suggestion: "Give them different names, like `item_#{declaration.name}` for the one inside the loop.")
             end
 
             bucket[declaration.name] = declaration.line ? declaration : declaration.with(line: start&.line, column: start&.column)
@@ -375,18 +375,18 @@ module Herb
 
           conditions.each_with_index do |arm, branch|
             expression = condition_expression(arm)
-            read = StateDirectives.condition_read(expression, states, @visitor, arm.location)
+            read = StateDirectives.condition_read(expression, states, @visitor, condition_anchor(arm, expression))
 
             return nil if read == :reported
 
             if read == :computed
-              return @visitor.slot_error("`#{expression}` computes with a state. The client cannot evaluate Ruby, so read the state bare, read it with a predicate, or compare it to a literal.", arm.location, :read)
+              return @visitor.slot_error("`#{expression}` computes with the state `#{mentioned_state(expression, states)&.name}`. The client resolves each condition itself and cannot run Ruby to pick a branch.", condition_anchor(arm, expression).location, :read, suggestion: read_advice(mentioned_state(expression, states)))
             end
 
             unless read.is_a?(StateDirectives::Read) || read.is_a?(StateDirectives::Combo)
               return nil if arms.empty?
 
-              return @visitor.slot_error("`#{expression}` sits in a state-driven conditional but reads no state. The client resolves every arm, so read a state here or move this branch out of the conditional.", arm.location, :conditional)
+              return @visitor.slot_error("`#{expression}` sits in a state-driven conditional but reads no state. The client resolves every arm, so an arm it cannot answer would never be chosen.", condition_anchor(arm, expression).location, :conditional, suggestion: "Read a state in this arm, or move this branch into its own conditional.")
             end
 
             StateDirectives.read_names(read).each { |name| rewrite_predicate(arm, name) }
@@ -413,12 +413,12 @@ module Herb
         #: (untyped, Hash[String, StateDirectives::Declaration]) -> Hash[Symbol, untyped]?
         def state_unless_for(node, states)
           expression = condition_expression(node)
-          read = StateDirectives.condition_read(expression, states, @visitor, node.location)
+          read = StateDirectives.condition_read(expression, states, @visitor, condition_anchor(node, expression))
 
           return nil if read.nil? || read == :reported
 
           if read == :computed
-            return @visitor.slot_error("`unless #{expression}` computes with a state. The client cannot evaluate Ruby, so read the state bare, read it with a predicate, or compare it to a literal.", node.location, :read)
+            return @visitor.slot_error("`unless #{expression}` computes with the state `#{mentioned_state(expression, states)&.name}`. The client resolves each condition itself and cannot run Ruby to pick a branch.", condition_anchor(node, expression).location, :read, suggestion: read_advice(mentioned_state(expression, states)))
           end
 
           return nil unless read.is_a?(StateDirectives::Read) || read.is_a?(StateDirectives::Combo)
@@ -438,12 +438,12 @@ module Herb
         #: (untyped, Hash[String, StateDirectives::Declaration]) -> Hash[Symbol, untyped]?
         def state_case_for(node, states)
           subject_source = condition_expression(node)
-          read = StateDirectives.condition_read(subject_source, states, @visitor, node.location)
+          read = StateDirectives.condition_read(subject_source, states, @visitor, condition_anchor(node, subject_source))
 
           return nil if read.nil? || read == :reported
 
           unless read.is_a?(StateDirectives::Read) && read.comparand.nil? && read.operator.nil? && read.transform.nil?
-            return @visitor.slot_error("`case #{subject_source}` switches on something other than a bare state read. The client resolves a `case` by looking the state up, so switch on the state itself.", node.location, :conditional)
+            return @visitor.slot_error("`case #{subject_source}` switches on something other than a bare state read. The client resolves a `case` by looking the state up.", condition_anchor(node, subject_source).location, :conditional, suggestion: "Switch on the state itself, like `case #{mentioned_state(subject_source, states)&.name}`.")
           end
 
           rewrite_predicate(node, read.name)
@@ -457,11 +457,11 @@ module Herb
             comparands = StateDirectives.when_comparands(list, declaration)
 
             if comparands == :computed
-              return @visitor.slot_error("`when #{list}` on the state `#{read.name}` has a comparand that is not a literal. The client resolves a `when` by lookup, so compare against literals only.", arm.location, :conditional)
+              return @visitor.slot_error("`when #{list}` on the state `#{read.name}` has a comparand that is not a literal. The client resolves a `when` by lookup.", condition_anchor(arm, list).location, :conditional, suggestion: "List literals instead, like `when #{declaration.default}`.")
             end
 
             if comparands == :mismatched
-              return @visitor.slot_error("`when #{list}` compares the #{declaration.kind.to_s.capitalize} state `#{read.name}` against a literal of another type, so it can never match. Compare it against #{StateDirectives.kind_article(declaration.kind)} literal instead.", arm.location, :compare)
+              return @visitor.slot_error("`when #{list}` compares the #{declaration.kind.to_s.capitalize} state `#{read.name}` against a literal of another type, so it can never match.", condition_anchor(arm, list).location, :compare, suggestion: "Use #{StateDirectives.kind_article(declaration.kind)} literal in every arm, like `when #{declaration.default}`.")
             end
 
             next unless comparands.is_a?(Array)
@@ -475,6 +475,31 @@ module Herb
           else_branch = node.else_clause ? node.conditions.size : nil
 
           { arms: arms, else: else_branch, signature: signature_of(sources, else_branch) }
+        end
+
+        #: (String, Hash[String, StateDirectives::Declaration]) -> StateDirectives::Declaration?
+        def mentioned_state(expression, states)
+          states.each_value.find { |declaration| StateDirectives.mentions_any?(expression, { declaration.name => declaration }) }
+        end
+
+        #: (StateDirectives::Declaration?) -> String
+        def read_advice(declaration)
+          return "Read the state bare, or compare it to a literal." unless declaration
+
+          name = declaration.name
+
+          return "Read `#{name}` bare, like `<% if #{name} %>`, or as `#{name}?`." if declaration.kind == :boolean
+
+          "Read `#{name}` bare, like `<% if #{name} %>`, or compare it to a literal, like `#{name} == #{declaration.default}`."
+        end
+
+        #: (untyped, String) -> StateAnchor
+        def condition_anchor(node, expression)
+          content = node.content if node.respond_to?(:content)
+
+          return StateAnchor.new(node.location) unless content.is_a?(Herb::Token)
+
+          StateAnchor.new(content.location, token: content, expression: expression)
         end
 
         #: (untyped) -> String
@@ -515,7 +540,7 @@ module Herb
 
           return nil unless increment && states.key?(increment.name)
 
-          read = StateDirectives.condition_read(condition_expression(node), states, @visitor, node.location)
+          read = StateDirectives.condition_read(condition_expression(node), states, @visitor, condition_anchor(node, condition_expression(node)))
 
           return nil unless read.is_a?(StateDirectives::Read) || read.is_a?(StateDirectives::Combo)
 
@@ -553,7 +578,7 @@ module Herb
             end
           end
 
-          @visitor.slot_error("`#{content.strip}` assigns the state `#{assigned.first}`. The client never sees a server-side write, so seed the initial value in the declaration, derive it from other states, count items with `#{assigned.first} += 1` behind a state condition in a keyed loop, or write it at runtime with `data-herb-set` or `state.set`.", node.location, :assignment)
+          @visitor.slot_error("`#{content.strip}` assigns the state `#{assigned.first}`. The client never sees a server-side write, so the value it holds would drift from the one the server rendered.", node.location, :assignment, suggestion: "Seed the initial value in the declaration, derive it from other states, count items with `#{assigned.first} += 1` behind a state condition in a keyed loop, or write it at runtime with `data-herb-set` or `state.set`.")
         end
 
         #: (StateDirectives::FoldIncrement, when_read: untyped, location: Herb::Location?) -> void
@@ -562,23 +587,23 @@ module Herb
           declaration = @region_states[name]
 
           unless declaration
-            return @visitor.slot_error("`#{name} += #{increment.by}` counts into `#{name}`, which is an item state. A count lives once per region, so declare `#{name}` at the top of the template instead.", location, :count)
+            return @visitor.slot_error("`#{name} += #{increment.by}` counts into `#{name}`, which is an item state. A count lives once per region, not once per item.", location, :count, suggestion: "Declare `#{name}` at the top of the template, outside the loop.")
           end
 
           if declaration.derived
-            return @visitor.slot_error("`#{name} += #{increment.by}` counts into `#{name}`, which is derived from `#{declaration.default}`. A state is either derived or counted, so drop the derivation or the count.", location, :count)
+            return @visitor.slot_error("`#{name} += #{increment.by}` counts into `#{name}`, which is derived from `#{declaration.default}`. A state is either derived or counted, never both.", location, :count, suggestion: "Drop the derivation from `#{name}`, or count into a second state.")
           end
 
           unless declaration.kind == :integer
-            return @visitor.slot_error("`#{name} += #{increment.by}` counts into the #{declaration.kind.to_s.capitalize} state `#{name}`. A count is a number, so declare it as an Integer, like `(#{name}: 0)`.", location, :count)
+            return @visitor.slot_error("`#{name} += #{increment.by}` counts into the #{declaration.kind.to_s.capitalize} state `#{name}`. A count is a number.", location, :count, suggestion: "Declare `#{name}` as an Integer, like `(#{name}: 0)`.")
           end
 
           if @state_counts.any? { |count| count[:name] == name }
-            return @visitor.slot_error("`#{name}` is counted twice. One state holds one count, so declare a second state for the second count.", location, :count)
+            return @visitor.slot_error("`#{name}` is counted twice. One state holds one count.", location, :count, suggestion: "Declare a second state for the second count.")
           end
 
           if @visitor.recorded_expressions.any? { |expression| StateDirectives.mentions_any?(expression, { name => declaration }) }
-            return @visitor.slot_error("`#{name}` is read before its count is complete. The server renders that read mid-count and the client cannot keep it current, so move the read after the loop.", location, :count)
+            return @visitor.slot_error("`#{name}` is read before its count is complete. The server renders that read mid-count and the client cannot keep it current.", location, :count, suggestion: "Move the read below the loop that counts `#{name}`.")
           end
 
           @state_counts << { name: name, by: increment.by, collection: @visitor.current_collection, when: when_read }
@@ -605,7 +630,7 @@ module Herb
 
               next unless StateDirectives.mentions_any?(expression, mentioned)
 
-              next @visitor.slot_error("`#{count[:name]}` is read inside the loop that counts it. The count is complete only after the loop, so move the read below it.", node.location, :count)
+              next @visitor.slot_error("`#{count[:name]}` is read inside the loop that counts it. The count is complete only after the loop.", node.location, :count, suggestion: "Move the read below the loop.")
             end
           end
         end
@@ -665,7 +690,7 @@ module Herb
 
           return unless read
 
-          @visitor.slot_error("`#{read}` reads a state inside an interpolated attribute that mixes other dynamic parts. A state write cannot supply the other values, so give the state its own attribute or its own output.", node.location, :read)
+          @visitor.slot_error("`#{read}` reads a state inside an interpolated attribute that mixes other dynamic parts. A state write cannot supply the other values.", node.location, :read, suggestion: "Give the state its own attribute, or its own output outside this one.")
         end
 
         #: () -> void
@@ -709,12 +734,12 @@ module Herb
 
         #: (untyped, Integer, untyped, String, Hash[String, StateDirectives::Declaration]) -> void
         def register_state_value(node, index, slot, expression, states)
-          read = slot.valued? ? StateDirectives.condition_read(expression, states, @visitor, node.location) : nil
+          read = slot.valued? ? StateDirectives.condition_read(expression, states, @visitor, condition_anchor(node, expression)) : nil
 
           return if read == :reported
 
           unless read.is_a?(StateDirectives::Read) || read.is_a?(StateDirectives::Combo)
-            return @visitor.slot_error("`#{expression}` computes with a state. The client cannot evaluate Ruby, so read the state bare, read it with a predicate, or compare it to a literal.", node.location, :read)
+            return @visitor.slot_error("`#{expression}` computes with the state `#{mentioned_state(expression, states)&.name}`. The client cannot run Ruby to keep the result current.", condition_anchor(node, expression).location, :read, suggestion: "Show the value with `<%= #{mentioned_state(expression, states)&.name} %>`, or declare a second state for the computed answer and set it from app code.")
           end
 
           StateDirectives.read_names(read).each { |name| rewrite_predicate(node, name) }
@@ -727,12 +752,12 @@ module Herb
           return nil unless slot.type == :attribute || (slot.type == :boolean_attribute && !@state_presence.key?(index))
           return nil unless slot.attribute && Herb::HTML::Util.boolean_attribute?(slot.attribute)
 
-          read = StateDirectives.condition_read(expression, states, @visitor, node.location)
+          read = StateDirectives.condition_read(expression, states, @visitor, condition_anchor(node, expression))
 
           return nil unless read.is_a?(StateDirectives::Read) || read.is_a?(StateDirectives::Combo)
 
           if read.is_a?(StateDirectives::Read) && read.comparand.nil? && read.against.nil? && read.operator.nil? && !StateKinds::FALSY.include?(read.kind)
-            return @visitor.slot_error("`#{slot.attribute}=\"<%= #{expression} %>\"` reads #{StateDirectives.subject_phrase(read)} as a presence. Only `nil` and `false` are falsy in Ruby, so the attribute could never turn off. Compare the state to a literal, or declare it as a boolean.", node.location, :read)
+            return @visitor.slot_error("`#{slot.attribute}=\"<%= #{expression} %>\"` reads #{StateDirectives.subject_phrase(read)} as a presence. Only `nil` and `false` are falsy in Ruby, so the attribute could never turn off.", condition_anchor(node, expression).location, :read, suggestion: "Compare `#{read.name}` to a literal, like `#{read.name} == #{states.fetch(read.name).default}`, or declare it as a boolean.")
           end
 
           open_tag = @visitor.open_tag_for(node)

--- a/lib/herb/engine/slots/state_directives.rb
+++ b/lib/herb/engine/slots/state_directives.rb
@@ -689,7 +689,9 @@ module Herb
             end
 
             unless ordered || kind == read.kind || kind == :nil || read.kind == :seeded
-              return visitor.slot_error("`#{node.slice}` compares #{subject_phrase(read)} against #{kind_article(kind)} literal, so it can never match.", anchor.locate(literal), :compare, suggestion: "Compare it against #{kind_article(read.kind)} literal, like `#{read.name} == #{states.fetch(read.name).default}`.")
+              consequence = operator == "!=" ? "so it always matches" : "so it can never match"
+
+              return visitor.slot_error("`#{node.slice}` compares #{subject_phrase(read)} against #{kind_article(kind)} literal, #{consequence}.", anchor.locate(literal), :compare, suggestion: "Compare it against #{kind_article(read.kind)} literal, like `#{read.name} == #{states.fetch(read.name).default}`.")
             end
 
             Read.new(name: read.name, comparand: literal.slice, kind: read.kind, operator: operator, against: nil, transform: read.transform, against_transform: nil)

--- a/lib/herb/engine/slots/state_directives.rb
+++ b/lib/herb/engine/slots/state_directives.rb
@@ -3,6 +3,7 @@
 
 require "prism"
 
+require_relative "state_anchor"
 require_relative "state_kinds"
 require_relative "state_operators"
 require_relative "state_predicates"
@@ -76,8 +77,8 @@ module Herb
         )
 
         module Silent
-          #: (String, Herb::Location?, Symbol) -> nil
-          def self.slot_error(_message, _location, _family)
+          #: (String, Herb::Location?, Symbol, **untyped) -> nil
+          def self.slot_error(_message, _location, _family, **_options)
             nil
           end
 
@@ -113,15 +114,16 @@ module Herb
             }
           end
 
-          #: (String, Hash[String, Declaration], untyped, Herb::Location?) -> (Read | Combo | Symbol)?
-          def condition_read(expression, states, visitor, location)
+          #: (String, Hash[String, Declaration], untyped, (StateAnchor | Herb::Location)?) -> (Read | Combo | Symbol)?
+          def condition_read(expression, states, visitor, anchor)
+            anchor = StateAnchor.new(anchor) unless anchor.is_a?(StateAnchor)
             source = expression.strip
             parsed = expression_node(source)
 
             return mentions_any?(source, states) ? :computed : nil if parsed.nil?
 
             said = visitor.diagnostic_count
-            read = tree_read(parsed, states, visitor, location)
+            read = tree_read(parsed, states, visitor, anchor)
 
             return :reported if visitor.diagnostic_count > said
             return read if read
@@ -129,26 +131,27 @@ module Herb
             mentions_any?(source, states) ? :computed : nil
           end
 
-          #: (untyped, Hash[String, Declaration], untyped, Herb::Location?) -> (Read | Combo | Symbol)?
-          def tree_read(node, states, visitor, location)
+          #: (untyped, Hash[String, Declaration], untyped, (StateAnchor | Herb::Location)?) -> (Read | Combo | Symbol)?
+          def tree_read(node, states, visitor, anchor)
+            anchor = StateAnchor.new(anchor) unless anchor.is_a?(StateAnchor)
             node = unwrap_parentheses(node)
 
-            read = bare_read(node, states, visitor, location)
+            read = bare_read(node, states, visitor, anchor)
             return read if read
 
-            predicate = predicate_read(node, states, visitor, location)
+            predicate = predicate_read(node, states, visitor, anchor)
             return predicate if predicate
 
-            transform = transform_read(node, states, visitor, location)
+            transform = transform_read(node, states, visitor, anchor)
             return transform if transform
 
-            negated = negated_read(node, states, visitor, location)
+            negated = negated_read(node, states, visitor, anchor)
             return negated if negated
 
-            equality = equality_read(node, states, visitor, location)
+            equality = equality_read(node, states, visitor, anchor)
             return equality if equality
 
-            combo_read(node, states, visitor, location)
+            combo_read(node, states, visitor, anchor)
           end
 
           #: (untyped) -> untyped
@@ -162,20 +165,45 @@ module Herb
             unwrap_parentheses(body.body.first)
           end
 
-          #: (untyped, Hash[String, Declaration], untyped, Herb::Location?) -> (Combo | Symbol)?
-          def combo_read(node, states, visitor, location)
+          #: (untyped, Hash[String, Declaration], untyped, StateAnchor) -> (Combo | Symbol)?
+          def combo_read(node, states, visitor, anchor)
             op = case node
                  when Prism::AndNode then "all"
                  when Prism::OrNode then "any"
                  else return nil
                  end
 
-            parts = flatten_combo(node, node.class).map { |part| tree_read(part, states, visitor, location) }
+            said = visitor.diagnostic_count
+            branches = flatten_combo(node, node.class)
+            parts = branches.map { |part| tree_read(part, states, visitor, anchor) }
 
             return nil if parts.none? { |part| part.is_a?(Read) || part.is_a?(Combo) }
-            return :computed if parts.any? { |part| part.nil? || part == :computed }
+            return :reported if visitor.diagnostic_count > said
+
+            server = branches.zip(parts).find { |_, part| part.nil? || part == :computed }&.first
+
+            return :computed if server && !anchor.condition?
+
+            if server
+              read = branches.zip(parts).find { |_, part| part.is_a?(Read) || part.is_a?(Combo) }&.last
+
+              return mixed_combo(node, server, read, visitor, anchor)
+            end
 
             Combo.new(op: op, parts: parts)
+          end
+
+          #: (untyped, untyped, untyped, untyped, StateAnchor) -> nil
+          def mixed_combo(node, server, read, visitor, anchor)
+            named = read && read_names(read).first
+            reads = named ? "the state `#{named}`" : "a state"
+
+            visitor.slot_error(
+              "`#{server.slice}` is server Ruby inside a condition that also reads #{reads}. The client resolves each side of `#{node.is_a?(Prism::AndNode) ? "&&" : "||"}` itself and has no value for this one.",
+              anchor.locate(server),
+              :read,
+              suggestion: "Move `#{server.slice}` into its own conditional around this one, or declare a state for it and set it from app code."
+            )
           end
 
           #: (untyped, untyped) -> Array[untyped]
@@ -413,7 +441,7 @@ module Herb
             location = default&.location || state.name&.location || parsing.location
 
             if state.kind == "missing" || default.nil?
-              return refused(name, "The state `#{name}` has no default. Give it one, since the server renders a value for every state, like `(#{name}: false)`.", visitor, state.name&.location || parsing.location)
+              return refused(name, "The state `#{name}` has no default. The server renders a value for every state, so there is nothing to render or to seed the client with.", visitor, state.name&.location || parsing.location, suggestion: "Give it a default, like `(#{name}: false)`.")
             end
 
             source = default.content.to_s
@@ -423,11 +451,11 @@ module Herb
 
             case state.kind
             when "float"
-              refused(name, "The state `#{name}` has a Float default. Ruby and JavaScript disagree on how to print a float, so declare it as an Integer or a String instead.", visitor, location, source)
+              refused(name, "The state `#{name}` has a Float default. Ruby and JavaScript disagree on how to print a float, so the server and the client would render different text.", visitor, location, default: source, suggestion: "Declare it as an Integer or a String instead.")
             when "array"
-              refused(name, "The state `#{name}` has an Array default. A list on the page is a collection of items, so declare an item-scoped boolean inside the loop instead.", visitor, location, source)
+              refused(name, "The state `#{name}` has an Array default. A list on the page is a collection of items, not one state holding many values.", visitor, location, default: source, suggestion: "Declare an item-scoped state inside the loop instead.")
             when "hash"
-              refused(name, "The state `#{name}` has a Hash default. Declare each leaf as its own state, like `(#{name}_title: \"\")`.", visitor, location, source)
+              refused(name, "The state `#{name}` has a Hash default. A state holds one value the client can write and read back.", visitor, location, default: source, suggestion: "Declare each leaf as its own state, like `(#{name}_title: \"\")`.")
             when "bare"
               derived_default(name, source, location, parsing) || bare_default(name, source, location, parsing)
             else
@@ -436,9 +464,11 @@ module Herb
             end
           end
 
-          #: (String, String, untyped, Herb::Location?, ?String) -> Declaration
-          def refused(name, message, visitor, location, default = "nil")
-            visitor.slot_error(message, location, :declaration)
+          #: (String, String, untyped, Herb::Location?, **untyped) -> Declaration
+          def refused(name, message, visitor, location, **options)
+            default = options.fetch(:default, "nil") #: String
+
+            visitor.slot_error(message, location, :declaration, suggestion: options[:suggestion])
 
             Declaration.new(name: name, kind: :seeded, default: default, derived: nil, line: nil, column: nil)
           end
@@ -452,12 +482,12 @@ module Herb
             return nil if value.nil?
 
             said = visitor.diagnostic_count
-            read = tree_read(value, declared, visitor, location) #: untyped
+            read = tree_read(value, declared, visitor, StateAnchor.new(location, context: :default)) #: untyped
 
             return Declaration.new(name: name, kind: :seeded, default: source, derived: nil, line: nil, column: nil) if visitor.diagnostic_count > said
 
             if read == :computed
-              return refused(name, "The state `#{name}` defaults to `#{source}`, which mixes state reads with other Ruby. A derived state reads only other states and a seed reads none, so split the two apart.", visitor, location, source)
+              return refused(name, "The state `#{name}` defaults to `#{source}`, which mixes state reads with other Ruby. A derived state reads only other states and a seed reads none.", visitor, location, default: source, suggestion: "Split the two apart, so `#{name}` derives from states only.")
             end
 
             if read.nil?
@@ -465,11 +495,11 @@ module Herb
               (parsing.names - declared.keys - [name]).each { |candidate| later[candidate] = true }
 
               if mentions_any?(source, later)
-                return refused(name, "The state `#{name}` reads a state declared after it. A derived state reads only states declared before it, so move `#{name}` after the states it reads.", visitor, location)
+                return refused(name, "The state `#{name}` reads a state declared after it. A derived state reads only states declared before it.", visitor, location, suggestion: "Move `#{name}` after the states it reads.")
               end
 
               if mentions_any?(source, declared)
-                return refused(name, "The state `#{name}` defaults to `#{source}`, which mixes state reads with other Ruby. A derived state reads only other states and a seed reads none, so split the two apart.", visitor, location, source)
+                return refused(name, "The state `#{name}` defaults to `#{source}`, which mixes state reads with other Ruby. A derived state reads only other states and a seed reads none.", visitor, location, default: source, suggestion: "Split the two apart, so `#{name}` derives from states only.")
               end
 
               return nil
@@ -494,13 +524,13 @@ module Herb
             end
 
             if parsing.enclosing.key?(identifier)
-              return refused(name, "The state `#{name}` reads `#{identifier}` from an enclosing scope. A derived state reads only states from its own signature, so declare `#{name}` beside the states it reads.", visitor, location)
+              return refused(name, "The state `#{name}` reads `#{identifier}` from an enclosing scope. A derived state reads only states from its own signature.", visitor, location, suggestion: "Declare `#{name}` beside the states it reads.")
             end
 
             kind = parsing.locals[identifier]
 
             unless kind
-              return refused(name, "The state `#{name}` defaults to `#{identifier}`, which is not a declared strict local. A name that was never passed raises at render, so add `#{identifier}` to the `locals:` signature.", visitor, location)
+              return refused(name, "The state `#{name}` defaults to `#{identifier}`, which is not a declared strict local. A name that was never passed raises at render.", visitor, location, suggestion: "Add `#{identifier}` to the `locals:` signature.")
             end
 
             Declaration.new(name: name, kind: kind, default: identifier, derived: nil, line: nil, column: nil)
@@ -517,8 +547,8 @@ module Herb
             body.one? ? body.first : nil
           end
 
-          #: (untyped, Hash[String, Declaration], untyped, Herb::Location?) -> Read?
-          def bare_read(node, states, _visitor, _location)
+          #: (untyped, Hash[String, Declaration], untyped, StateAnchor) -> Read?
+          def bare_read(node, states, _visitor, _anchor)
             if node.is_a?(Prism::LocalVariableReadNode)
               declaration = states[node.name.to_s]
 
@@ -539,13 +569,13 @@ module Herb
             Read.new(name: name, comparand: nil, kind: declaration.kind, operator: nil, against: nil, transform: nil, against_transform: nil)
           end
 
-          #: (untyped, Hash[String, Declaration], untyped, Herb::Location?) -> Read?
-          def operand_read(node, states, visitor, location)
-            bare_read(node, states, visitor, location) || transform_read(node, states, visitor, location)
+          #: (untyped, Hash[String, Declaration], untyped, StateAnchor) -> Read?
+          def operand_read(node, states, visitor, anchor)
+            bare_read(node, states, visitor, anchor) || transform_read(node, states, visitor, anchor)
           end
 
-          #: (untyped, Hash[String, Declaration], untyped, Herb::Location?) -> Read?
-          def transform_read(node, states, visitor, location)
+          #: (untyped, Hash[String, Declaration], untyped, StateAnchor) -> Read?
+          def transform_read(node, states, visitor, anchor)
             return nil unless node.is_a?(Prism::CallNode)
 
             transform = TRANSFORMS[node.name.to_s]
@@ -557,21 +587,21 @@ module Herb
 
             return nil unless receiver
 
-            read = bare_read(receiver, states, visitor, location)
+            read = bare_read(receiver, states, visitor, anchor)
 
             return nil unless read.is_a?(Read)
 
             kinds = transform.fetch(:kinds)
 
             if kinds && read.kind != :seeded && !kinds.include?(read.kind)
-              return visitor.slot_error("`#{node.slice}` reads the #{read.kind.to_s.capitalize} state `#{read.name}` with `#{node.name}`. Only #{transform.fetch(:only)} can be read with `#{node.name}`, so compare `#{read.name}` itself instead.", location, :read)
+              return visitor.slot_error("`#{node.slice}` reads the #{read.kind.to_s.capitalize} state `#{read.name}` with `#{node.name}`. Only #{transform.fetch(:only)} can be read with `#{node.name}`.", anchor.locate(node), :read, suggestion: "Compare `#{read.name}` itself instead, like `#{read.name} == #{states.fetch(read.name).default}`.")
             end
 
             Read.new(name: read.name, comparand: nil, kind: transform.fetch(:returns), operator: nil, against: nil, transform: transform.fetch(:operation), against_transform: nil)
           end
 
-          #: (untyped, Hash[String, Declaration], untyped, Herb::Location?) -> Read?
-          def predicate_read(node, states, visitor, location)
+          #: (untyped, Hash[String, Declaration], untyped, StateAnchor) -> Read?
+          def predicate_read(node, states, visitor, anchor)
             return nil unless node.is_a?(Prism::CallNode)
 
             predicate = PREDICATES[node.name.to_s]
@@ -583,25 +613,25 @@ module Herb
 
             return nil unless receiver
 
-            read = bare_read(receiver, states, visitor, location)
+            read = bare_read(receiver, states, visitor, anchor)
 
             return nil unless read.is_a?(Read)
 
             kinds = predicate[:kinds]
 
             if kinds && read.kind != :seeded && !kinds.include?(read.kind)
-              return visitor.slot_error("`#{node.slice}` reads the #{read.kind.to_s.capitalize} state `#{read.name}` with `#{node.name}`. Only #{predicate.fetch(:only)} can be read with `#{node.name}`, so compare `#{read.name}` to a literal instead.", location, :read)
+              return visitor.slot_error("`#{node.slice}` reads the #{read.kind.to_s.capitalize} state `#{read.name}` with `#{node.name}`. Only #{predicate.fetch(:only)} can be read with `#{node.name}`.", anchor.locate(node), :read, suggestion: "Compare `#{read.name}` to a literal instead, or declare it as #{kind_article(predicate.fetch(:kinds)&.first)} state.")
             end
 
             Read.new(name: read.name, comparand: predicate[:comparand], kind: read.kind, operator: predicate[:operator], against: nil, transform: nil, against_transform: nil)
           end
 
-          #: (untyped, Hash[String, Declaration], untyped, Herb::Location?) -> (Read | Combo)?
-          def negated_read(node, states, visitor, location)
+          #: (untyped, Hash[String, Declaration], untyped, StateAnchor) -> (Read | Combo)?
+          def negated_read(node, states, visitor, anchor)
             return nil unless node.is_a?(Prism::CallNode) && node.name == :!
             return nil unless node.receiver && node.arguments.nil? && node.block.nil?
 
-            inner = tree_read(unwrap_parentheses(node.receiver), states, visitor, location)
+            inner = tree_read(unwrap_parentheses(node.receiver), states, visitor, anchor)
 
             return nil unless inner.is_a?(Read) || inner.is_a?(Combo)
 
@@ -619,8 +649,8 @@ module Herb
             read.with(operator: NEGATED_OPERATORS.fetch(read.operator || "=="), kind: :boolean)
           end
 
-          #: (untyped, Hash[String, Declaration], untyped, Herb::Location?) -> Read?
-          def equality_read(node, states, visitor, location)
+          #: (untyped, Hash[String, Declaration], untyped, StateAnchor) -> Read?
+          def equality_read(node, states, visitor, anchor)
             return nil unless node.is_a?(Prism::CallNode)
             return nil unless node.name == :== || node.name == :!= || ORDERED_OPERATORS.include?(node.name)
 
@@ -629,21 +659,21 @@ module Herb
 
             return nil unless left && right && node.arguments&.arguments&.one?
 
-            left_read = operand_read(left, states, visitor, location)
-            right_read = operand_read(right, states, visitor, location)
+            left_read = operand_read(left, states, visitor, anchor)
+            right_read = operand_read(right, states, visitor, anchor)
             read = left_read || right_read
 
             return nil unless read
 
             if left_read && right_read
-              return state_pair_read(node, left_read, right_read, visitor, location)
+              return state_pair_read(node, left_read, right_read, visitor, anchor)
             end
 
             literal = left_read ? right : left
             kind = KINDS[literal.class.name]
 
             unless kind
-              return visitor.slot_error("`#{node.slice}` compares the state `#{read.name}` against something that is not a literal. The client resolves a comparison by lookup, so compare against a literal instead.", location, :compare)
+              return visitor.slot_error("`#{node.slice}` compares the state `#{read.name}` against `#{literal.slice}`, which is not a literal. The client resolves a comparison by looking the state up, so it has no value for the other side.", anchor.locate(literal), :compare, suggestion: "Compare `#{read.name}` to a literal, like `#{read.name} == #{states.fetch(read.name).default}`, or declare a state for `#{literal.slice}` and set it from app code.")
             end
 
             operator = node.name == :== ? nil : node.name.to_s
@@ -651,22 +681,22 @@ module Herb
             ordered = operator && operator != "!="
 
             if ordered && read.kind != :integer && read.kind != :seeded
-              return visitor.slot_error("`#{node.slice}` orders #{subject_phrase(read)}. Ordering compares numbers, so declare `#{read.name}` as an Integer or compare it with `==` instead.", location, :compare)
+              return visitor.slot_error("`#{node.slice}` orders #{subject_phrase(read)}. Ordering compares numbers.", anchor.locate(node), :compare, suggestion: "Declare `#{read.name}` as an Integer, like `(#{read.name}: 0)`, or compare it with `==` instead.")
             end
 
             if ordered && kind != :integer
-              return visitor.slot_error("`#{node.slice}` orders the state `#{read.name}` against #{kind_article(kind)} literal. Ordering compares numbers, so compare it against an Integer literal instead.", location, :compare)
+              return visitor.slot_error("`#{node.slice}` orders the state `#{read.name}` against #{kind_article(kind)} literal. Ordering compares numbers.", anchor.locate(literal), :compare, suggestion: "Compare `#{read.name}` against an Integer literal, like `#{read.name} > 0`.")
             end
 
             unless ordered || kind == read.kind || kind == :nil || read.kind == :seeded
-              return visitor.slot_error("`#{node.slice}` compares #{subject_phrase(read)} against #{kind_article(kind)} literal, so it can never match. Compare it against #{kind_article(read.kind)} literal instead.", location, :compare)
+              return visitor.slot_error("`#{node.slice}` compares #{subject_phrase(read)} against #{kind_article(kind)} literal, so it can never match.", anchor.locate(literal), :compare, suggestion: "Compare it against #{kind_article(read.kind)} literal, like `#{read.name} == #{states.fetch(read.name).default}`.")
             end
 
             Read.new(name: read.name, comparand: literal.slice, kind: read.kind, operator: operator, against: nil, transform: read.transform, against_transform: nil)
           end
 
-          #: (untyped, Read, Read, untyped, Herb::Location?) -> Read?
-          def state_pair_read(node, left, right, visitor, location)
+          #: (untyped, Read, Read, untyped, StateAnchor) -> Read?
+          def state_pair_read(node, left, right, visitor, anchor)
             operator = node.name == :== ? nil : node.name.to_s
 
             if right.transform && !left.transform
@@ -677,11 +707,11 @@ module Herb
             ordered = operator && operator != "!="
 
             if ordered && (left.kind != :integer || right.kind != :integer) && left.kind != :seeded && right.kind != :seeded
-              return visitor.slot_error("`#{node.slice}` orders #{subject_phrase(left)} against #{subject_phrase(right)}. Ordering compares numbers, so both sides have to be Integers.", location, :compare)
+              return visitor.slot_error("`#{node.slice}` orders #{subject_phrase(left)} against #{subject_phrase(right)}. Ordering compares numbers.", anchor.locate(node), :compare, suggestion: "Make both sides Integers, or compare them with `==` instead.")
             end
 
             if !ordered && left.kind != right.kind && left.kind != :seeded && right.kind != :seeded
-              return visitor.slot_error("`#{node.slice}` compares #{subject_phrase(left)} with #{subject_phrase(right)}, so it can never match. Compare values of the same kind.", location, :compare)
+              return visitor.slot_error("`#{node.slice}` compares #{subject_phrase(left)} with #{subject_phrase(right)}, so it can never match.", anchor.locate(node), :compare, suggestion: "Compare values of the same kind, or redeclare one of the two states.")
             end
 
             Read.new(name: left.name, comparand: nil, kind: left.kind, operator: operator, against: right.name, transform: left.transform, against_transform: right.transform)

--- a/lib/herb/engine/slots/visitor.rb
+++ b/lib/herb/engine/slots/visitor.rb
@@ -36,6 +36,8 @@ module Herb
       #     visitors = mode ? [Herb::Engine::Slots::Visitor.new(mode: mode)] : []
       #
       class Visitor < Herb::Visitor
+        STATE_FAMILIES = [:read, :compare, :declaration, :conditional, :count, :assignment].freeze #: Array[Symbol]
+
         extend Herb::Visitor::Experimental
         include Herb::Visitor::ContextAware
         include Herb::Visitor::Diagnostics
@@ -183,13 +185,18 @@ module Herb
           @degraded
         end
 
-        #: (String, Herb::Location?, Symbol) -> nil
-        def slot_error(message, location, family)
-          error(message, location, code: "slots-#{family}")
+        #: (String, Herb::Location?, Symbol, ?suggestion: String?) -> nil
+        def slot_error(message, location, family, suggestion: nil)
+          error(message, location, code: diagnostic_code_for(family), suggestion: suggestion)
 
           @degraded = true
 
           nil
+        end
+
+        #: (Symbol) -> String
+        def diagnostic_code_for(family)
+          STATE_FAMILIES.include?(family) ? "herb-state-#{family}" : "slots-#{family}"
         end
 
         #: () -> String
@@ -915,7 +922,7 @@ module Herb
           name = static_attribute_value(name_attribute)
 
           unless name && !name.empty?
-            return slot_error("`#{NAME_ATTRIBUTE}` on `<#{node.tag_name&.value}>` is computed or empty. A slot name is an address the browser looks up, so give it a static, non-empty value.", name_attribute.location, :name)
+            return slot_error("`#{NAME_ATTRIBUTE}` on `<#{node.tag_name&.value}>` is computed or empty. A slot name is an address the browser looks up, so it has to be known before the page renders.", name_attribute.location, :name, suggestion: "Give it a static, non-empty value.")
           end
 
           candidates = @annotations[base..].to_a.select { |annotation|
@@ -956,15 +963,15 @@ module Herb
           return unless annotation
 
           if scope_names.key?(name)
-            return slot_error("Two slots in the same scope are both named `#{name}`. A slot name is an address, so give one of them a different name.", name_location(named), :name)
+            return slot_error("Two slots in the same scope are both named `#{name}`. A slot name is an address, and two slots cannot share one.", name_location(named), :name, suggestion: "Give one of them a different name.")
           end
 
           if (existing = annotation.name)
-            return slot_error("`#{NAME_ATTRIBUTE}=\"#{name}\"` claims the slot already named `#{existing}`. Both elements hold the same slot, so keep one name or wrap what each should address in its own element.", name_location(named), :name)
+            return slot_error("`#{NAME_ATTRIBUTE}=\"#{name}\"` claims the slot already named `#{existing}`. Both elements hold the same slot.", name_location(named), :name, suggestion: "Keep one of the two names, or wrap what each should address in its own element.")
           end
 
           if attribute_conflict?(name, annotation, named[:scope])
-            return slot_error("The name `#{name}` collides with the `#{name}` attribute slot in the same scope. An attribute slot is already addressable by its attribute, so drop the name or rename it.", name_location(named), :name)
+            return slot_error("The name `#{name}` collides with the `#{name}` attribute slot in the same scope. An attribute slot is already addressable by its attribute.", name_location(named), :name, suggestion: "Drop the name, or rename it.")
           end
 
           scope_names[name] = annotation
@@ -979,11 +986,11 @@ module Herb
           candidates = named[:candidates].reject(&:dropped).map(&:survivor).uniq
 
           if candidates.empty?
-            return slot_error("`#{NAME_ATTRIBUTE}=\"#{name}\"` on `<#{tag}>` names no slot, since the element holds nothing dynamic. Move the name onto an element that wraps an ERB output, or remove it.", name_location(named), :name)
+            return slot_error("`#{NAME_ATTRIBUTE}=\"#{name}\"` on `<#{tag}>` names no slot, since the element holds nothing dynamic.", name_location(named), :name, suggestion: "Move the name onto an element that wraps an ERB output, or remove it.")
           end
 
           unless candidates.one?
-            return slot_error("`#{NAME_ATTRIBUTE}=\"#{name}\"` on `<#{tag}>` is ambiguous between #{candidates.size} slots. Wrap the one it should name in its own element.", name_location(named), :name)
+            return slot_error("`#{NAME_ATTRIBUTE}=\"#{name}\"` on `<#{tag}>` is ambiguous between #{candidates.size} slots.", name_location(named), :name, suggestion: "Wrap the one it should name in its own element.")
           end
 
           candidates.fetch(0)

--- a/sig/herb/engine/slots/state_anchor.rbs
+++ b/sig/herb/engine/slots/state_anchor.rbs
@@ -1,0 +1,35 @@
+# Generated from lib/herb/engine/slots/state_anchor.rb with RBS::Inline
+
+module Herb
+  class Engine
+    module Slots
+      # Points a diagnostic at the part of an expression that is actually wrong.
+      #
+      # A condition reaches the state compiler as a string that was cut out of an ERB token, so a
+      # Prism node inside it knows only its own offset within that string. This carries the token
+      # the string came from and turns those offsets back into a location in the template. When it
+      # has nothing to work with it answers the whole node's location, which is what every
+      # diagnostic used before.
+      class StateAnchor
+        attr_reader location: Herb::Location?
+
+        # : (Herb::Location?, ?token: Herb::Token?, ?expression: String?, ?context: Symbol) -> void
+        def initialize: (Herb::Location?, ?token: Herb::Token?, ?expression: String?, ?context: Symbol) -> void
+
+        # : () -> bool
+        def condition?: () -> bool
+
+        # : (::Prism::Node) -> Herb::Location?
+        def locate: (::Prism::Node) -> Herb::Location?
+
+        private
+
+        # : (::Prism::Node) -> Integer?
+        def character_offset: (::Prism::Node) -> Integer?
+
+        # : (Integer) -> Herb::Position
+        def advance: (Integer) -> Herb::Position
+      end
+    end
+  end
+end

--- a/sig/herb/engine/slots/state_compiler.rbs
+++ b/sig/herb/engine/slots/state_compiler.rbs
@@ -96,6 +96,15 @@ module Herb
         # : (untyped, Hash[String, StateDirectives::Declaration]) -> Hash[Symbol, untyped]?
         def state_case_for: (untyped, Hash[String, StateDirectives::Declaration]) -> Hash[Symbol, untyped]?
 
+        # : (String, Hash[String, StateDirectives::Declaration]) -> StateDirectives::Declaration?
+        def mentioned_state: (String, Hash[String, StateDirectives::Declaration]) -> StateDirectives::Declaration?
+
+        # : (StateDirectives::Declaration?) -> String
+        def read_advice: (StateDirectives::Declaration?) -> String
+
+        # : (untyped, String) -> StateAnchor
+        def condition_anchor: (untyped, String) -> StateAnchor
+
         # : (untyped) -> String
         def condition_expression: (untyped) -> String
 

--- a/sig/herb/engine/slots/state_directives.rbs
+++ b/sig/herb/engine/slots/state_directives.rbs
@@ -122,8 +122,8 @@ module Herb
         end
 
         module Silent
-          # : (String, Herb::Location?, Symbol) -> nil
-          def self.slot_error: (String, Herb::Location?, Symbol) -> nil
+          # : (String, Herb::Location?, Symbol, **untyped) -> nil
+          def self.slot_error: (String, Herb::Location?, Symbol, **untyped) -> nil
 
           # : (?Symbol?) -> Integer
           def self.diagnostic_count: (?Symbol?) -> Integer
@@ -132,17 +132,20 @@ module Herb
         # : (untyped, Hash[String, Symbol], visitor: untyped, ?enclosing: Hash[String, Declaration]) -> Array[Declaration]
         def self.parse: (untyped, Hash[String, Symbol], visitor: untyped, ?enclosing: Hash[String, Declaration]) -> Array[Declaration]
 
-        # : (String, Hash[String, Declaration], untyped, Herb::Location?) -> (Read | Combo | Symbol)?
-        def self.condition_read: (String, Hash[String, Declaration], untyped, Herb::Location?) -> (Read | Combo | Symbol)?
+        # : (String, Hash[String, Declaration], untyped, (StateAnchor | Herb::Location)?) -> (Read | Combo | Symbol)?
+        def self.condition_read: (String, Hash[String, Declaration], untyped, (StateAnchor | Herb::Location)?) -> (Read | Combo | Symbol)?
 
-        # : (untyped, Hash[String, Declaration], untyped, Herb::Location?) -> (Read | Combo | Symbol)?
-        def self.tree_read: (untyped, Hash[String, Declaration], untyped, Herb::Location?) -> (Read | Combo | Symbol)?
+        # : (untyped, Hash[String, Declaration], untyped, (StateAnchor | Herb::Location)?) -> (Read | Combo | Symbol)?
+        def self.tree_read: (untyped, Hash[String, Declaration], untyped, (StateAnchor | Herb::Location)?) -> (Read | Combo | Symbol)?
 
         # : (untyped) -> untyped
         def self.unwrap_parentheses: (untyped) -> untyped
 
-        # : (untyped, Hash[String, Declaration], untyped, Herb::Location?) -> (Combo | Symbol)?
-        def self.combo_read: (untyped, Hash[String, Declaration], untyped, Herb::Location?) -> (Combo | Symbol)?
+        # : (untyped, Hash[String, Declaration], untyped, StateAnchor) -> (Combo | Symbol)?
+        def self.combo_read: (untyped, Hash[String, Declaration], untyped, StateAnchor) -> (Combo | Symbol)?
+
+        # : (untyped, untyped, untyped, untyped, StateAnchor) -> nil
+        def self.mixed_combo: (untyped, untyped, untyped, untyped, StateAnchor) -> nil
 
         # : (untyped, untyped) -> Array[untyped]
         def self.flatten_combo: (untyped, untyped) -> Array[untyped]
@@ -195,8 +198,8 @@ module Herb
         # : (untyped, Parsing) -> Declaration
         private def self.classify: (untyped, Parsing) -> Declaration
 
-        # : (String, String, untyped, Herb::Location?, ?String) -> Declaration
-        private def self.refused: (String, String, untyped, Herb::Location?, ?String) -> Declaration
+        # : (String, String, untyped, Herb::Location?, **untyped) -> Declaration
+        private def self.refused: (String, String, untyped, Herb::Location?, **untyped) -> Declaration
 
         # : (String, String, Herb::Location?, Parsing) -> Declaration?
         private def self.derived_default: (String, String, Herb::Location?, Parsing) -> Declaration?
@@ -210,29 +213,29 @@ module Herb
         # : (String) -> untyped
         private def self.expression_node: (String) -> untyped
 
-        # : (untyped, Hash[String, Declaration], untyped, Herb::Location?) -> Read?
-        private def self.bare_read: (untyped, Hash[String, Declaration], untyped, Herb::Location?) -> Read?
+        # : (untyped, Hash[String, Declaration], untyped, StateAnchor) -> Read?
+        private def self.bare_read: (untyped, Hash[String, Declaration], untyped, StateAnchor) -> Read?
 
-        # : (untyped, Hash[String, Declaration], untyped, Herb::Location?) -> Read?
-        private def self.operand_read: (untyped, Hash[String, Declaration], untyped, Herb::Location?) -> Read?
+        # : (untyped, Hash[String, Declaration], untyped, StateAnchor) -> Read?
+        private def self.operand_read: (untyped, Hash[String, Declaration], untyped, StateAnchor) -> Read?
 
-        # : (untyped, Hash[String, Declaration], untyped, Herb::Location?) -> Read?
-        private def self.transform_read: (untyped, Hash[String, Declaration], untyped, Herb::Location?) -> Read?
+        # : (untyped, Hash[String, Declaration], untyped, StateAnchor) -> Read?
+        private def self.transform_read: (untyped, Hash[String, Declaration], untyped, StateAnchor) -> Read?
 
-        # : (untyped, Hash[String, Declaration], untyped, Herb::Location?) -> Read?
-        private def self.predicate_read: (untyped, Hash[String, Declaration], untyped, Herb::Location?) -> Read?
+        # : (untyped, Hash[String, Declaration], untyped, StateAnchor) -> Read?
+        private def self.predicate_read: (untyped, Hash[String, Declaration], untyped, StateAnchor) -> Read?
 
-        # : (untyped, Hash[String, Declaration], untyped, Herb::Location?) -> (Read | Combo)?
-        private def self.negated_read: (untyped, Hash[String, Declaration], untyped, Herb::Location?) -> (Read | Combo)?
+        # : (untyped, Hash[String, Declaration], untyped, StateAnchor) -> (Read | Combo)?
+        private def self.negated_read: (untyped, Hash[String, Declaration], untyped, StateAnchor) -> (Read | Combo)?
 
         # : (Read | Combo) -> (Read | Combo)
         private def self.negate: (Read | Combo) -> (Read | Combo)
 
-        # : (untyped, Hash[String, Declaration], untyped, Herb::Location?) -> Read?
-        private def self.equality_read: (untyped, Hash[String, Declaration], untyped, Herb::Location?) -> Read?
+        # : (untyped, Hash[String, Declaration], untyped, StateAnchor) -> Read?
+        private def self.equality_read: (untyped, Hash[String, Declaration], untyped, StateAnchor) -> Read?
 
-        # : (untyped, Read, Read, untyped, Herb::Location?) -> Read?
-        private def self.state_pair_read: (untyped, Read, Read, untyped, Herb::Location?) -> Read?
+        # : (untyped, Read, Read, untyped, StateAnchor) -> Read?
+        private def self.state_pair_read: (untyped, Read, Read, untyped, StateAnchor) -> Read?
       end
     end
   end

--- a/sig/herb/engine/slots/visitor.rbs
+++ b/sig/herb/engine/slots/visitor.rbs
@@ -19,6 +19,8 @@ module Herb
       #     mode = Herb::Engine::Slots::Visitor.directive_mode(source)
       #     visitors = mode ? [Herb::Engine::Slots::Visitor.new(mode: mode)] : []
       class Visitor < Herb::Visitor
+        STATE_FAMILIES: Array[Symbol]
+
         extend Herb::Visitor::Experimental
 
         include Herb::Visitor::ContextAware
@@ -128,8 +130,11 @@ module Herb
         # : () -> bool
         def degraded?: () -> bool
 
-        # : (String, Herb::Location?, Symbol) -> nil
-        def slot_error: (String, Herb::Location?, Symbol) -> nil
+        # : (String, Herb::Location?, Symbol, ?suggestion: String?) -> nil
+        def slot_error: (String, Herb::Location?, Symbol, ?suggestion: String?) -> nil
+
+        # : (Symbol) -> String
+        def diagnostic_code_for: (Symbol) -> String
 
         # : () -> String
         def version: () -> String

--- a/test/engine/report/error_page_test.rb
+++ b/test/engine/report/error_page_test.rb
@@ -34,7 +34,7 @@ module Engine
       Herb::Diagnostic.new(
         template: "app/views/posts/_post.html.erb",
         message: "The state `rate` has a Float default.",
-        code: "slots-declaration",
+        code: "herb-state-declaration",
         origin: "Herb Compiler",
         location: Herb::Location.from(3, 4, 3, 9),
         suggestion: "Declare it as an Integer or a String instead."
@@ -143,7 +143,7 @@ module Engine
 
         entries = payload(body.first)["diagnostics"]
 
-        assert_equal(["MissingClosingTagError", "slots-declaration"], entries.map { |entry| entry["code"] })
+        assert_equal(["MissingClosingTagError", "herb-state-declaration"], entries.map { |entry| entry["code"] })
         assert_equal(["blocking", "blocking"], entries.map { |entry| entry["overlay"] })
       end
 

--- a/test/engine/report/session_test.rb
+++ b/test/engine/report/session_test.rb
@@ -91,7 +91,7 @@ module Engine
     end
 
     def compiled_entry
-      { message: "m", code: "slots-declaration", severity: :error, origin: "Herb Compiler", phase: :compile }
+      { message: "m", code: "herb-state-declaration", severity: :error, origin: "Herb Compiler", phase: :compile }
     end
 
     def in_project(contents = "<div>\n  <span>\n</div>\n")
@@ -142,7 +142,7 @@ module Engine
         Herb::Engine::Runtime::Session.record_compile_diagnostics("app/views/gone.html.erb", [compiled_entry])
       end
 
-      assert_equal ["slots-declaration"], session.report.diagnostics.map(&:code)
+      assert_equal ["herb-state-declaration"], session.report.diagnostics.map(&:code)
       assert_empty session.report.sources
     end
 

--- a/test/engine/slots/diagnostics_test.rb
+++ b/test/engine/slots/diagnostics_test.rb
@@ -11,7 +11,7 @@ module Engine
     class DiagnosticsTest < Minitest::Spec
       include SnapshotUtils
 
-      FLOAT_DEFAULT = "The state `rate` has a Float default. Ruby and JavaScript disagree on how to print a float, so declare it as an Integer or a String instead." #: String
+      FLOAT_DEFAULT = "The state `rate` has a Float default. Ruby and JavaScript disagree on how to print a float, so the server and the client would render different text." #: String
 
       THREE_BAD_STATES = <<~ERB
         <h1>Report</h1>
@@ -83,8 +83,8 @@ module Engine
         assert_equal(
           [
             FLOAT_DEFAULT,
-            "The state `draft` has a Hash default. Declare each leaf as its own state, like `(draft_title: \"\")`.",
-            "The state `tally` has an Array default. A list on the page is a collection of items, so declare an item-scoped boolean inside the loop instead."
+            "The state `draft` has a Hash default. A state holds one value the client can write and read back.",
+            "The state `tally` has an Array default. A list on the page is a collection of items, not one state holding many values."
           ],
           diagnostics.map(&:message)
         )
@@ -93,13 +93,13 @@ module Engine
       test "one template reports problems from unrelated parts of itself" do
         diagnostics, = report(THREE_FAMILIES)
 
-        assert_equal ["slots-declaration", "slots-name", "slots-compare"], diagnostics.map(&:code)
+        assert_equal ["herb-state-declaration", "slots-name", "herb-state-compare"], diagnostics.map(&:code)
 
         assert_equal(
           [
             FLOAT_DEFAULT,
-            "Two slots in the same scope are both named `body`. A slot name is an address, so give one of them a different name.",
-            "`sort == 3` compares the String state `sort` against an Integer literal, so it can never match. Compare it against a String literal instead."
+            "Two slots in the same scope are both named `body`. A slot name is an address, and two slots cannot share one.",
+            "`sort == 3` compares the String state `sort` against an Integer literal, so it can never match."
           ],
           diagnostics.map(&:message)
         )
@@ -130,7 +130,7 @@ module Engine
         assert_equal "app/views/test.html.erb", diagnostic.template
         assert_equal :error, diagnostic.severity
         assert_equal :compile, diagnostic.phase
-        assert_equal "slots-declaration", diagnostic.code
+        assert_equal "herb-state-declaration", diagnostic.code
       end
 
       test "hands the page its findings so they reach the browser" do
@@ -149,7 +149,7 @@ module Engine
       test "findings from different families both reach the page" do
         _, src = report(THREE_FAMILIES)
 
-        assert_equal ["slots-declaration", "slots-name", "slots-compare"], recorded(src).map(&:code)
+        assert_equal ["herb-state-declaration", "slots-name", "herb-state-compare"], recorded(src).map(&:code)
       end
 
       test "findings of one family on one line reach the page as one" do
@@ -178,9 +178,9 @@ module Engine
         assert_equal ["app/views/test.html.erb:2:23:", "app/views/test.html.erb:2:35:", "app/views/test.html.erb:2:57:"], shown.scan(%r{app/views/test\.html\.erb:\d+:\d+:}).uniq
         assert_equal(
           [
-            "slots-declaration: #{FLOAT_DEFAULT}",
-            "slots-declaration: The state `draft` has a Hash default. Declare each leaf as its own state, like `(draft_title: \"\")`.",
-            "slots-declaration: The state `tally` has an Array default. A list on the page is a collection of items, so declare an item-scoped boolean inside the loop instead."
+            "herb-state-declaration: #{FLOAT_DEFAULT}",
+            "herb-state-declaration: The state `draft` has a Hash default. A state holds one value the client can write and read back.",
+            "herb-state-declaration: The state `tally` has an Array default. A list on the page is a collection of items, not one state holding many values."
           ],
           error.diagnostics.map { |diagnostic| "#{diagnostic.code}: #{diagnostic.message}" }
         )

--- a/test/engine/slots/names_test.rb
+++ b/test/engine/slots/names_test.rb
@@ -67,7 +67,7 @@ module Engine
           compile(%(<p data-herb-name="pair"><%= @first %> and <%= @second %></p>))
         end
 
-        assert_equal ["`data-herb-name=\"pair\"` on `<p>` is ambiguous between 2 slots. Wrap the one it should name in its own element."], compiler_findings(error)
+        assert_equal ["`data-herb-name=\"pair\"` on `<p>` is ambiguous between 2 slots."], compiler_findings(error)
       end
 
       test "an element holding nothing dynamic names no slot" do
@@ -75,7 +75,7 @@ module Engine
           compile(%(<p data-herb-name="static">plain text</p>))
         end
 
-        assert_equal ["`data-herb-name=\"static\"` on `<p>` names no slot, since the element holds nothing dynamic. Move the name onto an element that wraps an ERB output, or remove it."], compiler_findings(error)
+        assert_equal ["`data-herb-name=\"static\"` on `<p>` names no slot, since the element holds nothing dynamic."], compiler_findings(error)
       end
 
       test "a computed name is refused" do
@@ -83,7 +83,7 @@ module Engine
           compile(%(<p data-herb-name="<%= @name %>"><%= @body %></p>))
         end
 
-        assert_equal ["`data-herb-name` on `<p>` is computed or empty. A slot name is an address the browser looks up, so give it a static, non-empty value."], compiler_findings(error)
+        assert_equal ["`data-herb-name` on `<p>` is computed or empty. A slot name is an address the browser looks up, so it has to be known before the page renders."], compiler_findings(error)
       end
 
       test "two slots in one scope cannot share a name" do
@@ -91,7 +91,7 @@ module Engine
           compile(%(<p data-herb-name="body"><%= @a %></p><div data-herb-name="body"><%= @b %></div>))
         end
 
-        assert_equal ["Two slots in the same scope are both named `body`. A slot name is an address, so give one of them a different name."], compiler_findings(error)
+        assert_equal ["Two slots in the same scope are both named `body`. A slot name is an address, and two slots cannot share one."], compiler_findings(error)
       end
 
       test "a name may repeat between an item and its region" do
@@ -110,7 +110,7 @@ module Engine
           compile(%(<div id="<%= @id %>"><p data-herb-name="id"><%= @body %></p></div>))
         end
 
-        assert_equal ["The name `id` collides with the `id` attribute slot in the same scope. An attribute slot is already addressable by its attribute, so drop the name or rename it."], compiler_findings(error)
+        assert_equal ["The name `id` collides with the `id` attribute slot in the same scope. An attribute slot is already addressable by its attribute."], compiler_findings(error)
       end
 
       test "a collapsed conditional does not shift the collision check" do
@@ -133,7 +133,7 @@ module Engine
           compile(%(<div data-herb-name="outer"><span data-herb-name="inner"><%= @x %></span></div>))
         end
 
-        assert_equal ["`data-herb-name=\"outer\"` claims the slot already named `inner`. Both elements hold the same slot, so keep one name or wrap what each should address in its own element."], compiler_findings(error)
+        assert_equal ["`data-herb-name=\"outer\"` claims the slot already named `inner`. Both elements hold the same slot."], compiler_findings(error)
       end
 
       test "a nested container's slots do not confuse the count" do

--- a/test/engine/slots/states_test.rb
+++ b/test/engine/slots/states_test.rb
@@ -151,6 +151,12 @@ module Engine
         assert_equal :seeded, visitor.state_declarations[:region].first[:kind]
       end
 
+      def diagnostic_for(template)
+        error = assert_raises(Herb::Engine::CompilationError) { compile(template) }
+
+        error.diagnostics.first #: as !nil
+      end
+
       def refuse(template, message)
         error = assert_raises(Herb::Engine::CompilationError) { compile(template) }
 
@@ -165,60 +171,60 @@ module Engine
 
         refuse(
           "<%# herb:state (rate: 1.0) %><p><%= rate %></p>",
-          "The state `rate` has a Float default. Ruby and JavaScript disagree on how to print a float, so declare it as an Integer or a String instead."
+          "The state `rate` has a Float default. Ruby and JavaScript disagree on how to print a float, so the server and the client would render different text."
         )
 
         refuse(
           "<%# herb:state (rate: 1e3) %><p><%= rate %></p>",
-          "The state `rate` has a Float default. Ruby and JavaScript disagree on how to print a float, so declare it as an Integer or a String instead."
+          "The state `rate` has a Float default. Ruby and JavaScript disagree on how to print a float, so the server and the client would render different text."
         )
 
         refuse(
           "<%# herb:state (selected: []) %><p><%= selected %></p>",
-          "The state `selected` has an Array default. A list on the page is a collection of items, so declare an item-scoped boolean inside the loop instead."
+          "The state `selected` has an Array default. A list on the page is a collection of items, not one state holding many values."
         )
 
         refuse(
           "<%# herb:state (draft: { title: \"\" }) %><p><%= draft %></p>",
-          "The state `draft` has a Hash default. Declare each leaf as its own state, like `(draft_title: \"\")`."
+          "The state `draft` has a Hash default. A state holds one value the client can write and read back."
         )
 
         refuse(
           "<%# herb:state (open: open_initially) %><p><%= open %></p>",
-          "The state `open` defaults to `open_initially`, which is not a declared strict local. A name that was never passed raises at render, so add `open_initially` to the `locals:` signature."
+          "The state `open` defaults to `open_initially`, which is not a declared strict local. A name that was never passed raises at render."
         )
 
         refuse(
           "<%# locals: (open: false) %>\n<%# herb:state (open: false) %><p><%= open %></p>",
-          "`open` is both a strict local and a state. A local comes from the caller and a state is owned by the client, so rename one of the two."
+          "`open` is both a strict local and a state. A local comes from the caller and a state is owned by the client, so the name has two owners."
         )
 
         refuse(
           "<ul><% @items.each do |item| %><%# herb:state (open: false) %><li id=\"<%= item %>\"><%= open %></li><% end %></ul>" \
           "<%# herb:state (open: false) %>",
-          "The state `open` is declared in both an item and its region. A later read could mean either one, so give them different names."
+          "The state `open` is declared in both an item and its region, so a later read could mean either one."
         )
 
         refuse(
           "<%# herb:state (attempts: 0) %><p><%= attempts + 1 %></p>",
-          "`attempts + 1` computes with a state. The client cannot evaluate Ruby, so read the state bare, read it with a predicate, or compare it to a literal."
+          "`attempts + 1` computes with the state `attempts`. The client cannot run Ruby to keep the result current."
         )
 
         refuse(
           "<%# herb:state (sort: \"name\") %><div><% if sort == 3 %>a<% end %></div>",
-          "`sort == 3` compares the String state `sort` against an Integer literal, so it can never match. Compare it against a String literal instead."
+          "`sort == 3` compares the String state `sort` against an Integer literal, so it can never match."
         )
 
         refuse(
           "<%# herb:state (sort: \"name\") %><div><% case sort %><% when SORTS %>a<% end %></div>",
-          "`when SORTS` on the state `sort` has a comparand that is not a literal. The client resolves a `when` by lookup, so compare against literals only."
+          "`when SORTS` on the state `sort` has a comparand that is not a literal. The client resolves a `when` by lookup."
         )
       end
 
       test "a `when` against a literal of another kind is refused" do
         refuse(
           "<%# herb:state (sort: \"name\") %><div><% case sort %><% when 3 %>a<% end %></div>",
-          "`when 3` compares the String state `sort` against a literal of another type, so it can never match. Compare it against a String literal instead."
+          "`when 3` compares the String state `sort` against a literal of another type, so it can never match."
         )
       end
 
@@ -233,7 +239,7 @@ module Engine
       test "a mixed conditional refuses the arm that reads no state" do
         refuse(
           "<%# herb:state (pending: false) %><div><% if pending? %>a<% elsif @admin %>b<% else %>c<% end %></div>",
-          "`@admin` sits in a state-driven conditional but reads no state. The client resolves every arm, so read a state here or move this branch out of the conditional."
+          "`@admin` sits in a state-driven conditional but reads no state. The client resolves every arm, so an arm it cannot answer would never be chosen."
         )
       end
 
@@ -293,6 +299,42 @@ module Engine
         assert_includes rendered, "Present"
       end
 
+      test "a state mistake is coded under the directive it belongs to" do
+        diagnostic = diagnostic_for(%(<%# herb:state (count: 0) %><div><% if count.empty? %>x<% end %></div>))
+
+        assert_equal "herb-state-read", diagnostic.code
+        assert_equal "Herb Compiler", diagnostic.origin
+        assert_equal "Visitor", diagnostic.data[:validator]
+      end
+
+      test "a diagnostic carries a suggestion beside its message" do
+        diagnostic = diagnostic_for(%(<%# herb:state (sort: "name") %><div><% if sort == 3 %>a<% end %></div>))
+
+        assert_equal "`sort == 3` compares the String state `sort` against an Integer literal, so it can never match.", diagnostic.message
+        assert_equal "Compare it against a String literal, like `sort == \"name\"`.", diagnostic.suggestion
+      end
+
+      test "a diagnostic points at the part of the expression that is wrong" do
+        diagnostic = diagnostic_for(<<~ERB)
+          <%# herb:state (draft: "") %>
+
+          <% if draft.length > 3 && Current.user.admin? %>
+            Long
+          <% end %>
+        ERB
+
+        assert_equal 3, diagnostic.location&.start&.line
+        assert_equal 26, diagnostic.location&.start&.column
+        assert_equal 45, diagnostic.location&.end&.column
+      end
+
+      test "a combination naming server Ruby says which side the client cannot answer" do
+        diagnostic = diagnostic_for(%(<%# herb:state (draft: "") %><div><% if draft.blank? || Current.user.admin? %>x<% end %></div>))
+
+        assert_equal "`Current.user.admin?` is server Ruby inside a condition that also reads the state `draft`. The client resolves each side of `||` itself and has no value for this one.", diagnostic.message
+        assert_equal "Move `Current.user.admin?` into its own conditional around this one, or declare a state for it and set it from app code.", diagnostic.suggestion
+      end
+
       test "a predicate compiles into the comparison it stands for" do
         {
           %(<%# herb:state (draft: "") %><div><% if draft.empty? %>x<% end %></div>) => ["draft", { "value" => "" }],
@@ -326,27 +368,27 @@ module Engine
       test "a predicate on a state of another kind is refused" do
         refuse(
           %(<%# herb:state (draft: "") %><div><% if draft.zero? %>x<% end %></div>),
-          "`draft.zero?` reads the String state `draft` with `zero?`. Only an Integer state can be read with `zero?`, so compare `draft` to a literal instead."
+          "`draft.zero?` reads the String state `draft` with `zero?`. Only an Integer state can be read with `zero?`."
         )
 
         refuse(
           %(<%# herb:state (count: 0) %><div><% if count.empty? %>x<% end %></div>),
-          "`count.empty?` reads the Integer state `count` with `empty?`. Only a String or a Symbol state can be read with `empty?`, so compare `count` to a literal instead."
+          "`count.empty?` reads the Integer state `count` with `empty?`. Only a String or a Symbol state can be read with `empty?`."
         )
 
         refuse(
           %(<%# herb:state (count: 0) %><div><% if count.blank? %>x<% end %></div>),
-          "`count.blank?` reads the Integer state `count` with `blank?`. Only a Boolean, a String or a Nil state can be read with `blank?`, so compare `count` to a literal instead."
+          "`count.blank?` reads the Integer state `count` with `blank?`. Only a Boolean, a String or a Nil state can be read with `blank?`."
         )
 
         refuse(
           %(<%# herb:state (draft: "") %><div><% if draft.positive? %>x<% end %></div>),
-          "`draft.positive?` reads the String state `draft` with `positive?`. Only an Integer state can be read with `positive?`, so compare `draft` to a literal instead."
+          "`draft.positive?` reads the String state `draft` with `positive?`. Only an Integer state can be read with `positive?`."
         )
 
         refuse(
           %(<%# herb:state (tab: :first) %><div><% if tab.present? %>x<% end %></div>),
-          "`tab.present?` reads the Symbol state `tab` with `present?`. Only a Boolean, a String or a Nil state can be read with `present?`, so compare `tab` to a literal instead."
+          "`tab.present?` reads the Symbol state `tab` with `present?`. Only a Boolean, a String or a Nil state can be read with `present?`."
         )
       end
 
@@ -427,12 +469,12 @@ module Engine
       test "length on a state of another kind is refused" do
         refuse(
           %(<%# herb:state (count: 0) %><div><% if count.length > 3 %>x<% end %></div>),
-          "`count.length` reads the Integer state `count` with `length`. Only a String or a Symbol state can be read with `length`, so compare `count` itself instead."
+          "`count.length` reads the Integer state `count` with `length`. Only a String or a Symbol state can be read with `length`."
         )
 
         refuse(
           %(<%# herb:state (count: 0) %><div><% if count.size > 3 %>x<% end %></div>),
-          "`count.size` reads the Integer state `count` with `size`. Only a String or a Symbol state can be read with `size`, so compare `count` itself instead."
+          "`count.size` reads the Integer state `count` with `size`. Only a String or a Symbol state can be read with `size`."
         )
       end
 
@@ -461,14 +503,14 @@ module Engine
       test "two transformed sides keep their kinds compatible" do
         refuse(
           %(<%# herb:state (draft: "", other: "") %><div><% if draft.length > other.to_s %>x<% end %></div>),
-          "`draft.length > other.to_s` orders the length of the state `draft` against the to_s of the state `other`. Ordering compares numbers, so both sides have to be Integers."
+          "`draft.length > other.to_s` orders the length of the state `draft` against the to_s of the state `other`. Ordering compares numbers."
         )
       end
 
       test "a transform compared against a state of another kind is refused" do
         refuse(
           %(<%# herb:state (draft: "", filter: "all") %><div><% if draft.length > filter %>x<% end %></div>),
-          "`draft.length > filter` orders the length of the state `draft` against the String state `filter`. Ordering compares numbers, so both sides have to be Integers."
+          "`draft.length > filter` orders the length of the state `draft` against the String state `filter`. Ordering compares numbers."
         )
       end
 
@@ -580,7 +622,7 @@ module Engine
         end
 
         assert_equal(
-          ["`draft.upcase` computes with a state. The client cannot evaluate Ruby, so read the state bare, read it with a predicate, or compare it to a literal."],
+          ["`draft.upcase` computes with the state `draft`. The client cannot run Ruby to keep the result current."],
           compiler_findings(error)
         )
       end
@@ -619,7 +661,7 @@ module Engine
         end
 
         assert_equal(
-          ["`status` reads a state inside an interpolated attribute that mixes other dynamic parts. A state write cannot supply the other values, so give the state its own attribute or its own output."],
+          ["`status` reads a state inside an interpolated attribute that mixes other dynamic parts. A state write cannot supply the other values."],
           compiler_findings(error)
         )
       end
@@ -654,7 +696,7 @@ module Engine
 
         refuse(
           "<%# herb:state (sort: \"name\") %><div><% if sort != 3 %>x<% end %></div>",
-          "`sort != 3` compares the String state `sort` against an Integer literal, so it can never match. Compare it against a String literal instead."
+          "`sort != 3` compares the String state `sort` against an Integer literal, so it can never match."
         )
       end
 
@@ -672,12 +714,12 @@ module Engine
       test "a state pair keeps its kinds compatible" do
         refuse(
           "<%# herb:state (sort: \"name\", attempts: 0) %><div><% if sort == attempts %>x<% end %></div>",
-          "`sort == attempts` compares the String state `sort` with the Integer state `attempts`, so it can never match. Compare values of the same kind."
+          "`sort == attempts` compares the String state `sort` with the Integer state `attempts`, so it can never match."
         )
 
         refuse(
           "<%# herb:state (sort: \"name\", other: \"x\") %><div><% if sort > other %>x<% end %></div>",
-          "`sort > other` orders the String state `sort` against the String state `other`. Ordering compares numbers, so both sides have to be Integers."
+          "`sort > other` orders the String state `sort` against the String state `other`. Ordering compares numbers."
         )
       end
 
@@ -690,12 +732,12 @@ module Engine
       test "ordering refuses non-integer states and comparands" do
         refuse(
           "<%# herb:state (sort: \"name\") %><div><% if sort > \"a\" %>x<% end %></div>",
-          "`sort > \"a\"` orders the String state `sort`. Ordering compares numbers, so declare `sort` as an Integer or compare it with `==` instead."
+          "`sort > \"a\"` orders the String state `sort`. Ordering compares numbers."
         )
 
         refuse(
           "<%# herb:state (attempts: 0) %><div><% if attempts > \"a\" %>x<% end %></div>",
-          "`attempts > \"a\"` orders the state `attempts` against a String literal. Ordering compares numbers, so compare it against an Integer literal instead."
+          "`attempts > \"a\"` orders the state `attempts` against a String literal. Ordering compares numbers."
         )
       end
 
@@ -747,7 +789,7 @@ module Engine
       test "a combo mixing a state with server code raises" do
         refuse(
           "<%# herb:state (pending: false) %><div><% if pending? && current_user.admin? %>x<% else %>y<% end %></div>",
-          "`pending? && current_user.admin?` computes with a state. The client cannot evaluate Ruby, so read the state bare, read it with a predicate, or compare it to a literal."
+          "`current_user.admin?` is server Ruby inside a condition that also reads the state `pending`. The client resolves each side of `&&` itself and has no value for this one."
         )
       end
 
@@ -810,19 +852,19 @@ module Engine
       test "a derived default mixing states with other Ruby raises" do
         refuse(
           %(<%# herb:state (pending: false, busy: pending || current_user.admin?) %><p><%= pending %></p>),
-          "The state `busy` defaults to `pending || current_user.admin?`, which mixes state reads with other Ruby. A derived state reads only other states and a seed reads none, so split the two apart."
+          "The state `busy` defaults to `pending || current_user.admin?`, which mixes state reads with other Ruby. A derived state reads only other states and a seed reads none."
         )
 
         refuse(
           %(<%# herb:state (attempts: 0, doubled: attempts + 1) %><p><%= attempts %></p>),
-          "The state `doubled` defaults to `attempts + 1`, which mixes state reads with other Ruby. A derived state reads only other states and a seed reads none, so split the two apart."
+          "The state `doubled` defaults to `attempts + 1`, which mixes state reads with other Ruby. A derived state reads only other states and a seed reads none."
         )
       end
 
       test "a derived state cannot read forward" do
         refuse(
           %(<%# herb:state (busy: pending || failed, pending: false, failed: false) %><p><%= pending %></p>),
-          "The state `busy` reads a state declared after it. A derived state reads only states declared before it, so move `busy` after the states it reads."
+          "The state `busy` reads a state declared after it. A derived state reads only states declared before it."
         )
       end
 
@@ -841,7 +883,7 @@ module Engine
 
         refuse(
           template,
-          "The state `mirror` reads `open` from an enclosing scope. A derived state reads only states from its own signature, so declare `mirror` beside the states it reads."
+          "The state `mirror` reads `open` from an enclosing scope. A derived state reads only states from its own signature."
         )
       end
 
@@ -900,7 +942,7 @@ module Engine
       test "assigning a state outside a fold raises" do
         refuse(
           %(<%# herb:state (pending: false) %><div><% pending = true %><% if pending? %>A<% end %></div>),
-          "`pending = true` assigns the state `pending`. The client never sees a server-side write, so seed the initial value in the declaration, derive it from other states, count items with `pending += 1` behind a state condition in a keyed loop, or write it at runtime with `data-herb-set` or `state.set`."
+          "`pending = true` assigns the state `pending`. The client never sees a server-side write, so the value it holds would drift from the one the server rendered."
         )
       end
 
@@ -923,7 +965,7 @@ module Engine
 
             <p><%= total %></p>
           ERB
-          "`total += 1` assigns the state `total`. The client never sees a server-side write, so seed the initial value in the declaration, derive it from other states, count items with `total += 1` behind a state condition in a keyed loop, or write it at runtime with `data-herb-set` or `state.set`."
+          "`total += 1` assigns the state `total`. The client never sees a server-side write, so the value it holds would drift from the one the server rendered."
         )
       end
 
@@ -934,7 +976,7 @@ module Engine
             <p><%= total %></p>
             <ul><% @items.each do |item| %><%# herb:key item %><% total += 1 %><li id="i<%= item %>"><%= item %></li><% end %></ul>
           ERB
-          "`total` is read before its count is complete. The server renders that read mid-count and the client cannot keep it current, so move the read after the loop."
+          "`total` is read before its count is complete. The server renders that read mid-count and the client cannot keep it current."
         )
 
         refuse(
@@ -942,7 +984,7 @@ module Engine
             <%# herb:state (total: 0) %>
             <ul><% @items.each do |item| %><%# herb:key item %><% total += 1 %><li id="i<%= item %>"><%= total %></li><% end %></ul>
           ERB
-          "`total` is read inside the loop that counts it. The count is complete only after the loop, so move the read below it."
+          "`total` is read inside the loop that counts it. The count is complete only after the loop."
         )
       end
 
@@ -952,7 +994,7 @@ module Engine
             <%# herb:state (label: "x") %>
             <ul><% @items.each do |item| %><%# herb:key item %><% label += 1 %><li id="i<%= item %>"><%= item %></li><% end %></ul>
           ERB
-          "`label += 1` counts into the String state `label`. A count is a number, so declare it as an Integer, like `(label: 0)`."
+          "`label += 1` counts into the String state `label`. A count is a number."
         )
 
         refuse(
@@ -960,7 +1002,7 @@ module Engine
             <%# herb:slots client %>
             <ul><% @items.each do |item| %><%# herb:key item %><%# herb:state (mine: 0) %><% mine += 1 %><li id="i<%= item %>"><%= item %></li><% end %></ul>
           ERB
-          "`mine += 1` counts into `mine`, which is an item state. A count lives once per region, so declare `mine` at the top of the template instead."
+          "`mine += 1` counts into `mine`, which is an item state. A count lives once per region, not once per item."
         )
 
         refuse(
@@ -969,7 +1011,7 @@ module Engine
             <ul><% @items.each do |item| %><%# herb:key item %><% total += 1 %><% total += 1 %><li id="i<%= item %>"><%= item %></li><% end %></ul>
             <p><%= total %></p>
           ERB
-          "`total` is counted twice. One state holds one count, so declare a second state for the second count."
+          "`total` is counted twice. One state holds one count."
         )
       end
 
@@ -979,7 +1021,7 @@ module Engine
             <%# herb:state (pending: false, busy: pending) %>
             <ul><% @items.each do |item| %><%# herb:key item %><% busy += 1 %><li id="i<%= item %>"><%= item %></li><% end %></ul>
           ERB
-          "`busy += 1` counts into `busy`, which is derived from `pending`. A state is either derived or counted, so drop the derivation or the count."
+          "`busy += 1` counts into `busy`, which is derived from `pending`. A state is either derived or counted, never both."
         )
       end
 
@@ -1029,7 +1071,7 @@ module Engine
       test "a computed tag helper attribute raises" do
         refuse(
           %(<%# herb:slots client %><%# herb:state (draft: "") %><%= tag.input value: draft.upcase %>),
-          "`draft.upcase` computes with a state. The client cannot evaluate Ruby, so read the state bare, read it with a predicate, or compare it to a literal."
+          "`draft.upcase` computes with the state `draft`. The client cannot run Ruby to keep the result current."
         )
       end
 
@@ -1136,7 +1178,7 @@ module Engine
         end
 
         assert_equal(
-          ["`unless attempts * 2 > 3` computes with a state. The client cannot evaluate Ruby, so read the state bare, read it with a predicate, or compare it to a literal."],
+          ["`unless attempts * 2 > 3` computes with the state `attempts`. The client resolves each condition itself and cannot run Ruby to pick a branch."],
           compiler_findings(error)
         )
       end
@@ -1207,7 +1249,7 @@ module Engine
         end
 
         assert_equal(
-          ["`muted=\"<%= status %>\"` reads the String state `status` as a presence. Only `nil` and `false` are falsy in Ruby, so the attribute could never turn off. Compare the state to a literal, or declare it as a boolean."],
+          ["`muted=\"<%= status %>\"` reads the String state `status` as a presence. Only `nil` and `false` are falsy in Ruby, so the attribute could never turn off."],
           compiler_findings(error)
         )
       end
@@ -1220,7 +1262,7 @@ module Engine
           ERB
         end
 
-        assert_includes error.message, "computes with a state"
+        assert_includes error.message, "computes with the state `draft`"
       end
 
       test "a mismatched comparand in a boolean attribute still raises" do

--- a/test/engine/slots/states_test.rb
+++ b/test/engine/slots/states_test.rb
@@ -696,7 +696,7 @@ module Engine
 
         refuse(
           "<%# herb:state (sort: \"name\") %><div><% if sort != 3 %>x<% end %></div>",
-          "`sort != 3` compares the String state `sort` against an Integer literal, so it can never match."
+          "`sort != 3` compares the String state `sort` against an Integer literal, so it always matches."
         )
       end
 


### PR DESCRIPTION
Follow up on #2467. A `herb:state` mistake reported the whole ERB tag, filed itself under a code that said nothing about `herb:state`, and put the way out inside the sentence describing the problem.

**Before**

```
## slots-read
app/views/chat/show.html.erb:9:1

`draft.length > 3 && Current.user.admin?` computes with a state. The client cannot evaluate
Ruby, so read the state bare, read it with a predicate, or compare it to a literal.
```

**After**

```
## herb-state-read
app/views/chat/show.html.erb:9:26

`Current.user.admin?` is server Ruby inside a condition that also reads the state `draft`.
The client resolves each side of `&&` itself and has no value for this one.

Suggestion: Move `Current.user.admin?` into its own conditional around this one, or declare
a state for it and set it from app code.
```


A condition reaches the state compiler as a string cut out of an ERB token, so a Prism node inside it knows only its own offset within that string. `StateAnchor` carries the token the string came from and turns those offsets back into a template location.

```erb
<% if draft.length > 3 && Current.user.admin? %>
                          ^^^^^^^^^^^^^^^^^^^
```

Two details it has to get right. Prism reports byte offsets while columns are characters, so it converts through `byteslice`, and a condition split over several lines needs the line arithmetic instead of a column delta. When it has nothing to work with it answers the whole node's location, which is what every diagnostic used before.

#### The linter says the same thing the engine says

The `herb-state-*` rules check the same mistakes the engine does, in their own words, so the same template read differently depending on whether you saw it in the editor or in the browser. The rules now carry the engine's sentences. Since the TypeScript `Diagnostic` has no `suggestion` field, an offense keeps the fix in the message, after the sentence describing the problem.

Two behaviours moved across with the prose. `herb-state-valid-reads` now names the server side of a mixed combination and puts the offense on it, the way the engine does, instead of naming the whole condition. And it refuses a presence read of a state that is never falsy, which the engine has always refused and the linter accepted.

```erb
<%# herb:state (draft: "") %>
<button disabled="<%= draft %>">Send</button>
```

> `disabled="<%= draft %>"` reads the String state `draft` as a presence. Only `nil` and `false` are falsy in Ruby, so the attribute could never turn off. Compare `draft` to a literal, like `draft == ""`, or declare it as a boolean.

Comparing the two sides turned up one engine mistake as well. A comparison against a literal of the wrong kind reported "so it can never match" for `!=` too, where the truth is the opposite.

```erb
<% if sort != 3 %>
```

> `sort != 3` compares the String state `sort` against an Integer literal, so it always matches.