### PR TITLE
Engine: Compile a custom ERB opening the way a comment is compiled

### DIFF
--- a/lib/herb/ast/helpers.rb
+++ b/lib/herb/ast/helpers.rb
@@ -53,6 +53,11 @@ module Herb
       end
 
       #: (String) -> bool
+      def erb_omitted?(opening)
+        erb_comment?(opening) || erb_custom_opening?(opening)
+      end
+
+      #: (String) -> bool
       def erb_output?(opening)
         opening.include?("=") && !erb_comment?(opening)
       end
@@ -63,7 +68,9 @@ module Herb
 
         close_tag = node.close_tag
 
-        close_tag if close_tag.is_a?(Herb::AST::HTMLOmittedCloseTagNode)
+        return unless close_tag.is_a?(Herb::AST::HTMLOmittedCloseTagNode)
+
+        close_tag
       end
 
       #: (Herb::AST::Node?) -> bool

--- a/lib/herb/engine/compiler.rb
+++ b/lib/herb/engine/compiler.rb
@@ -431,9 +431,9 @@ module Herb
 
         check_for_escaped_erb_tag!(opening)
 
-        if !skip_comment_check && erb_comment?(opening)
+        if !skip_comment_check && erb_omitted?(opening)
           unless @trim
-            keep_line_count(node)
+            keep_span_line_count(node)
 
             return
           end
@@ -448,12 +448,10 @@ module Herb
             save_pending_leading_whitespace!(leading_space) if !leading_space.empty? && follows_newline
           end
 
-          keep_line_count(node, extra: swallows_newline ? 1 : 0)
+          keep_span_line_count(node, extra: swallows_newline ? 1 : 0)
 
           return
         end
-
-        return if erb_custom_opening?(opening)
 
         code = ::Herb::Engine::Helpers.strip_trailing_comment(node.content.value.strip)
 
@@ -466,6 +464,16 @@ module Herb
         end
 
         keep_line_count(node, at: code_index)
+      end
+
+      #: (untyped, ?extra: Integer) -> void
+      def keep_span_line_count(node, extra: 0)
+        lines = node.content.value.count("\n") + extra
+
+        return unless lines.positive?
+
+        @padding_before ||= Hash.new(0)
+        @padding_before[@tokens.length] += lines
       end
 
       def keep_line_count(node, extra: 0, at: nil)
@@ -768,11 +776,10 @@ module Herb
 
       #: (untyped) -> bool
       def newline_follows?(node)
-        return true unless @source_lines
-
         position = node.tag_closing&.location&.end || node.location&.end
 
-        return true unless position
+        return false if position && !position.line.positive?
+        return true unless position && @source_lines
 
         line = @source_lines[position.line - 1]
 

--- a/sig/herb/ast/helpers.rbs
+++ b/sig/herb/ast/helpers.rbs
@@ -25,6 +25,9 @@ module Herb
       def erb_custom_opening?: (String) -> bool
 
       # : (String) -> bool
+      def erb_omitted?: (String) -> bool
+
+      # : (String) -> bool
       def erb_output?: (String) -> bool
 
       # : (Herb::AST::Node?) -> Herb::AST::HTMLOmittedCloseTagNode?

--- a/sig/herb/engine/compiler.rbs
+++ b/sig/herb/engine/compiler.rbs
@@ -128,6 +128,9 @@ module Herb
 
       def process_erb_tag: (untyped node, ?skip_comment_check: untyped) -> untyped
 
+      # : (untyped, ?extra: Integer) -> void
+      def keep_span_line_count: (untyped, ?extra: Integer) -> void
+
       def keep_line_count: (untyped node, ?extra: untyped, ?at: untyped) -> untyped
 
       def add_text: (untyped text) -> untyped

--- a/test/engine/visitors/instrumentation_test.rb
+++ b/test/engine/visitors/instrumentation_test.rb
@@ -65,6 +65,10 @@ module Engine
       test "reaches into a conditional" do
         instrumented("<% if admin? %><%= secret %><% end %>")
       end
