### PR TITLE
Engine: Take newline after a trimmed tag back when nothing follows

### DIFF
--- a/lib/herb/engine/compiler.rb
+++ b/lib/herb/engine/compiler.rb
@@ -32,6 +32,7 @@ module Herb
         @context_stack = [:html_content]
         @trim_next_whitespace = false
         @last_trim_consumed_newline = false
+        @pending_trim_newline_index = nil #: Integer?
         @pending_leading_whitespace = nil
         @pending_leading_whitespace_insert_index = 0
         @current_element_source = nil
@@ -72,6 +73,8 @@ module Herb
 
       def visit_document_node(node)
         visit_all(node.children)
+
+        settle_pending_trim_newline!(false)
       end
 
       def visit_html_element_node(node)
@@ -497,9 +500,12 @@ module Herb
           text = text.sub(/\A[ \t]*\r?\n/, "")
           @trim_next_whitespace = false
 
+          settle_pending_trim_newline!(@last_trim_consumed_newline)
           restore_pending_leading_whitespace! unless @last_trim_consumed_newline
         else
           @last_trim_consumed_newline = false
+
+          settle_pending_trim_newline!(false)
         end
 
         @pending_leading_whitespace = nil
@@ -609,6 +615,8 @@ module Herb
       end
 
       def process_erb_output(node, opening, code)
+        settle_pending_trim_newline!(false)
+
         if @trim_next_whitespace && @pending_leading_whitespace
           restore_pending_leading_whitespace!
           @pending_leading_whitespace = nil
@@ -759,15 +767,16 @@ module Herb
           effective_leading_space = leading_space.empty? ? removed_whitespace : leading_space
           right_space = if Herb::Engine::Helpers.heredoc?(code)
                           "\n"
-                        elsif newline_follows?(node)
-                          " \n"
-                        else
+                        elsif without_source?(node)
                           " "
+                        else
+                          " \n"
                         end
 
           @pending_leading_whitespace_insert_index = @tokens.length
           @pending_leading_whitespace = effective_leading_space if !effective_leading_space.empty? && follows_newline
           @tokens << [:code, "#{effective_leading_space}#{code}#{right_space}", current_context]
+          @pending_trim_newline_index = @tokens.length - 1 if right_space.end_with?(" \n")
           @trim_next_whitespace = true
         else
           @tokens << [:code, code, current_context]
@@ -775,21 +784,23 @@ module Herb
       end
 
       #: (untyped) -> bool
-      def newline_follows?(node)
+      def without_source?(node)
         position = node.tag_closing&.location&.end || node.location&.end
 
-        return false if position && !position.line.positive?
-        return true unless position && @source_lines
+        !position.nil? && !position.line.positive?
+      end
 
-        line = @source_lines[position.line - 1]
+      #: (bool) -> void
+      def settle_pending_trim_newline!(keep)
+        index = @pending_trim_newline_index
 
-        return false unless line
+        return unless index
 
-        rest = line[position.column..]
+        @pending_trim_newline_index = nil
 
-        return false unless rest
+        return if keep
 
-        rest.match?(/\A[ \t]*\r?\n\z/)
+        @tokens[index][1] = @tokens[index][1].chomp
       end
 
       def save_pending_leading_whitespace!(whitespace)

--- a/sig/herb/engine/compiler.rbs
+++ b/sig/herb/engine/compiler.rbs
@@ -182,7 +182,10 @@ module Herb
       def apply_trim: (untyped node, untyped code) -> untyped
 
       # : (untyped) -> bool
-      def newline_follows?: (untyped) -> bool
+      def without_source?: (untyped) -> bool
+
+      # : (bool) -> void
+      def settle_pending_trim_newline!: (bool) -> void
 
       def save_pending_leading_whitespace!: (untyped whitespace) -> untyped
 

--- a/test/line_fidelity_allowlist.txt
+++ b/test/line_fidelity_allowlist.txt
@@ -1,11 +1,4 @@
 Engine::BlockCommentsTest#test_0001_ruby block comments with =begin and =end multiline
 Engine::BlockCommentsTest#test_0007_ruby block comments with =begin and =end mutliline and no space before ERB closing tag
-Engine::ERBCommentsTest#test_0003_inline ruby comment between code
-Engine::ERBCommentsTest#test_0004_inline ruby comment before and between code
-Engine::ERBCommentsTest#test_0006_inline ruby comment multiline
 Engine::ExamplesCompilationTest#test_0004_block comment compilation
-Engine::RenderNodeCompilationTest#test_0006_emits a render inside a loop
 Engine::WhitespaceTrimmingTest#test_0031_output tag with -%> followed by another expression tag
-Engine::WhitespaceTrimmingTest#test_0036_leading whitespace before statement tag with inline expression is preserved
-Engine::WhitespaceTrimmingTest#test_0045_leading whitespace preserved when control tag with inline output follows a trimmed code-only line
-Engine::WhitespaceTrimmingTest#test_0046_leading whitespace preserved after multiple consecutive trimmed code-only lines

--- a/test/snapshots/engine/action_view/postfix_conditional_test/test_0001_tag.div_with_postfix_if_condition_1521d1754f7c2d2d9799eaf682356fa9.txt
+++ b/test/snapshots/engine/action_view/postfix_conditional_test/test_0001_tag.div_with_postfix_if_condition_1521d1754f7c2d2d9799eaf682356fa9.txt
@@ -2,6 +2,5 @@
 source: "Engine::ActionView::PostfixConditionalTest#test_0001_tag.div with postfix if condition"
 input: "{source: \"<%= tag.div(\\\"visible\\\", class: \\\"notice\\\") if condition %>\", options: {visitors: [#<Herb::Engine::OptimizeVisitor>], locals: {condition: true}}}"
 ---
-_buf = ::String.new; if condition 
- _buf << '<div class="notice">visible</div>'.freeze; end;
+_buf = ::String.new; if condition ; _buf << '<div class="notice">visible</div>'.freeze; end;
 _buf.to_s

--- a/test/snapshots/engine/action_view/postfix_conditional_test/test_0002_tag.div_with_postfix_unless_condition_7ddab06e3b934a0b40fcf019e9db8e4b.txt
+++ b/test/snapshots/engine/action_view/postfix_conditional_test/test_0002_tag.div_with_postfix_unless_condition_7ddab06e3b934a0b40fcf019e9db8e4b.txt
@@ -2,6 +2,5 @@
 source: "Engine::ActionView::PostfixConditionalTest#test_0002_tag.div with postfix unless condition"
 input: "{source: \"<%= tag.div(\\\"hidden\\\", class: \\\"warning\\\") unless condition %>\", options: {visitors: [#<Herb::Engine::OptimizeVisitor>], locals: {condition: false}}}"
 ---
