### PR TITLE
Linter: Allow to lint a rendered page in the browser

### DIFF
--- a/javascript/packages/client/src/directives.ts
+++ b/javascript/packages/client/src/directives.ts
@@ -15,12 +15,14 @@ export { MIRRORED_COMPARISONS, NEGATED_COMPARISONS, ORDERED_COMPARISONS, COMPARI
 export { STATE_DEFAULT_KINDS, LITERAL_STATE_KINDS, UNKNOWN_STATE_KINDS, FALSY_STATE_KINDS, PRISM_LITERAL_KINDS, stateKindArticle } from "./state-kinds"
 
 export { clauses, names, balancedQuotes, splitOutsideQuotes, unquote } from "./grammar/parsing"
+export { isMarker, parseMarker } from "./markup/markers"
 
 export type { Clause } from "./grammar/parsing"
-export type { ActionName, ActionSchema, HerbAttribute } from "./grammar/attributes"
 export type { StatePredicate } from "./state-predicates"
 export type { StateTransform } from "./state-transforms"
 export type { StateDefaultKind, StateValueKind } from "./state-kinds"
+export type { ActionName, ActionSchema, HerbAttribute } from "./grammar/attributes"
+export type { MarkerData, RegionOpenMarker, RegionCloseMarker } from "./markup/markers"
 
 import { STATE_PREDICATES } from "./state-predicates"
 import { STATE_TRANSFORMS } from "./state-transforms"

--- a/javascript/packages/config/src/config-schema.ts
+++ b/javascript/packages/config/src/config-schema.ts
@@ -25,6 +25,8 @@ export const FRAMEWORKS = {
 
 export const FRAMEWORK_NAMES = Object.keys(FRAMEWORKS) as (keyof typeof FRAMEWORKS)[]
 
+export const ENVIRONMENT_NAMES = ["cli", "browser"] as const
+
 const RuleConfigBaseSchema = z.object({
   enabled: z.boolean().optional().describe("Whether the rule is enabled"),
   severity: SeverityConfigSchema.optional().describe("Severity level for the rule"),
@@ -32,6 +34,7 @@ const RuleConfigBaseSchema = z.object({
   include: z.array(z.string()).optional().describe("Additional glob patterns to include for this rule (additive, ignored when 'only' is present)"),
   only: z.array(z.string()).optional().describe("Only apply this rule to files matching these glob patterns (overrides all 'include' patterns)"),
   exclude: z.array(z.string()).optional().describe("Don't apply this rule to files matching these glob patterns"),
+  environments: z.array(z.enum(ENVIRONMENT_NAMES)).optional().describe("Where this rule runs: 'cli' for templates read from source, 'browser' for a rendered page read from a live DOM. Defaults to ['cli'], so a rule only runs against a rendered page when it says it can"),
 })
 
 export const RuleConfigSchema = RuleConfigBaseSchema.optional()
@@ -61,6 +64,8 @@ export const FormatterConfigSchema = z.object({
 }).strict().optional()
 
 export const FrameworkSchema = z.enum(FRAMEWORK_NAMES).optional()
+
+export const EnvironmentSchema = z.enum(ENVIRONMENT_NAMES)
   .describe("Framework context (default: 'ruby')")
 
 export const TemplateEngineSchema = z.enum(["erubi", "erb", "herb"]).optional()

--- a/javascript/packages/config/src/config.ts
+++ b/javascript/packages/config/src/config.ts
@@ -4,7 +4,7 @@ import packageJson from "../package.json"
 import configTemplate from "./config-template.yml"
 import defaultsYaml from "../../../../lib/herb/defaults.yml"
 
-import { stringify, parse, parseDocument, isMap, isScalar, isAlias, visit } from "yaml"
+import { stringify, parse, parseDocument, isMap, isScalar, visit } from "yaml"
 import { semverGreaterThan } from "@herb-tools/core"
 import { promises as fs, accessSync, readFileSync, readdirSync, statSync } from "fs"
 import { fromZodError } from "zod-validation-error"
@@ -13,7 +13,7 @@ import { deepMerge } from "./merge.js"
 import { ZodError, z } from "zod"
 import { HerbConfigSchema } from "./config-schema.js"
 
-import type { FrameworkSchema, TemplateEngineSchema } from "./config-schema.js"
+import type { FrameworkSchema, EnvironmentSchema, TemplateEngineSchema } from "./config-schema.js"
 
 import type { DiagnosticSeverity } from "@herb-tools/core"
 
@@ -98,6 +98,7 @@ export type RuleConfig = {
   include?: string[]
   only?: string[]
   exclude?: string[]
+  environments?: Environment[]
 }
 
 export type LinterConfig = {
@@ -134,6 +135,7 @@ export type HerbConfigOptions = {
 }
 
 export type Framework = z.infer<typeof FrameworkSchema>
+export type Environment = z.infer<typeof EnvironmentSchema>
 export type TemplateEngine = z.infer<typeof TemplateEngineSchema>
 
 export type HerbConfig = HerbConfigOptions & {

--- a/javascript/packages/config/src/index.ts
+++ b/javascript/packages/config/src/index.ts
@@ -1,5 +1,6 @@
 export { Config, resolveSeverity, ALL_RULES_KEY, defaultPersonalSettings } from "./config.js"
 export { HerbConfigSchema, FRAMEWORKS, FRAMEWORK_NAMES } from "./config-schema.js"
+export { ENVIRONMENT_NAMES } from "./config-schema.js"
 export { addHerbExtensionRecommendation, getExtensionsJsonRelativePath } from "./vscode.js"
 
 export type {
@@ -17,7 +18,8 @@ export type {
   ConfigValidationError,
   SeverityConfig,
   LinterMode,
-  PersonalHerbSettings
+  PersonalHerbSettings,
+  Environment,
 } from "./config.js"
 
 export type { VSCodeExtensionsJson } from "./vscode.js"

--- a/javascript/packages/linter/package.json
+++ b/javascript/packages/linter/package.json
@@ -23,7 +23,7 @@
     "test": "vitest run",
     "test:watch": "vitest --watch",
     "check:rule-versions": "! grep -rl 'static introducedIn = \"unreleased\"' src/rules/ 2>/dev/null || (echo '\\n\u2717 Found linter rules with introducedIn = \"unreleased\". Update them to a release version before publishing.\\n' && exit 1)",
-    "typecheck": "tsc -p tsconfig.test.json",
+    "typecheck": "tsc -p tsconfig.test.json && tsc -p tsconfig.browser-test.json",
     "prepublishOnly": "yarn check:rule-versions && yarn clean && yarn build && yarn test"
   },
   "exports": {

--- a/javascript/packages/linter/package.json
+++ b/javascript/packages/linter/package.json
@@ -40,6 +40,11 @@
       "require": "./dist/cli.cjs",
       "default": "./dist/cli.js"
     },
+    "./browser": {
+      "types": "./dist/types/browser/index.d.ts",
+      "import": "./dist/browser/index.js",
+      "default": "./dist/browser/index.js"
+    },
     "./loader": {
       "types": "./dist/types/loader.d.ts",
       "import": "./dist/loader.js",

--- a/javascript/packages/linter/rolldown.config.mjs
+++ b/javascript/packages/linter/rolldown.config.mjs
@@ -46,6 +46,17 @@ export default [
     external: isExternal,
   },
 
+  // Browser entry point (ESM only, carries no `@herb-tools/browser` parser)
+  {
+    input: "src/browser/index.ts",
+    output: {
+      file: "dist/browser/index.js",
+      format: "esm",
+      sourcemap: true,
+    },
+    external: isExternal,
+  },
+
   // Library exports (ESM)
   {
     input: "src/index.ts",

--- a/javascript/packages/linter/src/browser/backend.ts
+++ b/javascript/packages/linter/src/browser/backend.ts
@@ -1,0 +1,58 @@
+import { HerbBackend, LexResult, ParseResult, ParserOptions, TokenList } from "@herb-tools/core"
+
+import { domToAST } from "./dom-to-ast.js"
+
+import type { ParseOptions } from "@herb-tools/core"
+import type { DOMNodeLike } from "./dom-to-ast.js"
+
+export interface DOMParserLike {
+  parseFromString(source: string, type: string): DOMNodeLike
+}
+
+function ambientParser(): DOMParserLike {
+  const Parser = (globalThis as { DOMParser?: new () => DOMParserLike }).DOMParser
+
+  if (!Parser) {
+    throw new Error("HerbDOMBackend needs a DOMParser to read markup with, and there is none here")
+  }
+
+  return new Parser()
+}
+
+export class HerbDOMBackend extends HerbBackend {
+  readonly lintEnvironment = "browser" as const
+
+  private readonly parser: DOMParserLike | null
+
+  constructor(parser: DOMParserLike | null = null) {
+    super(async () => ({}) as never)
+
+    this.parser = parser
+  }
+
+  async load(): Promise<this> {
+    return this
+  }
+
+  parse<const Options extends ParseOptions>(source: string, _options?: Options): never {
+    const document = (this.parser ?? ambientParser()).parseFromString(source, "text/html")
+
+    return new ParseResult(domToAST(document), source, [], [], new ParserOptions(), null) as never
+  }
+
+  lex(source: string): LexResult {
+    return new LexResult(TokenList.from([]), source, [], [])
+  }
+
+  lexFile(_path: string): LexResult {
+    throw new Error("HerbDOMBackend reads markup, not files")
+  }
+
+  parseFile(_path: string): never {
+    throw new Error("HerbDOMBackend reads markup, not files")
+  }
+
+  backendVersion(): string {
+    return "dom"
+  }
+}

--- a/javascript/packages/linter/src/browser/dom-to-ast.ts
+++ b/javascript/packages/linter/src/browser/dom-to-ast.ts
@@ -1,0 +1,248 @@
+import { isVoidElement, SourcePath } from "@herb-tools/core"
+import { parseMarker } from "@herb-tools/client/directives"
+
+import { Range, DocumentNode, HTMLAttributeNameNode, HTMLAttributeNode, HTMLAttributeValueNode, HTMLCloseTagNode, HTMLCommentNode, HTMLElementNode, HTMLOpenTagNode, HTMLTextNode, LiteralNode, Location, Token } from "@herb-tools/core"
+
+import type { Node } from "@herb-tools/core"
+
+export interface DOMNodeLike {
+  nodeType: number
+}
+
+export interface DOMTextLike extends DOMNodeLike {
+  data: string
+}
+
+export interface DOMAttributeLike {
+  name: string
+  value: string
+}
+
+export interface DOMElementLike extends DOMNodeLike {
+  tagName: string
+  attributes: ArrayLike<DOMAttributeLike>
+  childNodes: ArrayLike<DOMNodeLike>
+}
+
+export interface DOMParentLike extends DOMNodeLike {
+  childNodes: ArrayLike<DOMNodeLike>
+}
+
+export interface WithDOMNode {
+  [DOM_NODE]?: DOMNodeLike
+}
+
+export interface WithSourcePath {
+  [SOURCE_PATH]?: SourcePath
+}
+
+const ELEMENT_NODE = 1
+const TEXT_NODE = 3
+const COMMENT_NODE = 8
+const DOCUMENT_NODE = 9
+const DOCUMENT_FRAGMENT_NODE = 11
+const NO_LOCATION = Location.fromOptional(null)
+
+export const SOURCE_ATTRIBUTE = "data-herb-source"
+export const DOM_NODE = Symbol.for("herb.domNode")
+export const SOURCE_PATH = Symbol.for("herb.sourcePath")
+
+function regionOpenedBy(data: string): SourcePath | null {
+  const marker = parseMarker(data.trim())
+
+  if (marker?.kind !== "region-open") return null
+
+  return marker.file === "" ? null : new SourcePath(marker.file, { line: 1, column: 0 })
+}
+
+function regionClosedBy(data: string): boolean {
+  return parseMarker(data.trim())?.kind === "region-close"
+}
+
+function locationFrom(source: SourcePath | null): Location {
+  const position = source?.position ?? null
+
+  return position ? new Location(position, position) : NO_LOCATION
+}
+
+function sourceOn(element: DOMElementLike): SourcePath | null {
+  for (const attribute of Array.from(element.attributes)) {
+    if (attribute.name === SOURCE_ATTRIBUTE) return SourcePath.parse(attribute.value)
+  }
+
+  return null
+}
+
+export function sourcePathOf(node: object): SourcePath | null {
+  return (node as WithSourcePath)[SOURCE_PATH] ?? null
+}
+
+export function sourcePathsIn(root: Node): Map<Location, SourcePath> {
+  const found = new Map<Location, SourcePath>()
+
+  const walk = (node: Node | null | undefined) => {
+    if (!node) return
+
+    const source = sourcePathOf(node)
+
+    if (source && node.location) {
+      found.set(node.location, source)
+    }
+
+    for (const child of node.childNodes()) {
+      walk(child)
+    }
+  }
+
+  walk(root)
+
+  return found
+}
+
+function token(type: string, value: string, location: Location = NO_LOCATION): Token {
+  return new Token(value, Range.fromOptional(null), location, type)
+}
+
+function literal(content: string, location: Location = NO_LOCATION): LiteralNode {
+  return LiteralNode.build({ content, location })
+}
+
+function attribute(name: string, value: string, location: Location): HTMLAttributeNode {
+  return HTMLAttributeNode.build({
+    location,
+    name: HTMLAttributeNameNode.build({ children: [literal(name, location)], location }),
+    equals: token("TOKEN_EQUALS", "=", location),
+    value: HTMLAttributeValueNode.build({
+      open_quote: token("TOKEN_QUOTE", '"', location),
+      children: [literal(value, location)],
+      close_quote: token("TOKEN_QUOTE", '"', location),
+      quoted: true,
+      location,
+    }),
+  })
+}
+
+function attributes(element: DOMElementLike, location: Location): HTMLAttributeNode[] {
+  return Array.from(element.attributes).map((attr) => attribute(attr.name, attr.value, location))
+}
+
+function tag(element: DOMElementLike): string {
+  return element.tagName.toLowerCase()
+}
+
+function elementNode(element: DOMElementLike, inherited: SourcePath | null, region: SourcePath | null): HTMLElementNode {
+  const name = tag(element)
+  const isVoid = isVoidElement(name)
+  const source = sourceOn(element) ?? inherited ?? region
+  const location = locationFrom(source)
+  const tagName = token("TOKEN_HTML_TAG_NAME", name, location)
+
+  const openTag = HTMLOpenTagNode.build({
+    tag_opening: token("TOKEN_HTML_TAG_START", "<", location),
+    tag_name: tagName,
+    tag_closing: token("TOKEN_HTML_TAG_END", ">", location),
+    children: attributes(element, location),
+    is_void: isVoid,
+    location,
+  })
+
+  const closeTag = isVoid ? null : HTMLCloseTagNode.build({
+    tag_opening: token("TOKEN_HTML_TAG_START_CLOSE", "</", location),
+    tag_name: tagName,
+    tag_closing: token("TOKEN_HTML_TAG_END", ">", location),
+    location,
+  })
+
+  const node = HTMLElementNode.build({
+    open_tag: openTag,
+    tag_name: tagName,
+    body: isVoid ? [] : children(element, source, region),
+    close_tag: closeTag,
+    is_void: isVoid,
+    element_source: "DOM",
+    location,
+  })
+
+  ;(node as HTMLElementNode & WithDOMNode)[DOM_NODE] = element
+  ;(openTag as HTMLOpenTagNode & WithDOMNode)[DOM_NODE] = element
+
+  if (source) {
+    ;(node as HTMLElementNode & WithSourcePath)[SOURCE_PATH] = source
+    ;(openTag as HTMLOpenTagNode & WithSourcePath)[SOURCE_PATH] = source
+
+  }
+
+  return node
+}
+
+function commentNode(comment: DOMTextLike, source: SourcePath | null): HTMLCommentNode {
+  const location = locationFrom(source)
+
+  return HTMLCommentNode.build({
+    comment_start: token("TOKEN_HTML_COMMENT_START", "<!--", location),
+    children: [literal(comment.data, location)],
+    comment_end: token("TOKEN_HTML_COMMENT_END", "-->", location),
+    location,
+  })
+}
+
+function textNode(text: DOMTextLike, source: SourcePath | null): HTMLTextNode {
+  return HTMLTextNode.build({ content: text.data, location: locationFrom(source) })
+}
+
+function convert(node: DOMNodeLike, inherited: SourcePath | null, region: SourcePath | null): Node | null {
+  switch (node.nodeType) {
+    case ELEMENT_NODE: {
+      return elementNode(node as DOMElementLike, inherited, region)
+    }
+
+    case TEXT_NODE: {
+      return textNode(node as DOMTextLike, inherited ?? region)
+    }
+
+    case COMMENT_NODE: {
+      return commentNode(node as DOMTextLike, inherited ?? region)
+    }
+
+    default: return null
+  }
+}
+
+function children(node: DOMParentLike, inherited: SourcePath | null, region: SourcePath | null): Node[] {
+  const nodes: Node[] = []
+  const enclosing: (SourcePath | null)[] = []
+
+  let current = region
+
+  for (const child of Array.from(node.childNodes)) {
+    if (child.nodeType === COMMENT_NODE) {
+      const data = (child as DOMTextLike).data
+      const opened = regionOpenedBy(data)
+
+      if (opened) {
+        enclosing.push(current)
+        current = opened
+      } else if (regionClosedBy(data)) {
+        current = enclosing.pop() ?? region
+      }
+    }
+
+    const converted = convert(child, inherited, current)
+
+    if (converted !== null) {
+      nodes.push(converted)
+    }
+  }
+
+  return nodes
+}
+
+export function domToAST(root: DOMNodeLike): DocumentNode {
+  const holdsChildren = root.nodeType === DOCUMENT_NODE || root.nodeType === DOCUMENT_FRAGMENT_NODE
+
+  const roots = holdsChildren
+    ? children(root as DOMParentLike, null, null)
+    : [convert(root, null, null)].filter((child): child is Node => child !== null)
+
+  return DocumentNode.build({ children: roots, location: NO_LOCATION })
+}

--- a/javascript/packages/linter/src/browser/index.ts
+++ b/javascript/packages/linter/src/browser/index.ts
@@ -1,0 +1,12 @@
+export { DOM_NODE, SOURCE_PATH, SOURCE_ATTRIBUTE } from "./dom-to-ast.js"
+
+export { domToAST, sourcePathOf, sourcePathsIn } from "./dom-to-ast.js"
+export { browserRules } from "./rules.js"
+export { sourcePathFor } from "./lint-dom.js"
+
+export { HerbDOMBackend } from "./backend.js"
+export { BrowserRule } from "./rule.js"
+export { BrowserScopedStyleNoUnusedSelectorRule } from "./rules/browser-scoped-style-no-unused-selector.js"
+
+export type { BrowserRuleClass } from "./rule.js"
+export type { DOMNodeLike, DOMElementLike, DOMParentLike, DOMTextLike, DOMAttributeLike, WithDOMNode, WithSourcePath } from "./dom-to-ast.js"

--- a/javascript/packages/linter/src/browser/lint-dom.ts
+++ b/javascript/packages/linter/src/browser/lint-dom.ts
@@ -1,0 +1,39 @@
+import { DOM_NODE } from "./dom-to-ast.js"
+
+import { SourcePath } from "@herb-tools/core"
+
+import type { Node } from "@herb-tools/core"
+import type { DOMNodeLike, DOMElementLike, WithDOMNode } from "./dom-to-ast.js"
+
+export const SOURCE_ATTRIBUTE = "data-herb-source"
+
+function attributeValue(element: DOMElementLike, name: string): string | null {
+  for (const attribute of Array.from(element.attributes)) {
+    if (attribute.name === name) {
+      return attribute.value
+    }
+  }
+
+  return null
+}
+
+export function sourcePathFor(node: Node, projectPath: string | null = null): SourcePath | null {
+  const element = (node as Node & WithDOMNode)[DOM_NODE]
+  if (!element) return null
+
+  let current: DOMNodeLike | null = element
+
+  while (current) {
+    if (current.nodeType === 1) {
+      const stamp = attributeValue(current as DOMElementLike, SOURCE_ATTRIBUTE)
+
+      if (stamp) {
+        return SourcePath.parse(stamp, projectPath)
+      }
+    }
+
+    current = (current as { parentNode?: DOMNodeLike | null }).parentNode ?? null
+  }
+
+  return null
+}

--- a/javascript/packages/linter/src/browser/rule.ts
+++ b/javascript/packages/linter/src/browser/rule.ts
@@ -1,0 +1,36 @@
+import { DEFAULT_RULE_CONFIG } from "../types.js"
+
+import { Location } from "@herb-tools/core"
+
+import type { DOMNodeLike } from "./dom-to-ast.js"
+import type { UnboundLintOffense, LintContext, LintSeverity, FullRuleConfig, RuleVersion } from "../types.js"
+
+export abstract class BrowserRule {
+  static type = "browser" as const
+  static ruleName: string
+  static introducedIn: RuleVersion
+  static autocorrectable = false
+
+  get ruleName(): string {
+    return (this.constructor as typeof BrowserRule).ruleName
+  }
+
+  get defaultConfig(): FullRuleConfig {
+    return { ...DEFAULT_RULE_CONFIG, environments: ["browser"] }
+  }
+
+  protected createOffense(message: string, severity?: LintSeverity): UnboundLintOffense {
+    return {
+      rule: this.ruleName,
+      code: this.ruleName,
+      source: "Herb Linter",
+      message,
+      location: Location.fromOptional(null),
+      severity,
+    }
+  }
+
+  abstract check(root: DOMNodeLike, context?: Partial<LintContext>): UnboundLintOffense[]
+}
+
+export type BrowserRuleClass = (new () => BrowserRule) & typeof BrowserRule

--- a/javascript/packages/linter/src/browser/rules.ts
+++ b/javascript/packages/linter/src/browser/rules.ts
@@ -1,0 +1,7 @@
+import { BrowserScopedStyleNoUnusedSelectorRule } from "./rules/browser-scoped-style-no-unused-selector.js"
+
+import type { BrowserRuleClass } from "./rule.js"
+
+export const browserRules: BrowserRuleClass[] = [
+  BrowserScopedStyleNoUnusedSelectorRule as BrowserRuleClass,
+]

--- a/javascript/packages/linter/src/browser/rules/browser-scoped-style-no-unused-selector.ts
+++ b/javascript/packages/linter/src/browser/rules/browser-scoped-style-no-unused-selector.ts
@@ -1,0 +1,128 @@
+import { BrowserRule } from "../rule.js"
+
+import type { DOMNodeLike, DOMElementLike } from "../dom-to-ast.js"
+import type { UnboundLintOffense, LintContext } from "../../types.js"
+
+interface CSSRuleLike {
+  selectorText?: string
+  cssRules?: ArrayLike<CSSRuleLike>
+}
+
+interface StyleSheetLike {
+  cssRules: ArrayLike<CSSRuleLike>
+}
+
+interface StyleElementLike extends DOMElementLike {
+  sheet?: StyleSheetLike | null
+}
+
+interface QueryableLike extends DOMNodeLike {
+  querySelectorAll(selectors: string): ArrayLike<unknown>
+  matches?(selectors: string): boolean
+}
+
+const ELEMENT_NODE = 1
+export const ANCHOR_ATTRIBUTE = "data-herb-style-scoped"
+
+function isElement(node: DOMNodeLike): node is DOMElementLike {
+  return node.nodeType === ELEMENT_NODE
+}
+
+function attributeValue(element: DOMElementLike, name: string): string | null {
+  for (const attribute of Array.from(element.attributes)) {
+    if (attribute.name === name) {
+      return attribute.value
+    }
+  }
+
+  return null
+}
+
+function hasAttribute(element: DOMElementLike, name: string): boolean {
+  return Array.from(element.attributes).some((attribute) => attribute.name === name)
+}
+
+function elements(root: DOMNodeLike): DOMElementLike[] {
+  if (!isElement(root) && !("childNodes" in root)) return []
+
+  const found: DOMElementLike[] = []
+  const queue: DOMNodeLike[] = [root]
+
+  while (queue.length > 0) {
+    const node = queue.shift()!
+
+    if (isElement(node)) {
+      found.push(node)
+    }
+
+    const children = (node as { childNodes?: ArrayLike<DOMNodeLike> }).childNodes
+
+    if (children) {
+      queue.push(...Array.from(children))
+    }
+  }
+
+  return found
+}
+
+function selectors(rules: ArrayLike<CSSRuleLike>): string[] {
+  return Array.from(rules).flatMap((rule) => {
+    if (rule.selectorText) {
+      return [rule.selectorText]
+    }
+
+    if (rule.cssRules) {
+      return selectors(rule.cssRules)
+    }
+
+    return []
+  })
+}
+
+function matches(scope: QueryableLike, selector: string): boolean {
+  try {
+    if (scope.matches?.(selector)) {
+      return true
+    }
+
+    return scope.querySelectorAll(selector).length > 0
+  } catch {
+    return true
+  }
+}
+
+function isScoped(element: DOMElementLike): boolean {
+  return hasAttribute(element, "scoped") || attributeValue(element, ANCHOR_ATTRIBUTE) !== null
+}
+
+export class BrowserScopedStyleNoUnusedSelectorRule extends BrowserRule {
+  static ruleName = "browser-scoped-style-no-unused-selector"
+
+  check(root: DOMNodeLike, _context?: Partial<LintContext>): UnboundLintOffense[] {
+    const scope = root as QueryableLike
+
+    if (typeof scope.querySelectorAll !== "function") return []
+
+    const offenses: UnboundLintOffense[] = []
+
+    for (const element of elements(root)) {
+      if (element.tagName.toLowerCase() !== "style") continue
+      if (!isScoped(element)) continue
+
+      const sheet = (element as StyleElementLike).sheet
+      if (!sheet) continue
+
+      for (const selector of selectors(sheet.cssRules)) {
+        if (matches(scope, selector)) continue
+
+        offenses.push(
+          this.createOffense(
+            `Selector \`${selector}\` matches nothing on the rendered page. Remove it, or check whether the markup it was written for still exists.`
+          )
+        )
+      }
+    }
+
+    return offenses
+  }
+}

--- a/javascript/packages/linter/src/linter.ts
+++ b/javascript/packages/linter/src/linter.ts
@@ -1,6 +1,6 @@
 import picomatch from "picomatch"
 
-import { DEFAULT_FRAMEWORK, Location, semverGreaterThan } from "@herb-tools/core"
+import { DEFAULT_FRAMEWORK, Location, ParseResult, ParserOptions, semverGreaterThan } from "@herb-tools/core"
 import { IdentityPrinter, IndentPrinter } from "@herb-tools/printer"
 
 import { rules } from "./rules.js"
@@ -8,14 +8,20 @@ import { findNodeByLocation } from "./utils/rule-utils.js"
 import { parseHerbDisableLine } from "./herb-disable-comment-utils.js"
 import { hasLinterIgnoreDirective } from "./linter-ignore.js"
 import { ParseCache } from "./parse-cache.js"
+import { domToAST, sourcePathsIn } from "./browser/dom-to-ast.js"
+import { browserRules } from "./browser/rules.js"
+
+import type { DOMNodeLike } from "./browser/dom-to-ast.js"
 
 import { ParserNoErrorsRule } from "./rules/parser-no-errors.js"
 
-import { DEFAULT_RULE_CONFIG } from "./types.js"
+import { DEFAULT_RULE_CONFIG, DEFAULT_ENVIRONMENT } from "./types.js"
 import { resolveSeverity, ALL_RULES_KEY } from "@herb-tools/config/schema"
 
-import type { RuleClass, ParserRuleClass, LexerRuleClass, SourceRuleClass, Rule, ParserRule, LexerRule, SourceRule, LintResult, LintOffense, UnboundLintOffense, LintContext, AutofixResult, RuleVersion, LinterMode, Framework } from "./types.js"
-import type { ParseResult, LexResult, HerbBackend, ParserOptions } from "@herb-tools/core"
+import type { DocumentNode } from "@herb-tools/core"
+import type { Environment } from "@herb-tools/config"
+import type { RuleClass, ParserRuleClass, LexerRuleClass, SourceRuleClass, Rule, ParserRule, LexerRule, SourceRule, LintResult, LintOffense, UnboundLintOffense, LintContext, AutofixResult, RuleVersion, LinterMode, Framework, FullRuleConfig } from "./types.js"
+import type { LexResult, HerbBackend } from "@herb-tools/core"
 import type { RuleConfig, Config } from "@herb-tools/config"
 
 export interface LinterOptions {
@@ -324,6 +330,25 @@ export class Linter {
   }
 
   /**
+   * Whether a rule answers in the environment it is being run in.
+   *
+   * The rule says where it applies, config overrides that, and a rule that says nothing runs only
+   * where templates are read from source. That last part is where this differs from
+   * `appliesToFramework`, which treats silence as "everywhere": most rules have never considered a
+   * rendered page, so silence there has to mean no.
+   */
+  appliesTo(rule: { ruleName: string; defaultConfig?: FullRuleConfig }, environment: Environment | undefined): boolean {
+    return this.appliesToEnvironment(rule as Rule, environment)
+  }
+
+  protected appliesToEnvironment(rule: Rule, environment: Environment | undefined): boolean {
+    const userEnvironments = this.config?.linter?.rules?.[rule.ruleName]?.environments
+    const environments = userEnvironments ?? rule.defaultConfig?.environments ?? [DEFAULT_ENVIRONMENT]
+
+    return environments.includes(environment ?? DEFAULT_ENVIRONMENT)
+  }
+
+  /**
    * The parser options a rule is run with.
    *
    * A rule asking for `action_view_helpers` is saying it wants to see Action
@@ -363,6 +388,10 @@ export class Linter {
     const ruleName = rule.ruleName
 
     if (!this.onlyRules && !this.allRules && !this.appliesToFramework(rule, context?.framework)) {
+      return []
+    }
+
+    if (!this.appliesToEnvironment(rule, context?.environment)) {
       return []
     }
 
@@ -446,7 +475,10 @@ export class Linter {
 
     if (ignoreDisableComments) {
       for (const offense of ruleOffenses) {
-        const line = offense.location.start.line
+        const line = offense.location?.start?.line ?? null
+
+        if (line === null) continue
+
         const disabledRules = herbDisableCache?.get(line) || []
 
         if (disabledRules.includes(ruleName) || disabledRules.includes("all")) {
@@ -458,7 +490,13 @@ export class Linter {
     }
 
     for (const offense of ruleOffenses) {
-      const line = offense.location.start.line
+      const line = offense.location?.start?.line ?? null
+
+      if (line === null) {
+        kept.push(offense)
+        continue
+      }
+
       const disabledRules = herbDisableCache?.get(line) || []
 
       if (disabledRules.includes(ruleName) || disabledRules.includes("all")) {
@@ -485,10 +523,14 @@ export class Linter {
 
   /**
    * Lint source code using Parser/AST, Lexer, and Source rules.
-   * @param source - The source code to lint
+   * @param source - The source code to lint, or a DOM node to lint as a rendered page
    * @param context - Optional context for linting (e.g., fileName for distinguishing files vs snippets)
    */
-  lint(source: string, context?: Partial<LintContext>): LintResult {
+  lint(source: string | DOMNodeLike, context?: Partial<LintContext>): LintResult {
+    if (typeof source !== "string") {
+      return this.lintElement(source, context)
+    }
+
     this.offenses = []
     this.parseCache.clear()
 
@@ -541,6 +583,7 @@ export class Linter {
       indentWidth: context?.indentWidth ?? this.config?.formatter?.indentWidth,
       indentStyle: context?.indentStyle ?? this.config?.formatter?.indentStyle,
       framework: context?.framework ?? this.config?.framework,
+      environment: context?.environment ?? this.backendEnvironment,
       herb: context?.herb ?? this.herb
     }
 
@@ -605,6 +648,109 @@ export class Linter {
     }
 
     return result
+  }
+
+  /**
+   * The environment a backend puts the linter in, when it is one that says so.
+   *
+   * `HerbDOMBackend` parses with the browser, so a tree it produced carries what a DOM carries and
+   * not what a template does. Rules that have not said they answer on a rendered page would be
+   * reading locations that are not there, whether the markup arrived as a string or as an element.
+   */
+  protected get backendEnvironment(): Environment | undefined {
+    return (this.herb as Partial<{ lintEnvironment: Environment }>).lintEnvironment
+  }
+
+  /**
+   * Lints what the browser built for a page, after every template behind it has run.
+   *
+   * Takes anything the DOM calls a node: a `Document`, a `DocumentFragment`, or a single element
+   * such as `document.body`. Both the rules that read an AST and the rules that can only be
+   * answered against a live DOM run, each one filtered by the environment it declares.
+   *
+   *     const linter = Linter.from(new HerbDOMBackend())
+   *
+   *     linter.lintElement(document.body)
+   *
+   * `lint` accepts the same thing, so `linter.lint(document.body)` reaches here too.
+   *
+   * An offense comes back carrying the template it was written in whenever the element it points
+   * at was stamped, or sits inside a region the engine marked.
+   */
+  lintElement(root: DOMNodeLike, context?: Partial<LintContext>): LintResult {
+    const document = domToAST(root)
+    const result = this.lintDocument(document, context)
+    const sources = sourcePathsIn(document)
+
+    const offenses = result.offenses.map(offense => {
+      const file = sources.get(offense.location)
+
+      return file ? { ...offense, file } : offense
+    })
+
+    for (const ruleClass of browserRules) {
+      const rule = new ruleClass()
+
+      if (!this.appliesTo(rule, context?.environment ?? "browser")) continue
+
+      for (const offense of rule.check(root, context)) {
+        offenses.push({ ...offense, severity: offense.severity ?? "error" })
+      }
+    }
+
+    return {
+      ...result,
+      offenses,
+      errors: offenses.filter((offense) => offense.severity === "error").length,
+      warnings: offenses.filter((offense) => offense.severity === "warning").length,
+      info: offenses.filter((offense) => offense.severity === "info").length,
+      hints: offenses.filter((offense) => offense.severity === "hint").length,
+    }
+  }
+
+  /**
+   * Lints a document that did not come from source text.
+   *
+   * A tree built from a live DOM has no source behind it, so the parts of `lint` that read one are
+   * left out: there are no `herb:disable` comments to honour, no lexing, and no autofix. Only
+   * parser rules run, and the rules that can only be answered against a live DOM are not among
+   * them, so `lintElement` is what a caller holding a DOM wants.
+   *
+   * Positions are whatever the tree carries. A tree from `domToAST` has the ones its stamps named,
+   * and one built by hand has none.
+   */
+  lintDocument(document: DocumentNode, context?: Partial<LintContext>): LintResult {
+    this.offenses = []
+
+    const parseResult = new ParseResult(document, "", [], [], new ParserOptions(), null)
+
+    const fullContext: Partial<LintContext> = {
+      ...context,
+      validRuleNames: this.getAvailableRules().map(ruleClass => ruleClass.ruleName),
+      framework: context?.framework ?? this.config?.framework,
+      environment: context?.environment ?? "browser",
+      herb: context?.herb ?? this.herb
+    }
+
+    for (const ruleClass of this.rules) {
+      if (!this.isParserRuleClass(ruleClass)) continue
+
+      const rule = new ruleClass() as ParserRule
+      const unboundOffenses = this.executeRule(ruleClass, rule, parseResult, null as unknown as LexResult, "", fullContext)
+
+      this.offenses.push(...this.bindSeverity(unboundOffenses, ruleClass.ruleName))
+    }
+
+    const offenses = this.offenses
+
+    return {
+      offenses,
+      errors: offenses.filter(offense => offense.severity === "error").length,
+      warnings: offenses.filter(offense => offense.severity === "warning").length,
+      info: offenses.filter(offense => offense.severity === "info").length,
+      hints: offenses.filter(offense => offense.severity === "hint").length,
+      ignored: 0
+    }
   }
 
   /**

--- a/javascript/packages/linter/src/rules/a11y-nested-interactive-elements.ts
+++ b/javascript/packages/linter/src/rules/a11y-nested-interactive-elements.ts
@@ -80,7 +80,8 @@ export class A11yNestedInteractiveElementsRule extends ParserRule {
   get defaultConfig(): FullRuleConfig {
     return {
       enabled: false,
-      severity: "error"
+      severity: "error",
+      environments: ["cli", "browser"],
     }
   }
 

--- a/javascript/packages/linter/src/rules/html-anchor-require-href.ts
+++ b/javascript/packages/linter/src/rules/html-anchor-require-href.ts
@@ -89,7 +89,8 @@ export class HTMLAnchorRequireHrefRule extends ParserRule {
   get defaultConfig(): FullRuleConfig {
     return {
       enabled: true,
-      severity: "error"
+      severity: "error",
+      environments: ["cli", "browser"],
     }
   }
 

--- a/javascript/packages/linter/src/rules/html-body-only-elements.ts
+++ b/javascript/packages/linter/src/rules/html-body-only-elements.ts
@@ -35,7 +35,7 @@ export class HTMLBodyOnlyElementsRule extends ParserRule {
     return {
       enabled: true,
       severity: "error",
-      exclude: ["**/*.xml", "**/*.xml.erb"]
+      exclude: ["**/*.xml", "**/*.xml.erb"],
     }
   }
 

--- a/javascript/packages/linter/src/rules/html-details-has-summary.ts
+++ b/javascript/packages/linter/src/rules/html-details-has-summary.ts
@@ -52,7 +52,8 @@ export class HTMLDetailsHasSummaryRule extends ParserRule {
   get defaultConfig(): FullRuleConfig {
     return {
       enabled: true,
-      severity: "warning"
+      severity: "warning",
+      environments: ["cli", "browser"],
     }
   }
 

--- a/javascript/packages/linter/src/rules/html-head-only-elements.ts
+++ b/javascript/packages/linter/src/rules/html-head-only-elements.ts
@@ -96,7 +96,8 @@ export class HTMLHeadOnlyElementsRule extends ParserRule {
     return {
       enabled: true,
       severity: "error",
-      exclude: ["**/*.xml", "**/*.xml.erb"]
+      exclude: ["**/*.xml", "**/*.xml.erb"],
+      environments: ["cli", "browser"],
     }
   }
 

--- a/javascript/packages/linter/src/rules/html-iframe-has-title.ts
+++ b/javascript/packages/linter/src/rules/html-iframe-has-title.ts
@@ -51,7 +51,8 @@ export class HTMLIframeHasTitleRule extends ParserRule {
   get defaultConfig(): FullRuleConfig {
     return {
       enabled: true,
-      severity: "warning"
+      severity: "warning",
+      environments: ["cli", "browser"],
     }
   }
 

--- a/javascript/packages/linter/src/rules/html-img-require-alt.ts
+++ b/javascript/packages/linter/src/rules/html-img-require-alt.ts
@@ -58,7 +58,8 @@ export class HTMLImgRequireAltRule extends ParserRule {
   get defaultConfig(): FullRuleConfig {
     return {
       enabled: true,
-      severity: "warning"
+      severity: "warning",
+      environments: ["cli", "browser"],
     }
   }
 

--- a/javascript/packages/linter/src/rules/html-no-aria-hidden-on-focusable.ts
+++ b/javascript/packages/linter/src/rules/html-no-aria-hidden-on-focusable.ts
@@ -42,7 +42,8 @@ export class HTMLNoAriaHiddenOnFocusableRule extends ParserRule {
   get defaultConfig(): FullRuleConfig {
     return {
       enabled: true,
-      severity: "warning"
+      severity: "warning",
+      environments: ["cli", "browser"],
     }
   }
 

--- a/javascript/packages/linter/src/rules/html-no-duplicate-ids.ts
+++ b/javascript/packages/linter/src/rules/html-no-duplicate-ids.ts
@@ -315,7 +315,8 @@ export class HTMLNoDuplicateIdsRule extends ParserRule {
   get defaultConfig(): FullRuleConfig {
     return {
       enabled: true,
-      severity: "error"
+      severity: "error",
+      environments: ["cli", "browser"],
     }
   }
 

--- a/javascript/packages/linter/src/rules/html-no-duplicate-meta-names.ts
+++ b/javascript/packages/linter/src/rules/html-no-duplicate-meta-names.ts
@@ -189,7 +189,8 @@ export class HTMLNoDuplicateMetaNamesRule extends ParserRule {
   get defaultConfig(): FullRuleConfig {
     return {
       enabled: true,
-      severity: "error"
+      severity: "error",
+      environments: ["cli", "browser"],
     }
   }
 

--- a/javascript/packages/linter/src/rules/html-no-empty-headings.ts
+++ b/javascript/packages/linter/src/rules/html-no-empty-headings.ts
@@ -111,7 +111,8 @@ export class HTMLNoEmptyHeadingsRule extends ParserRule {
   get defaultConfig(): FullRuleConfig {
     return {
       enabled: true,
-      severity: "warning"
+      severity: "warning",
+      environments: ["cli", "browser"],
     }
   }
 

--- a/javascript/packages/linter/src/rules/html-no-nested-forms.ts
+++ b/javascript/packages/linter/src/rules/html-no-nested-forms.ts
@@ -139,7 +139,7 @@ export class HTMLNoNestedFormsRule extends ParserRule {
   get defaultConfig(): FullRuleConfig {
     return {
       enabled: true,
-      severity: "error"
+      severity: "error",
     }
   }
 

--- a/javascript/packages/linter/src/rules/html-no-nested-links.ts
+++ b/javascript/packages/linter/src/rules/html-no-nested-links.ts
@@ -82,7 +82,7 @@ export class HTMLNoNestedLinksRule extends ParserRule {
   get defaultConfig(): FullRuleConfig {
     return {
       enabled: true,
-      severity: "error"
+      severity: "error",
     }
   }
 

--- a/javascript/packages/linter/src/rules/html-no-positive-tab-index.ts
+++ b/javascript/packages/linter/src/rules/html-no-positive-tab-index.ts
@@ -26,7 +26,8 @@ export class HTMLNoPositiveTabIndexRule extends ParserRule {
   get defaultConfig(): FullRuleConfig {
     return {
       enabled: true,
-      severity: "warning"
+      severity: "warning",
+      environments: ["cli", "browser"],
     }
   }
 

--- a/javascript/packages/linter/src/types.ts
+++ b/javascript/packages/linter/src/types.ts
@@ -1,10 +1,10 @@
 import { Diagnostic, LexResult, ParseResult, Location } from "@herb-tools/core"
 
-import type { DiagnosticTag, HerbError } from "@herb-tools/core"
+import type { DiagnosticTag, HerbError, SourcePath } from "@herb-tools/core"
 import type { rules } from "./rules.js"
 import type { HerbBackend, Node, ParserOptions } from "@herb-tools/core"
 import type { AncestorChain, RenderGraph, PartialIndex } from "@herb-tools/analysis"
-import type { Framework, RuleConfig, SeverityConfig, LinterMode } from "@herb-tools/config"
+import type { Framework, Environment, RuleConfig, SeverityConfig, LinterMode } from "@herb-tools/config"
 import type { Mutable } from "@herb-tools/rewriter"
 import type { RuleVersion } from "@herb-tools/core"
 
@@ -55,6 +55,8 @@ export interface UnboundLintOffense<TAutofixContext extends BaseAutofixContext =
   severity?: LintSeverity
   /** The call chain that justified the offense */
   renderedFrom?: AncestorChain
+  /** The template the offense was written in */
+  file?: SourcePath
 }
 
 /**
@@ -96,6 +98,15 @@ export const DEFAULT_RULE_CONFIG: FullRuleConfig = {
   severity: "error",
   exclude: []
 }
+
+/**
+ * Where a rule runs when neither the rule nor config says.
+ *
+ * The linter decides this, because it is the thing that runs rules. The config package only
+ * records what a user asked for.
+ * Config only has to know which names are valid.
+ */
+export const DEFAULT_ENVIRONMENT: Environment = "cli"
 
 /**
  * Base class for parser rules.
@@ -262,6 +273,7 @@ export interface LintContext {
   indentWidth: number | undefined
   indentStyle: "space" | "tab" | undefined
   framework: Framework | undefined
+  environment: Environment | undefined
   partials: PartialIndex | undefined
   partialCallers: RenderGraph | undefined
   projectPath: string | undefined
@@ -279,6 +291,7 @@ export const DEFAULT_LINT_CONTEXT: LintContext = {
   indentWidth: undefined,
   indentStyle: undefined,
   framework: undefined,
+  environment: undefined,
   partials: undefined,
   partialCallers: undefined,
   projectPath: undefined,

--- a/javascript/packages/linter/test/browser/browser-rule.test.ts
+++ b/javascript/packages/linter/test/browser/browser-rule.test.ts
@@ -1,0 +1,100 @@
+import { describe, test } from "vitest"
+
+import { BrowserScopedStyleNoUnusedSelectorRule } from "../../src/browser/rules/browser-scoped-style-no-unused-selector.js"
+import { createBrowserRuleTest } from "./support/browser-rule-test.js"
+
+const { expectNoOffenses, expectError, assertOffenses } = createBrowserRuleTest(BrowserScopedStyleNoUnusedSelectorRule as any)
+
+const unused = (selector: string) => `Selector \`${selector}\` matches nothing on the rendered page. Remove it, or check whether the markup it was written for still exists.`
+
+describe("browser-scoped-style-no-unused-selector", () => {
+  test("says nothing about a selector the page actually uses", () => {
+    expectNoOffenses(`
+      <style scoped>.card { color: red }</style>
+      <div class="card">used</div>
+    `)
+  })
+
+  test("reports a selector that matches nothing on the rendered page", () => {
+    expectError(unused(".gone"))
+
+    assertOffenses(`
+      <style scoped>.gone { color: red }</style>
+      <div class="card">used</div>
+    `)
+  })
+
+  test("judges each selector on its own", () => {
+    expectError(unused(".dead"))
+
+    assertOffenses(`
+      <style scoped>
+        .used { color: red }
+        .dead { color: red }
+        .alive { color: red }
+      </style>
+      <div class="used"></div>
+      <div class="alive"></div>
+    `)
+  })
+
+  test("looks inside a media query", () => {
+    expectError(unused(".nested-dead"))
+
+    assertOffenses(`
+      <style scoped>
+        @media (min-width: 100px) {
+          .nested-dead { color: red }
+        }
+      </style>
+    `)
+  })
+
+  test("says nothing about a selector that matches the element it is scoped to", () => {
+    expectNoOffenses(`
+      <div class="card">
+        <style scoped>.card { color: red }</style>
+      </div>
+    `)
+  })
+
+  test("never sees a selector the browser could not parse", () => {
+    expectError(unused(".gone"))
+
+    assertOffenses(`
+      <style scoped>
+        !!invalid { color: red }
+        .gone { color: red }
+      </style>
+    `)
+  })
+
+  test("ignores a style element that is not scoped", () => {
+    expectNoOffenses(`<style>.gone { color: red }</style>`)
+  })
+
+  test("finds a scoped block on a page the engine compiled, where `scoped` is already gone", () => {
+    expectError(unused(".dead[data-herb-scope-2940ba8a]"))
+
+    assertOffenses(`
+      <style data-herb-style-scoped="data-herb-scope-2940ba8a">
+        .used[data-herb-scope-2940ba8a] { color: red }
+        .dead[data-herb-scope-2940ba8a] { color: red }
+      </style>
+      <div class="used" data-herb-scope-2940ba8a></div>
+    `)
+  })
+
+  test("says nothing about a plain style element the engine never scoped", () => {
+    expectNoOffenses(`
+      <style>.gone { color: red }</style>
+    `)
+  })
+
+  test("reads a selector the browser normalised, not the one that was written", () => {
+    expectNoOffenses(`
+      <style scoped>DIV.Card { color: red }</style>
+      <div class="Card"></div>
+    `)
+  })
+})

--- a/javascript/packages/linter/test/browser/dom-to-ast.test.ts
+++ b/javascript/packages/linter/test/browser/dom-to-ast.test.ts
@@ -1,0 +1,425 @@
+import { describe, test, expect, afterEach } from "vitest"
+
+import { domToAST, DOM_NODE, sourcePathOf } from "../../src/browser/dom-to-ast.js"
+
+import { dom, element, resetDOM } from "./support/dom.js"
+
+import type { WithDOMNode } from "../../src/browser/dom-to-ast.js"
+import type { HTMLElementNode } from "@herb-tools/core"
+
+afterEach(resetDOM)
+
+const inspect = (root: Node) => "\n" + domToAST(root as any).treeInspect().split("\n").map((line) => line.trimEnd()).join("\n").trimEnd() + "\n"
+const first = (root: Node) => domToAST(root as any).children[0] as HTMLElementNode
+
+describe("domToAST", () => {
+  test("builds an element, its open and close tag, and nothing it was not given", () => {
+    expect(inspect(element`<div></div>`)).toMatchInlineSnapshot(`
+      "
+      @ DocumentNode (location: ∅)
+      ├── errors: []
+      └── children: (1 item)
+          └── @ HTMLElementNode (location: ∅)
+              ├── errors: []
+              ├── open_tag:
+              │   └── @ HTMLOpenTagNode (location: ∅)
+              │       ├── errors: []
+              │       ├── tag_opening: "<" (location: ∅)
+              │       ├── tag_name: "div" (location: ∅)
+              │       ├── tag_closing: ">" (location: ∅)
+              │       ├── children: []
+              │       └── is_void: false
+              │
+              ├── tag_name: "div" (location: ∅)
+              ├── body: []
+              ├── close_tag:
+              │   └── @ HTMLCloseTagNode (location: ∅)
+              │       ├── errors: []
+              │       ├── tag_opening: "</" (location: ∅)
+              │       ├── tag_name: "div" (location: ∅)
+              │       ├── children: []
+              │       └── tag_closing: ">" (location: ∅)
+              │
+              ├── is_void: false
+              └── element_source: "DOM"
+      "
+    `)
+  })
+
+  test("lowercases the tag name the DOM reports in upper case", () => {
+    expect(first(element`<div></div>`).tag_name?.value).toBe("div")
+  })
+
+  test("carries attributes across as name and value nodes", () => {
+    expect(inspect(element`<div class="card"></div>`)).toMatchInlineSnapshot(`
+      "
+      @ DocumentNode (location: ∅)
+      ├── errors: []
+      └── children: (1 item)
+          └── @ HTMLElementNode (location: ∅)
+              ├── errors: []
+              ├── open_tag:
+              │   └── @ HTMLOpenTagNode (location: ∅)
+              │       ├── errors: []
+              │       ├── tag_opening: "<" (location: ∅)
+              │       ├── tag_name: "div" (location: ∅)
+              │       ├── tag_closing: ">" (location: ∅)
+              │       ├── children: (1 item)
+              │       │   └── @ HTMLAttributeNode (location: ∅)
+              │       │       ├── errors: []
+              │       │       ├── name:
+              │       │       │   └── @ HTMLAttributeNameNode (location: ∅)
+              │       │       │       ├── errors: []
+              │       │       │       └── children: (1 item)
+              │       │       │           └── @ LiteralNode (location: ∅)
+              │       │       │               ├── errors: []
+              │       │       │               └── content: "class"
+              │       │       │
+              │       │       │
+              │       │       │
+              │       │       ├── equals: "=" (location: ∅)
+              │       │       └── value:
+              │       │           └── @ HTMLAttributeValueNode (location: ∅)
+              │       │               ├── errors: []
+              │       │               ├── open_quote: """ (location: ∅)
+              │       │               ├── children: (1 item)
+              │       │               │   └── @ LiteralNode (location: ∅)
+              │       │               │       ├── errors: []
+              │       │               │       └── content: "card"
+              │       │               │
+              │       │               │
+              │       │               ├── close_quote: """ (location: ∅)
+              │       │               └── quoted: true
+              │       │
+              │       │
+              │       │
+              │       └── is_void: false
+              │
+              ├── tag_name: "div" (location: ∅)
+              ├── body: []
+              ├── close_tag:
+              │   └── @ HTMLCloseTagNode (location: ∅)
+              │       ├── errors: []
+              │       ├── tag_opening: "</" (location: ∅)
+              │       ├── tag_name: "div" (location: ∅)
+              │       ├── children: []
+              │       └── tag_closing: ">" (location: ∅)
+              │
+              ├── is_void: false
+              └── element_source: "DOM"
+      "
+    `)
+  })
+
+  test("nests children", () => {
+    expect(inspect(element`<div><span>hi</span></div>`)).toMatchInlineSnapshot(`
+      "
+      @ DocumentNode (location: ∅)
+      ├── errors: []
+      └── children: (1 item)
+          └── @ HTMLElementNode (location: ∅)
+              ├── errors: []
+              ├── open_tag:
+              │   └── @ HTMLOpenTagNode (location: ∅)
+              │       ├── errors: []
+              │       ├── tag_opening: "<" (location: ∅)
+              │       ├── tag_name: "div" (location: ∅)
+              │       ├── tag_closing: ">" (location: ∅)
+              │       ├── children: []
+              │       └── is_void: false
+              │
+              ├── tag_name: "div" (location: ∅)
+              ├── body: (1 item)
+              │   └── @ HTMLElementNode (location: ∅)
+              │       ├── errors: []
+              │       ├── open_tag:
+              │       │   └── @ HTMLOpenTagNode (location: ∅)
+              │       │       ├── errors: []
+              │       │       ├── tag_opening: "<" (location: ∅)
+              │       │       ├── tag_name: "span" (location: ∅)
+              │       │       ├── tag_closing: ">" (location: ∅)
+              │       │       ├── children: []
+              │       │       └── is_void: false
+              │       │
+              │       ├── tag_name: "span" (location: ∅)
+              │       ├── body: (1 item)
+              │       │   └── @ HTMLTextNode (location: ∅)
+              │       │       ├── errors: []
+              │       │       └── content: "hi"
+              │       │
+              │       │
+              │       ├── close_tag:
+              │       │   └── @ HTMLCloseTagNode (location: ∅)
+              │       │       ├── errors: []
+              │       │       ├── tag_opening: "</" (location: ∅)
+              │       │       ├── tag_name: "span" (location: ∅)
+              │       │       ├── children: []
+              │       │       └── tag_closing: ">" (location: ∅)
+              │       │
+              │       ├── is_void: false
+              │       └── element_source: "DOM"
+              │
+              │
+              ├── close_tag:
+              │   └── @ HTMLCloseTagNode (location: ∅)
+              │       ├── errors: []
+              │       ├── tag_opening: "</" (location: ∅)
+              │       ├── tag_name: "div" (location: ∅)
+              │       ├── children: []
+              │       └── tag_closing: ">" (location: ∅)
+              │
+              ├── is_void: false
+              └── element_source: "DOM"
+      "
+    `)
+  })
+
+  test("keeps comments", () => {
+    expect(inspect(element`<div><!-- note --></div>`)).toMatchInlineSnapshot(`
+      "
+      @ DocumentNode (location: ∅)
+      ├── errors: []
+      └── children: (1 item)
+          └── @ HTMLElementNode (location: ∅)
+              ├── errors: []
+              ├── open_tag:
+              │   └── @ HTMLOpenTagNode (location: ∅)
+              │       ├── errors: []
+              │       ├── tag_opening: "<" (location: ∅)
+              │       ├── tag_name: "div" (location: ∅)
+              │       ├── tag_closing: ">" (location: ∅)
+              │       ├── children: []
+              │       └── is_void: false
+              │
+              ├── tag_name: "div" (location: ∅)
+              ├── body: (1 item)
+              │   └── @ HTMLCommentNode (location: ∅)
+              │       ├── errors: []
+              │       ├── comment_start: "<!--" (location: ∅)
+              │       ├── children: (1 item)
+              │       │   └── @ LiteralNode (location: ∅)
+              │       │       ├── errors: []
+              │       │       └── content: " note "
+              │       │
+              │       │
+              │       └── comment_end: "-->" (location: ∅)
+              │
+              │
+              ├── close_tag:
+              │   └── @ HTMLCloseTagNode (location: ∅)
+              │       ├── errors: []
+              │       ├── tag_opening: "</" (location: ∅)
+              │       ├── tag_name: "div" (location: ∅)
+              │       ├── children: []
+              │       └── tag_closing: ">" (location: ∅)
+              │
+              ├── is_void: false
+              └── element_source: "DOM"
+      "
+    `)
+  })
+
+  test("gives a void element no closing tag and no body", () => {
+    expect(inspect(element`<img src="a.png">`)).toMatchInlineSnapshot(`
+      "
+      @ DocumentNode (location: ∅)
+      ├── errors: []
+      └── children: (1 item)
+          └── @ HTMLElementNode (location: ∅)
+              ├── errors: []
+              ├── open_tag:
+              │   └── @ HTMLOpenTagNode (location: ∅)
+              │       ├── errors: []
+              │       ├── tag_opening: "<" (location: ∅)
+              │       ├── tag_name: "img" (location: ∅)
+              │       ├── tag_closing: ">" (location: ∅)
+              │       ├── children: (1 item)
+              │       │   └── @ HTMLAttributeNode (location: ∅)
+              │       │       ├── errors: []
+              │       │       ├── name:
+              │       │       │   └── @ HTMLAttributeNameNode (location: ∅)
+              │       │       │       ├── errors: []
+              │       │       │       └── children: (1 item)
+              │       │       │           └── @ LiteralNode (location: ∅)
+              │       │       │               ├── errors: []
+              │       │       │               └── content: "src"
+              │       │       │
+              │       │       │
+              │       │       │
+              │       │       ├── equals: "=" (location: ∅)
+              │       │       └── value:
+              │       │           └── @ HTMLAttributeValueNode (location: ∅)
+              │       │               ├── errors: []
+              │       │               ├── open_quote: """ (location: ∅)
+              │       │               ├── children: (1 item)
+              │       │               │   └── @ LiteralNode (location: ∅)
+              │       │               │       ├── errors: []
+              │       │               │       └── content: "a.png"
+              │       │               │
+              │       │               │
+              │       │               ├── close_quote: """ (location: ∅)
+              │       │               └── quoted: true
+              │       │
+              │       │
+              │       │
+              │       └── is_void: true
+              │
+              ├── tag_name: "img" (location: ∅)
+              ├── body: []
+              ├── close_tag: ∅
+              ├── is_void: true
+              └── element_source: "DOM"
+      "
+    `)
+  })
+
+  test("drops a node kind it has no place for", () => {
+    expect(inspect(element`<div><?php ?></div>`)).toMatchInlineSnapshot(`
+      "
+      @ DocumentNode (location: ∅)
+      ├── errors: []
+      └── children: (1 item)
+          └── @ HTMLElementNode (location: ∅)
+              ├── errors: []
+              ├── open_tag:
+              │   └── @ HTMLOpenTagNode (location: ∅)
+              │       ├── errors: []
+              │       ├── tag_opening: "<" (location: ∅)
+              │       ├── tag_name: "div" (location: ∅)
+              │       ├── tag_closing: ">" (location: ∅)
+              │       ├── children: []
+              │       └── is_void: false
+              │
+              ├── tag_name: "div" (location: ∅)
+              ├── body: []
+              ├── close_tag:
+              │   └── @ HTMLCloseTagNode (location: ∅)
+              │       ├── errors: []
+              │       ├── tag_opening: "</" (location: ∅)
+              │       ├── tag_name: "div" (location: ∅)
+              │       ├── children: []
+              │       └── tag_closing: ">" (location: ∅)
+              │
+              ├── is_void: false
+              └── element_source: "DOM"
+      "
+    `)
+  })
+
+  test("unwraps a document or fragment down to its children", () => {
+    const fragment = document.createDocumentFragment()
+
+    fragment.append(document.createElement("main"))
+
+    expect(inspect(fragment)).toMatchInlineSnapshot(`
+      "
+      @ DocumentNode (location: ∅)
+      ├── errors: []
+      └── children: (1 item)
+          └── @ HTMLElementNode (location: ∅)
+              ├── errors: []
+              ├── open_tag:
+              │   └── @ HTMLOpenTagNode (location: ∅)
+              │       ├── errors: []
+              │       ├── tag_opening: "<" (location: ∅)
+              │       ├── tag_name: "main" (location: ∅)
+              │       ├── tag_closing: ">" (location: ∅)
+              │       ├── children: []
+              │       └── is_void: false
+              │
+              ├── tag_name: "main" (location: ∅)
+              ├── body: []
+              ├── close_tag:
+              │   └── @ HTMLCloseTagNode (location: ∅)
+              │       ├── errors: []
+              │       ├── tag_opening: "</" (location: ∅)
+              │       ├── tag_name: "main" (location: ∅)
+              │       ├── children: []
+              │       └── tag_closing: ">" (location: ∅)
+              │
+              ├── is_void: false
+              └── element_source: "DOM"
+      "
+    `)
+  })
+
+  describe("the live element", () => {
+    test("is carried on the element node and its open tag", () => {
+      const source = element`<div></div>`
+      const node = first(source)
+
+      expect((node as HTMLElementNode & WithDOMNode)[DOM_NODE]).toBe(source)
+      expect((node.open_tag! as any)[DOM_NODE]).toBe(source)
+    })
+  })
+
+  describe("where an element was written", () => {
+    const found = (root: Node, selector: string) => {
+      const element = (root as any).querySelector(selector)
+
+      const walk = (node: any): any => {
+        if (!node) return null
+        if (node[DOM_NODE] === element) return node
+
+        for (const child of node.childNodes()) {
+          const hit = walk(child)
+
+          if (hit) return hit
+        }
+
+        return null
+      }
+
+      return walk(domToAST(root as any))
+    }
+
+    const startOf = (node: any) => [node.location.start.line, node.location.start.column]
+
+    test("a stamp names the line and column it was written at", () => {
+      const node = found(dom(`<div data-herb-source="app/views/posts/_card.html.erb:8:3"><img id="a" src="/a.png"></div>`), "#a")
+
+      expect(startOf(node)).toEqual([8, 2])
+      expect(sourcePathOf(node)?.path).toBe("app/views/posts/_card.html.erb")
+    })
+
+    test("a region marker names the file, and answers with the top of it", () => {
+      const node = found(dom(`<!--herb-region:app/views/posts/index.html.erb:c8082c87:0--><img id="b" src="/b.png"><!--/herb-region:app/views/posts/index.html.erb-->`), "#b")
+
+      expect(startOf(node)).toEqual([1, 0])
+      expect(sourcePathOf(node)?.path).toBe("app/views/posts/index.html.erb")
+    })
+
+    test("a stamp inside a region wins over the region", () => {
+      const node = found(dom(`<!--herb-region:app/views/posts/index.html.erb:c8082c87:0--><img id="c" data-herb-source="app/views/posts/_card.html.erb:4:1" src="/c.png"><!--/herb-region:app/views/posts/index.html.erb-->`), "#c")
+
+      expect(startOf(node)).toEqual([4, 0])
+      expect(sourcePathOf(node)?.path).toBe("app/views/posts/_card.html.erb")
+    })
+
+    test("a region closes back to the one around it", () => {
+      const root = dom(`<!--herb-region:outer.html.erb:c8082c87:0--><!--herb-region:inner.html.erb:c8082c87:0--><img id="d" src="/d.png"><!--/herb-region:inner.html.erb--><img id="e" src="/e.png"><!--/herb-region:outer.html.erb-->`)
+
+      expect(sourcePathOf(found(root, "#d"))?.path).toBe("inner.html.erb")
+      expect(sourcePathOf(found(root, "#e"))?.path).toBe("outer.html.erb")
+    })
+
+    test("a marker missing the version and occurrence names no region", () => {
+      const node = found(dom(`<!--herb-region:app/views/posts/index.html.erb--><img id="g" src="/g.png">`), "#g")
+
+      expect(sourcePathOf(node)).toBeNull()
+    })
+
+    test("a file with a colon in it still reads as the file", () => {
+      const node = found(dom(`<!--herb-region:app/views/a:b.html.erb:c8082c87:0--><img id="h" src="/h.png">`), "#h")
+
+      expect(sourcePathOf(node)?.path).toBe("app/views/a:b.html.erb")
+    })
+
+    test("neither a stamp nor a region leaves it unplaced", () => {
+      const node = found(dom(`<img id="f" src="/f.png">`), "#f")
+
+      expect(node.location).toBeNull()
+      expect(sourcePathOf(node)).toBeNull()
+    })
+  })
+})

--- a/javascript/packages/linter/test/browser/file-attribution.test.ts
+++ b/javascript/packages/linter/test/browser/file-attribution.test.ts
@@ -1,0 +1,51 @@
+import { describe, test, expect } from "vitest"
+import { dom } from "./support/dom.js"
+import { createBrowserLinter } from "./support/browser-linter.js"
+
+const lint = (markup: string) => {
+  return createBrowserLinter({ only: ["html-img-require-alt"] }).lintElement(dom(markup) as any)
+}
+
+describe("the file an offense came from", () => {
+  test("a stamped element names the file, line and column", () => {
+    const { offenses } = lint(`<div data-herb-source="app/views/posts/_card.html.erb:8:3"><img src="/a.png"></div>`)
+
+    expect(offenses).toHaveLength(1)
+    expect(offenses[0].file?.toString()).toBe("app/views/posts/_card.html.erb:8:3")
+  })
+
+  test("an element inside a region marker names the file alone", () => {
+    const { offenses } = lint(`<!--herb-region:app/views/posts/index.html.erb:c8082c87:0--><img src="/b.png"><!--/herb-region:app/views/posts/index.html.erb-->`)
+
+    expect(offenses).toHaveLength(1)
+    expect(offenses[0].file?.path).toBe("app/views/posts/index.html.erb")
+    expect(offenses[0].file?.toString()).toBe("app/views/posts/index.html.erb:1:1")
+  })
+
+  test("an element with neither leaves the offense unattributed", () => {
+    const { offenses } = lint(`<img src="/c.png">`)
+
+    expect(offenses).toHaveLength(1)
+    expect(offenses[0].file).toBeUndefined()
+  })
+
+  test("every rule that fires against a stamped tree gets one", () => {
+    const markup = `<div data-herb-source="app/views/posts/_card.html.erb:8:3">
+      <img src="/a.png">
+      <iframe src="/x"></iframe>
+      <a>no href</a>
+      <h1></h1>
+      <details><p>no summary</p></details>
+      <input tabindex="5">
+      <button aria-hidden="true">x</button>
+      <p id="dup"></p><p id="dup"></p>
+    </div>`
+
+    const result = createBrowserLinter().lint(dom(markup) as any)
+
+    const table = result.offenses.map((offense: any) => [offense.rule, offense.file ? "file" : "NO FILE"])
+
+    expect(table.filter((row: any) => row[1] !== "file")).toEqual([])
+    expect(table.length).toBe(8)
+  })
+})

--- a/javascript/packages/linter/test/browser/lint-dom.test.ts
+++ b/javascript/packages/linter/test/browser/lint-dom.test.ts
@@ -1,0 +1,158 @@
+import { describe, test, expect, afterEach } from "vitest"
+
+import { sourcePathFor } from "../../src/browser/lint-dom.js"
+import { domToAST } from "../../src/browser/dom-to-ast.js"
+import { BrowserScopedStyleNoUnusedSelectorRule } from "../../src/browser/rules/browser-scoped-style-no-unused-selector.js"
+
+import { dom, element, resetDOM } from "./support/dom.js"
+import { createBrowserLinter, ruleFor } from "./support/browser-linter.js"
+
+import type { HTMLElementNode } from "@herb-tools/core"
+
+afterEach(resetDOM)
+
+const linter = () => createBrowserLinter({ only: ["html-no-duplicate-ids", "a11y-nested-interactive-elements"] })
+
+describe("linting a rendered page", () => {
+  test("finds a duplicate id across two subtrees, which is what only a rendered page shows", () => {
+    const tree = dom`
+      <section><p id="note"></p></section>
+      <aside><p id="note"></p></aside>
+    `
+
+    expect(linter().lintElement(tree).offenses.map((offense) => offense.message)).toEqual([
+      "Duplicate ID `note` found. IDs must be unique within a document.",
+    ])
+  })
+
+  test("says nothing when the ids are distinct" , () => {
+    const tree = dom`
+      <p id="one"></p>
+      <p id="two"></p>
+    `
+
+    expect(linter().lintElement(tree).offenses).toEqual([])
+  })
+
+  test("cannot see a form nested in another form, because the browser deletes it on the way in", () => {
+    const tree = element`<form><div><form></form></div></form>`
+    const nested = createBrowserLinter({ only: ["html-no-nested-forms"] })
+
+    expect(tree.querySelectorAll("form").length).toBe(0)
+    expect(nested.lintElement(tree).offenses).toEqual([])
+  })
+
+  test("cannot see a link nested in another link, because the browser pulls them apart", () => {
+    const tree = dom`<a href="/a"><span><a href="/b">x</a></span></a>`
+    const nested = createBrowserLinter({ only: ["html-no-nested-links"] })
+
+    expect(tree.querySelectorAll("a").length).toBe(2)
+    expect(tree.querySelectorAll("a a").length).toBe(0)
+    expect(nested.lintElement(tree).offenses).toEqual([])
+  })
+
+  test("reports without a position when nothing in the tree was stamped", () => {
+    const tree = dom`
+      <p id="note"></p>
+      <p id="note"></p>
+    `
+
+    const [offense] = linter().lintElement(tree).offenses
+
+    expect(offense).toBeDefined()
+    expect(offense.location).toBeNull()
+  })
+})
+
+describe("sourcePathFor", () => {
+  test("reads the stamp off the element itself, back to what was written", () => {
+    const source = element`<div data-herb-source="app/views/posts/_card.html.erb:8:3"></div>`
+    const node = domToAST(source).children[0] as HTMLElementNode
+
+    expect(sourcePathFor(node)!.toString()).toBe("app/views/posts/_card.html.erb:8:3")
+  })
+
+  test("walks up to the nearest stamped ancestor for markup that carries none", () => {
+    const outer = element`<div data-herb-source="layout.html.erb:2:1"><span></span></div>`
+    const node = domToAST(outer).children[0] as HTMLElementNode
+    const span = node.body[0] as HTMLElementNode
+
+    expect(sourcePathFor(span)!.toString()).toBe("layout.html.erb:2:1")
+  })
+
+  test("answers with nothing when nothing in the tree is stamped", () => {
+    const node = domToAST(element`<div></div>`).children[0] as HTMLElementNode
+
+    expect(sourcePathFor(node)).toBeNull()
+  })
+
+  test("reads the stamp against a project, so it can be written out in full", () => {
+    const source = element`<div data-herb-source="app/views/x.html.erb:8:3"></div>`
+    const node = domToAST(source).children[0] as HTMLElementNode
+
+    expect(sourcePathFor(node, "/Users/marco/blog")!.absolute.toString()).toBe("/Users/marco/blog/app/views/x.html.erb:8:3")
+  })
+
+  test("answers with nothing for a node that came from no DOM element", () => {
+    const node = domToAST(element`<div>hi</div>`).children[0] as HTMLElementNode
+
+    expect(sourcePathFor(node.body[0])).toBeNull()
+  })
+})
+
+describe("which rules run in the browser", () => {
+  const tree = () => dom`
+    <p id="note"></p>
+    <p id="note"></p>
+    <img>
+  `
+
+  const namesFor = (config?: any) => createBrowserLinter({ config }).lintElement(tree()).offenses.map((offense) => offense.rule)
+
+  test("runs a rule that says it answers on a rendered page", () => {
+    const names = namesFor()
+
+    expect(names).toContain("html-no-duplicate-ids")
+    expect(names).toContain("html-img-require-alt")
+  })
+
+  test("leaves out a rule that says nothing about where it runs", () => {
+    const names = namesFor()
+
+    expect(names).not.toContain("html-attribute-double-quotes")
+    expect(names).not.toContain("erb-no-silent-statement")
+  })
+
+  test("lets config bring in a rule the rule itself leaves out", () => {
+    const rule = ruleFor("html-no-self-closing")
+
+    const withoutConfig = createBrowserLinter()
+    const withConfig = createBrowserLinter({
+      config: { linter: { rules: { "html-no-self-closing": { environments: ["cli", "browser"] } } } } as any
+    })
+
+    expect(withoutConfig.appliesTo(rule, "browser")).toBe(false)
+    expect(withConfig.appliesTo(rule, "browser")).toBe(true)
+  })
+
+  test("lets config take out a rule the rule itself runs", () => {
+    const config = { linter: { rules: { "html-no-duplicate-ids": { environments: ["cli"] } } } }
+
+    expect(namesFor(config)).not.toContain("html-no-duplicate-ids")
+  })
+
+  test("takes a browser rule out when config narrows it to the command line", () => {
+    const config = { linter: { rules: { "browser-scoped-style-no-unused-selector": { environments: ["cli"] } } } }
+    const rule = new BrowserScopedStyleNoUnusedSelectorRule()
+
+    expect(createBrowserLinter().appliesTo(rule, "browser")).toBe(true)
+    expect(createBrowserLinter({ config: config as any }).appliesTo(rule, "browser")).toBe(false)
+  })
+
+  test("leaves the command line alone, where a rule saying nothing still runs", () => {
+    const rule = ruleFor("html-attribute-double-quotes")
+
+    expect(createBrowserLinter().appliesTo(rule, "cli")).toBe(true)
+    expect(createBrowserLinter().appliesTo(rule, undefined)).toBe(true)
+  })
+})

--- a/javascript/packages/linter/test/browser/lint-element.test.ts
+++ b/javascript/packages/linter/test/browser/lint-element.test.ts
@@ -1,0 +1,50 @@
+import { describe, test, expect } from "vitest"
+import { dom } from "./support/dom.js"
+import { createBrowserLinter } from "./support/browser-linter.js"
+
+const ruleNames = (result: any) => result.offenses.map((offense: any) => offense.rule).sort()
+
+describe("linting what is on the page", () => {
+  test("lint takes an element", () => {
+    const root = dom(`<img src="/a.png">`)
+
+    expect(ruleNames(createBrowserLinter().lint(root as any))).toEqual(["html-img-require-alt"])
+  })
+
+  test("lintElement takes the same element", () => {
+    const root = dom(`<img src="/a.png">`)
+
+    expect(ruleNames(createBrowserLinter().lintElement(root as any))).toEqual(["html-img-require-alt"])
+  })
+
+  test("lint still takes a string", () => {
+    expect(ruleNames(createBrowserLinter().lint(`<img src="/a.png">`))).toEqual(["html-img-require-alt"])
+  })
+
+  test("lint on an element answers the way lintElement does", () => {
+    const root = dom(`<p id="a"></p><p id="a"></p>`)
+
+    expect(ruleNames(createBrowserLinter().lint(root as any))).toEqual(ruleNames(createBrowserLinter().lintElement(root as any)))
+  })
+
+  test("an element reaches the rules that need a live DOM", () => {
+    const root = dom(`<style scoped>.used { color: red } .unused { color: blue }</style><p class="used"></p>`)
+
+    expect(ruleNames(createBrowserLinter().lint(root as any))).toContain("browser-scoped-style-no-unused-selector")
+  })
+
+  test("a rule answered against the live DOM reports without a position", () => {
+    const root = dom(`<style scoped>.gone { color: red }</style>`)
+
+    const offense = createBrowserLinter().lint(root as any).offenses.find((one: any) => one.rule === "browser-scoped-style-no-unused-selector")
+
+    expect(offense).toBeDefined()
+    expect(offense!.location).toBeNull()
+  })
+
+  test("a string does not, because it has no stylesheets to ask about", () => {
+    const result = createBrowserLinter().lint(`<style scoped>.unused { color: blue }</style>`)
+
+    expect(ruleNames(result)).not.toContain("browser-scoped-style-no-unused-selector")
+  })
+})

--- a/javascript/packages/linter/test/browser/rules/a11y-nested-interactive-elements.test.ts
+++ b/javascript/packages/linter/test/browser/rules/a11y-nested-interactive-elements.test.ts
@@ -1,0 +1,18 @@
+import { describe, test } from "vitest"
+
+import { A11yNestedInteractiveElementsRule } from "../../../src/rules/a11y-nested-interactive-elements.js"
+import { createBrowserRuleTest } from "../support/browser-rule-test.js"
+
+const { expectNoOffenses, expectError, assertOffenses } = createBrowserRuleTest(A11yNestedInteractiveElementsRule)
+
+describe("a11y-nested-interactive-elements in the browser", () => {
+  test("passes for two interactive elements side by side", () => {
+    expectNoOffenses(`<button>one</button><button>two</button>`)
+  })
+
+  test("fails for one interactive element inside another, which the parser keeps", () => {
+    expectError(`Found \`<button>\` nested inside of \`<button>\`. Nesting interactive elements produces invalid HTML, and assistive technologies, such as screen readers, might ignore or respond unexpectedly to such nested controls.`)
+
+    assertOffenses(`<button><button>inner</button></button>`)
+  })
+})

--- a/javascript/packages/linter/test/browser/rules/html-anchor-require-href.test.ts
+++ b/javascript/packages/linter/test/browser/rules/html-anchor-require-href.test.ts
@@ -1,0 +1,18 @@
+import { describe, test } from "vitest"
+
+import { HTMLAnchorRequireHrefRule } from "../../../src/rules/html-anchor-require-href.js"
+import { createBrowserRuleTest } from "../support/browser-rule-test.js"
+
+const { expectNoOffenses, expectError, assertOffenses } = createBrowserRuleTest(HTMLAnchorRequireHrefRule)
+
+describe("html-anchor-require-href in the browser", () => {
+  test("passes for an anchor the page rendered with an href", () => {
+    expectNoOffenses(`<a href="/">Home</a>`)
+  })
+
+  test("fails for an anchor that rendered without one", () => {
+    expectError(`Add an \`href\` attribute to \`<a>\` to ensure it is focusable and accessible. Links should navigate somewhere. If you need a clickable element without navigation, use a \`<button>\` instead.`)
+
+    assertOffenses(`<a>Home</a>`)
+  })
+})

--- a/javascript/packages/linter/test/browser/rules/html-details-has-summary.test.ts
+++ b/javascript/packages/linter/test/browser/rules/html-details-has-summary.test.ts
@@ -1,0 +1,18 @@
+import { describe, test } from "vitest"
+
+import { HTMLDetailsHasSummaryRule } from "../../../src/rules/html-details-has-summary.js"
+import { createBrowserRuleTest } from "../support/browser-rule-test.js"
+
+const { expectNoOffenses, expectWarning, assertOffenses } = createBrowserRuleTest(HTMLDetailsHasSummaryRule)
+
+describe("html-details-has-summary in the browser", () => {
+  test("passes for details the page rendered with a summary", () => {
+    expectNoOffenses(`<details><summary>More</summary><p>x</p></details>`)
+  })
+
+  test("fails for details that rendered without one", () => {
+    expectWarning(`\`<details>\` element must have a direct \`<summary>\` child element.`)
+
+    assertOffenses(`<details><p>x</p></details>`)
+  })
+})

--- a/javascript/packages/linter/test/browser/rules/html-head-only-elements.test.ts
+++ b/javascript/packages/linter/test/browser/rules/html-head-only-elements.test.ts
@@ -1,0 +1,18 @@
+import { describe, test } from "vitest"
+
+import { HTMLHeadOnlyElementsRule } from "../../../src/rules/html-head-only-elements.js"
+import { createBrowserRuleTest } from "../support/browser-rule-test.js"
+
+const { expectNoOffenses, expectError, assertOffenses } = createBrowserRuleTest(HTMLHeadOnlyElementsRule)
+
+describe("html-head-only-elements in the browser", () => {
+  test("passes for a body element where it belongs", () => {
+    expectNoOffenses(`<div><p>fine</p></div>`)
+  })
+
+  test("fails for a head-only element the page rendered in the body", () => {
+    expectError(`Element \`<title>\` must be placed inside the \`<head>\` tag.`)
+
+    assertOffenses(`<div><title>misplaced</title></div>`)
+  })
+})

--- a/javascript/packages/linter/test/browser/rules/html-iframe-has-title.test.ts
+++ b/javascript/packages/linter/test/browser/rules/html-iframe-has-title.test.ts
@@ -1,0 +1,18 @@
+import { describe, test } from "vitest"
+
+import { HTMLIframeHasTitleRule } from "../../../src/rules/html-iframe-has-title.js"
+import { createBrowserRuleTest } from "../support/browser-rule-test.js"
+
+const { expectNoOffenses, expectWarning, assertOffenses } = createBrowserRuleTest(HTMLIframeHasTitleRule)
+
+describe("html-iframe-has-title in the browser", () => {
+  test("passes for an iframe the page rendered with a title", () => {
+    expectNoOffenses(`<iframe src="/a" title="Report"></iframe>`)
+  })
+
+  test("fails for an iframe that rendered without one", () => {
+    expectWarning(`\`<iframe>\` elements must have a \`title\` attribute that describes the content of the frame for screen reader users.`)
+
+    assertOffenses(`<iframe src="/a"></iframe>`)
+  })
+})

--- a/javascript/packages/linter/test/browser/rules/html-img-require-alt.test.ts
+++ b/javascript/packages/linter/test/browser/rules/html-img-require-alt.test.ts
@@ -1,0 +1,18 @@
+import { describe, test } from "vitest"
+
+import { HTMLImgRequireAltRule } from "../../../src/rules/html-img-require-alt.js"
+import { createBrowserRuleTest } from "../support/browser-rule-test.js"
+
+const { expectNoOffenses, expectWarning, assertOffenses } = createBrowserRuleTest(HTMLImgRequireAltRule)
+
+describe("html-img-require-alt in the browser", () => {
+  test("passes for an img the page rendered with alt", () => {
+    expectNoOffenses(`<img src="/logo.png" alt="Company logo">`)
+  })
+
+  test("fails for an img that rendered without one", () => {
+    expectWarning(`Missing required \`alt\` attribute on \`<img>\` tag. Add \`alt=""\` for decorative images or \`alt="description"\` for informative images.`)
+
+    assertOffenses(`<img src="/logo.png">`)
+  })
+})

--- a/javascript/packages/linter/test/browser/rules/html-no-aria-hidden-on-focusable.test.ts
+++ b/javascript/packages/linter/test/browser/rules/html-no-aria-hidden-on-focusable.test.ts
@@ -1,0 +1,18 @@
+import { describe, test } from "vitest"
+
+import { HTMLNoAriaHiddenOnFocusableRule } from "../../../src/rules/html-no-aria-hidden-on-focusable.js"
+import { createBrowserRuleTest } from "../support/browser-rule-test.js"
+
+const { expectNoOffenses, expectWarning, assertOffenses } = createBrowserRuleTest(HTMLNoAriaHiddenOnFocusableRule)
+
+describe("html-no-aria-hidden-on-focusable in the browser", () => {
+  test("passes for aria-hidden on something not focusable", () => {
+    expectNoOffenses(`<div aria-hidden="true"></div>`)
+  })
+
+  test("fails for aria-hidden on something the page left focusable", () => {
+    expectWarning(`Elements that are focusable should not have \`aria-hidden="true"\` because it will cause confusion for assistive technology users.`)
+
+    assertOffenses(`<button aria-hidden="true">x</button>`)
+  })
+})

--- a/javascript/packages/linter/test/browser/rules/html-no-duplicate-ids.test.ts
+++ b/javascript/packages/linter/test/browser/rules/html-no-duplicate-ids.test.ts
@@ -1,0 +1,18 @@
+import { describe, test } from "vitest"
+
+import { HTMLNoDuplicateIdsRule } from "../../../src/rules/html-no-duplicate-ids.js"
+import { createBrowserRuleTest } from "../support/browser-rule-test.js"
+
+const { expectNoOffenses, expectError, assertOffenses } = createBrowserRuleTest(HTMLNoDuplicateIdsRule)
+
+describe("html-no-duplicate-ids in the browser", () => {
+  test("passes for two ids the page rendered distinct", () => {
+    expectNoOffenses(`<p id="one"></p><p id="two"></p>`)
+  })
+
+  test("fails for the same id rendered twice, which one template cannot see", () => {
+    expectError(`Duplicate ID \`note\` found. IDs must be unique within a document.`)
+
+    assertOffenses(`<p id="note"></p><p id="note"></p>`)
+  })
+})

--- a/javascript/packages/linter/test/browser/rules/html-no-duplicate-meta-names.test.ts
+++ b/javascript/packages/linter/test/browser/rules/html-no-duplicate-meta-names.test.ts
@@ -1,0 +1,18 @@
+import { describe, test } from "vitest"
+
+import { HTMLNoDuplicateMetaNamesRule } from "../../../src/rules/html-no-duplicate-meta-names.js"
+import { createBrowserRuleTest } from "../support/browser-rule-test.js"
+
+const { expectNoOffenses, expectError, assertOffenses } = createBrowserRuleTest(HTMLNoDuplicateMetaNamesRule)
+
+describe("html-no-duplicate-meta-names in the browser", () => {
+  test("passes for two meta names the page rendered distinct", () => {
+    expectNoOffenses(`<meta name="description" content="a"><meta name="keywords" content="b">`)
+  })
+
+  test("fails for the same meta name rendered twice", () => {
+    expectError(`Duplicate \`<meta>\` tag with \`name="description"\`. Meta names should be unique within the \`<head>\` section.`)
+
+    assertOffenses(`<meta name="description" content="a"><meta name="description" content="b">`)
+  })
+})

--- a/javascript/packages/linter/test/browser/rules/html-no-empty-headings.test.ts
+++ b/javascript/packages/linter/test/browser/rules/html-no-empty-headings.test.ts
@@ -1,0 +1,18 @@
+import { describe, test } from "vitest"
+
+import { HTMLNoEmptyHeadingsRule } from "../../../src/rules/html-no-empty-headings.js"
+import { createBrowserRuleTest } from "../support/browser-rule-test.js"
+
+const { expectNoOffenses, expectWarning, assertOffenses } = createBrowserRuleTest(HTMLNoEmptyHeadingsRule)
+
+describe("html-no-empty-headings in the browser", () => {
+  test("passes for a heading the page rendered with text", () => {
+    expectNoOffenses(`<h1>Title</h1>`)
+  })
+
+  test("fails for a heading that rendered empty", () => {
+    expectWarning(`Heading element \`<h1>\` must not be empty. Provide accessible text content for screen readers and SEO.`)
+
+    assertOffenses(`<h1></h1>`)
+  })
+})

--- a/javascript/packages/linter/test/browser/rules/html-no-positive-tab-index.test.ts
+++ b/javascript/packages/linter/test/browser/rules/html-no-positive-tab-index.test.ts
@@ -1,0 +1,18 @@
+import { describe, test } from "vitest"
+
+import { HTMLNoPositiveTabIndexRule } from "../../../src/rules/html-no-positive-tab-index.js"
+import { createBrowserRuleTest } from "../support/browser-rule-test.js"
+
+const { expectNoOffenses, expectWarning, assertOffenses } = createBrowserRuleTest(HTMLNoPositiveTabIndexRule)
+
+describe("html-no-positive-tab-index in the browser", () => {
+  test("passes for a tab index the page rendered as zero", () => {
+    expectNoOffenses(`<div tabindex="0"></div>`)
+  })
+
+  test("fails for a positive tab index", () => {
+    expectWarning(`Do not use positive \`tabindex\` values as they are error prone and can severely disrupt navigation experience for keyboard users. Use \`tabindex="0"\` to make an element focusable or \`tabindex="-1"\` to remove it from the tab sequence.`)
+
+    assertOffenses(`<div tabindex="3"></div>`)
+  })
+})

--- a/javascript/packages/linter/test/browser/support-dom.test.ts
+++ b/javascript/packages/linter/test/browser/support-dom.test.ts
@@ -1,0 +1,32 @@
+import { describe, test, expect, afterEach } from "vitest"
+import { dom, element, resetDOM } from "./support/dom.js"
+
+afterEach(resetDOM)
+
+describe("the DOM helper", () => {
+  test("keeps table markup that a div container would throw away", () => {
+    const root = dom`<tr><td>x</td></tr>`
+
+    expect(root.querySelectorAll("td").length).toBe(1)
+    expect(root.innerHTML).toBe("<tr><td>x</td></tr>")
+  })
+
+  test("keeps the other elements that need a parent to be parsed", () => {
+    expect(dom`<td>x</td>`.querySelectorAll("td").length).toBe(1)
+    expect(dom`<tbody><tr><td>x</td></tr></tbody>`.querySelectorAll("tr").length).toBe(1)
+    expect(dom`<option>x</option>`.querySelectorAll("option").length).toBe(1)
+    expect(dom`<caption>x</caption>`.querySelectorAll("caption").length).toBe(1)
+  })
+
+  test("gives a style element a live sheet, because the document owns it", () => {
+    const root = dom`<style scoped>.a { color: red }</style>`
+    const style = root.querySelector("style") as HTMLStyleElement
+
+    expect(style.sheet).not.toBeNull()
+    expect(style.sheet!.cssRules.length).toBe(1)
+  })
+
+  test("still reads ordinary markup the way it is written", () => {
+    expect(element`<div class="card"><p>hi</p></div>`.outerHTML).toBe(`<div class="card"><p>hi</p></div>`)
+  })
+})

--- a/javascript/packages/linter/test/browser/support/browser-linter.ts
+++ b/javascript/packages/linter/test/browser/support/browser-linter.ts
@@ -1,0 +1,31 @@
+import { Linter } from "../../../src/linter.js"
+import { HerbDOMBackend } from "../../../src/browser/backend.js"
+
+import type { Config } from "@herb-tools/config"
+import type { FullRuleConfig } from "../../../src/types.js"
+
+interface LinterOptions {
+  only?: string[]
+  config?: Config
+}
+
+/**
+ * A linter that parses with the browser, for a test about what the linter does with a rendered
+ * page. `createBrowserRuleTest` is the one to reach for when the test is about a single rule and
+ * the offenses it reports.
+ *
+ *     createBrowserLinter({ only: ["html-no-duplicate-ids"] }).lintElement(root)
+ */
+export function createBrowserLinter({ only, config }: LinterOptions = {}): Linter {
+  return Linter.from(new HerbDOMBackend(), config, undefined, only ? { only } : undefined)
+}
+
+export function ruleFor(ruleName: string): { ruleName: string; defaultConfig?: FullRuleConfig } {
+  const ruleClass = createBrowserLinter().rules.find((candidate) => candidate.ruleName === ruleName)
+
+  if (!ruleClass) {
+    throw new Error(`No rule named "${ruleName}"`)
+  }
+
+  return new ruleClass() as { ruleName: string; defaultConfig?: FullRuleConfig }
+}

--- a/javascript/packages/linter/test/browser/support/browser-rule-test.ts
+++ b/javascript/packages/linter/test/browser/support/browser-rule-test.ts
@@ -1,0 +1,124 @@
+import { afterEach, expect } from "vitest"
+import dedent from "dedent"
+
+import { dom, resetDOM } from "./dom.js"
+import { createBrowserLinter } from "./browser-linter.js"
+
+import type { LintOffense, LintSeverity, RuleClass } from "../../../src/types.js"
+
+interface BrowserLinterTestHelpers {
+  expectNoOffenses: (markup: string) => void
+  expectError: (message: string) => void
+  expectWarning: (message: string) => void
+  expectInfo: (message: string) => void
+  expectHint: (message: string) => void
+  assertOffenses: (markup: string) => void
+}
+
+/**
+ * A test helper for asking one rule about a rendered page, shaped the same way `createLinterTest`
+ * is, so a rule reads the same whichever side it is being tested from.
+ *
+ * An expectation is a message and a severity. A location is left out, because markup written in a
+ * test carries no stamp saying which template it came from.
+ *
+ * Works for a `BrowserRule` too, which is handed a real attached DOM instead of a string, since a
+ * rule reading the CSSOM has nothing to read from markup that was never in the document.
+ *
+ * Markup that needs a parent to be parsed cannot be written here on its own. A bare `<tr>` or
+ * `<option>` handed to the browser as a document is dropped, and the case would pass while
+ * asserting nothing. Write the table or the select around it, the way a page would have it.
+ *
+ * The markup goes through the browser's own parser, which repairs as it reads. A rule looking for
+ * something the parser fixes on the way in can never report it, so every rule declaring
+ * `environments: ["cli", "browser"]` has a file beside this one proving it still can.
+ *
+ * @example
+ * ```ts
+ * const { expectNoOffenses, expectWarning, assertOffenses } = createBrowserRuleTest(MyRule)
+ *
+ * test("valid case", () => {
+ *   expectNoOffenses(`<img src="/a.png" alt="a">`)
+ * })
+ *
+ * test("invalid case", () => {
+ *   expectWarning("Missing required `alt` attribute on `<img>` tag.")
+ *
+ *   assertOffenses(`<img src="/a.png">`)
+ * })
+ * ```
+ */
+export function createBrowserRuleTest(ruleClass: RuleClass): BrowserLinterTestHelpers {
+  const expected: Record<LintSeverity, string[]> = { error: [], warning: [], info: [], hint: [] }
+  let hasAsserted = false
+
+  const pending = () => Object.values(expected).reduce((total, messages) => total + messages.length, 0)
+  const needsLiveDOM = (ruleClass as { type?: string }).type === "browser"
+  const lint = (markup: string): LintOffense[] => {
+    const linter = createBrowserLinter({ only: [ruleClass.ruleName] })
+    const source = needsLiveDOM ? dom(dedent(markup)) : dedent(markup)
+
+    return linter
+      .lint(source as never, { environment: "browser" })
+      .offenses.filter((offense) => offense.rule === ruleClass.ruleName)
+  }
+
+  const report = (severity: LintSeverity, actual: LintOffense[]) =>
+    `Expected ${expected[severity].length} ${severity}(s) from rule "${ruleClass.ruleName}" but found ${actual.length}.\n` +
+    `Expected:\n${expected[severity].map((message) => `  - "${message}"`).join("\n")}\n` +
+    `Actual:\n${actual.map((offense) => `  - "${offense.message}"`).join("\n")}`
+
+  afterEach(resetDOM)
+
+  afterEach(() => {
+    if (!hasAsserted && pending() > 0) {
+      throw new Error(
+        `Test has ${pending()} pending expectation(s) that were never asserted. ` +
+        `Did you forget to call assertOffenses() or expectNoOffenses()?`
+      )
+    }
+
+    for (const severity of Object.keys(expected) as LintSeverity[]) expected[severity].length = 0
+
+    hasAsserted = false
+  })
+
+  const expectSeverity = (severity: LintSeverity) => (message: string) => {
+    expected[severity].push(message)
+  }
+
+  return {
+    expectNoOffenses: (markup) => {
+      if (pending() > 0) {
+        throw new Error("Cannot call expectNoOffenses() after registering expectations with expectWarning(), expectError(), expectInfo() or expectHint()")
+      }
+
+      hasAsserted = true
+
+      expect(lint(markup).map((offense) => offense.message)).toEqual([])
+    },
+
+    expectError: expectSeverity("error"),
+    expectWarning: expectSeverity("warning"),
+    expectInfo: expectSeverity("info"),
+    expectHint: expectSeverity("hint"),
+
+    assertOffenses: (markup) => {
+      if (pending() === 0) {
+        throw new Error("Cannot call assertOffenses() with no expectations. Use expectNoOffenses() instead.")
+      }
+
+      hasAsserted = true
+
+      const offenses = lint(markup)
+
+      for (const severity of Object.keys(expected) as LintSeverity[]) {
+        const actual = offenses.filter((offense) => offense.severity === severity)
+
+        if (actual.length !== expected[severity].length) throw new Error(report(severity, actual))
+
+        expect(actual.map((offense) => offense.message)).toEqual(expected[severity])
+      }
+    },
+  }
+}

--- a/javascript/packages/linter/test/browser/support/dom.ts
+++ b/javascript/packages/linter/test/browser/support/dom.ts
@@ -1,0 +1,22 @@
+import dedent from "dedent"
+
+export function dom(strings: TemplateStringsArray | string, ...values: unknown[]): HTMLElement {
+  const template = document.createElement("template")
+
+  template.innerHTML = dedent(strings as TemplateStringsArray, ...values)
+
+  const container = document.createElement("div")
+
+  container.append(template.content)
+  document.body.append(container)
+
+  return container
+}
+
+export function element(strings: TemplateStringsArray | string, ...values: unknown[]): Element {
+  return dom(strings, ...values).firstElementChild!
+}
+
+export function resetDOM(): void {
+  document.body.innerHTML = ""
+}

--- a/javascript/packages/linter/tsconfig.browser-test.json
+++ b/javascript/packages/linter/tsconfig.browser-test.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "lib": ["ES2022", "dom"],
+    "types": ["node"],
+    "noEmit": true,
+    "rootDir": "."
+  },
+  "include": ["src/**/*", "types/**/*", "test/browser/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/javascript/packages/linter/tsconfig.test.json
+++ b/javascript/packages/linter/tsconfig.test.json
@@ -6,5 +6,5 @@
     "rootDir": "."
   },
   "include": ["src/**/*", "types/**/*", "test/**/*"],
-  "exclude": ["node_modules", "dist"]
+  "exclude": ["node_modules", "dist", "test/browser/**/*"]
 }

--- a/javascript/packages/linter/vitest.config.ts
+++ b/javascript/packages/linter/vitest.config.ts
@@ -1,8 +1,30 @@
 import { defineConfig } from "vitest/config"
+import { playwright } from "@vitest/browser-playwright"
 
 export default defineConfig({
   test: {
-    isolate: false,
-    snapshotSerializers: ["./test/snapshot-serializer.ts"],
+    projects: [
+      {
+        test: {
+          name: "node",
+          include: ["test/**/*.test.ts"],
+          exclude: ["test/browser/**"],
+          isolate: false,
+          snapshotSerializers: ["./test/snapshot-serializer.ts"],
+        },
+      },
+      {
+        test: {
+          name: "browser",
+          include: ["test/browser/**/*.test.ts"],
+          browser: {
+            enabled: true,
+            headless: true,
+            provider: playwright(),
+            instances: [{ browser: "chromium" }],
+          },
+        },
+      },
+    ],
   },
 })


### PR DESCRIPTION
The linter reads templates. A page has already been through them, and some things are only visible once it has: two partials that each declare `id="note"` are both correct on their own and wrong together, and a scoped style block's selectors can only be judged against the markup that actually rendered. This pull request lets the linter run against a live DOM, and points what it finds back at the template the markup was written in.

```js
import { Linter } from "@herb-tools/linter"
import { HerbDOMBackend } from "@herb-tools/linter/browser"

const linter = Linter.from(new HerbDOMBackend())

linter.lint(document.body)
```

`lint` takes a DOM node as readily as it takes a string, and `lintElement` is the same walk under a name that says so. Both accept a `Document`, a `DocumentFragment`, or a single element.

#### How it works

`HerbDOMBackend` parses with the browser instead of with Herb, so the linter works on a page with no parser shipped alongside it. `domToAST` walks the live tree into a Herb AST, hanging the DOM element off each node it built so a finding can be traced back to something a reader can highlight.

What comes back is the repaired tree, which is the point and also the catch. A rule looking for something the browser fixes on the way in can never report it: nested `<form>` elements are deleted, nested `<a>` elements are pulled apart, and a body-only element written in the head is moved into the body. Those three rules say so instead of promising findings they cannot produce.

#### Where a rule runs

A rule declares where it answers, following the same shape `frameworks` already uses:

```ts
get defaultConfig(): FullRuleConfig {
  return { enabled: true, severity: "error", environments: ["cli", "browser"] }
}
```

Absent means `["cli"]`. That asymmetry with `frameworks` is deliberate: rules vastly outnumber browser-capable ones, so a rule that has never considered the DOM is not asked about it. Configuration overrides the rule either way.

```yaml
linter:
  rules:
    html-no-self-closing:
      environments: [cli, browser]
```

#### Rules that need the page itself

Some questions have no answer in an AST. `BrowserRule` takes the live DOM root instead of a `ParseResult`, and `browser-scoped-style-no-unused-selector` is the first: it reads `style.sheet.cssRules` and asks the document whether anything still matches.

```html
<style data-herb-style-scoped="data-herb-scope-2940ba8a">
  .used[data-herb-scope-2940ba8a] { color: red }
  .dead[data-herb-scope-2940ba8a] { color: red }
</style>
<div class="used" data-herb-scope-2940ba8a></div>
```

```
Selector `.dead[data-herb-scope-2940ba8a]` matches nothing on the rendered page.
```

The anchor comes from #2477. `ScopedStyle::Visitor` takes `scoped` back out once it has narrowed the selectors, so until that lands a compiled page carries nothing saying the block was ever scoped, and this rule finds nothing on one while appearing to work. It reads hand-written `scoped` too, which is what the tests use for the cases that are not about the engine, so nothing here is blocked on it.

#### Pointing a finding back at a template

An offense on a rendered page needs to name a file, and a `Location` carries a position with no path. Offenses gain a `file`, resolved from what the page already carries:

* `data-herb-source`, its own or its nearest stamped ancestor
* an enclosing `<!--herb-region:…-->` marker

The stamps come from `SourceAttributionVisitor`, and the region markers are the ones `Slots::Markers` already writes. They are read with `parseMarker` from `@herb-tools/client/directives`.