+
+      test "wraps an output tag in a template that ends with a blank line" do
+        instrumented("<div><%= title %></div>\n\n")
+      end
     end
 
     describe "what it must not change" do

--- a/test/line_fidelity_allowlist.txt
+++ b/test/line_fidelity_allowlist.txt
@@ -4,10 +4,6 @@ Engine::ERBCommentsTest#test_0003_inline ruby comment between code
 Engine::ERBCommentsTest#test_0004_inline ruby comment before and between code
 Engine::ERBCommentsTest#test_0006_inline ruby comment multiline
 Engine::ExamplesCompilationTest#test_0004_block comment compilation
-Engine::ExamplesCompilationTest#test_0017_graphql compilation
-Engine::GraphQLTest#test_0003_graphql tag with surrounding html
-Engine::GraphQLTest#test_0004_graphql tag with comment and html
-Engine::GraphQLTest#test_0005_graphql tag with query variables
 Engine::RenderNodeCompilationTest#test_0006_emits a render inside a loop
 Engine::WhitespaceTrimmingTest#test_0031_output tag with -%> followed by another expression tag
 Engine::WhitespaceTrimmingTest#test_0036_leading whitespace before statement tag with inline expression is preserved

--- a/test/snapshots/engine/erb_openers_test/test_0004_several_configured_openers_are_omitted_from_compilation_bc52d2b80da3f9069136f2377c0b7b03.txt
+++ b/test/snapshots/engine/erb_openers_test/test_0004_several_configured_openers_are_omitted_from_compilation_bc52d2b80da3f9069136f2377c0b7b03.txt
@@ -2,8 +2,8 @@
 source: "Engine::ERBOpenersTest#test_0004_several configured openers are omitted from compilation"
 input: "{source: \"<%graphql query { id } %>\\n<%herb slot :header %>\\n<p><%= name %></p>\\n\", options: {parser_options: {erb_openers: [\"graphql\", \"herb\"]}}}"
 ---
-_buf = ::String.new; _buf << '
+_buf = ::String.new; _buf << '<p>'.freeze; 
 
-<p>'.freeze; _buf << (name).to_s; _buf << '</p>
+ _buf << (name).to_s; _buf << '</p>
 '.freeze;
 _buf.to_s

--- a/test/snapshots/engine/erb_tag_variations_test/test_0008_lt%graphql_%gt_multiline_2e41c2e3455cd01e57ecbac212066f95.txt
+++ b/test/snapshots/engine/erb_tag_variations_test/test_0008_lt%graphql_%gt_multiline_2e41c2e3455cd01e57ecbac212066f95.txt
@@ -2,4 +2,3 @@
 source: "Engine::ERBTagVariationsTest#test_0008_<%graphql %> multiline"
 input: "{source: \"<%graphql\\n  fragment UserFragment on User {\\n    name\\n  }\\n%>\\n\", locals: {}, options: {parser_options: {erb_openers: [\"graphql\"]}}}"
 ---
-

--- a/test/snapshots/engine/erb_tag_variations_test/test_0008_lt%graphql_%gt_multiline_63f82dff73f941d8d51fec9abd738c21.txt
+++ b/test/snapshots/engine/erb_tag_variations_test/test_0008_lt%graphql_%gt_multiline_63f82dff73f941d8d51fec9abd738c21.txt
@@ -2,6 +2,5 @@
 source: "Engine::ERBTagVariationsTest#test_0008_<%graphql %> multiline"
 input: "{source: \"<%graphql\\n  fragment UserFragment on User {\\n    name\\n  }\\n%>\\n\", options: {parser_options: {erb_openers: [\"graphql\"]}}}"
 ---
-_buf = ::String.new; _buf << '
-'.freeze;
+_buf = ::String.new;
 _buf.to_s