-_buf = ::String.new; unless condition 
- _buf << '<div class="warning">hidden</div>'.freeze; end;
+_buf = ::String.new; unless condition ; _buf << '<div class="warning">hidden</div>'.freeze; end;
 _buf.to_s

--- a/test/snapshots/engine/action_view/postfix_conditional_test/test_0003_link_to_with_postfix_if_condition_ef353bd70e7dc5c7ded7d7f010b5cb69.txt
+++ b/test/snapshots/engine/action_view/postfix_conditional_test/test_0003_link_to_with_postfix_if_condition_ef353bd70e7dc5c7ded7d7f010b5cb69.txt
@@ -2,6 +2,5 @@
 source: "Engine::ActionView::PostfixConditionalTest#test_0003_link_to with postfix if condition"
 input: "{source: \"<%= link_to \\\"Settings\\\", \\\"/settings\\\" if condition %>\", options: {visitors: [#<Herb::Engine::OptimizeVisitor>], locals: {condition: true}}}"
 ---
-_buf = ::String.new; if condition 
- _buf << '<a href="/settings">Settings</a>'.freeze; end;
+_buf = ::String.new; if condition ; _buf << '<a href="/settings">Settings</a>'.freeze; end;
 _buf.to_s

--- a/test/snapshots/engine/action_view/postfix_conditional_test/test_0004_image_tag_with_postfix_if_condition_145c392f4147ca091bda27f472a971fb.txt
+++ b/test/snapshots/engine/action_view/postfix_conditional_test/test_0004_image_tag_with_postfix_if_condition_145c392f4147ca091bda27f472a971fb.txt
@@ -2,6 +2,5 @@
 source: "Engine::ActionView::PostfixConditionalTest#test_0004_image_tag with postfix if condition"
 input: "{source: \"<%= image_tag \\\"icon.png\\\", alt: \\\"Icon\\\" if condition %>\", options: {visitors: [#<Herb::Engine::OptimizeVisitor>], locals: {condition: true}}}"
 ---
-_buf = ::String.new; if condition 
- _buf << '<img alt="Icon" src="'.freeze; _buf << ::Herb::Engine.attr((image_path("icon.png"))); _buf << '" />'.freeze; end;
+_buf = ::String.new; if condition ; _buf << '<img alt="Icon" src="'.freeze; _buf << ::Herb::Engine.attr((image_path("icon.png"))); _buf << '" />'.freeze; end;
 _buf.to_s

--- a/test/snapshots/engine/action_view/postfix_conditional_test/test_0005_content_tag_with_postfix_unless_condition_996f3ed756ed57cf6d91c9a91c92f1c3.txt
+++ b/test/snapshots/engine/action_view/postfix_conditional_test/test_0005_content_tag_with_postfix_unless_condition_996f3ed756ed57cf6d91c9a91c92f1c3.txt
@@ -2,6 +2,5 @@
 source: "Engine::ActionView::PostfixConditionalTest#test_0005_content_tag with postfix unless condition"
 input: "{source: \"<%= content_tag(:p, \\\"Notice\\\", class: \\\"alert\\\") unless condition %>\", options: {visitors: [#<Herb::Engine::OptimizeVisitor>], locals: {condition: false}}}"
 ---
-_buf = ::String.new; unless condition 
- _buf << '<p class="alert">Notice</p>'.freeze; end;
+_buf = ::String.new; unless condition ; _buf << '<p class="alert">Notice</p>'.freeze; end;
 _buf.to_s

--- a/test/snapshots/engine/action_view/postfix_conditional_test/test_0006_string_literal_with_postfix_if_condition_b1e5385473231e7f93cfaf46b82319af.txt
+++ b/test/snapshots/engine/action_view/postfix_conditional_test/test_0006_string_literal_with_postfix_if_condition_b1e5385473231e7f93cfaf46b82319af.txt
@@ -2,6 +2,5 @@
 source: "Engine::ActionView::PostfixConditionalTest#test_0006_string literal with postfix if condition"
 input: "{source: \"<%= \\\"Notice\\\" if condition %>\", options: {visitors: [#<Herb::Engine::OptimizeVisitor>], locals: {condition: true}}}"
 ---
-_buf = ::String.new; if condition 
- _buf << 'Notice'.freeze; end;
+_buf = ::String.new; if condition ; _buf << 'Notice'.freeze; end;
 _buf.to_s

--- a/test/snapshots/engine/action_view/postfix_conditional_test/test_0007_string_literal_that_would_be_HTML-escaped_with_postfix_if_condition_639727d9a71015c2fb9b57f5503a29cf.txt
+++ b/test/snapshots/engine/action_view/postfix_conditional_test/test_0007_string_literal_that_would_be_HTML-escaped_with_postfix_if_condition_639727d9a71015c2fb9b57f5503a29cf.txt
@@ -2,6 +2,5 @@
 source: "Engine::ActionView::PostfixConditionalTest#test_0007_string literal that would be HTML-escaped with postfix if condition"
 input: "{source: \"<%= \\\"5 > 3\\\" if condition %>\", options: {escape: true, visitors: [#<Herb::Engine::OptimizeVisitor>]}}"
 ---
-__herb = ::Herb::Engine; _buf = ::String.new; if condition 
- _buf << __herb.h(("5 > 3")); end;
+__herb = ::Herb::Engine; _buf = ::String.new; if condition ; _buf << __herb.h(("5 > 3")); end;
 _buf.to_s

--- a/test/snapshots/engine/action_view/ternary_conditional_test/test_0001_ternary_with_tag_helpers_in_both_branches_55ffe03baa4d38f4700c12afad41ba09.txt
+++ b/test/snapshots/engine/action_view/ternary_conditional_test/test_0001_ternary_with_tag_helpers_in_both_branches_55ffe03baa4d38f4700c12afad41ba09.txt
@@ -2,6 +2,5 @@
 source: "Engine::ActionView::TernaryConditionalTest#test_0001_ternary with tag helpers in both branches"
 input: "{source: \"<%= active ? tag.div(\\\"On\\\") : tag.span(\\\"Off\\\") %>\", options: {visitors: [#<Herb::Engine::OptimizeVisitor>], locals: {active: true}}}"
 ---
