### PR TITLE
Engine: Assert that an ERB tag compiles to the line it was written on

### DIFF
--- a/test/line_fidelity_allowlist.txt
+++ b/test/line_fidelity_allowlist.txt
@@ -1,0 +1,43 @@
+Engine::BlockCommentsTest#test_0001_ruby block comments with =begin and =end multiline
+Engine::BlockCommentsTest#test_0002_ruby block comments inside erb tags
+Engine::BlockCommentsTest#test_0003_ruby block comments with code before and after
+Engine::BlockCommentsTest#test_0007_ruby block comments with =begin and =end mutliline and no space before ERB closing tag
+Engine::DebugModeTest#test_0065_block with debug disable comment content erb expressions do NOT get debug spans
+Engine::DebugModeTest#test_0066_block with debug disable comment suppresses debug spans for multiple expressions
+Engine::DebugModeTest#test_0067_block with debug disable comment suppresses debug spans in nested html
+Engine::DebugModeTest#test_0068_debug disable comment works on non-content_for blocks
+Engine::DebugModeTest#test_0069_debug disable comment with extra whitespace
+Engine::DebugModeTest::marking which render a tag came from#test_0001_says nothing about the render unless asked
+Engine::DebugModeTest::marking which render a tag came from#test_0002_compiles the marker as a tag the session fills in
+Engine::ERBCommentsTest#test_0003_inline ruby comment between code
+Engine::ERBCommentsTest#test_0004_inline ruby comment before and between code
+Engine::ERBCommentsTest#test_0006_inline ruby comment multiline
+Engine::ExamplesCompilationTest#test_0004_block comment compilation
+Engine::ExamplesCompilationTest#test_0017_graphql compilation
+Engine::GraphQLTest#test_0003_graphql tag with surrounding html
+Engine::GraphQLTest#test_0004_graphql tag with comment and html
+Engine::GraphQLTest#test_0005_graphql tag with query variables
+Engine::InlineRenderTest#test_0012_detects circular references and falls back
+Engine::InstrumentationTest::what it emits#test_0001_wraps an output tag
+Engine::InstrumentationTest::what it emits#test_0002_frames a block rather than wrapping it
+Engine::InstrumentationTest::what it emits#test_0003_frames an assignment rather than wrapping it
+Engine::InstrumentationTest::what it emits#test_0004_opens and closes around a statement
+Engine::InstrumentationTest::what it emits#test_0006_reaches into a conditional
+Engine::InstrumentationTest::what it says a render was reached by#test_0001_frames a partial
+Engine::InstrumentationTest::what it says a render was reached by#test_0002_frames a collection
+Engine::InstrumentationTest::what it says a render was reached by#test_0004_frames a template
+Engine::InstrumentationTest::what it says a render was reached by#test_0005_frames an object, which only Rails can classify
+Engine::RenderNodeCompilationTest#test_0006_emits a render inside a loop
+Engine::ScopedStyleVisitorTest#test_0023_carries the scope into the markup a client rebuilds a branch from
+Engine::Slots::ManifestChannelTest#test_0001_writes nothing at all unless a delivery asks for it
+Engine::Slots::ManifestChannelTest#test_0014_a template with nothing of its own to say records nothing
+Engine::Slots::ManifestChannelTest#test_0015_and inlines nothing either
+Engine::Slots::ManifestCollectorTest#test_0006_a project that extracts its manifests sends none with the page
+Engine::Slots::MarkersTest#test_0016_compiles slot markers into the generated source
+Engine::Slots::MarkersTest#test_0017_compiles a conditional into the generated source
+Engine::Slots::MarkersTest#test_0018_compiles a collection into the generated source
+Engine::Slots::MarkersTest#test_0019_compiles attribute slots into the generated source
+Engine::WhitespaceTrimmingTest#test_0031_output tag with -%> followed by another expression tag
+Engine::WhitespaceTrimmingTest#test_0036_leading whitespace before statement tag with inline expression is preserved
+Engine::WhitespaceTrimmingTest#test_0045_leading whitespace preserved when control tag with inline output follows a trimmed code-only line
+Engine::WhitespaceTrimmingTest#test_0046_leading whitespace preserved after multiple consecutive trimmed code-only lines

--- a/test/snapshot_utils.rb
+++ b/test/snapshot_utils.rb
@@ -61,6 +61,8 @@ module SnapshotUtils
     snapshot_key = { source: source, options: engine_options }.to_s
     assert_snapshot_matches(expected, snapshot_key)
 
+    assert_erb_tags_keep_their_line(source, engine.src)
+
     prism_result = Prism.parse(engine.src)
     syntax_errors = prism_result.errors.reject { |e| e.type == :invalid_yield }
 
@@ -500,6 +502,77 @@ module SnapshotUtils
     metadata
   end
 
