### PR TITLE
Engine: Keep the line an `=end` was written on

### DIFF
--- a/lib/herb/engine.rb
+++ b/lib/herb/engine.rb
@@ -198,7 +198,8 @@ module Herb
       terminate_expression
 
       if code.include?("=begin") || code.include?("=end")
-        @src << "\n" << code << "\n"
+        @src << "\n" << code
+        @src << "\n" unless code.end_with?("\n")
       else
         @src.chomp! if @src.end_with?("\n") && code.start_with?(" ") && !code.end_with?("\n")
 

--- a/lib/herb/engine/compiler.rb
+++ b/lib/herb/engine/compiler.rb
@@ -482,13 +482,13 @@ module Herb
       def keep_line_count(node, extra: 0, at: nil)
         raw = node.content.value
 
-        return if raw.include?("=begin") || raw.include?("=end")
-
         leading = raw[0, raw.length - raw.lstrip.length].to_s.count("\n")
         trailing = raw.count("\n") - raw.strip.count("\n") - leading + extra
 
+        block_comment = raw.include?("=begin") || raw.include?("=end")
+
         @padding_before ||= Hash.new(0)
-        @padding_before[at] += leading if at && leading.positive?
+        @padding_before[at] += leading if at && leading.positive? && !block_comment
         @padding_before[@tokens.length] += trailing if trailing.positive?
       end
 

--- a/test/line_fidelity_allowlist.txt
+++ b/test/line_fidelity_allowlist.txt
@@ -1,4 +1,0 @@
-Engine::BlockCommentsTest#test_0001_ruby block comments with =begin and =end multiline
-Engine::BlockCommentsTest#test_0007_ruby block comments with =begin and =end mutliline and no space before ERB closing tag
-Engine::ExamplesCompilationTest#test_0004_block comment compilation
-Engine::WhitespaceTrimmingTest#test_0031_output tag with -%> followed by another expression tag

--- a/test/snapshot_utils.rb
+++ b/test/snapshot_utils.rb
@@ -647,6 +647,7 @@ module SnapshotUtils
 
   def erb_tags_off_their_line(source, compiled)
     lines = compiled.lines
+    source_lines = source.lines
 
     erb_content_nodes(Herb.parse(source).value).filter_map do |node|
       opening = node.tag_opening&.value.to_s
@@ -662,6 +663,7 @@ module SnapshotUtils
       first = code.lines.first.to_s.strip
 
       next if lines[line - 1].to_s.include?(first)
+      next if source_lines[line - 2].to_s.match?(/-%>[ \t]*\r?\n?\z/)
       next unless compiled.include?(first)
 
       [line, first]

--- a/test/snapshots/engine/block_comments_test/test_0001_ruby_block_comments_with_=begin_and_=end_multiline_ff404c4e708f59f532b4042441e458ad.txt
+++ b/test/snapshots/engine/block_comments_test/test_0001_ruby_block_comments_with_=begin_and_=end_multiline_ff404c4e708f59f532b4042441e458ad.txt
@@ -4,11 +4,9 @@ input: "{source: \"<%\\n=begin %>\\n  This, while unusual, is a legal form of co
 ---
 _buf = ::String.new;
 =begin 
-
  _buf << '  This, while unusual, is a legal form of commenting.
 '.freeze;
 =end 
-
  _buf << '<div>Hey there</div>
 '.freeze;
 _buf.to_s

--- a/test/snapshots/engine/block_comments_test/test_0002_ruby_block_comments_inside_erb_tags_95bcfa3f3e28634bf923f18df0cd38a1.txt
+++ b/test/snapshots/engine/block_comments_test/test_0002_ruby_block_comments_inside_erb_tags_95bcfa3f3e28634bf923f18df0cd38a1.txt
@@ -6,7 +6,6 @@ _buf = ::String.new;
 =begin
 This is a comment
 =end 
-
  _buf << '<p>Content</p>
-'.freeze;
+'.freeze; 
 _buf.to_s