-_buf = ::String.new; if active 
- _buf << '<div>On</div>'.freeze; else; _buf << '<span>Off</span>'.freeze; end;
+_buf = ::String.new; if active ; _buf << '<div>On</div>'.freeze; else; _buf << '<span>Off</span>'.freeze; end;
 _buf.to_s

--- a/test/snapshots/engine/action_view/ternary_conditional_test/test_0002_ternary_with_different_element_types_6f760000757fa451416a0ac64503ba42.txt
+++ b/test/snapshots/engine/action_view/ternary_conditional_test/test_0002_ternary_with_different_element_types_6f760000757fa451416a0ac64503ba42.txt
@@ -2,6 +2,5 @@
 source: "Engine::ActionView::TernaryConditionalTest#test_0002_ternary with different element types"
 input: "{source: \"<%= condition ? tag.strong(\\\"Yes\\\") : tag.em(\\\"No\\\") %>\", options: {visitors: [#<Herb::Engine::OptimizeVisitor>], locals: {condition: false}}}"
 ---
-_buf = ::String.new; if condition 
- _buf << '<strong>Yes</strong>'.freeze; else; _buf << '<em>No</em>'.freeze; end;
+_buf = ::String.new; if condition ; _buf << '<strong>Yes</strong>'.freeze; else; _buf << '<em>No</em>'.freeze; end;
 _buf.to_s

--- a/test/snapshots/engine/action_view/ternary_conditional_test/test_0003_ternary_with_link_to_in_true_branch_47f49f54b8e2fe8d21cbbb5305a42f3e.txt
+++ b/test/snapshots/engine/action_view/ternary_conditional_test/test_0003_ternary_with_link_to_in_true_branch_47f49f54b8e2fe8d21cbbb5305a42f3e.txt
@@ -2,6 +2,5 @@
 source: "Engine::ActionView::TernaryConditionalTest#test_0003_ternary with link_to in true branch"
 input: "{source: \"<%= admin ? link_to(\\\"Dashboard\\\", \\\"/admin\\\") : link_to(\\\"Home\\\", \\\"/\\\") %>\", options: {visitors: [#<Herb::Engine::OptimizeVisitor>], locals: {admin: true}}}"
 ---
-_buf = ::String.new; if admin 
- _buf << '<a href="/admin">Dashboard</a>'.freeze; else; _buf << '<a href="/">Home</a>'.freeze; end;
+_buf = ::String.new; if admin ; _buf << '<a href="/admin">Dashboard</a>'.freeze; else; _buf << '<a href="/">Home</a>'.freeze; end;
 _buf.to_s

--- a/test/snapshots/engine/action_view/ternary_conditional_test/test_0004_non-output_ternary_without_helpers_is_not_transformed_caa3e27fd096d4cfd4020b1f55c6db4a.txt
+++ b/test/snapshots/engine/action_view/ternary_conditional_test/test_0004_non-output_ternary_without_helpers_is_not_transformed_caa3e27fd096d4cfd4020b1f55c6db4a.txt
@@ -2,5 +2,5 @@
 source: "Engine::ActionView::TernaryConditionalTest#test_0004_non-output ternary without helpers is not transformed"
 input: "{source: \"<% admin ? \\\"Admin\\\" : \\\"User\\\" %>\", options: {visitors: [#<Herb::Engine::OptimizeVisitor>], locals: {admin: true}}}"
 ---
-_buf = ::String.new; admin ? "Admin" : "User" 
+_buf = ::String.new; admin ? "Admin" : "User" ;
 _buf.to_s

--- a/test/snapshots/engine/action_view/ternary_conditional_test/test_0005_non-output_ternary_with_helpers_is_not_transformed_a622613bd9673aa3c77109b6b77940af.txt
+++ b/test/snapshots/engine/action_view/ternary_conditional_test/test_0005_non-output_ternary_with_helpers_is_not_transformed_a622613bd9673aa3c77109b6b77940af.txt
@@ -2,5 +2,5 @@
 source: "Engine::ActionView::TernaryConditionalTest#test_0005_non-output ternary with helpers is not transformed"
 input: "{source: \"<% admin ? tag.div(\\\"Admin\\\") : tag.span(\\\"User\\\") %>\", options: {visitors: [#<Herb::Engine::OptimizeVisitor>], locals: {admin: true}}}"
 ---
-_buf = ::String.new; admin ? tag.div("Admin") : tag.span("User") 
+_buf = ::String.new; admin ? tag.div("Admin") : tag.span("User") ;
 _buf.to_s

--- a/test/snapshots/engine/action_view/ternary_conditional_test/test_0006_ternary_with_string_literals_in_both_branches_63be512684ea85ff233351e9bbd251f4.txt
+++ b/test/snapshots/engine/action_view/ternary_conditional_test/test_0006_ternary_with_string_literals_in_both_branches_63be512684ea85ff233351e9bbd251f4.txt
@@ -2,6 +2,5 @@
 source: "Engine::ActionView::TernaryConditionalTest#test_0006_ternary with string literals in both branches"
 input: "{source: \"<%= active ? \\\"On\\\" : \\\"Off\\\" %>\", options: {visitors: [#<Herb::Engine::OptimizeVisitor>], locals: {active: true}}}"
 ---
-_buf = ::String.new; if active 
- _buf << 'On'.freeze; else; _buf << 'Off'.freeze; end;
+_buf = ::String.new; if active ; _buf << 'On'.freeze; else; _buf << 'Off'.freeze; end;
 _buf.to_s

--- a/test/snapshots/engine/action_view/ternary_conditional_test/test_0008_ternary_with_literals_that_would_be_HTML-escaped_8321c6d088528bc271f6ae3d11a80181.txt
+++ b/test/snapshots/engine/action_view/ternary_conditional_test/test_0008_ternary_with_literals_that_would_be_HTML-escaped_8321c6d088528bc271f6ae3d11a80181.txt
@@ -2,6 +2,5 @@
 source: "Engine::ActionView::TernaryConditionalTest#test_0008_ternary with literals that would be HTML-escaped"
 input: "{source: \"<%= active ? \\\"5 > 3\\\" : \\\"a & b\\\" %>\", options: {escape: true, visitors: [#<Herb::Engine::OptimizeVisitor>]}}"
 ---
-__herb = ::Herb::Engine; _buf = ::String.new; if active 
- _buf << __herb.h(("5 > 3")); else; _buf << __herb.h(("a & b")); end;
+__herb = ::Herb::Engine; _buf = ::String.new; if active ; _buf << __herb.h(("5 > 3")); else; _buf << __herb.h(("a & b")); end;
 _buf.to_s

