### PR TITLE
Engine: Keep the line a multi-line ERB tag's code starts on

### DIFF
--- a/lib/herb/engine/compiler.rb
+++ b/lib/herb/engine/compiler.rb
@@ -457,22 +457,28 @@ module Herb
 
         code = ::Herb::Engine::Helpers.strip_trailing_comment(node.content.value.strip)
 
+        code_index = @tokens.length
+
         if erb_output?(opening)
           process_erb_output(node, opening, code)
         else
           apply_trim(node, code)
         end
 
-        keep_line_count(node)
+        keep_line_count(node, at: code_index)
       end
 
-      def keep_line_count(node, extra: 0)
-        lines = node.content.value.count("\n") - node.content.value.strip.count("\n") + extra
+      def keep_line_count(node, extra: 0, at: nil)
+        raw = node.content.value
 
-        return unless lines.positive?
+        return if raw.include?("=begin") || raw.include?("=end")
+
+        leading = raw[0, raw.length - raw.lstrip.length].to_s.count("\n")
+        trailing = raw.count("\n") - raw.strip.count("\n") - leading + extra
 
         @padding_before ||= Hash.new(0)
-        @padding_before[@tokens.length] += lines
+        @padding_before[at] += leading if at && leading.positive?
+        @padding_before[@tokens.length] += trailing if trailing.positive?
       end
 
       def add_text(text)

--- a/sig/herb/engine/compiler.rbs
+++ b/sig/herb/engine/compiler.rbs
@@ -128,7 +128,7 @@ module Herb
 
       def process_erb_tag: (untyped node, ?skip_comment_check: untyped) -> untyped
 
-      def keep_line_count: (untyped node, ?extra: untyped) -> untyped
+      def keep_line_count: (untyped node, ?extra: untyped, ?at: untyped) -> untyped
 
       def add_text: (untyped text) -> untyped
 

--- a/test/line_fidelity_allowlist.txt
+++ b/test/line_fidelity_allowlist.txt
@@ -1,6 +1,4 @@
 Engine::BlockCommentsTest#test_0001_ruby block comments with =begin and =end multiline
-Engine::BlockCommentsTest#test_0002_ruby block comments inside erb tags
-Engine::BlockCommentsTest#test_0003_ruby block comments with code before and after
 Engine::BlockCommentsTest#test_0007_ruby block comments with =begin and =end mutliline and no space before ERB closing tag
 Engine::ERBCommentsTest#test_0003_inline ruby comment between code
 Engine::ERBCommentsTest#test_0004_inline ruby comment before and between code

--- a/test/snapshot_utils.rb
+++ b/test/snapshot_utils.rb
@@ -653,11 +653,12 @@ module SnapshotUtils
 
       next if opening.empty? || opening.start_with?("<%#")
 
-      code = Herb::Engine::Helpers.strip_trailing_comment(node.content&.value.to_s.strip)
+      raw = node.content&.value.to_s
+      code = Herb::Engine::Helpers.strip_trailing_comment(raw.strip)
 
       next if code.empty?
 
-      line = node.tag_opening.location.start.line
+      line = node.tag_opening.location.start.line + raw[0, raw.length - raw.lstrip.length].to_s.count("\n")
       first = code.lines.first.to_s.strip
 
       next if lines[line - 1].to_s.include?(first)

--- a/test/snapshots/engine/block_comments_test/test_0001_ruby_block_comments_with_=begin_and_=end_multiline_ff404c4e708f59f532b4042441e458ad.txt
+++ b/test/snapshots/engine/block_comments_test/test_0001_ruby_block_comments_with_=begin_and_=end_multiline_ff404c4e708f59f532b4042441e458ad.txt
@@ -6,10 +6,9 @@ _buf = ::String.new;
 =begin 
 
  _buf << '  This, while unusual, is a legal form of commenting.
-'.freeze; 
-
+'.freeze;
 =end 
 
  _buf << '<div>Hey there</div>
-'.freeze; 
+'.freeze;
 _buf.to_s

--- a/test/snapshots/engine/block_comments_test/test_0002_ruby_block_comments_inside_erb_tags_95bcfa3f3e28634bf923f18df0cd38a1.txt
+++ b/test/snapshots/engine/block_comments_test/test_0002_ruby_block_comments_inside_erb_tags_95bcfa3f3e28634bf923f18df0cd38a1.txt
@@ -8,6 +8,5 @@ This is a comment
 =end 
 
  _buf << '<p>Content</p>
-'.freeze; 
-
+'.freeze;
 _buf.to_s

--- a/test/snapshots/engine/block_comments_test/test_0003_ruby_block_comments_with_code_before_and_after_0ee0ba8a9a25359175b884cf66f37b2c.txt
+++ b/test/snapshots/engine/block_comments_test/test_0003_ruby_block_comments_with_code_before_and_after_0ee0ba8a9a25359175b884cf66f37b2c.txt
@@ -9,8 +9,6 @@ Multi-line comment
 spanning multiple lines
 =end 
 
- 
-
  y = 2 
  _buf << '<div>'.freeze; _buf << (x + y).to_s; _buf << '</div>
 '.freeze;

--- a/test/snapshots/engine/block_comments_test/test_0007_ruby_block_comments_with_=begin_and_=end_mutliline_and_no_space_before_ERB_closing_tag_72379778fa34572e48b949a780f761b1.txt
+++ b/test/snapshots/engine/block_comments_test/test_0007_ruby_block_comments_with_=begin_and_=end_mutliline_and_no_space_before_ERB_closing_tag_72379778fa34572e48b949a780f761b1.txt
@@ -6,10 +6,9 @@ _buf = ::String.new;
 =begin 
 
  _buf << '  This, while unusual, is a legal form of commenting.
