### PR TITLE
Engine: Keep line a block expression with a trailing comment

### DIFF
--- a/lib/herb/engine/compiler.rb
+++ b/lib/herb/engine/compiler.rb
@@ -314,7 +314,7 @@ module Herb
 
         if opening.include?("=")
           should_escape = should_escape_output?(opening)
-          code = node.content.value.strip
+          code = ::Herb::Engine::Helpers.strip_trailing_comment(node.content.value.strip)
 
           @tokens << if should_escape
                        [:expr_block_escaped, code, current_context]
@@ -351,7 +351,7 @@ module Herb
       def visit_erb_block_end_node(node, escaped: false)
         remove_trailing_whitespace_from_last_token! if @trim && left_trim?(node)
 
-        code = node.content.value.strip
+        code = ::Herb::Engine::Helpers.strip_trailing_comment(node.content.value.strip)
 
         if @trim && at_line_start?
           leading_space = extract_and_remove_leading_space!

--- a/test/line_fidelity_allowlist.txt
+++ b/test/line_fidelity_allowlist.txt
@@ -2,11 +2,6 @@ Engine::BlockCommentsTest#test_0001_ruby block comments with =begin and =end mul
 Engine::BlockCommentsTest#test_0002_ruby block comments inside erb tags
 Engine::BlockCommentsTest#test_0003_ruby block comments with code before and after
 Engine::BlockCommentsTest#test_0007_ruby block comments with =begin and =end mutliline and no space before ERB closing tag
-Engine::DebugModeTest#test_0065_block with debug disable comment content erb expressions do NOT get debug spans
-Engine::DebugModeTest#test_0066_block with debug disable comment suppresses debug spans for multiple expressions
-Engine::DebugModeTest#test_0067_block with debug disable comment suppresses debug spans in nested html
-Engine::DebugModeTest#test_0068_debug disable comment works on non-content_for blocks
-Engine::DebugModeTest#test_0069_debug disable comment with extra whitespace
 Engine::DebugModeTest::marking which render a tag came from#test_0001_says nothing about the render unless asked
 Engine::DebugModeTest::marking which render a tag came from#test_0002_compiles the marker as a tag the session fills in
 Engine::ERBCommentsTest#test_0003_inline ruby comment between code

--- a/test/snapshots/engine/debug_mode_test/test_0065_block_with_debug_disable_comment_content_erb_expressions_do_NOT_get_debug_spans_d2b3eddf63c7e82f2d5db326f5481467.txt
+++ b/test/snapshots/engine/debug_mode_test/test_0065_block_with_debug_disable_comment_content_erb_expressions_do_NOT_get_debug_spans_d2b3eddf63c7e82f2d5db326f5481467.txt
@@ -2,8 +2,7 @@
 source: "Engine::DebugModeTest#test_0065_block with debug disable comment content erb expressions do NOT get debug spans"
 input: "{source: \"<%= content_for :sidebar do # herb:debug disable %>\\n  <div><%= \\\"Sidebar content\\\" %></div>\\n<% end %>\\n\", options: {visitors: [#<Herb::Engine::DebugVisitor>]}}"
 ---