--- a/test/snapshots/engine/erb_comments_test/test_0001_inline_ruby_comment_on_same_line_ece56a54ce9835acc67012583c42fc01.txt
+++ b/test/snapshots/engine/erb_comments_test/test_0001_inline_ruby_comment_on_same_line_ece56a54ce9835acc67012583c42fc01.txt
@@ -3,5 +3,5 @@ source: "Engine::ERBCommentsTest#test_0001_inline ruby comment on same line"
 input: "{source: \"<% if true %><% # Comment here %><% end %>\", options: {}}"
 ---
 _buf = ::String.new; if true 
- end 
+ end ;
 _buf.to_s

--- a/test/snapshots/engine/erb_comments_test/test_0002_inline_ruby_comment_with_newline_32dd50121c8e2af22b8a7e5efd92940f.txt
+++ b/test/snapshots/engine/erb_comments_test/test_0002_inline_ruby_comment_with_newline_32dd50121c8e2af22b8a7e5efd92940f.txt
@@ -3,5 +3,5 @@ source: "Engine::ERBCommentsTest#test_0002_inline ruby comment with newline"
 input: "{source: \"<% if true %><% # Comment here %>\\n<% end %>\", options: {}}"
 ---
 _buf = ::String.new; if true 
- end 
+ end ;
 _buf.to_s

--- a/test/snapshots/engine/erb_comments_test/test_0003_inline_ruby_comment_between_code_987d6e126382f02311aa0c1a0e0007bc.txt
+++ b/test/snapshots/engine/erb_comments_test/test_0003_inline_ruby_comment_between_code_987d6e126382f02311aa0c1a0e0007bc.txt
@@ -2,6 +2,5 @@
 source: "Engine::ERBCommentsTest#test_0003_inline ruby comment between code"
 input: "{source: \"<% if true %><% # Comment here %><%= \\\"hello\\\" %><% end %>\", options: {}}"
 ---
-_buf = ::String.new; if true 
- _buf << ("hello").to_s; end;
+_buf = ::String.new; if true ; _buf << ("hello").to_s; end;
 _buf.to_s

--- a/test/snapshots/engine/erb_comments_test/test_0004_inline_ruby_comment_before_and_between_code_d6e28172fd69bf4538744950bffb2848.txt
+++ b/test/snapshots/engine/erb_comments_test/test_0004_inline_ruby_comment_before_and_between_code_d6e28172fd69bf4538744950bffb2848.txt
@@ -2,6 +2,5 @@
 source: "Engine::ERBCommentsTest#test_0004_inline ruby comment before and between code"
 input: "{source: \"<% # Comment here %><% if true %><% # Comment here %><%= \\\"hello\\\" %><% end %>\", options: {}}"
 ---
-_buf = ::String.new; if true 
- _buf << ("hello").to_s; end;
+_buf = ::String.new; if true ; _buf << ("hello").to_s; end;
 _buf.to_s

--- a/test/snapshots/engine/erb_comments_test/test_0005_inline_ruby_comment_with_spaces_a1f69e41bb63eacbc881533c704e17a4.txt
+++ b/test/snapshots/engine/erb_comments_test/test_0005_inline_ruby_comment_with_spaces_a1f69e41bb63eacbc881533c704e17a4.txt
@@ -2,6 +2,5 @@
 source: "Engine::ERBCommentsTest#test_0005_inline ruby comment with spaces"
 input: "{source: \"<%  # Comment %> <% code = \\\"test\\\" %><%= code %>\", options: {}}"
 ---
-_buf = ::String.new;  code = "test" 
- _buf << (code).to_s;
+_buf = ::String.new;  code = "test" ; _buf << (code).to_s;
 _buf.to_s

--- a/test/snapshots/engine/erb_comments_test/test_0006_inline_ruby_comment_multiline_1dc1e842d2fb5a2484c2e2fa0eca3678.txt
+++ b/test/snapshots/engine/erb_comments_test/test_0006_inline_ruby_comment_multiline_1dc1e842d2fb5a2484c2e2fa0eca3678.txt
@@ -3,7 +3,5 @@ source: "Engine::ERBCommentsTest#test_0006_inline ruby comment multiline"
 input: "{source: \"<% # Comment\\nmore %> <% code = \\\"test\\\" %><%= code %>\", options: {}}"
 ---
 _buf = ::String.new; # Comment
-more 
-  code = "test" 
- _buf << (code).to_s;
+more ;  code = "test" ; _buf << (code).to_s;
 _buf.to_s

--- a/test/snapshots/engine/erb_openers_test/test_0002_a_tag_that_only_shares_a_prefix_with_a_configured_opener_is_compiled_as_Ruby_d1d4c7d63e000a81326f6cba73523177.txt
+++ b/test/snapshots/engine/erb_openers_test/test_0002_a_tag_that_only_shares_a_prefix_with_a_configured_opener_is_compiled_as_Ruby_d1d4c7d63e000a81326f6cba73523177.txt
@@ -2,5 +2,5 @@
 source: "Engine::ERBOpenersTest#test_0002_a tag that only shares a prefix with a configured opener is compiled as Ruby"
 input: "{source: \"<%herbal_tea %>\", options: {parser_options: {erb_openers: [\"herb\"]}}}"
 ---
-_buf = ::String.new; herbal_tea 
+_buf = ::String.new; herbal_tea ;
 _buf.to_s

--- a/test/snapshots/engine/erb_openers_test/test_0003_graphql_is_compiled_as_Ruby_when_it_is_not_configured_93af27b4ecbde2f888e6382690f1a750.txt
+++ b/test/snapshots/engine/erb_openers_test/test_0003_graphql_is_compiled_as_Ruby_when_it_is_not_configured_93af27b4ecbde2f888e6382690f1a750.txt
@@ -2,5 +2,5 @@
 source: "Engine::ERBOpenersTest#test_0003_graphql is compiled as Ruby when it is not configured"
 input: "{source: \"<%graphql_query %>\", options: {parser_options: {erb_openers: [\"herb\"]}}}"
 ---
-_buf = ::String.new; graphql_query 
+_buf = ::String.new; graphql_query ;
 _buf.to_s