+  LINE_FIDELITY_ALLOWLIST_PATH = File.expand_path("line_fidelity_allowlist.txt", __dir__)
+
+  def line_fidelity_allowlist
+    SnapshotUtils.line_fidelity_allowlist
+  end
+
+  def self.line_fidelity_allowlist
+    @line_fidelity_allowlist ||=
+      if File.exist?(LINE_FIDELITY_ALLOWLIST_PATH)
+        File.readlines(LINE_FIDELITY_ALLOWLIST_PATH, chomp: true).reject(&:empty?).to_set
+      else
+        Set.new
+      end
+  end
+
+  def self.line_fidelity_allowlist_ran
+    @line_fidelity_allowlist_ran ||= Set.new
+  end
+
+  def self.line_fidelity_allowlist_needed
+    @line_fidelity_allowlist_needed ||= Set.new
+  end
+
+  def self.line_fidelity_run_failed?
+    @line_fidelity_run_failed || false
+  end
+
+  def self.line_fidelity_run_failed!
+    @line_fidelity_run_failed = true
+  end
+
+  def self.stale_line_fidelity_allowlist_entries
+    return Set.new if line_fidelity_run_failed?
+
+    line_fidelity_allowlist_ran - line_fidelity_allowlist_needed
+  end
+
+  def after_teardown
+    super
+
+    SnapshotUtils.line_fidelity_run_failed! if failures.any? { |failure| !failure.is_a?(Minitest::Skip) }
+  end
+
+  def assert_erb_tags_keep_their_line(source, compiled)
+    off = erb_tags_off_their_line(source, compiled)
+    identifier = "#{self.class}##{name}"
+
+    if ENV["UPDATE_LINE_FIDELITY_ALLOWLIST"]
+      File.open(LINE_FIDELITY_ALLOWLIST_PATH, "a") { |file| file.puts(identifier) } unless off.empty?
+
+      return
+    end
+
+    if line_fidelity_allowlist.include?(identifier)
+      SnapshotUtils.line_fidelity_allowlist_ran << identifier
+      SnapshotUtils.line_fidelity_allowlist_needed << identifier unless off.empty?
+
+      return
+    end
+
+    assert off.empty?, <<~MESSAGE
+      An ERB tag compiles to a line other than the one it was written on, so a
+      backtrace from this template would name the wrong line:
+
+      #{off.map { |line, code| "  source line #{line}: #{code[0, 60]}" }.join("\n")}
+
+      Compiled source:
+      #{compiled}
+    MESSAGE
+  end
+
   private
 
   def evaluate_actionview_source(source, locals)
@@ -564,5 +637,33 @@ module SnapshotUtils
           .tr("-", "_")
           .tr(" ", "_")
           .downcase
+  end
+
+  def erb_content_nodes(node, found = [])
+    found << node if node.class.name&.end_with?("ERBContentNode")
+    node.compact_child_nodes.each { |child| erb_content_nodes(child, found) } if node.respond_to?(:compact_child_nodes)
+    found
+  end
+
+  def erb_tags_off_their_line(source, compiled)
+    lines = compiled.lines
+
+    erb_content_nodes(Herb.parse(source).value).filter_map do |node|
+      opening = node.tag_opening&.value.to_s
+
+      next if opening.empty? || opening.start_with?("<%#")
+
+      code = Herb::Engine::Helpers.strip_trailing_comment(node.content&.value.to_s.strip)
+
+      next if code.empty?
+
+      line = node.tag_opening.location.start.line
+      first = code.lines.first.to_s.strip
+
+      next if lines[line - 1].to_s.include?(first)
+      next unless compiled.include?(first)
+
+      [line, first]
+    end
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -28,6 +28,20 @@ require_relative "snapshot_utils"
 Minitest::Spec::DSL.send(:alias_method, :test, :it)
 Minitest::Spec::DSL.send(:alias_method, :xtest, :xit)
 
+Minitest.after_run do
+  stale = SnapshotUtils.stale_line_fidelity_allowlist_entries
+
+  if !stale.empty? && !ENV["UPDATE_LINE_FIDELITY_ALLOWLIST"]
+    abort(<<~MESSAGE)
+
+      Every ERB tag now compiles to the line it was written on for #{stale.size} allowlisted #{stale.size == 1 ? "test" : "tests"}.
+      Remove #{stale.size == 1 ? "this entry" : "these entries"} from test/line_fidelity_allowlist.txt:
+
+      #{stale.sort.map { |entry| "  #{entry}" }.join("\n")}
+    MESSAGE
+  end
+end
+
 def cyclic_string(length)
   sequence = ("a".."z").to_a + ("0".."9").to_a
   sequence.cycle.take(length).join


### PR DESCRIPTION
Follow up on #2391 and #2480.

`ActionView` maps a compiled line back to a source line one to one, so the line an ERB tag lands on in the compiled output is the line a backtrace, an error page, and `Template#spot` will name. When the compiler emits an extra newline, or swallows one, every tag below it reports the wrong line for the rest of the template.

Both #2391 and #2480 fixed one instance of this, and both were found by hand. This pull request adds a check that finds them automatically. Every call to `assert_compiled_snapshot` now parses the source, walks it for `ERBContentNode`s, and asserts that each tag's own code appears on its own line in the compiled output.

```
An ERB tag compiles to a line other than the one it was written on, so a
backtrace from this template would name the wrong line:

  source line 3: user.name

Compiled source:
...
```

Static text is not checked. Only the ERB needs to stay true to its source line, and the compiler is free to merge, reorder, or drop the literal chunks between tags.

Code the `OptimizeVisitor` eliminates is not drift either, so a tag whose code is absent from the compiled output entirely is skipped. Without that, a constant-folded conditional reads as a tag that moved.

There are 43 tests where a tag does not currently land on its source line, so the assertion starts from an allowlist in `test/line_fidelity_allowlist.txt` and ratchets in both directions. A test that is not listed must keep its lines. A test that is listed, and that now keeps all of its lines, fails the run as well.

```
Every ERB tag now compiles to the line it was written on for 5 allowlisted tests.
Remove these entries from test/line_fidelity_allowlist.txt:

  Engine::DebugModeTest#test_0065_block with debug disable comment content erb expressions do NOT get debug spans
  ...
```

That check runs from `Minitest.after_run`, and it only judges tests that actually ran, so running a single file does not ask you to delete the other 40 entries. It also stands down when the suite already failed, because a test that dies before its second snapshot call would otherwise look falsely clean.

Regenerate the whole list with:

```bash
rm test/line_fidelity_allowlist.txt && UPDATE_LINE_FIDELITY_ALLOWLIST=1 bundle exec rake test
```