-_buf = ::String.new; _buf << (content_for :sidebar do # herb:debug disable
-; _buf << '
+_buf = ::String.new; _buf << (content_for :sidebar do; _buf << '
   <div>'.freeze; _buf << ("Sidebar content").to_s; _buf << '</div>
 '.freeze; end )
 _buf.to_s

--- a/test/snapshots/engine/debug_mode_test/test_0066_block_with_debug_disable_comment_suppresses_debug_spans_for_multiple_expressions_5f0effffe860c65587c4e7317fd5c90f.txt
+++ b/test/snapshots/engine/debug_mode_test/test_0066_block_with_debug_disable_comment_suppresses_debug_spans_for_multiple_expressions_5f0effffe860c65587c4e7317fd5c90f.txt
@@ -2,8 +2,7 @@
 source: "Engine::DebugModeTest#test_0066_block with debug disable comment suppresses debug spans for multiple expressions"
 input: "{source: \"<%= content_for :title do # herb:debug disable %>\\n  <%= [t('app_title.text', app_name: AppSettings.app_name), breadcrumb_trail&.first&.name].compact.join(\\\" | \\\") %>\\n  <%= :subtitle %>\\n<% end %>\\n\", options: {visitors: [#<Herb::Engine::DebugVisitor>]}}"
 ---
-_buf = ::String.new; _buf << (content_for :title do # herb:debug disable
-; _buf << '
+_buf = ::String.new; _buf << (content_for :title do; _buf << '
   '.freeze; _buf << ([t('app_title.text', app_name: AppSettings.app_name), breadcrumb_trail&.first&.name].compact.join(" | ")).to_s; _buf << '
   '.freeze; _buf << (:subtitle).to_s; _buf << '
 '.freeze; end )

--- a/test/snapshots/engine/debug_mode_test/test_0067_block_with_debug_disable_comment_suppresses_debug_spans_in_nested_html_179209df0495f4262b735f32c28a1727.txt
+++ b/test/snapshots/engine/debug_mode_test/test_0067_block_with_debug_disable_comment_suppresses_debug_spans_in_nested_html_179209df0495f4262b735f32c28a1727.txt
@@ -2,8 +2,7 @@
 source: "Engine::DebugModeTest#test_0067_block with debug disable comment suppresses debug spans in nested html"
 input: "{source: \"<%= content_for :sidebar do # herb:debug disable %>\\n  <div><%= \\\"First\\\" %></div>\\n  <p><%= \\\"Second\\\" %></p>\\n  <span><%= \\\"Third\\\" %></span>\\n<% end %>\\n\", options: {visitors: [#<Herb::Engine::DebugVisitor>]}}"
 ---
-_buf = ::String.new; _buf << (content_for :sidebar do # herb:debug disable
-; _buf << '
+_buf = ::String.new; _buf << (content_for :sidebar do; _buf << '
   <div>'.freeze; _buf << ("First").to_s; _buf << '</div>
   <p>'.freeze; _buf << ("Second").to_s; _buf << '</p>
   <span>'.freeze; _buf << ("Third").to_s; _buf << '</span>

--- a/test/snapshots/engine/debug_mode_test/test_0068_debug_disable_comment_works_on_non-content_for_blocks_aa422c183c2270d551fafd1b69d29617.txt
+++ b/test/snapshots/engine/debug_mode_test/test_0068_debug_disable_comment_works_on_non-content_for_blocks_aa422c183c2270d551fafd1b69d29617.txt
@@ -2,8 +2,7 @@
 source: "Engine::DebugModeTest#test_0068_debug disable comment works on non-content_for blocks"
 input: "{source: \"<%= some_helper do # herb:debug disable %>\\n  <div><%= \\\"Hello\\\" %></div>\\n<% end %>\\n\", options: {visitors: [#<Herb::Engine::DebugVisitor>]}}"
 ---
-_buf = ::String.new; _buf << (some_helper do # herb:debug disable
-; _buf << '
+_buf = ::String.new; _buf << (some_helper do; _buf << '
   <div>'.freeze; _buf << ("Hello").to_s; _buf << '</div>
 '.freeze; end )
 _buf.to_s

--- a/test/snapshots/engine/debug_mode_test/test_0069_debug_disable_comment_with_extra_whitespace_329b04e2a2ab203abaa500095bc319ad.txt
+++ b/test/snapshots/engine/debug_mode_test/test_0069_debug_disable_comment_with_extra_whitespace_329b04e2a2ab203abaa500095bc319ad.txt
@@ -2,8 +2,7 @@
 source: "Engine::DebugModeTest#test_0069_debug disable comment with extra whitespace"
 input: "{source: \"<%= content_for :title do #   herb:debug   disable %>\\n  <%= \\\"Title\\\" %>\\n<% end %>\\n\", options: {visitors: [#<Herb::Engine::DebugVisitor>]}}"
 ---
-_buf = ::String.new; _buf << (content_for :title do #   herb:debug   disable
-; _buf << '
+_buf = ::String.new; _buf << (content_for :title do; _buf << '
   '.freeze; _buf << ("Title").to_s; _buf << '
 '.freeze; end )
 _buf.to_s

--- a/test/snapshots/engine/engine_block_test/test_0014_inline_comment_on_end_inside_output_block_does_not_break_parens_1c140392798ee0e334ac05bafcebe13b.txt
+++ b/test/snapshots/engine/engine_block_test/test_0014_inline_comment_on_end_inside_output_block_does_not_break_parens_1c140392798ee0e334ac05bafcebe13b.txt
@@ -2,6 +2,5 @@
 source: "Engine::EngineBlockTest#test_0014_inline comment on end inside output block does not break parens"
 input: "{source: \"<%= render Foo.new do %>hello<% end # comment %>\", options: {}}"
 ---
-_buf = ::String.new; _buf << (render Foo.new do; _buf << 'hello'.freeze; end # comment
-);
+_buf = ::String.new; _buf << (render Foo.new do; _buf << 'hello'.freeze; end);
 _buf.to_s


### PR DESCRIPTION
#2480 spliced a trailing comment out of the code emitted for an ERB tag, so that the comment could not swallow the rest of the compiled line. That splice only covered `process_erb_tag`. Block expressions take their own path through the compiler, so a comment on a block opening or on its `end` still pushed everything after it onto the next line.

```erb
<%= content_for :title do # herb:debug disable %>
  <%= user.name %>
  <%= user.email %>
<% end %>
```

**Before**

```ruby
 1 | _buf = ::String.new; _buf << (content_for :title do # herb:debug disable
 2 | ; _buf << '
 3 |   '.freeze; _buf << (user.name).to_s; _buf << '
 4 |   '.freeze; _buf << (user.email).to_s; _buf << '
 5 | '.freeze; end )
 6 | _buf.to_s
```

**After**

```ruby
 1 | _buf = ::String.new; _buf << (content_for :title do; _buf << '
 2 |   '.freeze; _buf << (user.name).to_s; _buf << '
 3 |   '.freeze; _buf << (user.email).to_s; _buf << '
 4 | '.freeze; end )
 5 | _buf.to_s
```

`user.name` is written on line 2 and now compiles to line 2. Before this change it compiled to line 3, and so did every tag below it, which is the line an error page or a backtrace would have named.

The same applies to a comment on the closing tag, as in `<% end # comment %>`.

Stripping the comment does not affect `# herb:debug disable`. The `DebugVisitor` reads that directive off the AST before compilation, and the splice happens when the code is emitted.

This takes the `test/line_fidelity_allowlist.txt` introduced in #2482 from 43 entries down to 38. The five `Engine::DebugModeTest` entries were reported by the allowlist's own staleness check.