--- a/test/snapshots/engine/erb_tag_variations_test/test_0001_lt%_code_%gt_5e7239d6cead61c6332db67fb845e154.txt
+++ b/test/snapshots/engine/erb_tag_variations_test/test_0001_lt%_code_%gt_5e7239d6cead61c6332db67fb845e154.txt
@@ -2,6 +2,5 @@
 source: "Engine::ERBTagVariationsTest#test_0001_<% code %>"
 input: "{source: \"<% x = 1 %><%= x %>\", options: {}}"
 ---
-_buf = ::String.new; x = 1 
- _buf << (x).to_s;
+_buf = ::String.new; x = 1 ; _buf << (x).to_s;
 _buf.to_s

--- a/test/snapshots/engine/graph_ql_test/test_0006_graphql_variable_assignment_is_not_omitted_be439528f24e66e46a140edbd3b01d91.txt
+++ b/test/snapshots/engine/graph_ql_test/test_0006_graphql_variable_assignment_is_not_omitted_be439528f24e66e46a140edbd3b01d91.txt
@@ -2,5 +2,5 @@
 source: "Engine::GraphQLTest#test_0006_graphql variable assignment is not omitted"
 input: "{source: \"<% graphql = \\\"query\\\" %>\", options: {parser_options: {erb_openers: [\"graphql\"]}}}"
 ---
-_buf = ::String.new; graphql = "query" 
+_buf = ::String.new; graphql = "query" ;
 _buf.to_s

--- a/test/snapshots/engine/graph_ql_test/test_0009_method_call_starting_with_graphql_is_compiled_as_Ruby_bf7b262b2b549626349abd8a00c41afd.txt
+++ b/test/snapshots/engine/graph_ql_test/test_0009_method_call_starting_with_graphql_is_compiled_as_Ruby_bf7b262b2b549626349abd8a00c41afd.txt
@@ -2,5 +2,5 @@
 source: "Engine::GraphQLTest#test_0009_method call starting with graphql is compiled as Ruby"
 input: "{source: \"<%graphql_helper %>\", options: {parser_options: {erb_openers: [\"graphql\"]}}}"
 ---
-_buf = ::String.new; graphql_helper 
+_buf = ::String.new; graphql_helper ;
 _buf.to_s

--- a/test/snapshots/engine/graph_ql_test/test_0010_code_starting_with_the_letters_graphql_is_compiled_as_Ruby_b56ce2a3ec47714fbbb48d3db8b25537.txt
+++ b/test/snapshots/engine/graph_ql_test/test_0010_code_starting_with_the_letters_graphql_is_compiled_as_Ruby_b56ce2a3ec47714fbbb48d3db8b25537.txt
@@ -2,5 +2,5 @@
 source: "Engine::GraphQLTest#test_0010_code starting with the letters graphql is compiled as Ruby"
 input: "{source: \"<%graphqlish %>\", options: {parser_options: {erb_openers: [\"graphql\"]}}}"
 ---
-_buf = ::String.new; graphqlish 
+_buf = ::String.new; graphqlish ;
 _buf.to_s

--- a/test/snapshots/engine/open_tag_whitespace_test/test_0014_preserves_indentation_of_an_inline_erb_conditional_among_attributes_4dcae3c8064408cd0c45f1ff679c2d12.txt
+++ b/test/snapshots/engine/open_tag_whitespace_test/test_0014_preserves_indentation_of_an_inline_erb_conditional_among_attributes_4dcae3c8064408cd0c45f1ff679c2d12.txt
@@ -4,8 +4,7 @@ input: "{source: \"<input\\n  type=\\\"text\\\"\\n  <% if required %>required<% 
 ---
 _buf = ::String.new; _buf << '<input
   type="text"
-  '.freeze;   if required 
- _buf << 'required'.freeze; end; _buf << '
+  '.freeze;   if required ; _buf << 'required'.freeze; end; _buf << '
 >
 '.freeze;
 _buf.to_s

--- a/test/snapshots/engine/remove_comments_test/test_0010_comment_inside_an_erb_branch_-_compilation_b749d943e08b58a1853083c0ebe78074.txt
+++ b/test/snapshots/engine/remove_comments_test/test_0010_comment_inside_an_erb_branch_-_compilation_b749d943e08b58a1853083c0ebe78074.txt
@@ -2,6 +2,5 @@
 source: "Engine::RemoveCommentsTest#test_0010_comment inside an erb branch - compilation"
 input: "{source: \"<% if admin? %><!-- admin only --><p>Admin</p><% else %><!-- everyone --><p>User</p><% end %>\", options: {escape: false, visitors: [#<Herb::Engine::RemoveCommentsVisitor>]}}"
 ---
-_buf = ::String.new; if admin? 
- _buf << '<p>Admin</p>'.freeze; else; _buf << '<p>User</p>'.freeze; end;
+_buf = ::String.new; if admin? ; _buf << '<p>Admin</p>'.freeze; else; _buf << '<p>User</p>'.freeze; end;
 _buf.to_s

--- a/test/snapshots/engine/render_node_compilation_test/test_0005_emits_a_render_in_statement_position_a4a4d5c4b1863281dd707eaf850cf938.txt
+++ b/test/snapshots/engine/render_node_compilation_test/test_0005_emits_a_render_in_statement_position_a4a4d5c4b1863281dd707eaf850cf938.txt
@@ -2,5 +2,5 @@
 source: "Engine::RenderNodeCompilationTest#test_0005_emits a render in statement position"
 input: "{source: \"<% render \\\"silent\\\" %>\", options: {parser_options: {render_nodes: true}}}"
 ---
-_buf = ::String.new; render "silent" 
+_buf = ::String.new; render "silent" ;
 _buf.to_s

--- a/test/snapshots/engine/render_node_compilation_test/test_0006_emits_a_render_inside_a_loop_c7982b2e84a425d4431fa1f6da900e98.txt
+++ b/test/snapshots/engine/render_node_compilation_test/test_0006_emits_a_render_inside_a_loop_c7982b2e84a425d4431fa1f6da900e98.txt
@@ -2,6 +2,5 @@
 source: "Engine::RenderNodeCompilationTest#test_0006_emits a render inside a loop"
 input: "{source: \"<% posts.each do |post| %><%= render post %><% end %>\", options: {parser_options: {render_nodes: true}}}"
 ---
-_buf = ::String.new; posts.each do |post| 
- _buf << (render post).to_s; end;
+_buf = ::String.new; posts.each do |post| ; _buf << (render post).to_s; end;
 _buf.to_s