--- a/test/snapshots/engine/evaluation_test/test_0034_graphql_72bde7c56cd4a80140f49ad19f4dbf47.txt
+++ b/test/snapshots/engine/evaluation_test/test_0034_graphql_72bde7c56cd4a80140f49ad19f4dbf47.txt
@@ -3,7 +3,6 @@ source: "Engine::EvaluationTest#test_0034_graphql"
 input: "{source: \"<%# app/views/products/product.html.erb %>\\n<%graphql\\n  fragment ProductFragment on Product {\\n    id\\n    title\\n    description\\n    price\\n  }\\n%>\\n\\n<article class=\\\"product\\\">\\n  <h1><%= product.title %></h1>\\n  <p class=\\\"description\\\"><%= product.description %></p>\\n  <span class=\\\"price\\\"><%= product.price %></span>\\n</article>\\n\", locals: {product: #<data title=\"title\", description=\"Description\", price=42.0>}, options: {escape: false, parser_options: {erb_openers: [\"graphql\"]}}}"
 ---
 
-
 <article class="product">
   <h1>title</h1>
   <p class="description">Description</p>

--- a/test/snapshots/engine/examples_compilation_test/test_0017_graphql_compilation_f72a327e5a2f6eade0311c8ad3846e3b.txt
+++ b/test/snapshots/engine/examples_compilation_test/test_0017_graphql_compilation_f72a327e5a2f6eade0311c8ad3846e3b.txt
@@ -3,9 +3,16 @@ source: "Engine::ExamplesCompilationTest#test_0017_graphql compilation"
 input: "{source: \"<%# app/views/products/product.html.erb %>\\n<%graphql\\n  fragment ProductFragment on Product {\\n    id\\n    title\\n    description\\n    price\\n  }\\n%>\\n\\n<article class=\\\"product\\\">\\n  <h1><%= product.title %></h1>\\n  <p class=\\\"description\\\"><%= product.description %></p>\\n  <span class=\\\"price\\\"><%= product.price %></span>\\n</article>\\n\", options: {escape: false, parser_options: {erb_openers: [\"graphql\"]}}}"
 ---
 _buf = ::String.new; _buf << '
-
 <article class="product">
   <h1>'.freeze; 
+
+
+
+
+
+
+
+
  _buf << (product.title).to_s; _buf << '</h1>
   <p class="description">'.freeze; _buf << (product.description).to_s; _buf << '</p>
   <span class="price">'.freeze; _buf << (product.price).to_s; _buf << '</span>

--- a/test/snapshots/engine/graph_ql_test/test_0001_graphql_tag_is_omitted_from_compilation_f5ab4a958767f2f2d5dc4808ad24644c.txt
+++ b/test/snapshots/engine/graph_ql_test/test_0001_graphql_tag_is_omitted_from_compilation_f5ab4a958767f2f2d5dc4808ad24644c.txt
@@ -2,6 +2,5 @@
 source: "Engine::GraphQLTest#test_0001_graphql tag is omitted from compilation"
 input: "{source: \"<%graphql\\n  fragment HumanFragment on Human {\\n    name\\n    homePlanet\\n  }\\n%>\\n\", options: {parser_options: {erb_openers: [\"graphql\"]}}}"
 ---
-_buf = ::String.new; _buf << '
-'.freeze;
+_buf = ::String.new;
 _buf.to_s

--- a/test/snapshots/engine/graph_ql_test/test_0003_graphql_tag_with_surrounding_html_8129bfaa51e02bf4a17b85897f5d0951.txt
+++ b/test/snapshots/engine/graph_ql_test/test_0003_graphql_tag_with_surrounding_html_8129bfaa51e02bf4a17b85897f5d0951.txt
@@ -3,8 +3,13 @@ source: "Engine::GraphQLTest#test_0003_graphql tag with surrounding html"
 input: "{source: \"<div>\\n  <%graphql\\n    fragment UserFragment on User {\\n      id\\n      email\\n    }\\n  %>\\n  <p>Hello <%= user.name %></p>\\n</div>\\n\", options: {parser_options: {erb_openers: [\"graphql\"]}}}"
 ---
 _buf = ::String.new; _buf << '<div>
