### PR TITLE
Engine: Keep a template's line numbers in the code it compiles to

### DIFF
--- a/lib/herb/engine.rb
+++ b/lib/herb/engine.rb
@@ -179,7 +179,25 @@ module Herb
     end
 
     def self.comment?(code)
-      code.include?("#")
+      stripped = code.rstrip
+
+      return false unless stripped.include?("#")
+      return true unless prism_available?
+
+      Prism.parse(stripped).comments.any? { |comment| comment.location.end_offset >= stripped.bytesize }
+    rescue StandardError
+      true
+    end
+
+    def self.prism_available?
+      return @prism_available unless @prism_available.nil?
+
+      @prism_available = begin
+        require "prism"
+        true
+      rescue LoadError
+        false
+      end
     end
 
     def self.heredoc?(code)

--- a/lib/herb/engine.rb
+++ b/lib/herb/engine.rb
@@ -189,6 +189,19 @@ module Herb
       true
     end
 
+    def self.strip_trailing_comment(code)
+      return code unless code.include?("#")
+      return code unless prism_available?
+
+      comment = Prism.parse(code).comments.find { |found| found.location.end_offset >= code.bytesize }
+
+      return code unless comment
+
+      code.byteslice(0, comment.location.start_offset).to_s.rstrip
+    rescue StandardError
+      code
+    end
+
     def self.prism_available?
       return @prism_available unless @prism_available.nil?
 

--- a/lib/herb/engine.rb
+++ b/lib/herb/engine.rb
@@ -10,6 +10,7 @@ require_relative "visitor/stack"
 require_relative "engine/runtime/session"
 require_relative "visitor/context_aware"
 require_relative "visitor/diagnostics"
+require_relative "engine/helpers"
 require_relative "engine/compiler"
 require_relative "engine/errors"
 require_relative "diagnostic/formatter"
@@ -178,45 +179,6 @@ module Herb
       value.is_a?(::String) || value.is_a?(::Symbol) ? value.to_s : value.to_json
     end
 