--- a/test/snapshots/engine/whitespace_trimming_test/test_0007_right_trim_does_not_affect_non-newline_content_8401eeac9b536aeae6fa532142803f97.txt
+++ b/test/snapshots/engine/whitespace_trimming_test/test_0007_right_trim_does_not_affect_non-newline_content_8401eeac9b536aeae6fa532142803f97.txt
@@ -2,6 +2,5 @@
 source: "Engine::WhitespaceTrimmingTest#test_0007_right trim does not affect non-newline content"
 input: "{source: \"<% if true -%>text<% end -%>more\", options: {}}"
 ---
-_buf = ::String.new; if true 
- _buf << 'text'.freeze; end; _buf << 'more'.freeze;
+_buf = ::String.new; if true ; _buf << 'text'.freeze; end; _buf << 'more'.freeze;
 _buf.to_s

--- a/test/snapshots/engine/whitespace_trimming_test/test_0014_left_trim_at_start_of_file_6e29dbbfa0adbfe7385b8c39b04341cd.txt
+++ b/test/snapshots/engine/whitespace_trimming_test/test_0014_left_trim_at_start_of_file_6e29dbbfa0adbfe7385b8c39b04341cd.txt
@@ -4,5 +4,5 @@ input: "{source: \"<%- if true %>\\nContent\\n<%- end %>\", options: {}}"
 ---
 _buf = ::String.new; if true 
  _buf << 'Content
-'.freeze; end 
+'.freeze; end ;
 _buf.to_s

--- a/test/snapshots/engine/whitespace_trimming_test/test_0015_right_trim_at_end_of_file_a8c9c24a1f7dda4a5a9da5ccd5bd5941.txt
+++ b/test/snapshots/engine/whitespace_trimming_test/test_0015_right_trim_at_end_of_file_a8c9c24a1f7dda4a5a9da5ccd5bd5941.txt
@@ -4,5 +4,5 @@ input: "{source: \"<% if true -%>\\nContent\\n<% end -%>\", options: {}}"
 ---
 _buf = ::String.new; if true 
  _buf << 'Content
-'.freeze; end 
+'.freeze; end ;
 _buf.to_s

--- a/test/snapshots/engine/whitespace_trimming_test/test_0025_output_tag_with_-%gt_followed_by_indented_control_tag_trims_whitespace_6e7bb5978f1744ca1f9e61ff9dabef21.txt
+++ b/test/snapshots/engine/whitespace_trimming_test/test_0025_output_tag_with_-%gt_followed_by_indented_control_tag_trims_whitespace_6e7bb5978f1744ca1f9e61ff9dabef21.txt
@@ -4,5 +4,5 @@ input: "{source: \"A<%= -%>\\n <% if true %>\\nB\\n<% end %>\", options: {}}"
 ---
 _buf = ::String.new; _buf << 'A'.freeze; _buf << ().to_s;  if true 
  _buf << 'B
-'.freeze; end 
+'.freeze; end ;
 _buf.to_s

--- a/test/snapshots/engine/whitespace_trimming_test/test_0026_output_tag_with_-%gt_followed_by_non-indented_control_tag_(baseline)_55d40b8bb7a8dfa86eb1e988dcd939dd.txt
+++ b/test/snapshots/engine/whitespace_trimming_test/test_0026_output_tag_with_-%gt_followed_by_non-indented_control_tag_(baseline)_55d40b8bb7a8dfa86eb1e988dcd939dd.txt
@@ -4,5 +4,5 @@ input: "{source: \"A<%= -%>\\n<% if true %>\\nB\\n<% end %>\", options: {}}"
 ---
 _buf = ::String.new; _buf << 'A'.freeze; _buf << ().to_s; if true 
  _buf << 'B
-'.freeze; end 
+'.freeze; end ;
 _buf.to_s

--- a/test/snapshots/engine/whitespace_trimming_test/test_0029_output_tag_with_-%gt_followed_by_else_branch_3c0c260c095f49c6cbbdad96c98f6362.txt
+++ b/test/snapshots/engine/whitespace_trimming_test/test_0029_output_tag_with_-%gt_followed_by_else_branch_3c0c260c095f49c6cbbdad96c98f6362.txt
@@ -6,5 +6,5 @@ _buf = ::String.new; if false
  _buf << 'X
 '.freeze; _buf << ().to_s; else 
  _buf << 'Y
-'.freeze; end 
+'.freeze; end ;
 _buf.to_s

--- a/test/snapshots/engine/whitespace_trimming_test/test_0030_output_tag_with_-%gt_followed_by_CRLF_and_control_tag_219878e332fa067b21678677f6f45100.txt
+++ b/test/snapshots/engine/whitespace_trimming_test/test_0030_output_tag_with_-%gt_followed_by_CRLF_and_control_tag_219878e332fa067b21678677f6f45100.txt
@@ -4,5 +4,5 @@ input: "{source: \"A<%= -%>\\r\\n <% if true %>\\r\\nB\\r\\n<% end %>\", options
 ---
 _buf = ::String.new; _buf << 'A'.freeze; _buf << ().to_s;  if true 
  _buf << 'B
-'.freeze; end 
+'.freeze; end ;
 _buf.to_s

--- a/test/snapshots/engine/whitespace_trimming_test/test_0032_leading_whitespace_before_statement_tag_with_inline_content_is_preserved_f5238974da382ba7163bacda3e26af7a.txt
+++ b/test/snapshots/engine/whitespace_trimming_test/test_0032_leading_whitespace_before_statement_tag_with_inline_content_is_preserved_f5238974da382ba7163bacda3e26af7a.txt
@@ -3,7 +3,6 @@ source: "Engine::WhitespaceTrimmingTest#test_0032_leading whitespace before stat
 input: "{source: \"<p>\\n  <% if true %>text<% end %>\\n</p>\", options: {}}"
 ---
 _buf = ::String.new; _buf << '<p>
-  '.freeze;   if true 
- _buf << 'text'.freeze; end; _buf << '
+  '.freeze;   if true ; _buf << 'text'.freeze; end; _buf << '
 </p>'.freeze;
 _buf.to_s

--- a/test/snapshots/engine/whitespace_trimming_test/test_0034_leading_whitespace_before_nested_statement_tags_with_inline_content_is_preserved_8a4dc1dd1aa0972409c05ef71ebc963d.txt
+++ b/test/snapshots/engine/whitespace_trimming_test/test_0034_leading_whitespace_before_nested_statement_tags_with_inline_content_is_preserved_8a4dc1dd1aa0972409c05ef71ebc963d.txt
@@ -4,7 +4,6 @@ input: "{source: \"<p>\\n  <% if true %><% if true %>text<% end %><% end %>\\n</
 ---
 _buf = ::String.new; _buf << '<p>
 '.freeze;   if true 
