### PR TITLE
Dev Tools: Run Linter on rendered page

### DIFF
--- a/javascript/packages/client/src/grammar/attributes.ts
+++ b/javascript/packages/client/src/grammar/attributes.ts
@@ -12,6 +12,7 @@ export const HERB_ATTRIBUTES = {
   slot: "data-herb-slot",
   name: "data-herb-name",
   region: "data-herb-region",
+  styleScoped: "data-herb-style-scoped",
   dependencies: "data-herb-dependencies",
   manifests: "data-herb-manifests",
   into: "data-herb-into",

--- a/javascript/packages/dev-tools/src/herb-dev-tools.ts
+++ b/javascript/packages/dev-tools/src/herb-dev-tools.ts
@@ -31,7 +31,7 @@ export class HerbDevTools {
   private static current: HerbDevTools | null = null
 
   static start(options: HerbDevToolsOptions = {}): HerbDevTools | null {
-    if (HerbDevTools.current) {
+    if (HerbDevTools.current || (typeof window !== 'undefined' && window.HerbDevTools)) {
       console.warn('[herb-dev-tools] already started, ignoring this start() call')
 
       return null
@@ -96,6 +96,10 @@ export class HerbDevTools {
 
   get runtimePanel(): RuntimePanel | null {
     return this.panel
+  }
+
+  get lintingEnabled(): boolean {
+    return this.overlay?.linterEnabled ?? true
   }
 
   report(input: RuntimeDiagnostic | RuntimeDiagnostic[]): RuntimeReportHandle {

--- a/javascript/packages/dev-tools/src/index.ts
+++ b/javascript/packages/dev-tools/src/index.ts
@@ -1,9 +1,12 @@
 export { DEV_SERVER_FIXED_EVENT } from './dev-server/types.js'
 export { DEV_TOOLS_START_EVENT } from './herb-dev-tools.js'
+export { HERB_LINTER_EVENT } from './overlay/overlay.js'
 
 export { HerbDevTools } from './herb-dev-tools.js'
+export { HerbOverlay } from './overlay/overlay.js'
 export { RuntimePanel } from './runtime/panel.js'
 
 export type { HerbDevToolsOptions } from './herb-dev-tools.js'
+export type { HerbOverlayOptions } from './overlay/overlay.js'
 export type { RuntimePanelOptions, RuntimeReportHandle } from './runtime/panel.js'
 export type { OverlayMode, RenderTreeNode, RuntimeDiagnostic, RuntimeReport } from './runtime/report.js'

--- a/javascript/packages/dev-tools/src/overlay/overlay.ts
+++ b/javascript/packages/dev-tools/src/overlay/overlay.ts
@@ -3,6 +3,8 @@ import overlayStyles from './overlay.css';
 import { injectStyle } from '../styles';
 import { SlotFlash } from '../slots/flash';
 
+export const HERB_LINTER_EVENT = 'herb:dev-tools:linter'
+
 export interface HerbOverlayOptions {
   projectPath?: string;
   autoInit?: boolean;
@@ -29,10 +31,11 @@ export class HerbOverlay {
   private currentlyHoveredERBElement: HTMLElement | null = null;
   private destroyed = false;
   private styleElement: HTMLStyleElement | null = null;
-
-  private static readonly SETTINGS_KEY = 'herb-dev-tools-settings';
   private slotFlash = new SlotFlash();
   private showingSlotUpdates = false;
+  private runningLinter = true;
+
+  private static readonly SETTINGS_KEY = 'herb-dev-tools-settings';
   private static readonly EDITOR_OPTIONS = [
     { value: 'auto', label: 'Auto (from server via RAILS_EDITOR or EDITOR)' },
     { value: 'atom', label: 'Atom' },
@@ -139,6 +142,7 @@ export class HerbOverlay {
         this.showingPartialOutlines = settings.showingPartialOutlines || false;
         this.showingComponentOutlines = settings.showingComponentOutlines || false;
         this.showingSlotUpdates = settings.showingSlotUpdates || false;
+        this.runningLinter = settings.runningLinter !== undefined ? settings.runningLinter : true;
         this.menuOpen = settings.menuOpen || false;
         if (settings.preferredEditor) {
           this.preferredEditor = settings.preferredEditor;
@@ -159,6 +163,7 @@ export class HerbOverlay {
       showingPartialOutlines: this.showingPartialOutlines,
       showingComponentOutlines: this.showingComponentOutlines,
       showingSlotUpdates: this.showingSlotUpdates,
+      runningLinter: this.runningLinter,
       menuOpen: this.menuOpen,
       preferredEditor: this.preferredEditor
     };
@@ -301,6 +306,14 @@ export class HerbOverlay {
             </label>
           </div>
 
+          <div class="herb-toggle-item">
+            <label class="herb-toggle-label">
+              <input type="checkbox" id="herbToggleLinter" class="herb-toggle-input">
+              <span class="herb-toggle-switch"></span>
+              <span class="herb-toggle-text">Lint Rendered Page</span>
+            </label>
+          </div>
+
           ${this.runtimePanelToggleHTML()}
 
           <div class="herb-editor-section">
@@ -341,28 +354,38 @@ export class HerbOverlay {
     }
   }
 
+  private handleMenuTriggerClick = () => {
+    const menuTrigger = document.getElementById('herbMenuTrigger');
+    const menuPanel = document.getElementById('herbMenuPanel');
+
+    if (!menuTrigger || !menuPanel) {
+      return;
+    }
+
+    this.menuOpen = !this.menuOpen;
+
+    if (this.menuOpen) {
+      this.options.onMenuOpen?.();
+
+      this.syncRuntimePanelToggle();
+
+      menuTrigger.classList.add('active');
+      menuPanel.classList.add('open');
+    } else {
+      menuTrigger.classList.remove('active');
+      menuPanel.classList.remove('open');
+    }
+
+    this.saveSettings();
+  }
+
   private setupMenuToggle() {
     const menuTrigger = document.getElementById('herbMenuTrigger');
     const menuPanel = document.getElementById('herbMenuPanel');
 
     if (menuTrigger && menuPanel) {
-      menuTrigger.addEventListener('click', () => {
-        this.menuOpen = !this.menuOpen;
-
-        if (this.menuOpen) {
-          this.options.onMenuOpen?.();
-
-          this.syncRuntimePanelToggle();
-
-          menuTrigger.classList.add('active');
-          menuPanel.classList.add('open');
-        } else {
-          menuTrigger.classList.remove('active');
-          menuPanel.classList.remove('open');
-        }
-
-        this.saveSettings();
-      });
+      menuTrigger.removeEventListener('click', this.handleMenuTriggerClick);
+      menuTrigger.addEventListener('click', this.handleMenuTriggerClick);
     }
   }
 
@@ -449,6 +472,15 @@ export class HerbOverlay {
           this.toggleERBOutlines(false);
         }
         this.toggleERBTags(toggleERBSwitch.checked);
+      });
+    }
+
+    const toggleLinterSwitch = document.getElementById('herbToggleLinter') as HTMLInputElement;
+
+    if (toggleLinterSwitch) {
+      toggleLinterSwitch.checked = this.runningLinter;
+      toggleLinterSwitch.addEventListener('change', () => {
+        this.toggleLinter(toggleLinterSwitch.checked);
       });
     }
 
@@ -778,6 +810,18 @@ export class HerbOverlay {
     });
 
     this.saveSettings();
+  }
+
+  private toggleLinter(run?: boolean) {
+    this.runningLinter = run !== undefined ? run : !this.runningLinter;
+
+    this.saveSettings();
+
+    document.dispatchEvent(new CustomEvent(HERB_LINTER_EVENT, { detail: { enabled: this.runningLinter } }));
+  }
+
+  get linterEnabled(): boolean {
+    return this.runningLinter;
   }
 
   private toggleSlotUpdates(show?: boolean) {

--- a/javascript/packages/dev-tools/src/runtime/panel.ts
+++ b/javascript/packages/dev-tools/src/runtime/panel.ts
@@ -2390,11 +2390,32 @@ function hiddenBy(element: Element): { reason: string, culprit: Element | null }
   return null
 }
 
+const IDENTIFYING_ATTRIBUTES = ['src', 'href', 'alt', 'name', 'type', 'value', 'title', 'role', 'class']
+const GENERATED_ATTRIBUTES = ['data-herb-debug-', 'data-herb-source', 'data-herb-scope-', 'data-herb-style-scoped', 'data-herb-slot', 'data-herb-region', 'data-herb-manifests', 'data-herb-dependencies']
+
+function isGenerated(name: string): boolean {
+  return GENERATED_ATTRIBUTES.some(generated => name.startsWith(generated))
+}
+
+function identifyingAttribute(element: Element): Attr | null {
+  const attributes = [...element.attributes].filter(attribute =>
+    !isGenerated(attribute.name) && attribute.name !== 'style' && attribute.name !== 'id'
+  )
+
+  for (const name of IDENTIFYING_ATTRIBUTES) {
+    const found = attributes.find(attribute => attribute.name === name)
+
+    if (found) return found
+  }
+
+  return attributes[0] ?? null
+}
+
 function describeElement(element: Element): string {
   const tag = element.tagName.toLowerCase()
   const id = element.id ? `#${element.id}` : ''
-  const herb = [...element.attributes].find(attribute => attribute.name.startsWith('data-herb-'))
-  const detail = herb ? ` ${herb.name}="${herb.value.length > 40 ? `${herb.value.slice(0, 40)}…` : herb.value}"` : ''
+  const attribute = identifyingAttribute(element)
+  const detail = attribute ? ` ${attribute.name}="${attribute.value.length > 40 ? `${attribute.value.slice(0, 40)}…` : attribute.value}"` : ''
 
   return `<${tag}${id}${detail}>`
 }

--- a/javascript/packages/dev-tools/test/menu-toggle.test.ts
+++ b/javascript/packages/dev-tools/test/menu-toggle.test.ts
@@ -4,13 +4,13 @@ import { HerbDevTools } from "../src/herb-dev-tools.js"
 
 afterEach(() => {
   localStorage.clear()
-  HerbDevTools.current?.stop()
+  HerbDevTools.instance?.stop()
   delete (window as any).HerbDevTools
   document.querySelector(".herb-floating-menu")?.remove()
   vi.restoreAllMocks()
 })
 
-const overlayOf = () => (HerbDevTools.current as any).overlay
+const overlayOf = () => (HerbDevTools.instance as any).overlay
 const trigger = () => document.getElementById("herbMenuTrigger") as HTMLElement
 const isOpen = () => document.getElementById("herbMenuPanel")!.classList.contains("open")
 

--- a/javascript/packages/dev-tools/test/menu-toggle.test.ts
+++ b/javascript/packages/dev-tools/test/menu-toggle.test.ts
@@ -1,0 +1,57 @@
+import { describe, test, expect, afterEach, vi } from "vitest"
+
+import { HerbDevTools } from "../src/herb-dev-tools.js"
+
+afterEach(() => {
+  localStorage.clear()
+  HerbDevTools.current?.stop()
+  delete (window as any).HerbDevTools
+  document.querySelector(".herb-floating-menu")?.remove()
+  vi.restoreAllMocks()
+})
+
+const overlayOf = () => (HerbDevTools.current as any).overlay
+const trigger = () => document.getElementById("herbMenuTrigger") as HTMLElement
+const isOpen = () => document.getElementById("herbMenuPanel")!.classList.contains("open")
+
+describe("the dev tools menu", () => {
+  test("opens on a click", () => {
+    localStorage.clear()
+
+    HerbDevTools.start()
+
+    trigger().click()
+
+    expect(isOpen()).toBe(true)
+  })
+
+  test("keeps toggling once per click after a second setup pass, which a double init causes", () => {
+    HerbDevTools.start()
+
+    const states: boolean[] = []
+
+    overlayOf().setupMenuToggle()
+
+    trigger().click()
+    states.push(isOpen())
+
+    trigger().click()
+    states.push(isOpen())
+
+    trigger().click()
+    states.push(isOpen())
+
+    expect(states).toEqual([true, false, true])
+  })
+
+  test("closes again on the next click", () => {
+    HerbDevTools.start()
+
+    overlayOf().setupMenuToggle()
+
+    trigger().click()
+    trigger().click()
+
+    expect(isOpen()).toBe(false)
+  })
+})

--- a/javascript/packages/dev-tools/test/start-guard.test.ts
+++ b/javascript/packages/dev-tools/test/start-guard.test.ts
@@ -3,7 +3,7 @@ import { describe, test, expect, afterEach, vi } from "vitest"
 import { HerbDevTools } from "../src/herb-dev-tools.js"
 
 afterEach(() => {
-  HerbDevTools.current?.stop()
+  HerbDevTools.instance?.stop()
   delete (window as any).HerbDevTools
   vi.restoreAllMocks()
 })

--- a/javascript/packages/dev-tools/test/start-guard.test.ts
+++ b/javascript/packages/dev-tools/test/start-guard.test.ts
@@ -1,0 +1,33 @@
+import { describe, test, expect, afterEach, vi } from "vitest"
+
+import { HerbDevTools } from "../src/herb-dev-tools.js"
+
+afterEach(() => {
+  HerbDevTools.current?.stop()
+  delete (window as any).HerbDevTools
+  vi.restoreAllMocks()
+})
+
+describe("starting dev tools", () => {
+  test("starts when the page has none", () => {
+    expect(HerbDevTools.start({ overlay: false })).not.toBeNull()
+    expect(window.HerbDevTools).toBeDefined()
+  })
+
+  test("does not start a second time", () => {
+    vi.spyOn(console, "warn").mockImplementation(() => {})
+
+    HerbDevTools.start({ overlay: false })
+
+    expect(HerbDevTools.start({ overlay: false })).toBeNull()
+  })
+
+  test("stands down for dev tools another copy of this class already started", () => {
+    vi.spyOn(console, "warn").mockImplementation(() => {})
+
+    ;(window as any).HerbDevTools = { fromAnotherBundle: true }
+
+    expect(HerbDevTools.start({ overlay: false })).toBeNull()
+    expect((window as any).HerbDevTools.fromAnotherBundle).toBe(true)
+  })
+})

--- a/javascript/packages/linter/src/browser/dev-tools.ts
+++ b/javascript/packages/linter/src/browser/dev-tools.ts
@@ -1,0 +1,108 @@
+import { ruleDocumentationUrl } from "../urls.js"
+
+import type { Linter } from "../linter.js"
+import type { DOMNodeLike } from "./dom-to-ast.js"
+import type { LintOffense, LintResult, LintContext, LintSeverity } from "../types.js"
+
+export const LINTER_ORIGIN = "Herb Linter (Rendered Page)"
+
+export interface RuntimePosition {
+  line: number
+  column: number
+}
+
+export interface RuntimeRange {
+  start: RuntimePosition
+  end?: RuntimePosition
+}
+
+export interface RuntimeDiagnosticLike {
+  template: string
+  message: string
+  code?: string
+  severity?: LintSeverity
+  origin?: string
+  docsUrl?: string
+  location?: RuntimeRange
+  phase?: "compile" | "runtime"
+  overlay?: false
+  element?: DOMNodeLike
+}
+
+export interface DevToolsLike {
+  report(input: RuntimeDiagnosticLike | RuntimeDiagnosticLike[]): { dismiss(): void }
+  clear(origin?: string): void
+  lintingEnabled?: boolean
+}
+
+interface WindowLike {
+  HerbDevTools?: DevToolsLike
+}
+
+export const LINTER_TOGGLE_EVENT = "herb:dev-tools:linter"
+const UNKNOWN_TEMPLATE = "(unknown template)"
+
+
+function rangeOf(offense: LintOffense): RuntimeRange | undefined {
+  if (!offense.location) return undefined
+
+  const { start, end } = offense.location
+
+  return { start: { line: start.line, column: start.column }, end: { line: end.line, column: end.column } }
+}
+
+export function toRuntimeDiagnostic(offense: LintOffense): RuntimeDiagnosticLike {
+  return {
+    template: offense.file?.path ?? UNKNOWN_TEMPLATE,
+    message: offense.message,
+    code: offense.rule,
+    severity: offense.severity,
+    origin: LINTER_ORIGIN,
+    docsUrl: ruleDocumentationUrl(offense.rule),
+    location: rangeOf(offense),
+    phase: "runtime",
+    overlay: false,
+    element: offense.element,
+  }
+}
+
+export function toRuntimeDiagnostics(result: LintResult): RuntimeDiagnosticLike[] {
+  return result.offenses.map(toRuntimeDiagnostic)
+}
+
+export function devToolsIn(scope: unknown = globalThis): DevToolsLike | null {
+  return (scope as WindowLike | undefined)?.HerbDevTools ?? null
+}
+
+export interface ReportOptions {
+  root?: DOMNodeLike
+  scope?: unknown
+  context?: Partial<LintContext>
+}
+
+export function reportToDevTools(linter: Linter, options: ReportOptions = {}): { result: LintResult | null; handle: { dismiss(): void } | null } {
+  const { root, scope, context } = options
+  const target = root ?? (globalThis as { document?: { body?: DOMNodeLike } }).document?.body
+
+  if (!target) {
+    throw new Error("reportToDevTools needs a root to lint, and there is no document on this page")
+  }
+
+  const devTools = devToolsIn(scope)
+
+  if (devTools?.lintingEnabled === false) {
+    devTools.clear(LINTER_ORIGIN)
+
+    return { result: null, handle: null }
+  }
+
+  const result = linter.lintElement(target, context)
+
+  if (!devTools) {
+    return { result, handle: null }
+  }
+
+  devTools.clear(LINTER_ORIGIN)
+
+  return { result, handle: devTools.report(toRuntimeDiagnostics(result)) }
+}

--- a/javascript/packages/linter/src/browser/dom-to-ast.ts
+++ b/javascript/packages/linter/src/browser/dom-to-ast.ts
@@ -20,6 +20,7 @@ export interface DOMAttributeLike {
 
 export interface DOMElementLike extends DOMNodeLike {
   tagName: string
+  localName: string
   attributes: ArrayLike<DOMAttributeLike>
   childNodes: ArrayLike<DOMNodeLike>
 }
@@ -65,9 +66,31 @@ function locationFrom(source: SourcePath | null): Location {
   return position ? new Location(position, position) : NO_LOCATION
 }
 
-function sourceOn(element: DOMElementLike): SourcePath | null {
+function attributeOn(element: DOMElementLike, name: string): string | null {
   for (const attribute of Array.from(element.attributes)) {
-    if (attribute.name === SOURCE_ATTRIBUTE) return SourcePath.parse(attribute.value)
+    if (attribute.name === name) return attribute.value
+  }
+
+  return null
+}
+
+function sourceOn(element: DOMElementLike): SourcePath | null {
+  const stamp = attributeOn(element, SOURCE_ATTRIBUTE)
+
+  return stamp === null ? null : SourcePath.parse(stamp)
+}
+
+export function sourcePathForElement(element: DOMNodeLike | null | undefined, projectPath: string | null = null): SourcePath | null {
+  let current: DOMNodeLike | null | undefined = element
+
+  while (current) {
+    if (current.nodeType === ELEMENT_NODE) {
+      const stamp = attributeOn(current as DOMElementLike, SOURCE_ATTRIBUTE)
+
+      if (stamp !== null) return SourcePath.parse(stamp, projectPath)
+    }
+
+    current = (current as { parentNode?: DOMNodeLike | null }).parentNode ?? null
   }
 
   return null
@@ -78,15 +101,23 @@ export function sourcePathOf(node: object): SourcePath | null {
 }
 
 export function sourcePathsIn(root: Node): Map<Location, SourcePath> {
-  const found = new Map<Location, SourcePath>()
+  return collect(root, sourcePathOf)
+}
+
+export function domNodesIn(root: Node): Map<Location, DOMNodeLike> {
+  return collect(root, (node) => (node as WithDOMNode)[DOM_NODE] ?? null)
+}
+
+function collect<T>(root: Node, of: (node: Node) => T | null): Map<Location, T> {
+  const found = new Map<Location, T>()
 
   const walk = (node: Node | null | undefined) => {
     if (!node) return
 
-    const source = sourcePathOf(node)
+    const value = of(node)
 
-    if (source && node.location) {
-      found.set(node.location, source)
+    if (value !== null && node.location) {
+      found.set(node.location, value)
     }
 
     for (const child of node.childNodes()) {

--- a/javascript/packages/linter/src/browser/index.ts
+++ b/javascript/packages/linter/src/browser/index.ts
@@ -1,6 +1,6 @@
 export { DOM_NODE, SOURCE_PATH, SOURCE_ATTRIBUTE } from "./dom-to-ast.js"
 
-export { domToAST, sourcePathOf, sourcePathsIn } from "./dom-to-ast.js"
+export { domToAST, sourcePathOf, sourcePathsIn, domNodesIn } from "./dom-to-ast.js"
 export { browserRules } from "./rules.js"
 export { sourcePathFor } from "./lint-dom.js"
 

--- a/javascript/packages/linter/src/browser/lint-dom.ts
+++ b/javascript/packages/linter/src/browser/lint-dom.ts
@@ -1,39 +1,11 @@
-import { DOM_NODE } from "./dom-to-ast.js"
-
-import { SourcePath } from "@herb-tools/core"
+import { DOM_NODE, SOURCE_ATTRIBUTE, sourcePathForElement } from "./dom-to-ast.js"
 
 import type { Node } from "@herb-tools/core"
-import type { DOMNodeLike, DOMElementLike, WithDOMNode } from "./dom-to-ast.js"
+import type { SourcePath } from "@herb-tools/core"
+import type { WithDOMNode } from "./dom-to-ast.js"
 
-export const SOURCE_ATTRIBUTE = "data-herb-source"
-
-function attributeValue(element: DOMElementLike, name: string): string | null {
-  for (const attribute of Array.from(element.attributes)) {
-    if (attribute.name === name) {
-      return attribute.value
-    }
-  }
-
-  return null
-}
+export { SOURCE_ATTRIBUTE }
 
 export function sourcePathFor(node: Node, projectPath: string | null = null): SourcePath | null {
-  const element = (node as Node & WithDOMNode)[DOM_NODE]
-  if (!element) return null
-
-  let current: DOMNodeLike | null = element
-
-  while (current) {
-    if (current.nodeType === 1) {
-      const stamp = attributeValue(current as DOMElementLike, SOURCE_ATTRIBUTE)
-
-      if (stamp) {
-        return SourcePath.parse(stamp, projectPath)
-      }
-    }
-
-    current = (current as { parentNode?: DOMNodeLike | null }).parentNode ?? null
-  }
-
-  return null
+  return sourcePathForElement((node as Node & WithDOMNode)[DOM_NODE], projectPath)
 }

--- a/javascript/packages/linter/src/browser/rule.ts
+++ b/javascript/packages/linter/src/browser/rule.ts
@@ -2,6 +2,8 @@ import { DEFAULT_RULE_CONFIG } from "../types.js"
 
 import { Location } from "@herb-tools/core"
 
+import { sourcePathForElement } from "./dom-to-ast.js"
+
 import type { DOMNodeLike } from "./dom-to-ast.js"
 import type { UnboundLintOffense, LintContext, LintSeverity, FullRuleConfig, RuleVersion } from "../types.js"
 
@@ -19,14 +21,18 @@ export abstract class BrowserRule {
     return { ...DEFAULT_RULE_CONFIG, environments: ["browser"] }
   }
 
-  protected createOffense(message: string, severity?: LintSeverity): UnboundLintOffense {
+  protected createOffense(message: string, element?: DOMNodeLike, severity?: LintSeverity): UnboundLintOffense {
+    const file = sourcePathForElement(element)
+
     return {
       rule: this.ruleName,
       code: this.ruleName,
-      source: "Herb Linter",
+      source: "Herb Linter (Browser)",
       message,
       location: Location.fromOptional(null),
       severity,
+      ...(element ? { element } : {}),
+      ...(file ? { file } : {}),
     }
   }
 

--- a/javascript/packages/linter/src/browser/rules/browser-scoped-style-no-unused-selector.ts
+++ b/javascript/packages/linter/src/browser/rules/browser-scoped-style-no-unused-selector.ts
@@ -1,7 +1,10 @@
+import { HERB_ATTRIBUTES } from "@herb-tools/client/directives"
+
 import { BrowserRule } from "../rule.js"
 
 import type { DOMNodeLike, DOMElementLike } from "../dom-to-ast.js"
 import type { UnboundLintOffense, LintContext } from "../../types.js"
+import type { FullRuleConfig } from "../../types.js"
 
 interface CSSRuleLike {
   selectorText?: string
@@ -16,16 +19,24 @@ interface StyleElementLike extends DOMElementLike {
   sheet?: StyleSheetLike | null
 }
 
+interface ScopedStyleElement extends StyleElementLike {
+  tagName: "style"
+  localName: "style"
+}
+
 interface QueryableLike extends DOMNodeLike {
   querySelectorAll(selectors: string): ArrayLike<unknown>
   matches?(selectors: string): boolean
 }
 
 const ELEMENT_NODE = 1
-export const ANCHOR_ATTRIBUTE = "data-herb-style-scoped"
 
 function isElement(node: DOMNodeLike): node is DOMElementLike {
   return node.nodeType === ELEMENT_NODE
+}
+
+function isStyleElement(node: DOMElementLike): node is StyleElementLike {
+  return node.localName == "style"
 }
 
 function attributeValue(element: DOMElementLike, name: string): string | null {
@@ -91,33 +102,42 @@ function matches(scope: QueryableLike, selector: string): boolean {
   }
 }
 
-function isScoped(element: DOMElementLike): boolean {
-  return hasAttribute(element, "scoped") || attributeValue(element, ANCHOR_ATTRIBUTE) !== null
+function isScoped(element: DOMElementLike): element is ScopedStyleElement {
+  return isStyleElement(element) && hasAttribute(element, "scoped") || attributeValue(element, HERB_ATTRIBUTES.styleScoped) !== null
 }
 
 export class BrowserScopedStyleNoUnusedSelectorRule extends BrowserRule {
   static ruleName = "browser-scoped-style-no-unused-selector"
 
+  get defaultConfig(): FullRuleConfig {
+    return {
+      ...super.defaultConfig,
+      severity: "info"
+    }
+  }
+
   check(root: DOMNodeLike, _context?: Partial<LintContext>): UnboundLintOffense[] {
     const scope = root as QueryableLike
 
-    if (typeof scope.querySelectorAll !== "function") return []
+    if (typeof scope.querySelectorAll !== "function") {
+      return []
+    }
 
     const offenses: UnboundLintOffense[] = []
 
     for (const element of elements(root)) {
-      if (element.tagName.toLowerCase() !== "style") continue
       if (!isScoped(element)) continue
+      if (!element.sheet) continue
 
-      const sheet = (element as StyleElementLike).sheet
-      if (!sheet) continue
-
-      for (const selector of selectors(sheet.cssRules)) {
-        if (matches(scope, selector)) continue
+      for (const selector of selectors(element.sheet.cssRules)) {
+        if (matches(scope, selector)) {
+          continue
+        }
 
         offenses.push(
           this.createOffense(
-            `Selector \`${selector}\` matches nothing on the rendered page. Remove it, or check whether the markup it was written for still exists.`
+            `Selector \`${selector}\` matches nothing on the rendered page. Remove it, or check whether the markup it was written for still exists.`,
+            element
           )
         )
       }

--- a/javascript/packages/linter/src/linter.ts
+++ b/javascript/packages/linter/src/linter.ts
@@ -8,7 +8,7 @@ import { findNodeByLocation } from "./utils/rule-utils.js"
 import { parseHerbDisableLine } from "./herb-disable-comment-utils.js"
 import { hasLinterIgnoreDirective } from "./linter-ignore.js"
 import { ParseCache } from "./parse-cache.js"
-import { domToAST, sourcePathsIn } from "./browser/dom-to-ast.js"
+import { domToAST, sourcePathsIn, domNodesIn } from "./browser/dom-to-ast.js"
 import { browserRules } from "./browser/rules.js"
 
 import type { DOMNodeLike } from "./browser/dom-to-ast.js"
@@ -681,11 +681,15 @@ export class Linter {
     const document = domToAST(root)
     const result = this.lintDocument(document, context)
     const sources = sourcePathsIn(document)
+    const elements = domNodesIn(document)
 
     const offenses = result.offenses.map(offense => {
       const file = sources.get(offense.location)
+      const element = elements.get(offense.location)
 
-      return file ? { ...offense, file } : offense
+      if (!file && !element) return offense
+
+      return { ...offense, ...(file ? { file } : {}), ...(element ? { element } : {}) }
     })
 
     for (const ruleClass of browserRules) {
@@ -693,9 +697,7 @@ export class Linter {
 
       if (!this.appliesTo(rule, context?.environment ?? "browser")) continue
 
-      for (const offense of rule.check(root, context)) {
-        offenses.push({ ...offense, severity: offense.severity ?? "error" })
-      }
+      offenses.push(...this.bindSeverity(rule.check(root, context), ruleClass.ruleName, rule))
     }
 
     return {
@@ -765,17 +767,17 @@ export class Linter {
    * @param ruleName - Name of the rule that produced the offenses
    * @returns Array of offenses with severity bound
    */
-  protected bindSeverity(unboundOffenses: UnboundLintOffense[], ruleName: string): LintOffense[] {
+  protected bindSeverity(unboundOffenses: UnboundLintOffense[], ruleName: string, rule?: { defaultConfig?: FullRuleConfig }): LintOffense[] {
     const ruleClass = this.findRuleClass(ruleName)
 
-    if (!ruleClass) {
+    if (!ruleClass && !rule) {
       return unboundOffenses.map(offense => ({
         ...offense,
         severity: "error" as const
       }))
     }
 
-    const ruleInstance = new ruleClass()
+    const ruleInstance = rule ?? new ruleClass!()
     const defaultSeverityConfig = ruleInstance.defaultConfig?.severity ?? DEFAULT_RULE_CONFIG.severity
 
     const userRuleConfig = this.config?.linter?.rules?.[ruleName]

--- a/javascript/packages/linter/src/rules/html-head-only-elements.ts
+++ b/javascript/packages/linter/src/rules/html-head-only-elements.ts
@@ -1,10 +1,13 @@
-import { ParserRule } from "../types"
-import { ElementStackVisitor, isHeadOnlyTag, isBodyOnlyTag } from "../utils/rule-utils"
-import { hasAttribute, getTagLocalName } from "@herb-tools/core"
+import { HERB_ATTRIBUTES } from "@herb-tools/client/directives"
 
-import type { ParseResult, HTMLElementNode, ParserOptions } from "@herb-tools/core"
-import type * as Nodes from "@herb-tools/core"
+import { hasAttribute, getTagLocalName } from "@herb-tools/core"
+import { isHeadOnlyTag, isBodyOnlyTag } from "../utils/rule-utils"
+
+import { ParserRule } from "../types"
+import { ElementStackVisitor } from "../utils/rule-utils"
+
 import type { UnboundLintOffense, LintContext, FullRuleConfig } from "../types"
+import type { ParserOptions, ParseResult, HTMLElementNode, ERBIfNode, ERBUnlessNode, ERBCaseNode, ERBCaseMatchNode } from "@herb-tools/core"
 
 const inTheBodyNotTheHead = (ancestors: string[]) => ancestors.includes("body") && !ancestors.includes("head")
 
@@ -18,19 +21,19 @@ class HeadOnlyElementsVisitor extends ElementStackVisitor {
   private bodyOnlyTagName: string | null = null
   private conditionalDepth = 0
 
-  visitERBIfNode(node: Nodes.ERBIfNode): void {
+  visitERBIfNode(node: ERBIfNode): void {
     this.withinConditional(() => super.visitERBIfNode(node))
   }
 
-  visitERBUnlessNode(node: Nodes.ERBUnlessNode): void {
+  visitERBUnlessNode(node: ERBUnlessNode): void {
     this.withinConditional(() => super.visitERBUnlessNode(node))
   }
 
-  visitERBCaseNode(node: Nodes.ERBCaseNode): void {
+  visitERBCaseNode(node: ERBCaseNode): void {
     this.withinConditional(() => super.visitERBCaseNode(node))
   }
 
-  visitERBCaseMatchNode(node: Nodes.ERBCaseMatchNode): void {
+  visitERBCaseMatchNode(node: ERBCaseMatchNode): void {
     this.withinConditional(() => super.visitERBCaseMatchNode(node))
   }
 
@@ -40,7 +43,7 @@ class HeadOnlyElementsVisitor extends ElementStackVisitor {
     if (tagName && isHeadOnlyTag(tagName)) {
       const isAllowedInSVG = (tagName === "title" || tagName === "style") && this.isInsideElement("svg")
       const isMetaWithItemprop = tagName === "meta" && hasAttribute(node, "itemprop")
-      const isScopedStyle = tagName === "style" && hasAttribute(node, "scoped")
+      const isScopedStyle = tagName === "style" && (hasAttribute(node, "scoped") || hasAttribute(node, HERB_ATTRIBUTES.styleScoped))
 
       if (!isAllowedInSVG && !isMetaWithItemprop && !isScopedStyle) {
         const { verdict, chain } = this.placementAcrossCallers(inTheBodyNotTheHead)

--- a/javascript/packages/linter/src/types.ts
+++ b/javascript/packages/linter/src/types.ts
@@ -4,6 +4,7 @@ import type { DiagnosticTag, HerbError, SourcePath } from "@herb-tools/core"
 import type { rules } from "./rules.js"
 import type { HerbBackend, Node, ParserOptions } from "@herb-tools/core"
 import type { AncestorChain, RenderGraph, PartialIndex } from "@herb-tools/analysis"
+import type { DOMNodeLike } from "./browser/dom-to-ast.js"
 import type { Framework, Environment, RuleConfig, SeverityConfig, LinterMode } from "@herb-tools/config"
 import type { Mutable } from "@herb-tools/rewriter"
 import type { RuleVersion } from "@herb-tools/core"
@@ -57,6 +58,8 @@ export interface UnboundLintOffense<TAutofixContext extends BaseAutofixContext =
   renderedFrom?: AncestorChain
   /** The template the offense was written in */
   file?: SourcePath
+  /** The element the offense is about, when what was linted is a live DOM */
+  element?: DOMNodeLike
 }
 
 /**

--- a/javascript/packages/linter/test/browser/browser-rule.test.ts
+++ b/javascript/packages/linter/test/browser/browser-rule.test.ts
@@ -1,9 +1,10 @@
-import { describe, test } from "vitest"
+import { describe, test, expect } from "vitest"
 
 import { BrowserScopedStyleNoUnusedSelectorRule } from "../../src/browser/rules/browser-scoped-style-no-unused-selector.js"
 import { createBrowserRuleTest } from "./support/browser-rule-test.js"
+import { dom } from "./support/dom.js"
 
-const { expectNoOffenses, expectError, assertOffenses } = createBrowserRuleTest(BrowserScopedStyleNoUnusedSelectorRule as any)
+const { expectNoOffenses, expectInfo, assertOffenses } = createBrowserRuleTest(BrowserScopedStyleNoUnusedSelectorRule as any)
 
 const unused = (selector: string) => `Selector \`${selector}\` matches nothing on the rendered page. Remove it, or check whether the markup it was written for still exists.`
 
@@ -16,7 +17,7 @@ describe("browser-scoped-style-no-unused-selector", () => {
   })
 
   test("reports a selector that matches nothing on the rendered page", () => {
-    expectError(unused(".gone"))
+    expectInfo(unused(".gone"))
 
     assertOffenses(`
       <style scoped>.gone { color: red }</style>
@@ -25,7 +26,7 @@ describe("browser-scoped-style-no-unused-selector", () => {
   })
 
   test("judges each selector on its own", () => {
-    expectError(unused(".dead"))
+    expectInfo(unused(".dead"))
 
     assertOffenses(`
       <style scoped>
@@ -39,7 +40,7 @@ describe("browser-scoped-style-no-unused-selector", () => {
   })
 
   test("looks inside a media query", () => {
-    expectError(unused(".nested-dead"))
+    expectInfo(unused(".nested-dead"))
 
     assertOffenses(`
       <style scoped>
@@ -59,7 +60,7 @@ describe("browser-scoped-style-no-unused-selector", () => {
   })
 
   test("never sees a selector the browser could not parse", () => {
-    expectError(unused(".gone"))
+    expectInfo(unused(".gone"))
 
     assertOffenses(`
       <style scoped>
@@ -74,7 +75,7 @@ describe("browser-scoped-style-no-unused-selector", () => {
   })
 
   test("finds a scoped block on a page the engine compiled, where `scoped` is already gone", () => {
-    expectError(unused(".dead[data-herb-scope-2940ba8a]"))
+    expectInfo(unused(".dead[data-herb-scope-2940ba8a]"))
 
     assertOffenses(`
       <style data-herb-style-scoped="data-herb-scope-2940ba8a">
@@ -96,5 +97,40 @@ describe("browser-scoped-style-no-unused-selector", () => {
       <style scoped>DIV.Card { color: red }</style>
       <div class="Card"></div>
     `)
+  })
+})
+
+describe("where a browser rule's finding came from", () => {
+  const check = (markup: string) => new BrowserScopedStyleNoUnusedSelectorRule().check(dom(markup) as any)
+
+  test("names the file from the nearest stamp above the element", () => {
+    const [offense] = check(`
+      <div data-herb-source="app/views/posts/index.html.erb:3:1">
+        <style data-herb-style-scoped="data-herb-scope-2940ba8a">.gone[data-herb-scope-2940ba8a] { color: red }</style>
+      </div>
+    `)
+
+    expect(offense.file?.toString()).toBe("app/views/posts/index.html.erb:3:1")
+  })
+
+  test("reads a stamp on the style element itself", () => {
+    const [offense] = check(`
+      <style data-herb-style-scoped="data-herb-scope-2940ba8a" data-herb-source="app/views/posts/_card.html.erb:9:2">.gone[data-herb-scope-2940ba8a] { color: red }</style>
+    `)
+
+    expect(offense.file?.toString()).toBe("app/views/posts/_card.html.erb:9:2")
+  })
+
+  test("points at the style element it is about", () => {
+    const root = dom`<style scoped id="sheet">.gone { color: red }</style>`
+    const [offense] = new BrowserScopedStyleNoUnusedSelectorRule().check(root as any)
+
+    expect(offense.element).toBe((root as any).querySelector("#sheet"))
+  })
+
+  test("leaves the file out when nothing above it was stamped", () => {
+    const [offense] = check(`<style scoped>.gone { color: red }</style>`)
+
+    expect(offense.file).toBeUndefined()
   })
 })

--- a/javascript/packages/linter/test/browser/dev-tools.test.ts
+++ b/javascript/packages/linter/test/browser/dev-tools.test.ts
@@ -1,0 +1,161 @@
+import { describe, test, expect, afterEach } from "vitest"
+
+import { reportToDevTools, toRuntimeDiagnostics, devToolsIn, LINTER_ORIGIN } from "../../src/browser/dev-tools.js"
+import { dom, resetDOM } from "./support/dom.js"
+import { createBrowserLinter } from "./support/browser-linter.js"
+
+import type { DevToolsLike, RuntimeDiagnosticLike } from "../../src/browser/dev-tools.js"
+
+afterEach(resetDOM)
+
+function fakeDevTools() {
+  const reported: RuntimeDiagnosticLike[][] = []
+  const cleared: (string | undefined)[] = []
+  let dismissed = 0
+
+  const devTools: DevToolsLike = {
+    report(input) {
+      reported.push(Array.isArray(input) ? input : [input])
+
+      return { dismiss: () => { dismissed += 1 } }
+    },
+    clear(origin) {
+      cleared.push(origin)
+    },
+  }
+
+  return { devTools, reported, cleared, dismissed: () => dismissed, scope: { HerbDevTools: devTools } }
+}
+
+const linter = () => createBrowserLinter({ only: ["html-img-require-alt"] })
+
+describe("reporting to dev tools", () => {
+  test("hands every offense over as a runtime diagnostic", () => {
+    const { scope, reported } = fakeDevTools()
+    const root = dom`<div data-herb-source="app/views/posts/_card.html.erb:8:3"><img src="/a.png"></div>`
+
+    const { result, handle } = reportToDevTools(linter(), { root, scope })
+
+    expect(result!.offenses).toHaveLength(1)
+    expect(handle).not.toBeNull()
+    expect(reported).toHaveLength(1)
+
+    const [diagnostic] = reported[0]
+
+    expect(diagnostic.template).toBe("app/views/posts/_card.html.erb")
+    expect(diagnostic.code).toBe("html-img-require-alt")
+    expect(diagnostic.severity).toBe("warning")
+    expect(diagnostic.origin).toBe("Herb Linter (Rendered Page)")
+    expect(diagnostic.phase).toBe("runtime")
+    expect(diagnostic.overlay).toBe(false)
+    expect(diagnostic.location?.start).toEqual({ line: 8, column: 2 })
+    expect(diagnostic.docsUrl).toBe("https://herb-tools.dev/linter/rules/html-img-require-alt")
+  })
+
+  test("points the diagnostic at the element it is about", () => {
+    const { scope, reported } = fakeDevTools()
+    const root = dom`<div data-herb-source="a.html.erb:1:1"><img id="target" src="/a.png"></div>`
+
+    reportToDevTools(linter(), { root, scope })
+
+    expect(reported[0][0].element).toBe((root as any).querySelector("#target"))
+  })
+
+  test("names an unattributed offense rather than dropping it", () => {
+    const { scope, reported } = fakeDevTools()
+
+    reportToDevTools(linter(), { root: dom`<img src="/a.png">`, scope })
+
+    expect(reported[0][0].template).toBe("(unknown template)")
+    expect(reported[0][0].location).toBeUndefined()
+  })
+
+  test("clears its own findings first, so a second run replaces the first", () => {
+    const { scope, cleared, reported } = fakeDevTools()
+    const root = dom`<img src="/a.png">`
+
+    reportToDevTools(linter(), { root, scope })
+    reportToDevTools(linter(), { root, scope })
+
+    expect(cleared).toEqual([LINTER_ORIGIN, LINTER_ORIGIN])
+    expect(reported).toHaveLength(2)
+  })
+
+  test("does not lint at all when the toggle is off, and clears what it left", () => {
+    const { scope, cleared, reported } = fakeDevTools()
+
+    scope.HerbDevTools.lintingEnabled = false
+
+    const { result, handle } = reportToDevTools(linter(), { root: dom`<img src="/a.png">`, scope })
+
+    expect(result).toBeNull()
+    expect(handle).toBeNull()
+    expect(reported).toEqual([])
+    expect(cleared).toEqual([LINTER_ORIGIN])
+  })
+
+  test("lints when the toggle is on", () => {
+    const { scope, reported } = fakeDevTools()
+
+    scope.HerbDevTools.lintingEnabled = true
+
+    reportToDevTools(linter(), { root: dom`<img src="/a.png">`, scope })
+
+    expect(reported[0]).toHaveLength(1)
+  })
+
+  test("lints when dev tools is too old to have a toggle", () => {
+    const { scope, reported } = fakeDevTools()
+
+    reportToDevTools(linter(), { root: dom`<img src="/a.png">`, scope })
+
+    expect(reported[0]).toHaveLength(1)
+  })
+
+  test("still lints when the page has no dev tools on it", () => {
+    const root = dom`<img src="/a.png">`
+
+    const { result, handle } = reportToDevTools(linter(), { root, scope: {} })
+
+    expect(result!.offenses).toHaveLength(1)
+    expect(handle).toBeNull()
+  })
+
+  test("lints the body when no root is given", () => {
+    const { scope, reported } = fakeDevTools()
+
+    dom`<img src="/a.png">`
+    reportToDevTools(linter(), { scope })
+
+    expect(reported[0]).toHaveLength(1)
+  })
+
+  test("hands back a handle that dismisses what it reported", () => {
+    const tools = fakeDevTools()
+    const { handle } = reportToDevTools(linter(), { root: dom`<img src="/a.png">`, scope: tools.scope })
+
+    handle!.dismiss()
+
+    expect(tools.dismissed()).toBe(1)
+  })
+})
+
+describe("finding dev tools", () => {
+  test("answers with nothing when the page has none", () => {
+    expect(devToolsIn({})).toBeNull()
+  })
+
+  test("answers with what the page has", () => {
+    const { devTools, scope } = fakeDevTools()
+
+    expect(devToolsIn(scope)).toBe(devTools)
+  })
+})
+
+describe("converting a result", () => {
+  test("turns every offense into a diagnostic", () => {
+    const result = linter().lintElement(dom`<img src="/a.png"><img src="/b.png">`)
+
+    expect(toRuntimeDiagnostics(result)).toHaveLength(2)
+  })
+})

--- a/javascript/packages/linter/test/browser/lint-dom.test.ts
+++ b/javascript/packages/linter/test/browser/lint-dom.test.ts
@@ -141,6 +141,17 @@ describe("which rules run in the browser", () => {
     expect(namesFor(config)).not.toContain("html-no-duplicate-ids")
   })
 
+  test("gives a browser rule the severity it declares, and lets config change it", () => {
+    const tree = () => dom`<style scoped>.gone { color: red }</style>`
+    const severities = (config?: any) =>
+      createBrowserLinter({ config }).lintElement(tree()).offenses
+        .filter((offense) => offense.rule === "browser-scoped-style-no-unused-selector")
+        .map((offense) => offense.severity)
+
+    expect(severities()).toEqual(["info"])
+    expect(severities({ linter: { rules: { "browser-scoped-style-no-unused-selector": { severity: "warning" } } } })).toEqual(["warning"])
+  })
+
   test("takes a browser rule out when config narrows it to the command line", () => {
     const config = { linter: { rules: { "browser-scoped-style-no-unused-selector": { environments: ["cli"] } } } }
     const rule = new BrowserScopedStyleNoUnusedSelectorRule()

--- a/javascript/packages/linter/test/browser/rules/html-head-only-elements.test.ts
+++ b/javascript/packages/linter/test/browser/rules/html-head-only-elements.test.ts
@@ -10,6 +10,19 @@ describe("html-head-only-elements in the browser", () => {
     expectNoOffenses(`<div><p>fine</p></div>`)
   })
 
+  test("passes for a scoped style block, which the page renders in the body on purpose", () => {
+    expectNoOffenses(`
+      <style data-herb-style-scoped="data-herb-scope-2940ba8a">.card[data-herb-scope-2940ba8a] { color: red }</style>
+      <div class="card" data-herb-scope-2940ba8a>Hi</div>
+    `)
+  })
+
+  test("fails for a style block the page rendered in the body with no scope behind it", () => {
+    expectError(`Element \`<style>\` must be placed inside the \`<head>\` tag.`)
+
+    assertOffenses(`<div>content</div><style>.card { color: red }</style>`)
+  })
+
   test("fails for a head-only element the page rendered in the body", () => {
     expectError(`Element \`<title>\` must be placed inside the \`<head>\` tag.`)
 

--- a/javascript/packages/linter/test/rules/html-head-only-elements.test.ts
+++ b/javascript/packages/linter/test/rules/html-head-only-elements.test.ts
@@ -181,6 +181,23 @@ describe("html-head-only-elements", () => {
     `)
   })
 
+  test("passes when a scoped style block was already narrowed, so `scoped` is gone", () => {
+    expectNoOffenses(dedent`
+      <html>
+        <head>
+          <title>My Page</title>
+        </head>
+        <body>
+          <style data-herb-style-scoped="data-herb-scope-2940ba8a">
+            .card[data-herb-scope-2940ba8a] { color: red; }
+          </style>
+
+          <div class="card" data-herb-scope-2940ba8a>Hi</div>
+        </body>
+      </html>
+    `)
+  })
+
   test("fails when a style block in the body was not written as scoped", () => {
     expectError("Element `<style>` must be placed inside the `<head>` tag.")
 


### PR DESCRIPTION
Follow up on #2478

This pull request puts what the linter finds in front of a reader, in the Herb Dev Tools panel, with a switch in the menu to turn it off.

<img width="75%" alt="CleanShot 2026-08-30 at 21 58 40@2x" src="https://github.com/user-attachments/assets/ea930b38-750a-4fc9-813d-99e520e6edb9" />



Findings arrive grouped by the template they were written in, with a render stack, a link to the rule's documentation, and a control that scrolls to the element and flashes it.

#### How it works

Dev tools does not depend on the linter, and it should not. The linter brings 100+ rules, Prism and PostCSS with it, and a panel that displays diagnostics needs none of that. The linter does not depend on dev tools either. The two meet at the `window.HerbDevTools` global, so the bridge lives in `@herb-tools/linter/browser` and declares the shape it fills in.

#### Turning it off

`Lint Rendered Page` sits in the dev tools menu, on by default and remembered per browser. Dev tools owns the switch without running anything, so it reports the setting through `HerbDevTools.lintingEnabled` and fires an event when it changes. Turning it off clears what was reported and skips the walk, which is what makes the switch worth having.

<img width="75%" alt="CleanShot 2026-08-30 at 21 58 01@2x" src="https://github.com/user-attachments/assets/057145f8-3fc0-4290-8cd0-b265b2b0c8e8" />