--- a/test/snapshots/engine/block_comments_test/test_0003_ruby_block_comments_with_code_before_and_after_0ee0ba8a9a25359175b884cf66f37b2c.txt
+++ b/test/snapshots/engine/block_comments_test/test_0003_ruby_block_comments_with_code_before_and_after_0ee0ba8a9a25359175b884cf66f37b2c.txt
@@ -8,7 +8,7 @@ _buf = ::String.new; x = 1
 Multi-line comment
 spanning multiple lines
 =end 
-
+ 
  y = 2 
  _buf << '<div>'.freeze; _buf << (x + y).to_s; _buf << '</div>
 '.freeze;

--- a/test/snapshots/engine/block_comments_test/test_0007_ruby_block_comments_with_=begin_and_=end_mutliline_and_no_space_before_ERB_closing_tag_72379778fa34572e48b949a780f761b1.txt
+++ b/test/snapshots/engine/block_comments_test/test_0007_ruby_block_comments_with_=begin_and_=end_mutliline_and_no_space_before_ERB_closing_tag_72379778fa34572e48b949a780f761b1.txt
@@ -4,11 +4,9 @@ input: "{source: \"<%\\n=begin%>\\n  This, while unusual, is a legal form of com
 ---
 _buf = ::String.new;
 =begin 
-
  _buf << '  This, while unusual, is a legal form of commenting.
 '.freeze;
 =end 
-
  _buf << '<div>Hey there</div>
 '.freeze;
 _buf.to_s

--- a/test/snapshots/engine/examples_compilation_test/test_0004_block_comment_compilation_d5c98b9f230e001f8aabf838d3774698.txt
+++ b/test/snapshots/engine/examples_compilation_test/test_0004_block_comment_compilation_d5c98b9f230e001f8aabf838d3774698.txt
@@ -4,11 +4,9 @@ input: "{source: \"<%\\n=begin %>\\n  This, while unusual, is a legal form of co
 ---
 _buf = ::String.new;
 =begin 
-
  _buf << '  This, while unusual, is a legal form of commenting.
 '.freeze;
 =end 
-
  _buf << '
 <div>Content</div>
 '.freeze;


### PR DESCRIPTION
A Ruby block comment is written into the compiled output with a newline on each side, so that `=begin` and `=end` land in column 0 where Ruby needs them. The trailing one was written whether or not the tag had already ended its line, so a template that opens a block comment and closes it in a later tag compiled everything after the comment one line low.

```erb
<%
=begin %>
  This, while unusual, is a legal form of commenting.
<%
=end %>
<div>Hey there</div>
```

**Before**

```ruby
 1 | _buf = ::String.new;
 2 | =begin 
 3 | 
 4 |  _buf << '  This, while unusual, is a legal form of commenting.
 5 | '.freeze;
 6 | =end 
 7 | 
 8 |  _buf << '<div>Hey there</div>
```

**After**

```ruby
 1 | _buf = ::String.new;
 2 | =begin 
 3 |  _buf << '  This, while unusual, is a legal form of commenting.
 4 | '.freeze;
 5 | =end 
 6 |  _buf << '<div>Hey there</div>
```

`=end` is written on line 5 and now compiles to line 5, and the `<div>` below it on line 6.

The newline the tag already carries is now left to do that job.

```ruby
@src << "\n" << code
@src << "\n" unless code.end_with?("\n")
```

`keep_line_count` skipped a block comment entirely, because the comment carries its own newlines and counting them again moved everything down twice. It now skips only the newlines before the comment, which are the ones the comment supplies. The newlines after it, between an `=end` and the `%>` that closes its tag, are counted like any other tag's.

That is what the two shapes disagreed about. A comment closed in the same tag it was opened in has a newline after its `=end`, and one closed in a later tag does not.

#### An explicit right trim is not drift

That leaves `test/line_fidelity_allowlist.txt` empty, so it is gone.

The last entry in it was never a defect. `-%>` removes the newline the author asked it to remove, so the tag below genuinely belongs on the line above, and Erubi compiles it the same way.

```erb
A<%= -%>
<%= "B" %>
```

The assertion now recognises that shape instead of carrying it as an exception, and every ERB tag in the suite compiles to the line it was written on.

The allowlist machinery in `test/snapshot_utils.rb` still works, and its staleness check will still say so if an entry is added and later becomes unnecessary. Retiring it is a reasonable follow-up now that there is nothing to list.
