### PR TITLE
Ruby: Find a Prism that carries its C sources when building from git

### DIFF
--- a/ext/herb/extconf.rb
+++ b/ext/herb/extconf.rb
@@ -7,7 +7,6 @@ extension_name = "herb"
 
 if Herb::Bootstrap.git_source? && !Herb::Bootstrap.templates_generated?
   puts "Building from source — running bootstrap..."
-  Herb::Bootstrap.generate_templates
 
   unless Herb::Bootstrap.prism_vendored?
     prism_path = Herb::Bootstrap.find_prism_gem_path
@@ -29,6 +28,8 @@ if Herb::Bootstrap.git_source? && !Herb::Bootstrap.templates_generated?
     puts "Vendoring Prism from #{prism_path}..."
     Herb::Bootstrap.vendor_prism(prism_gem_path: prism_path)
   end
+
+  Herb::Bootstrap.generate_templates
 
   root_path = Herb::Bootstrap::ROOT_PATH
   sha = `git -C #{root_path} rev-parse --short HEAD 2>/dev/null`.strip

--- a/lib/herb/bootstrap.rb
+++ b/lib/herb/bootstrap.rb
@@ -74,13 +74,9 @@ module Herb
     end
 
     def self.find_prism_from_gem_spec
-      path = Gem::Specification.find_by_name("prism").full_gem_path
-
-      return path if File.directory?(File.join(path, "src"))
-
-      nil
-    rescue Gem::MissingSpecError
-      nil
+      Gem::Specification.find_all_by_name("prism")
+                        .map(&:full_gem_path)
+                        .find { |path| File.directory?(File.join(path, "src")) }
     end
   end
 end


### PR DESCRIPTION
A git install generates part of Herb's C from Prism's `config.yml`, so it has to find a Prism with `src/` next to it. It asked RubyGems for the one Prism it considers best and gave up when that one had no sources under it.

Ruby ships Prism as a default gem, and a default gem unpacks only its `lib`. On any Ruby whose bundled Prism outranks the installed one, the answer came back sourceless and the lookup returned nil, even with a perfectly good Prism sitting behind it. `File.join` then raised a `TypeError` about nil, which says nothing about Prism at all.

Every installed Prism is considered now, newest first, and the first one carrying `src/` wins.

The check also moves above `generate_templates`, which is what needed Prism in the first place and what was raising before the check could run. So the message explaining all of this is reachable now, and it no longer claims the released gem has no C sources, which it does have.