- _buf << '  '.freeze; if true 
- _buf << 'text'.freeze; end; end; _buf << '
+ _buf << '  '.freeze; if true ; _buf << 'text'.freeze; end; end; _buf << '
 </p>'.freeze;
 _buf.to_s

--- a/test/snapshots/engine/whitespace_trimming_test/test_0035_leading_tabs_before_statement_tag_with_inline_content_is_preserved_e443d8e239bea70905fc088663ebcc66.txt
+++ b/test/snapshots/engine/whitespace_trimming_test/test_0035_leading_tabs_before_statement_tag_with_inline_content_is_preserved_e443d8e239bea70905fc088663ebcc66.txt
@@ -3,7 +3,6 @@ source: "Engine::WhitespaceTrimmingTest#test_0035_leading tabs before statement 
 input: "{source: \"<p>\\n\\t\\t<% if true %>text<% end %>\\n</p>\", options: {}}"
 ---
 _buf = ::String.new; _buf << '<p>
-		'.freeze; 		if true 
- _buf << 'text'.freeze; end; _buf << '
+		'.freeze; 		if true ; _buf << 'text'.freeze; end; _buf << '
 </p>'.freeze;
 _buf.to_s

--- a/test/snapshots/engine/whitespace_trimming_test/test_0036_leading_whitespace_before_statement_tag_with_inline_expression_is_preserved_df93b2839ea173e6ca1dba9e6df0ce27.txt
+++ b/test/snapshots/engine/whitespace_trimming_test/test_0036_leading_whitespace_before_statement_tag_with_inline_expression_is_preserved_df93b2839ea173e6ca1dba9e6df0ce27.txt
@@ -3,7 +3,6 @@ source: "Engine::WhitespaceTrimmingTest#test_0036_leading whitespace before stat
 input: "{source: \"<p>\\n  <% if true %><%= \\\"text\\\" %><% end %>\\n</p>\", options: {}}"
 ---
 _buf = ::String.new; _buf << '<p>
-  '.freeze;   if true 
- _buf << ("text").to_s; end; _buf << '
+  '.freeze;   if true ; _buf << ("text").to_s; end; _buf << '
 </p>'.freeze;
 _buf.to_s

--- a/test/snapshots/engine/whitespace_trimming_test/test_0037_deeply_nested_statement_tags_with_inline_content_1d6067825bdfc8e22f27556525a7b7c5.txt
+++ b/test/snapshots/engine/whitespace_trimming_test/test_0037_deeply_nested_statement_tags_with_inline_content_1d6067825bdfc8e22f27556525a7b7c5.txt
@@ -5,7 +5,6 @@ input: "{source: \"<p>\\n  <% if true %><% if true %><% if true %>text<% end %><
 _buf = ::String.new; _buf << '<p>
 '.freeze;   if true 
  if true 
- _buf << '  '.freeze; if true 
- _buf << 'text'.freeze; end; end; end; _buf << '
+ _buf << '  '.freeze; if true ; _buf << 'text'.freeze; end; end; end; _buf << '
 </p>'.freeze;
 _buf.to_s

--- a/test/snapshots/engine/whitespace_trimming_test/test_0038_leading_whitespace_with_else_branch_and_inline_content_a8783b4ddbc74d44bafd798ab5463718.txt
+++ b/test/snapshots/engine/whitespace_trimming_test/test_0038_leading_whitespace_with_else_branch_and_inline_content_a8783b4ddbc74d44bafd798ab5463718.txt
@@ -3,7 +3,6 @@ source: "Engine::WhitespaceTrimmingTest#test_0038_leading whitespace with else b
 input: "{source: \"<p>\\n  <% if false %>nope<% else %>text<% end %>\\n</p>\", options: {}}"
 ---
 _buf = ::String.new; _buf << '<p>
-  '.freeze;   if false 
- _buf << 'nope'.freeze; else; _buf << 'text'.freeze; end; _buf << '
+  '.freeze;   if false ; _buf << 'nope'.freeze; else; _buf << 'text'.freeze; end; _buf << '
 </p>'.freeze;
 _buf.to_s

--- a/test/snapshots/engine/whitespace_trimming_test/test_0039_leading_whitespace_with_elsif_and_inline_content_3327724b7b95d9490b727ff51dae3b32.txt
+++ b/test/snapshots/engine/whitespace_trimming_test/test_0039_leading_whitespace_with_elsif_and_inline_content_3327724b7b95d9490b727ff51dae3b32.txt
@@ -3,7 +3,6 @@ source: "Engine::WhitespaceTrimmingTest#test_0039_leading whitespace with elsif 
 input: "{source: \"<p>\\n  <% if false %>nope<% elsif true %>text<% end %>\\n</p>\", options: {}}"
 ---
 _buf = ::String.new; _buf << '<p>
-  '.freeze;   if false 
- _buf << 'nope'.freeze; elsif true; _buf << 'text'.freeze; end; _buf << '
+  '.freeze;   if false ; _buf << 'nope'.freeze; elsif true; _buf << 'text'.freeze; end; _buf << '
 </p>'.freeze;
 _buf.to_s

--- a/test/snapshots/engine/whitespace_trimming_test/test_0041_control_tag_with_right_trim_followed_by_inline_content_2b4b10075c0e57b1625bdc3aff956382.txt
+++ b/test/snapshots/engine/whitespace_trimming_test/test_0041_control_tag_with_right_trim_followed_by_inline_content_2b4b10075c0e57b1625bdc3aff956382.txt
@@ -3,7 +3,6 @@ source: "Engine::WhitespaceTrimmingTest#test_0041_control tag with right trim fo
 input: "{source: \"<p>\\n  <% if true -%>text<% end %>\\n</p>\", options: {}}"
 ---
 _buf = ::String.new; _buf << '<p>
-  '.freeze;   if true 
- _buf << 'text'.freeze; end; _buf << '
+  '.freeze;   if true ; _buf << 'text'.freeze; end; _buf << '
 </p>'.freeze;
 _buf.to_s

--- a/test/snapshots/engine/whitespace_trimming_test/test_0042_control_tag_with_left_trim_and_inline_content_dc5c2e0dafe07ebf14b9fde00f60c5fa.txt
+++ b/test/snapshots/engine/whitespace_trimming_test/test_0042_control_tag_with_left_trim_and_inline_content_dc5c2e0dafe07ebf14b9fde00f60c5fa.txt
@@ -3,7 +3,6 @@ source: "Engine::WhitespaceTrimmingTest#test_0042_control tag with left trim and
 input: "{source: \"<p>\\n  <%- if true %>text<% end %>\\n</p>\", options: {}}"
 ---
 _buf = ::String.new; _buf << '<p>