-'.freeze; 
-
+'.freeze;
 =end 
 
  _buf << '<div>Hey there</div>
-'.freeze; 
+'.freeze;
 _buf.to_s

--- a/test/snapshots/engine/engine_test/test_0019_heredoc_in_code_tag_compiles_to_valid_Ruby_4af6472f81c8026291897a7a34e6ae0b.txt
+++ b/test/snapshots/engine/engine_test/test_0019_heredoc_in_code_tag_compiles_to_valid_Ruby_4af6472f81c8026291897a7a34e6ae0b.txt
@@ -2,9 +2,9 @@
 source: "Engine::EngineTest#test_0019_heredoc in code tag compiles to valid Ruby"
 input: "{source: \"<%\\n  text = <<~TEXT\\n    Hello, world!\\n  TEXT\\n%>\\n\", options: {}}"
 ---
-_buf = ::String.new; text = <<~TEXT
+_buf = ::String.new; 
+ text = <<~TEXT
     Hello, world!
   TEXT
  
-
 _buf.to_s

--- a/test/snapshots/engine/engine_test/test_0021_heredoc_with_dash_syntax_in_code_tag_compiles_to_valid_Ruby_61fc267bae73b15dae254d0d5f9fbe0e.txt
+++ b/test/snapshots/engine/engine_test/test_0021_heredoc_with_dash_syntax_in_code_tag_compiles_to_valid_Ruby_61fc267bae73b15dae254d0d5f9fbe0e.txt
@@ -2,9 +2,9 @@
 source: "Engine::EngineTest#test_0021_heredoc with dash syntax in code tag compiles to valid Ruby"
 input: "{source: \"<%\\n  text = <<-TEXT\\n    Hello, world!\\n  TEXT\\n%>\\n\", options: {}}"
 ---
-_buf = ::String.new; text = <<-TEXT
+_buf = ::String.new; 
+ text = <<-TEXT
     Hello, world!
   TEXT
  
-
 _buf.to_s

--- a/test/snapshots/engine/engine_test/test_0022_heredoc_with_quoted_identifier_in_code_tag_compiles_to_valid_Ruby_c596f2621d8ae2223c3805e78ff1b3e3.txt
+++ b/test/snapshots/engine/engine_test/test_0022_heredoc_with_quoted_identifier_in_code_tag_compiles_to_valid_Ruby_c596f2621d8ae2223c3805e78ff1b3e3.txt
@@ -2,9 +2,9 @@
 source: "Engine::EngineTest#test_0022_heredoc with quoted identifier in code tag compiles to valid Ruby"
 input: "{source: \"<%\\n  text = <<~'TEXT'\\n    Hello, world!\\n  TEXT\\n%>\\n\", options: {}}"
 ---
-_buf = ::String.new; text = <<~'TEXT'
+_buf = ::String.new; 
+ text = <<~'TEXT'
     Hello, world!
   TEXT
  
-
 _buf.to_s

--- a/test/snapshots/engine/examples_compilation_test/test_0004_block_comment_compilation_d5c98b9f230e001f8aabf838d3774698.txt
+++ b/test/snapshots/engine/examples_compilation_test/test_0004_block_comment_compilation_d5c98b9f230e001f8aabf838d3774698.txt
@@ -6,11 +6,10 @@ _buf = ::String.new;
 =begin 
 
  _buf << '  This, while unusual, is a legal form of commenting.
-'.freeze; 
-
+'.freeze;
 =end 
 
  _buf << '
 <div>Content</div>
-'.freeze; 
+'.freeze;
 _buf.to_s


### PR DESCRIPTION
A tag whose code starts on a later line than its `<%` was compiled as though the code started on the opening line. `keep_line_count` counts the newlines a tag's content carries and pads the compiled output so the line numbers keep up, but it added all of that padding after the tag, including the newlines that came before the code.

```erb
<%
  text = <<~TEXT
    Hello, world!
  TEXT
%>
```

**Before**

```ruby
 1 | _buf = ::String.new; text = <<~TEXT
 2 |     Hello, world!
 3 |   TEXT
 4 |  
 5 | 
 6 | _buf.to_s
```

**After**

```ruby
 1 | _buf = ::String.new; 
 2 |  text = <<~TEXT
 3 |     Hello, world!
 4 |   TEXT
 5 |  
 6 | _buf.to_s
```

The padding is now split, so the newlines before the code are emitted before it and only the newlines after it follow.

#### Block comments

`=begin` and `=end` were counted twice. `add_code` already writes a block comment with a newline on each side, so the padding `keep_line_count` added on top pushed every tag below the comment down by two lines.

```erb
<% x = 1 %>
<%
=begin
Multi-line comment
spanning multiple lines
=end
%>
<% y = 2 %>
<div><%= x + y %></div>
```

`y = 2` is written on line 8 and compiled to line 10. It now compiles to line 8, and `x + y` to line 9.

#### The checker

`test/snapshot_utils.rb` anchored a tag on the line its `<%` was written on, which is the wrong line for any tag whose code starts further down. It now counts the newlines the content carries before its code and anchors there.

That is stricter, and it immediately found three heredoc tests whose drift the looser anchor had been hiding. Those are the heredocs fixed above.

This takes `test/line_fidelity_allowlist.txt` from 17 entries down to 15.