-  
-  <p>Hello '.freeze; _buf << (user.name).to_s; _buf << '</p>
+  <p>Hello '.freeze; 
+
+
+
+
+
+ _buf << (user.name).to_s; _buf << '</p>
 </div>
 '.freeze;
 _buf.to_s

--- a/test/snapshots/engine/graph_ql_test/test_0004_graphql_tag_with_comment_and_html_03e068d10c54bd781561f5ebe54373b3.txt
+++ b/test/snapshots/engine/graph_ql_test/test_0004_graphql_tag_with_comment_and_html_03e068d10c54bd781561f5ebe54373b3.txt
@@ -3,8 +3,13 @@ source: "Engine::GraphQLTest#test_0004_graphql tag with comment and html"
 input: "{source: \"<%# app/views/humans/human.html.erb %>\\n<%graphql\\n  fragment HumanFragment on Human {\\n    name\\n    homePlanet\\n  }\\n%>\\n\\n<p><%= human.name %> lives on <%= human.home_planet %>.</p>\\n\", options: {parser_options: {erb_openers: [\"graphql\"]}}}"
 ---
 _buf = ::String.new; _buf << '
-
 <p>'.freeze; 
+
+
+
+
+
+
  _buf << (human.name).to_s; _buf << ' lives on '.freeze; _buf << (human.home_planet).to_s; _buf << '.</p>
 '.freeze;
 _buf.to_s

--- a/test/snapshots/engine/graph_ql_test/test_0005_graphql_tag_with_query_variables_7c8071c7b3ba5f5ec96e6097ad67816f.txt
+++ b/test/snapshots/engine/graph_ql_test/test_0005_graphql_tag_with_query_variables_7c8071c7b3ba5f5ec96e6097ad67816f.txt
@@ -2,9 +2,18 @@
 source: "Engine::GraphQLTest#test_0005_graphql tag with query variables"
 input: "{source: \"<%graphql\\n  query Products($first: Int!) {\\n    products(first: $first) {\\n      nodes {\\n        id\\n        title\\n      }\\n    }\\n  }\\n%>\\n<ul>\\n  <% products.each do |product| %>\\n    <li><%= product.title %></li>\\n  <% end %>\\n</ul>\\n\", options: {parser_options: {erb_openers: [\"graphql\"]}}}"
 ---
-_buf = ::String.new; _buf << '
-<ul>
-'.freeze;   products.each do |product| 
+_buf = ::String.new; _buf << '<ul>
+'.freeze; 
+
+
+
+
+
+
+
+
+
+   products.each do |product| 
  _buf << '    <li>'.freeze; _buf << (product.title).to_s; _buf << '</li>
 '.freeze;   end 
  _buf << '</ul>

--- a/test/snapshots/engine/graph_ql_test/test_0007_graphql_tag_evaluated_produces_empty_output_2038b696c43b3ab973bad0ddae5cd182.txt
+++ b/test/snapshots/engine/graph_ql_test/test_0007_graphql_tag_evaluated_produces_empty_output_2038b696c43b3ab973bad0ddae5cd182.txt
@@ -2,4 +2,3 @@
 source: "Engine::GraphQLTest#test_0007_graphql tag evaluated produces empty output"
 input: "{source: \"<%graphql\\n  fragment TestFragment on Test {\\n    id\\n  }\\n%>\\n\", locals: {}, options: {parser_options: {erb_openers: [\"graphql\"]}}}"
 ---
-

--- a/test/snapshots/engine/graph_ql_test/test_0008_graphql_tag_with_html_evaluated_5d9628b534324210803f98ca83009819.txt
+++ b/test/snapshots/engine/graph_ql_test/test_0008_graphql_tag_with_html_evaluated_5d9628b534324210803f98ca83009819.txt
@@ -2,5 +2,4 @@
 source: "Engine::GraphQLTest#test_0008_graphql tag with html evaluated"
 input: "{source: \"<%graphql\\n  fragment UserFragment on User {\\n    name\\n  }\\n%>\\n<p>Hello World</p>\\n\", locals: {}, options: {parser_options: {erb_openers: [\"graphql\"]}}}"
 ---
