### PR TITLE
Language Service: Show how a scoped block is narrowed now

### DIFF
--- a/javascript/packages/language-service/src/hover_provider.ts
+++ b/javascript/packages/language-service/src/hover_provider.ts
@@ -205,7 +205,7 @@ const SCOPED_STYLE_DOC = dedent(`
 
   \`\`\`html
   <style>
-    .title:where([data-herb-scope-1a2b3c4d], [data-herb-scope-1a2b3c4d] *) {
+    .title[data-herb-scope-1a2b3c4d] {
       color: red;
     }
   </style>

--- a/javascript/packages/language-service/test/hover_provider.test.ts
+++ b/javascript/packages/language-service/test/hover_provider.test.ts
@@ -896,7 +896,7 @@ describe("scoped style hover", () => {
 
     expect(value).toContain("**`<style scoped>`** · Herb Engine")
     expect(value).toContain("applies only to the markup in this file")
-    expect(value).toContain(".title:where([data-herb-scope-1a2b3c4d], [data-herb-scope-1a2b3c4d] *)")
+    expect(value).toContain(".title[data-herb-scope-1a2b3c4d]")
     expect(value).toContain("https://herb-tools.dev/projects/engine#scopedstyle-visitor")
   })
 


### PR DESCRIPTION
This pull request updates the `<style scoped>` hover so the example it shows is what the engine actually produces.

Since [#2453](https://github.com/marcoroth/herb/pull/2453) every element the file wrote carries the scope attribute and every rule is narrowed by that attribute, so the same block comes out as:

```html
<style>
  .title[data-herb-scope-1a2b3c4d] {
    color: red;
  }
</style>
```