-  '.freeze;   if true 
- _buf << 'text'.freeze; end; _buf << '
+  '.freeze;   if true ; _buf << 'text'.freeze; end; _buf << '
 </p>'.freeze;
 _buf.to_s

--- a/test/snapshots/engine/whitespace_trimming_test/test_0043_multiple_inline_control_tags_on_separate_lines_preserve_their_whitespace_d46deb849bd60d1916b4a66493f0f170.txt
+++ b/test/snapshots/engine/whitespace_trimming_test/test_0043_multiple_inline_control_tags_on_separate_lines_preserve_their_whitespace_d46deb849bd60d1916b4a66493f0f170.txt
@@ -3,9 +3,7 @@ source: "Engine::WhitespaceTrimmingTest#test_0043_multiple inline control tags o
 input: "{source: \"<ul>\\n  <% if true %>A<% end %>\\n  <% if true %>B<% end %>\\n</ul>\", options: {}}"
 ---
 _buf = ::String.new; _buf << '<ul>
-  '.freeze;   if true 
- _buf << 'A'.freeze; end; _buf << '
-  '.freeze;   if true 
- _buf << 'B'.freeze; end; _buf << '
+  '.freeze;   if true ; _buf << 'A'.freeze; end; _buf << '
+  '.freeze;   if true ; _buf << 'B'.freeze; end; _buf << '
 </ul>'.freeze;
 _buf.to_s

--- a/test/snapshots/engine/whitespace_trimming_test/test_0045_leading_whitespace_preserved_when_control_tag_with_inline_output_follows_a_trimmed_code-only_line_86f61d8da1610bc0e16dbf95fedfa2c6.txt
+++ b/test/snapshots/engine/whitespace_trimming_test/test_0045_leading_whitespace_preserved_when_control_tag_with_inline_output_follows_a_trimmed_code-only_line_86f61d8da1610bc0e16dbf95fedfa2c6.txt
@@ -6,7 +6,6 @@ _buf = ::String.new; _buf << '<a>
 '.freeze;   if true 
  _buf << '    <strong>Title</strong>
 '.freeze;   end 
- _buf << '  '.freeze;   unless false 
- _buf << ("content").to_s; _buf << '#L'.freeze; _buf << (1).to_s; end; _buf << '
+ _buf << '  '.freeze;   unless false ; _buf << ("content").to_s; _buf << '#L'.freeze; _buf << (1).to_s; end; _buf << '
 </a>'.freeze;
 _buf.to_s

--- a/test/snapshots/engine/whitespace_trimming_test/test_0046_leading_whitespace_preserved_after_multiple_consecutive_trimmed_code-only_lines_63e8a2703e3380eb763408f82a42935d.txt
+++ b/test/snapshots/engine/whitespace_trimming_test/test_0046_leading_whitespace_preserved_after_multiple_consecutive_trimmed_code-only_lines_63e8a2703e3380eb763408f82a42935d.txt
@@ -8,7 +8,6 @@ _buf = ::String.new; _buf << '<div>
  _buf << '      <strong>inner</strong>
 '.freeze;     end 
    end 
- _buf << '  '.freeze;   if true 
- _buf << ("output").to_s; end; _buf << '
+ _buf << '  '.freeze;   if true ; _buf << ("output").to_s; end; _buf << '
 </div>'.freeze;
 _buf.to_s


### PR DESCRIPTION
When `trim` is on and a statement tag sits at the start of a line, the compiler swallows the newline that followed it and emits a replacement, so the code stays terminated. It emitted that replacement whether or not there was a newline to swallow. A statement tag with content after it on the same line therefore pushed that content onto the next line, and every tag below it compiled a line low.

Answering this when the tag is compiled needs to know what comes after it, and nothing at that point does. #2484 tried to read it from the source, which needs the tag's location, and the engine parses without locations on purpose, so that a template compiled by visitors that never read a location does not pay for locations it will not use. The answer was always the old one.

The compiler now emits the newline as before and takes it back once something arrives to show it was not needed.

```ruby
def settle_pending_trim_newline!(keep)
  index = @pending_trim_newline_index

  return unless index

  @pending_trim_newline_index = nil

  return if keep

  @tokens[index][1] = @tokens[index][1].chomp
end
```

Emitting it and retracting it, instead of withholding it and adding it later, is what makes this work. `at_line_start?` reads the previous token's trailing newline to decide whether the next tag begins a line, so a tag that is compiled before the question is settled sees exactly what it sees today.

The newline is taken back when the text that follows does not start with one, when an expression follows instead of text, and at the end of the template, where nothing follows at all. A tag a visitor injected has no source of its own and never gets the newline to begin with.

```erb
<p>
  <% if true %><%= "text" %><% end %>
</p>
```

**Before**

```ruby
 1 | _buf = ::String.new; _buf << '<p>
 2 |   '.freeze;   if true 
 3 |  _buf << ("text").to_s; end; _buf << '
 4 | </p>'.freeze;
 5 | _buf.to_s
```

**After**

```ruby
 1 | _buf = ::String.new; _buf << '<p>
 2 |   '.freeze;   if true ; _buf << ("text").to_s; end; _buf << '
 3 | </p>'.freeze;
 4 | _buf.to_s
```

`"text"` is written on line 2 and now compiles to line 2.

Compiling a 400 line template takes 3.62 ms, against 3.62 ms before this change. Reading the answer out of the source instead would have meant parsing with locations, which measured 4.15 ms.

#### Where it still holds the newline

Two statement tags written next to each other on one line keep the newline between them, because a tag arriving after another tag is not evidence either way. A `case` and the `when` below it are exactly that shape to the compiler, since the newline the author wrote between them is a child of the case node that never reaches the token stream, and taking the newline back there would put `when` on the line `case` was written on and diverge from Erubi.

```erb
<% if true %><% if true %>text<% end %><% end %>
```

The inner tag still compiles a line below the outer one. Both are written on the same line, so the inner one is off by one.

#### The allowlist

This takes `test/line_fidelity_allowlist.txt` from 11 entries down to 4. It clears `Engine::ERBCommentsTest` and `Engine::RenderNodeCompilationTest` completely, and all but one of `Engine::WhitespaceTrimmingTest`.