-
 <p>Hello World</p>

--- a/test/snapshots/engine/instrumentation_test/what_it_emits/test_0007_wraps_an_output_tag_in_a_template_that_ends_with_a_blank_line_053f4726206447833c67b615f37fe2b6.txt
+++ b/test/snapshots/engine/instrumentation_test/what_it_emits/test_0007_wraps_an_output_tag_in_a_template_that_ends_with_a_blank_line_053f4726206447833c67b615f37fe2b6.txt
@@ -1,0 +1,8 @@
+---
+source: "Engine::InstrumentationTest::what it emits#test_0007_wraps an output tag in a template that ends with a blank line"
+input: "{source: \"<div><%= title %></div>\\n\\n\", options: {filename: \"app/views/test.html.erb\", visitors: [#<Herb::Engine::InstrumentationVisitor>]}}"
+---
+_buf = ::String.new; ::Herb::Engine::Runtime::Session.enter_render("app/views/test.html.erb"); begin ; _buf << '<div>'.freeze; _buf << (::Herb::Engine::Runtime::Session.at("app/views/test.html.erb", 1, 5) { title }).to_s; _buf << '</div>
+
+'.freeze; ensure; ::Herb::Engine::Runtime::Session.leave_render; end ;
+_buf.to_s


### PR DESCRIPTION
A tag with a custom opening and an ERB comment are the same thing to the compiler, since neither one contributes anything to the output. The compiler had them on two different paths anyway. A comment went through the trim handling and had its lines counted, and a custom tag returned before either.

Such a tag usually spans several lines, so everything below it compiled that many lines too high.

```erb
<%# app/views/humans/human.html.erb %>
<%graphql
  fragment HumanFragment on Human {
    name
    homePlanet
  }
%>

<p><%= human.name %> lives on <%= human.home_planet %>.</p>
```

`human.name` is written on line 9 and compiled to line 4. It now compiles to line 9.

Both openings take the one path, and the compiler asks one question rather than naming either of them.

```ruby
if !skip_comment_check && erb_omitted?(opening)
```

```ruby
def erb_omitted?(opening)
  erb_comment?(opening) || erb_custom_opening?(opening)
end
```

`herb_analyze_ruby` already groups the two this way, in `src/analyze/analyze.c`, where a comment and a custom opening are the openings whose content is not analyzed as Ruby. `Herb::AST::Helpers#erb_omitted?` gives that group a name on the Ruby side, next to the `erb_custom_opening?` that #2491 introduced.

Counting the lines needed a change to go with it. `keep_line_count` counts the newlines around a tag's code, because the code itself is emitted and carries the newlines within it. Neither of these tags emits its code, so `keep_span_line_count` counts the newlines inside it too.

#### An omitted tag now ends its own line

Sharing the path means a tag with a custom opening swallows the newline that follows it, which is what a comment already does. A template that renders this today

```
\n\n<article class="product">
```

renders this instead.

```
\n<article class="product">
```

The blank line was the line the tag was written on. This is the only rendered output in the suite that moves.

#### A node with no source of its own

#2484 decided whether to emit a replacement newline by looking at what follows the tag in the source. That reads the tag's location, which the compiler does not have, because the engine parses with `track_locations: false`. It fell back to keeping the newline for every real tag.

The synthetic tags a visitor injects carry position `(0:0)` rather than no position at all, and line `0` indexed the source lines from the end. That returned the answer the fix needed, by accident.

It held for every template in the suite and broke on a template ending in a blank line, where the last line is a newline and the accident produced the opposite answer.

```erb
<div><%= title %></div>

```

With instrumentation on, `title` is written on line 1 and compiled to line 2.

A position of `(0:0)` is not a source position, since lines are numbered from 1, so it now answers the question directly. No snapshot moves.

```ruby
return false if position && !position.line.positive?
return true unless position && @source_lines
```

A template that ends with a blank line is now covered by a test, so the line-fidelity assertion holds it.

#### The allowlist

This takes `test/line_fidelity_allowlist.txt` from 15 entries down to 11.
