### PR TITLE
Engine: Keep the line an `end` closing a block expression was written on

### DIFF
--- a/lib/herb/engine.rb
+++ b/lib/herb/engine.rb
@@ -290,7 +290,7 @@ module Herb
         trailing_newline = code.end_with?("\n")
         code_stripped = code.chomp
 
-        @src.chomp! if @src.end_with?("\n") && code_stripped.start_with?(" ")
+        @src.chomp! if @src.end_with?("\n") && code_stripped.start_with?(" ") && !trailing_newline
 
         @src << " " << code_stripped
         @src << "\n" if Helpers.comment?(code_stripped)

--- a/test/snapshots/engine/examples_compilation_test/test_0024_nested_if_and_blocks_compilation_aa8aed9ef61b138a28efed42f4b72251.txt
+++ b/test/snapshots/engine/examples_compilation_test/test_0024_nested_if_and_blocks_compilation_aa8aed9ef61b138a28efed42f4b72251.txt
@@ -29,7 +29,8 @@ _buf = ::String.new; _buf << '<div id="output">
         <b>Not Friday</b>
         '.freeze; _buf << (" - Keep going!").to_s; _buf << '
       </h1>
-'.freeze;     end    end )
+'.freeze;     end 
+   end )
  _buf << '</div>
 '.freeze;
 _buf.to_s

--- a/test/snapshots/engine/whitespace_trimming_test/test_0023_whitespace_between_consecutive_end_tags_after_expression_block_is_trimmed_ed5d5ba409772c6c51c355fd31b98c23.txt
+++ b/test/snapshots/engine/whitespace_trimming_test/test_0023_whitespace_between_consecutive_end_tags_after_expression_block_is_trimmed_ed5d5ba409772c6c51c355fd31b98c23.txt
@@ -6,6 +6,7 @@ _buf = ::String.new; 1.times do
  _buf << '  '.freeze; _buf << (form_tag("/t") do; _buf << '
     '.freeze; _buf << (tag.p do; _buf << '
       text
-'.freeze;     end )   end )
+'.freeze;     end )
+   end )
  end 
 _buf.to_s


### PR DESCRIPTION
Follow up on #2479, which made a backtrace from a compiled template name the line someone actually wrote. This is one more place that moved a line, found once there was a way to see it.

`Herb::Engine#add_code` will not chomp the newline in front of it when the code it is about to write already carries one of its own:

```ruby
@src.chomp! if @src.end_with?("\n") && code.start_with?(" ") && !code.end_with?("\n")
```

`add_expression_block_end` does the same chomp without that last guard, so it ate a newline the `end` before it had written. Two `end` tags standing on their own lines compiled onto one, and every line after the pair moved up by one.

```erb
<%= form_for @model do |f| %>
  <% unless done %>
    <p>a</p>
    <% end %>
  <% end %>
```

```diff
-'.freeze;     end    end )
+'.freeze;     end
+   end )
```

Nothing renders differently. The two snapshots that move are compiled output, and the shape they show is the pair separating onto the lines the tags were written on.

Over the first 1877 files of [herb-corpus](https://github.com/marcoroth/herb-corpus), this puts another 115 ERB tags back on their own line, taking the count that compile to some other line from 751 to 636.

The guard `add_code` already carries is the whole fix, and the two methods agree now.