-    def self.comment?(code)
-      stripped = code.rstrip
-
-      return false unless stripped.include?("#")
-      return true unless prism_available?
-
-      Prism.parse(stripped).comments.any? { |comment| comment.location.end_offset >= stripped.bytesize }
-    rescue StandardError
-      true
-    end
-
-    def self.strip_trailing_comment(code)
-      return code unless code.include?("#")
-      return code unless prism_available?
-
-      comment = Prism.parse(code).comments.find { |found| found.location.end_offset >= code.bytesize }
-
-      return code unless comment
-
-      code.byteslice(0, comment.location.start_offset).to_s.rstrip
-    rescue StandardError
-      code
-    end
-
-    def self.prism_available?
-      return @prism_available unless @prism_available.nil?
-
-      @prism_available = begin
-        require "prism"
-        true
-      rescue LoadError
-        false
-      end
-    end
-
-    def self.heredoc?(code)
-      code.match?(/<<[~-]?\s*['"`]?\w/)
-    end
-
     protected
 
     #: () -> untyped
@@ -242,8 +204,7 @@ module Herb
 
         @src << " " << code
 
-        # TODO: rework and check for Prism::InlineComment as soon as we expose the Prism Nodes in the Herb AST
-        if self.class.comment?(code) || self.class.heredoc?(code)
+        if Helpers.comment?(code) || Helpers.heredoc?(code)
           @src << "\n" unless code[-1] == "\n"
         else
           @src << ";" unless code[-1] == "\n"
@@ -332,7 +293,7 @@ module Herb
         @src.chomp! if @src.end_with?("\n") && code_stripped.start_with?(" ")
 
         @src << " " << code_stripped
-        @src << "\n" if self.class.comment?(code_stripped)
+        @src << "\n" if Helpers.comment?(code_stripped)
         @src << (escaped ? "))" : ")")
         @src << (trailing_newline ? "\n" : ";")
 
@@ -343,8 +304,8 @@ module Herb
     end
 
     def trailing_newline(code)
-      return "\n" if self.class.comment?(code)
-      return "\n" if self.class.heredoc?(code)
+      return "\n" if Helpers.comment?(code)
+      return "\n" if Helpers.heredoc?(code)
 
       ""
     end

--- a/lib/herb/engine/compiler.rb
+++ b/lib/herb/engine/compiler.rb
@@ -446,7 +446,7 @@ module Herb
         end
         return if erb_graphql?(opening)
 
-        code = node.content.value.strip
+        code = ::Herb::Engine.strip_trailing_comment(node.content.value.strip)
 
         if erb_output?(opening)
           process_erb_output(node, opening, code)

--- a/lib/herb/engine/compiler.rb
+++ b/lib/herb/engine/compiler.rb
@@ -23,6 +23,7 @@ module Herb
         @engine = engine
         @escape = options.fetch(:escape) { options.fetch(:escape_html, false) }
         @tokens = [] #: Array[untyped]
+        @padding_before = Hash.new(0) #: Hash[Integer, Integer]
         @element_stack = [] #: Array[String]
         @context_stack = [:html_content]
         @trim_next_whitespace = false
@@ -429,12 +430,16 @@ module Herb
         if !skip_comment_check && erb_comment?(opening)
           follows_newline = leading_space_follows_newline?
           remove_trailing_whitespace_from_last_token! if left_trim?(node)
+          swallows_newline = at_line_start?
 
-          if at_line_start?
+          if swallows_newline
             leading_space = extract_and_remove_leading_space!
             @trim_next_whitespace = true
             save_pending_leading_whitespace!(leading_space) if !leading_space.empty? && follows_newline
           end
+
+          keep_line_count(node, extra: swallows_newline ? 1 : 0)
+
           return
         end
         return if erb_graphql?(opening)
@@ -446,6 +451,14 @@ module Herb
         else
           apply_trim(node, code)
         end
+
+        keep_line_count(node)
+      end
+
+      def keep_line_count(node, extra: 0)
+        lines = node.content.value.count("\n") - node.content.value.strip.count("\n") + extra
+
+        @padding_before[@tokens.length] += lines if lines.positive?
       end
 
       def add_text(text)
@@ -489,32 +502,44 @@ module Herb
         current_text = nil #: String?
         current_context = nil
 
-        tokens.each do |token|
-          type = token[0]
+        pending_padding = 0
 
-          if type == :text
-            value = token[1]
+        flush = lambda do
+          if current_text
+            optimized << [:text, current_text, current_context]
 
-            if current_text
-              current_text << value
-              current_context ||= token[2]
-            else
-              current_text = value.dup
-              current_context = token[2]
-            end
-          else
-            if current_text
-              optimized << [:text, current_text, current_context]
+            current_text = nil
+            current_context = nil
+          end
 
-              current_text = nil
-              current_context = nil
-            end
-
-            optimized << [type, token[1], token[2], token[3]]
+          if pending_padding.positive?
+            optimized << [:code, "\n" * pending_padding, nil]
+            pending_padding = 0
           end
         end
 
-        optimized << [:text, current_text, current_context] if current_text
+        tokens.each_with_index do |token, index|
+          pending_padding += @padding_before[index]
+
+          unless token[0] == :text
+            flush.call
+            optimized << [token[0], token[1], token[2], token[3]]
+
+            next
+          end
+
+          if current_text
+            current_text << token[1]
+            current_context ||= token[2]
+          else
+            current_text = token[1].dup
+            current_context = token[2]
+          end
+        end
+
+        pending_padding += @padding_before[tokens.length]
+
+        flush.call
 
         optimized
       end

--- a/lib/herb/engine/compiler.rb
+++ b/lib/herb/engine/compiler.rb
@@ -446,7 +446,7 @@ module Herb
         end
         return if erb_graphql?(opening)
 
-        code = ::Herb::Engine.strip_trailing_comment(node.content.value.strip)
+        code = ::Herb::Engine::Helpers.strip_trailing_comment(node.content.value.strip)
 
         if erb_output?(opening)
           process_erb_output(node, opening, code)
@@ -732,7 +732,7 @@ module Herb
         if at_line_start?
           leading_space = extract_and_remove_leading_space!
           effective_leading_space = leading_space.empty? ? removed_whitespace : leading_space
-          right_space = Herb::Engine.heredoc?(code) ? "\n" : " \n"
+          right_space = Herb::Engine::Helpers.heredoc?(code) ? "\n" : " \n"
 
           @pending_leading_whitespace_insert_index = @tokens.length
           @pending_leading_whitespace = effective_leading_space if !effective_leading_space.empty? && follows_newline

--- a/lib/herb/engine/compiler.rb
+++ b/lib/herb/engine/compiler.rb
@@ -5,6 +5,8 @@ require_relative "../html/util"
 module Herb
   class Engine
     class Compiler < ::Herb::Visitor
+      PADDING_NEWLINES = Array.new(17) { |count| ("\n" * count).freeze }.freeze #: Array[String]
+
       EXPRESSION_TOKEN_TYPES = [:expr, :expr_escaped, :expr_block, :expr_block_escaped].freeze
 
       TRAILING_WHITESPACE = /[ \t]+\z/
@@ -23,7 +25,7 @@ module Herb
         @engine = engine
         @escape = options.fetch(:escape) { options.fetch(:escape_html, false) }
         @tokens = [] #: Array[untyped]
-        @padding_before = Hash.new(0) #: Hash[Integer, Integer]
+        @padding_before = nil #: Hash[Integer, Integer]?
         @element_stack = [] #: Array[String]
         @context_stack = [:html_content]
         @trim_next_whitespace = false
@@ -458,7 +460,10 @@ module Herb
       def keep_line_count(node, extra: 0)
         lines = node.content.value.count("\n") - node.content.value.strip.count("\n") + extra
 
-        @padding_before[@tokens.length] += lines if lines.positive?
+        return unless lines.positive?
+
+        @padding_before ||= Hash.new(0)
+        @padding_before[@tokens.length] += lines
       end
 
       def add_text(text)
@@ -497,49 +502,85 @@ module Herb
 
       def optimize_tokens(tokens)
         return tokens if tokens.empty?
+        return optimize_tokens_with_padding(tokens) if @padding_before
 
         optimized = [] #: Array[untyped]
         current_text = nil #: String?
         current_context = nil
 
-        pending_padding = 0
+        tokens.each do |token|
+          type = token[0]
 
-        flush = lambda do
-          if current_text
-            optimized << [:text, current_text, current_context]
+          if type == :text
+            value = token[1]
 
-            current_text = nil
-            current_context = nil
-          end
+            if current_text
+              current_text << value
+              current_context ||= token[2]
+            else
+              current_text = value.dup
+              current_context = token[2]
+            end
+          else
+            if current_text
+              optimized << [:text, current_text, current_context]
 
-          if pending_padding.positive?
-            optimized << [:code, "\n" * pending_padding, nil]
-            pending_padding = 0
+              current_text = nil
+              current_context = nil
+            end
+
+            optimized << [type, token[1], token[2], token[3]]
           end
         end
+
+        optimized << [:text, current_text, current_context] if current_text
+
+        optimized
+      end
+
+      def padding_newlines(count)
+        PADDING_NEWLINES[count] || ("\n" * count)
+      end
+
+      def optimize_tokens_with_padding(tokens)
+        optimized = [] #: Array[untyped]
+        current_text = nil #: String?
+        current_context = nil
+        pending_padding = 0
 
         tokens.each_with_index do |token, index|
           pending_padding += @padding_before[index]
 
-          unless token[0] == :text
-            flush.call
-            optimized << [token[0], token[1], token[2], token[3]]
+          if token[0] == :text
+            if current_text
+              current_text << token[1]
+              current_context ||= token[2]
+            else
+              current_text = token[1].dup
+              current_context = token[2]
+            end
 
             next
           end
 
           if current_text
-            current_text << token[1]
-            current_context ||= token[2]
-          else
-            current_text = token[1].dup
-            current_context = token[2]
+            optimized << [:text, current_text, current_context]
+            current_text = nil
+            current_context = nil
           end
+
+          if pending_padding.positive?
+            optimized << [:code, padding_newlines(pending_padding), nil]
+            pending_padding = 0
+          end
+
+          optimized << [token[0], token[1], token[2], token[3]]
         end
 
-        pending_padding += @padding_before[tokens.length]
+        optimized << [:text, current_text, current_context] if current_text
 
-        flush.call
+        pending_padding += @padding_before[tokens.length]
+        optimized << [:code, padding_newlines(pending_padding), nil] if pending_padding.positive?
 
         optimized
       end

--- a/lib/herb/engine/helpers.rb
+++ b/lib/herb/engine/helpers.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+# typed: true
+
+module Herb
+  class Engine
+    module Helpers
+      #: (String) -> bool
+      def self.comment?(code)
+        stripped = code.rstrip
+
+        return false unless stripped.include?("#")
+        return true unless prism_available?
+
+        Prism.parse(stripped).comments.any? { |comment| comment.location.end_offset >= stripped.bytesize }
+      rescue StandardError
+        true
+      end
+
+      #: (String) -> bool
+      def self.heredoc?(code)
+        code.match?(/<<[~-]?\s*['"`]?\w/)
+      end
+
+      #: (String) -> String
+      def self.strip_trailing_comment(code)
+        return code unless code.include?("#")
+        return code unless prism_available?
+
+        comment = Prism.parse(code).comments.find { |found| found.location.end_offset >= code.bytesize }
+
+        return code unless comment
+
+        code.byteslice(0, comment.location.start_offset).to_s.rstrip
+      rescue StandardError
+        code
+      end
+
+      #: () -> bool
+      def self.prism_available?
+        return @prism_available unless @prism_available.nil?
+
+        @prism_available = begin
+          require "prism"
+          true
+        rescue LoadError
+          false
+        end
+      end
+    end
+  end
+end

--- a/sig/herb/engine.rbs
+++ b/sig/herb/engine.rbs
@@ -43,6 +43,8 @@ module Herb
 
     def self.comment?: (untyped code) -> untyped
 
+    def self.prism_available?: () -> untyped
+
     def self.heredoc?: (untyped code) -> untyped
 
     # : () -> untyped

--- a/sig/herb/engine.rbs
+++ b/sig/herb/engine.rbs
@@ -41,14 +41,6 @@ module Herb
 
     def self.nested_attribute_value: (untyped value) -> untyped
 
-    def self.comment?: (untyped code) -> untyped
-
-    def self.strip_trailing_comment: (untyped code) -> untyped
-
-    def self.prism_available?: () -> untyped
-
-    def self.heredoc?: (untyped code) -> untyped
-
     # : () -> untyped
     def compiler_class: () -> untyped
 

--- a/sig/herb/engine.rbs
+++ b/sig/herb/engine.rbs
@@ -43,6 +43,8 @@ module Herb
 
     def self.comment?: (untyped code) -> untyped
 
+    def self.strip_trailing_comment: (untyped code) -> untyped
+
     def self.prism_available?: () -> untyped
 
     def self.heredoc?: (untyped code) -> untyped

--- a/sig/herb/engine/compiler.rbs
+++ b/sig/herb/engine/compiler.rbs
@@ -3,6 +3,8 @@
 module Herb
   class Engine
     class Compiler < ::Herb::Visitor
+      PADDING_NEWLINES: Array[String]
+
       EXPRESSION_TOKEN_TYPES: untyped
 
       TRAILING_WHITESPACE: ::Regexp
@@ -126,6 +128,8 @@ module Herb
 
       def process_erb_tag: (untyped node, ?skip_comment_check: untyped) -> untyped
 
+      def keep_line_count: (untyped node, ?extra: untyped) -> untyped
+
       def add_text: (untyped text) -> untyped
 
       def add_code: (untyped code) -> untyped
@@ -135,6 +139,10 @@ module Herb
       def add_expression_escaped: (untyped code) -> untyped
 
       def optimize_tokens: (untyped tokens) -> untyped
+
+      def padding_newlines: (untyped count) -> untyped
+
+      def optimize_tokens_with_padding: (untyped tokens) -> untyped
 
       def process_erb_output: (untyped node, untyped opening, untyped code) -> untyped
 

--- a/sig/herb/engine/helpers.rbs
+++ b/sig/herb/engine/helpers.rbs
@@ -1,0 +1,19 @@
+# Generated from lib/herb/engine/helpers.rb with RBS::Inline
+
+module Herb
+  class Engine
+    module Helpers
+      # : (String) -> bool
+      def self.comment?: (String) -> bool
+
+      # : (String) -> bool
+      def self.heredoc?: (String) -> bool
+
+      # : (String) -> String
+      def self.strip_trailing_comment: (String) -> String
+
+      # : () -> bool
+      def self.prism_available?: () -> bool
+    end
+  end
+end

--- a/test/engine/engine_erubi_divergence_test.rb
+++ b/test/engine/engine_erubi_divergence_test.rb
@@ -30,8 +30,24 @@ module Engine
         .gsub("::Erubi.h", "::Herb::Engine.h")
     end
 
-    def without_erb_comment_line(source)
-      source.gsub("\n\n _buf", "\n _buf")
+    def without_trailing_space(source)
+      source.gsub(/ +$/, "")
+    end
+
+    def reported_line(engine, template)
+      engine.new(template, filename: "template.erb").src.then do |source|
+        eval(source, TOPLEVEL_BINDING.dup, "template.erb")
+        nil
+      end
+    rescue RuntimeError => e
+      e.backtrace.find { |line| line.include?("template.erb") }[/:(\d+)/, 1].to_i
+    end
+
+    def assert_reports_the_same_line_as_erubi(template)
+      expected = template.lines.index { |line| line.include?("<% raise %>") } + 1
+
+      assert_equal expected, reported_line(Herb::Engine, template)
+      assert_equal expected, reported_line(Erubi::Engine, template)
     end
 
     def assert_renders_the_same_as_erubi(template, options = {}, **locals)
@@ -137,13 +153,14 @@ module Engine
       assert_includes evaluate(herb, data: injection), "var data = \\x3c/script\\x3e;"
     end
 
-    test "does not leave a blank line where an ERB comment was" do
+    test "keeps the line an ERB comment was written on" do
       herb, erubi = assert_diverges_from_erubi("<%# a comment %>\n<div>Content</div>\n")
 
-      assert_equal "_buf = ::String.new; _buf << '<div>Content</div>\n'.freeze;\n_buf.to_s\n", herb
+      assert_equal "_buf = ::String.new; _buf << '<div>Content</div>\n'.freeze; \n_buf.to_s\n", herb
       assert_equal "_buf = ::String.new;\n _buf << '<div>Content</div>\n'.freeze;\n_buf.to_s\n", erubi
 
       assert_renders_the_same_as_erubi("<%# a comment %>\n<div>Content</div>\n")
+      assert_reports_the_same_line_as_erubi("<div>a</div>\n<%# a comment %>\n<% raise %>\n")
     end
 
     test "differs only by padding and the escape module across a whole template" do
@@ -167,7 +184,7 @@ module Engine
       assert_equal herb, with_herb_escape_module(without_expression_padding(erubi))
     end
 
-    test "differs only by padding and the comment line across a whole template" do
+    test "puts the line a comment took somewhere else than erubi does" do
       template = <<~ERB
         <!DOCTYPE html>
         <html>
@@ -183,9 +200,9 @@ module Engine
         </html>
       ERB
 
-      herb, erubi = assert_diverges_from_erubi(template)
+      assert_diverges_from_erubi(template)
 
-      assert_equal herb, without_erb_comment_line(without_expression_padding(erubi))
+      assert_renders_the_same_as_erubi(template)
     end
 
     test "separates a preamble that Erubi runs into the first append" do

--- a/test/snapshots/engine/block_comments_test/test_0001_ruby_block_comments_with_=begin_and_=end_multiline_ff404c4e708f59f532b4042441e458ad.txt
+++ b/test/snapshots/engine/block_comments_test/test_0001_ruby_block_comments_with_=begin_and_=end_multiline_ff404c4e708f59f532b4042441e458ad.txt
@@ -6,9 +6,10 @@ _buf = ::String.new;
 =begin 
 
  _buf << '  This, while unusual, is a legal form of commenting.
-'.freeze;
+'.freeze; 
+
 =end 
 
  _buf << '<div>Hey there</div>
-'.freeze;
+'.freeze; 
 _buf.to_s

--- a/test/snapshots/engine/block_comments_test/test_0002_ruby_block_comments_inside_erb_tags_95bcfa3f3e28634bf923f18df0cd38a1.txt
+++ b/test/snapshots/engine/block_comments_test/test_0002_ruby_block_comments_inside_erb_tags_95bcfa3f3e28634bf923f18df0cd38a1.txt
@@ -8,5 +8,6 @@ This is a comment
 =end 
 
  _buf << '<p>Content</p>
-'.freeze;
+'.freeze; 
+
 _buf.to_s

--- a/test/snapshots/engine/block_comments_test/test_0003_ruby_block_comments_with_code_before_and_after_0ee0ba8a9a25359175b884cf66f37b2c.txt
+++ b/test/snapshots/engine/block_comments_test/test_0003_ruby_block_comments_with_code_before_and_after_0ee0ba8a9a25359175b884cf66f37b2c.txt
@@ -9,6 +9,8 @@ Multi-line comment
 spanning multiple lines
 =end 
 
+ 
+
  y = 2 
  _buf << '<div>'.freeze; _buf << (x + y).to_s; _buf << '</div>
 '.freeze;

--- a/test/snapshots/engine/block_comments_test/test_0007_ruby_block_comments_with_=begin_and_=end_mutliline_and_no_space_before_ERB_closing_tag_72379778fa34572e48b949a780f761b1.txt
+++ b/test/snapshots/engine/block_comments_test/test_0007_ruby_block_comments_with_=begin_and_=end_mutliline_and_no_space_before_ERB_closing_tag_72379778fa34572e48b949a780f761b1.txt
@@ -6,9 +6,10 @@ _buf = ::String.new;
 =begin 
 
  _buf << '  This, while unusual, is a legal form of commenting.
-'.freeze;
+'.freeze; 
+
 =end 
 
  _buf << '<div>Hey there</div>
-'.freeze;
+'.freeze; 
 _buf.to_s

--- a/test/snapshots/engine/component_tags/visitor_test/test_0014_does_not_interpolate_Ruby_from_a_regular_attribute_value_308eed6f391a74365b2f7ad61083dae1.txt
+++ b/test/snapshots/engine/component_tags/visitor_test/test_0014_does_not_interpolate_Ruby_from_a_regular_attribute_value_308eed6f391a74365b2f7ad61083dae1.txt
@@ -2,6 +2,5 @@
 source: "Engine::ComponentTags::VisitorTest#test_0014_does not interpolate Ruby from a regular attribute value"
 input: "{source: \"<MyComponent name=\\\"\\\#{1 + 1}\\\" />\", options: {visitors: [#<Herb::Engine::ComponentTags::Visitor>]}}"
 ---
-_buf = ::String.new; _buf << (render MyComponent.new(name: "\#{1 + 1}")
-).to_s;
+_buf = ::String.new; _buf << (render MyComponent.new(name: "\#{1 + 1}")).to_s;
 _buf.to_s

--- a/test/snapshots/engine/component_tags/visitor_test/test_0017_an_ERB_expression_in_an_attribute_value_is_interpolated_into_the_string_92425b65ed8e9bc13b08ba26e9ce0d88.txt
+++ b/test/snapshots/engine/component_tags/visitor_test/test_0017_an_ERB_expression_in_an_attribute_value_is_interpolated_into_the_string_92425b65ed8e9bc13b08ba26e9ce0d88.txt
@@ -2,6 +2,5 @@
 source: "Engine::ComponentTags::VisitorTest#test_0017_an ERB expression in an attribute value is interpolated into the string"
 input: "{source: \"<MyComponent name=\\\"<%= @user.name %>\\\" />\", options: {visitors: [#<Herb::Engine::ComponentTags::Visitor>]}}"
 ---
-_buf = ::String.new; _buf << (render MyComponent.new(name: "#{@user.name}")
-).to_s;
+_buf = ::String.new; _buf << (render MyComponent.new(name: "#{@user.name}")).to_s;
 _buf.to_s

--- a/test/snapshots/engine/component_tags/visitor_test/test_0018_an_ERB_expression_mixed_with_text_in_an_attribute_value_keeps_both_8bbdb7c230636eeb0f02a67abd4846a3.txt
+++ b/test/snapshots/engine/component_tags/visitor_test/test_0018_an_ERB_expression_mixed_with_text_in_an_attribute_value_keeps_both_8bbdb7c230636eeb0f02a67abd4846a3.txt
@@ -2,6 +2,5 @@
 source: "Engine::ComponentTags::VisitorTest#test_0018_an ERB expression mixed with text in an attribute value keeps both"
 input: "{source: \"<MyComponent name=\\\"Hi <%= @user.name %>!\\\" />\", options: {visitors: [#<Herb::Engine::ComponentTags::Visitor>]}}"
 ---
-_buf = ::String.new; _buf << (render MyComponent.new(name: "Hi #{@user.name}!")
-).to_s;
+_buf = ::String.new; _buf << (render MyComponent.new(name: "Hi #{@user.name}!")).to_s;
 _buf.to_s

--- a/test/snapshots/engine/debug_mode_test/test_0015_erb_comments_do_NOT_get_debug_markup_50ad89dddd671292882c050dd1205e04.txt
+++ b/test/snapshots/engine/debug_mode_test/test_0015_erb_comments_do_NOT_get_debug_markup_50ad89dddd671292882c050dd1205e04.txt
@@ -4,5 +4,5 @@ input: "{source: \"<p>Content</p>\\n<%# This is a comment %>\\n<p>More content</
 ---
 _buf = ::String.new; _buf << '<p data-herb-debug-outline-type="view" data-herb-debug-file-name="unknown" data-herb-debug-file-relative-path="unknown" data-herb-debug-file-full-path="unknown" data-herb-debug-attach-to-parent="true">Content</p>
 <p>More content</p>
-'.freeze;
+'.freeze; 
 _buf.to_s

--- a/test/snapshots/engine/engine_erubi_compat_test/test_0005_handles_erb_comments_9c479c9d1b4668c4a5e3ecf9dfdc7d04.txt
+++ b/test/snapshots/engine/engine_erubi_compat_test/test_0005_handles_erb_comments_9c479c9d1b4668c4a5e3ecf9dfdc7d04.txt
@@ -3,5 +3,5 @@ source: "Engine::EngineErubiCompatTest#test_0005_handles erb comments"
 input: "{source: \"<%# This is a comment %>\\n<div>Content</div>\\n\", options: {}}"
 ---
 _buf = ::String.new; _buf << '<div>Content</div>
-'.freeze;
+'.freeze; 
 _buf.to_s

--- a/test/snapshots/engine/engine_erubi_compat_test/test_0015_handles_multiple_erb_constructs_in_complex_template_8033045d7c8ec7030c37a69705c95b59.txt
+++ b/test/snapshots/engine/engine_erubi_compat_test/test_0015_handles_multiple_erb_constructs_in_complex_template_8033045d7c8ec7030c37a69705c95b59.txt
@@ -21,5 +21,5 @@ _buf = ::String.new; _buf << '<!DOCTYPE html>
 '.freeze;   end 
  _buf << '</body>
 </html>
-'.freeze;
+'.freeze; 
 _buf.to_s

--- a/test/snapshots/engine/engine_test/test_0012_comments_710fe3f51d746ce1e228e58597aea388.txt
+++ b/test/snapshots/engine/engine_test/test_0012_comments_710fe3f51d746ce1e228e58597aea388.txt
@@ -6,5 +6,5 @@ _buf = ::String.new; _buf << '<!-- HTML comment -->
 <div>
   Content
 </div>
-'.freeze;
+'.freeze; 
 _buf.to_s

--- a/test/snapshots/engine/engine_test/test_0018_heredoc_with_trailing_arguments_compiles_to_valid_Ruby_46fb4e6ec5bd55cc1041f3f88ad9508c.txt
+++ b/test/snapshots/engine/engine_test/test_0018_heredoc_with_trailing_arguments_compiles_to_valid_Ruby_46fb4e6ec5bd55cc1041f3f88ad9508c.txt
@@ -8,5 +8,5 @@ _buf = ::String.new; _buf << (method_call <<~GRAPHQL, variables
   }
 GRAPHQL
 ).to_s; _buf << '
-'.freeze;
+'.freeze; 
 _buf.to_s

--- a/test/snapshots/engine/engine_test/test_0019_heredoc_in_code_tag_compiles_to_valid_Ruby_4af6472f81c8026291897a7a34e6ae0b.txt
+++ b/test/snapshots/engine/engine_test/test_0019_heredoc_in_code_tag_compiles_to_valid_Ruby_4af6472f81c8026291897a7a34e6ae0b.txt
@@ -5,4 +5,6 @@ input: "{source: \"<%\\n  text = <<~TEXT\\n    Hello, world!\\n  TEXT\\n%>\\n\",
 _buf = ::String.new; text = <<~TEXT
     Hello, world!
   TEXT
+ 
+
 _buf.to_s

--- a/test/snapshots/engine/engine_test/test_0020_heredoc_in_code_tag_inline_compiles_to_valid_Ruby_8767b3a12f6b010f26d6c31577e64603.txt
+++ b/test/snapshots/engine/engine_test/test_0020_heredoc_in_code_tag_inline_compiles_to_valid_Ruby_8767b3a12f6b010f26d6c31577e64603.txt
@@ -6,5 +6,5 @@ _buf = ::String.new; _buf << '<div>'.freeze; text = <<~TEXT
     Hello, world!
   TEXT
  _buf << '</div>
-'.freeze;
+'.freeze; 
 _buf.to_s

--- a/test/snapshots/engine/engine_test/test_0021_heredoc_with_dash_syntax_in_code_tag_compiles_to_valid_Ruby_61fc267bae73b15dae254d0d5f9fbe0e.txt
+++ b/test/snapshots/engine/engine_test/test_0021_heredoc_with_dash_syntax_in_code_tag_compiles_to_valid_Ruby_61fc267bae73b15dae254d0d5f9fbe0e.txt
@@ -5,4 +5,6 @@ input: "{source: \"<%\\n  text = <<-TEXT\\n    Hello, world!\\n  TEXT\\n%>\\n\",
 _buf = ::String.new; text = <<-TEXT
     Hello, world!
   TEXT
+ 
+
 _buf.to_s

--- a/test/snapshots/engine/engine_test/test_0022_heredoc_with_quoted_identifier_in_code_tag_compiles_to_valid_Ruby_c596f2621d8ae2223c3805e78ff1b3e3.txt
+++ b/test/snapshots/engine/engine_test/test_0022_heredoc_with_quoted_identifier_in_code_tag_compiles_to_valid_Ruby_c596f2621d8ae2223c3805e78ff1b3e3.txt
@@ -5,4 +5,6 @@ input: "{source: \"<%\\n  text = <<~'TEXT'\\n    Hello, world!\\n  TEXT\\n%>\\n\
 _buf = ::String.new; text = <<~'TEXT'
     Hello, world!
   TEXT
+ 
+
 _buf.to_s

--- a/test/snapshots/engine/engine_test/test_0023_heredoc_in_escaped_expression_tag_compiles_to_valid_Ruby_09b879fd48c9c55790c1b75c4a20b8a8.txt
+++ b/test/snapshots/engine/engine_test/test_0023_heredoc_in_escaped_expression_tag_compiles_to_valid_Ruby_09b879fd48c9c55790c1b75c4a20b8a8.txt
@@ -8,5 +8,5 @@ _buf = ::String.new; _buf << ::Herb::Engine.h((method_call <<~GRAPHQL, variables
   }
 GRAPHQL
 )); _buf << '
-'.freeze;
+'.freeze; 
 _buf.to_s

--- a/test/snapshots/engine/erb_comments_test/test_0013_trailing_comment_in_output_tag_ebdc3b7ae0e280d962092d8a9aeef5d3.txt
+++ b/test/snapshots/engine/erb_comments_test/test_0013_trailing_comment_in_output_tag_ebdc3b7ae0e280d962092d8a9aeef5d3.txt
@@ -2,6 +2,5 @@
 source: "Engine::ERBCommentsTest#test_0013_trailing comment in output tag"
 input: "{source: \"<%= value # this is a comment %>\", options: {}}"
 ---
-_buf = ::String.new; _buf << (value # this is a comment
-).to_s;
+_buf = ::String.new; _buf << (value).to_s;
 _buf.to_s

--- a/test/snapshots/engine/erb_comments_test/test_0014_trailing_comment_in_output_tag_with_method_call_45a0a51df0de4563a2f9282717c72a2a.txt
+++ b/test/snapshots/engine/erb_comments_test/test_0014_trailing_comment_in_output_tag_with_method_call_45a0a51df0de4563a2f9282717c72a2a.txt
@@ -2,6 +2,5 @@
 source: "Engine::ERBCommentsTest#test_0014_trailing comment in output tag with method call"
 input: "{source: \"<%= helper_method arg1, arg2 # trailing comment %>\", options: {}}"
 ---
-_buf = ::String.new; _buf << (helper_method arg1, arg2 # trailing comment
-).to_s;
+_buf = ::String.new; _buf << (helper_method arg1, arg2).to_s;
 _buf.to_s

--- a/test/snapshots/engine/erb_comments_test/test_0017_trailing_comment_in_escaped_output_tag_7dd87c688a265af1f3dcc5f0f96e8470.txt
+++ b/test/snapshots/engine/erb_comments_test/test_0017_trailing_comment_in_escaped_output_tag_7dd87c688a265af1f3dcc5f0f96e8470.txt
@@ -2,6 +2,5 @@
 source: "Engine::ERBCommentsTest#test_0017_trailing comment in escaped output tag"
 input: "{source: \"<%== value # this is a comment %>\", options: {}}"
 ---
-_buf = ::String.new; _buf << ::Herb::Engine.h((value # this is a comment
-));
+_buf = ::String.new; _buf << ::Herb::Engine.h((value));
 _buf.to_s

--- a/test/snapshots/engine/erb_tag_variations_test/test_0011_lt%#=_expression_%gt_with_surrounding_code_369da399a0268bc282a2a4109a8f1292.txt
+++ b/test/snapshots/engine/erb_tag_variations_test/test_0011_lt%#=_expression_%gt_with_surrounding_code_369da399a0268bc282a2a4109a8f1292.txt
@@ -5,5 +5,5 @@ input: "{source: \"<div>\\n  <%#= render \\\"partial\\\" %>\\n  <p>Visible conte
 _buf = ::String.new; _buf << '<div>
   <p>Visible content</p>
 </div>
-'.freeze;
+'.freeze; 
 _buf.to_s

--- a/test/snapshots/engine/erb_tag_variations_test/test_0023_mixed_commented_and_active_tags_42bad862846e13d9971b88af54358ad2.txt
+++ b/test/snapshots/engine/erb_tag_variations_test/test_0023_mixed_commented_and_active_tags_42bad862846e13d9971b88af54358ad2.txt
@@ -3,8 +3,10 @@ source: "Engine::ERBTagVariationsTest#test_0023_mixed commented and active tags"
 input: "{source: \"<div>\\n  <%#= render \\\"disabled_partial\\\" %>\\n  <%= value %>\\n  <%# this is a comment %>\\n  <%#== raw_disabled %>\\n  <p>Content</p>\\n</div>\\n\", options: {}}"
 ---
 _buf = ::String.new; _buf << '<div>
-  '.freeze; _buf << (value).to_s; _buf << '
+  '.freeze; 
+ _buf << (value).to_s; _buf << '
   <p>Content</p>
 </div>
-'.freeze;
+'.freeze; 
+
 _buf.to_s

--- a/test/snapshots/engine/erb_tag_variations_test/test_0024_all_commented_tag_variations_c2425edce28eaa127fa5294f9fbbad9f.txt
+++ b/test/snapshots/engine/erb_tag_variations_test/test_0024_all_commented_tag_variations_c2425edce28eaa127fa5294f9fbbad9f.txt
@@ -3,5 +3,9 @@ source: "Engine::ERBTagVariationsTest#test_0024_all commented tag variations"
 input: "{source: \"<%# regular comment %>\\n<%#= commented output %>\\n<%#== commented raw output %>\\n<%#- commented trim %>\\n<%#graphql query { user { id } } %>\\n<p>Visible</p>\\n\", options: {}}"
 ---
 _buf = ::String.new; _buf << '<p>Visible</p>
-'.freeze;
+'.freeze; 
+
+
+
+
 _buf.to_s

--- a/test/snapshots/engine/erb_tag_variations_test/test_0025_all_linter-formatted_commented_tag_variations_908737c13f1e14dd63d1525d558e2b2b.txt
+++ b/test/snapshots/engine/erb_tag_variations_test/test_0025_all_linter-formatted_commented_tag_variations_908737c13f1e14dd63d1525d558e2b2b.txt
@@ -3,5 +3,9 @@ source: "Engine::ERBTagVariationsTest#test_0025_all linter-formatted commented t
 input: "{source: \"<%# regular comment %>\\n<%# = commented output %>\\n<%# == commented raw output %>\\n<%# - commented trim %>\\n<%# graphql query { user { id } } %>\\n<p>Visible</p>\\n\", options: {}}"
 ---
 _buf = ::String.new; _buf << '<p>Visible</p>
-'.freeze;
+'.freeze; 
+
+
+
+
 _buf.to_s

--- a/test/snapshots/engine/examples_compilation_test/test_0004_block_comment_compilation_d5c98b9f230e001f8aabf838d3774698.txt
+++ b/test/snapshots/engine/examples_compilation_test/test_0004_block_comment_compilation_d5c98b9f230e001f8aabf838d3774698.txt
@@ -6,10 +6,11 @@ _buf = ::String.new;
 =begin 
 
  _buf << '  This, while unusual, is a legal form of commenting.
-'.freeze;
+'.freeze; 
+
 =end 
 
  _buf << '
 <div>Content</div>
-'.freeze;
+'.freeze; 
 _buf.to_s

--- a/test/snapshots/engine/examples_compilation_test/test_0017_graphql_compilation_c61e4057efeb22889331fe18ef9e09b7.txt
+++ b/test/snapshots/engine/examples_compilation_test/test_0017_graphql_compilation_c61e4057efeb22889331fe18ef9e09b7.txt
@@ -5,7 +5,8 @@ input: "{source: \"<%# app/views/products/product.html.erb %>\\n<%graphql\\n  fr
 _buf = ::String.new; _buf << '
 
 <article class="product">
-  <h1>'.freeze; _buf << (product.title).to_s; _buf << '</h1>
+  <h1>'.freeze; 
+ _buf << (product.title).to_s; _buf << '</h1>
   <p class="description">'.freeze; _buf << (product.description).to_s; _buf << '</p>
   <span class="price">'.freeze; _buf << (product.price).to_s; _buf << '</span>
 </article>

--- a/test/snapshots/engine/graph_ql_test/test_0004_graphql_tag_with_comment_and_html_173ebe3413c7549d66739043f20b95af.txt
+++ b/test/snapshots/engine/graph_ql_test/test_0004_graphql_tag_with_comment_and_html_173ebe3413c7549d66739043f20b95af.txt
@@ -4,6 +4,7 @@ input: "{source: \"<%# app/views/humans/human.html.erb %>\\n<%graphql\\n  fragme
 ---
 _buf = ::String.new; _buf << '
 
-<p>'.freeze; _buf << (human.name).to_s; _buf << ' lives on '.freeze; _buf << (human.home_planet).to_s; _buf << '.</p>
+<p>'.freeze; 
+ _buf << (human.name).to_s; _buf << ' lives on '.freeze; _buf << (human.home_planet).to_s; _buf << '.</p>
 '.freeze;
 _buf.to_s

--- a/test/snapshots/engine/instrumentation_test/what_it_emits/test_0005_leaves_a_comment_alone_6ddcbda2d6e149352b931732e54051a6.txt
+++ b/test/snapshots/engine/instrumentation_test/what_it_emits/test_0005_leaves_a_comment_alone_6ddcbda2d6e149352b931732e54051a6.txt
@@ -3,5 +3,6 @@ source: "Engine::InstrumentationTest::what it emits#test_0005_leaves a comment a
 input: "{source: \"<%# nothing to see %>\", options: {filename: \"app/views/test.html.erb\", visitors: [#<Herb::Engine::InstrumentationVisitor>]}}"
 ---
 _buf = ::String.new; ::Herb::Engine::Runtime::Session.enter_render("app/views/test.html.erb"); begin 
+ 
  ensure; ::Herb::Engine::Runtime::Session.leave_render; end 
 _buf.to_s


### PR DESCRIPTION
This pull request makes a backtrace from a compiled template name the line someone actually wrote.

A tag that spans lines was compiled onto one line, and a comment was compiled to nothing at all, so the generated Ruby ended up shorter than the template it came from. Everything after one of those tags sat higher in the compiled source than in the file, and a backtrace was off by however many tags came before it. It reads worst where it matters most: a template carrying a `<%# herb:state %>` directive was off by one for its whole length, so Rails' error page framed the wrong line, and so did every log line and every error report built from that backtrace.

```erb
<div>a</div>
<%# herb:state (unread: 0) %>

<% raise %>
```

```ruby
# before, the raise is reported on line 3
# after,  the raise is reported on line 4, where it is written
```

#### How it works

The lines a tag consumes are held and written once the text around them has been, which puts the next thing that can raise on the line it was written on. Static text is free to sit somewhere else in the compiled source, since it never appears in a backtrace, and leaving it free is what keeps a run of text in one append and one frozen literal.

A template with no comment and no tag spanning lines compiles through the same `optimize_tokens` as before. The instruction sequences a template compiles to are unchanged, verified by comparing `RubyVM::InstructionSequence` output against `main` for the same source.

Two things that also moved a tag off its line turned out to be about comments.

`Herb::Engine.comment?` decided whether an expression needed a newline in front of its closing paren by looking for a `#` anywhere in the code, so `link_to name, "https://host/#{id}"` counted as a comment, and so did any string containing a `#`. Prism is asked now, and only when a `#` is there at all, which leaves the common expression untouched.

An expression that really does end in a comment no longer compiles the comment at all. It cannot run, so instead of emitting it and then working around it, Prism says where it starts and it is left out. `<%= value # a note %>` compiles to `_buf << (value).to_s`, where it used to take two lines to say the same thing.

Over the first 1877 files of [herb-corpus](https://github.com/marcoroth/herb-corpus), the number of ERB tags that compile to a line other than the one they were written on goes from 2400 to 751, out of 11578 tags.

#### What is left

The 751 that remain are all one shape. Two tags that each stand alone on their line, both indented, fold the whitespace between them away and end up sharing a compiled line:

```erb
<%= form_for @model do |f| %>
  <% unless done %>
    <p>a</p>
    <% end %>
  <% end %>
```

That fold is what #2391 makes optional, so the rule for it wants `@trim` to be expressible and belongs on top of that pull request instead of here.