### PR TITLE
Engine: Retire the line fidelity allowlist

### DIFF
--- a/test/snapshot_utils.rb
+++ b/test/snapshot_utils.rb
@@ -502,65 +502,8 @@ module SnapshotUtils
     metadata
   end
 
-  LINE_FIDELITY_ALLOWLIST_PATH = File.expand_path("line_fidelity_allowlist.txt", __dir__)
-
-  def line_fidelity_allowlist
-    SnapshotUtils.line_fidelity_allowlist
-  end
-
-  def self.line_fidelity_allowlist
-    @line_fidelity_allowlist ||=
-      if File.exist?(LINE_FIDELITY_ALLOWLIST_PATH)
-        File.readlines(LINE_FIDELITY_ALLOWLIST_PATH, chomp: true).reject(&:empty?).to_set
-      else
-        Set.new
-      end
-  end
-
-  def self.line_fidelity_allowlist_ran
-    @line_fidelity_allowlist_ran ||= Set.new
-  end
-
-  def self.line_fidelity_allowlist_needed
-    @line_fidelity_allowlist_needed ||= Set.new
-  end
-
-  def self.line_fidelity_run_failed?
-    @line_fidelity_run_failed || false
-  end
-
-  def self.line_fidelity_run_failed!
-    @line_fidelity_run_failed = true
-  end
-
-  def self.stale_line_fidelity_allowlist_entries
-    return Set.new if line_fidelity_run_failed?
-
-    line_fidelity_allowlist_ran - line_fidelity_allowlist_needed
-  end
-
-  def after_teardown
-    super
-
-    SnapshotUtils.line_fidelity_run_failed! if failures.any? { |failure| !failure.is_a?(Minitest::Skip) }
-  end
-
   def assert_erb_tags_keep_their_line(source, compiled)
     off = erb_tags_off_their_line(source, compiled)
-    identifier = "#{self.class}##{name}"
-
-    if ENV["UPDATE_LINE_FIDELITY_ALLOWLIST"]
-      File.open(LINE_FIDELITY_ALLOWLIST_PATH, "a") { |file| file.puts(identifier) } unless off.empty?
-
-      return
-    end
-
-    if line_fidelity_allowlist.include?(identifier)
-      SnapshotUtils.line_fidelity_allowlist_ran << identifier
-      SnapshotUtils.line_fidelity_allowlist_needed << identifier unless off.empty?
-
-      return
-    end
 
     assert off.empty?, <<~MESSAGE
       An ERB tag compiles to a line other than the one it was written on, so a

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -28,20 +28,6 @@ require_relative "snapshot_utils"
 Minitest::Spec::DSL.send(:alias_method, :test, :it)
 Minitest::Spec::DSL.send(:alias_method, :xtest, :xit)
 
-Minitest.after_run do
-  stale = SnapshotUtils.stale_line_fidelity_allowlist_entries
-
-  if !stale.empty? && !ENV["UPDATE_LINE_FIDELITY_ALLOWLIST"]
-    abort(<<~MESSAGE)
-
-      Every ERB tag now compiles to the line it was written on for #{stale.size} allowlisted #{stale.size == 1 ? "test" : "tests"}.
-      Remove #{stale.size == 1 ? "this entry" : "these entries"} from test/line_fidelity_allowlist.txt:
-
-      #{stale.sort.map { |entry| "  #{entry}" }.join("\n")}
-    MESSAGE
-  end
-end
-
 def cyclic_string(length)
   sequence = ("a".."z").to_a + ("0".."9").to_a
   sequence.cycle.take(length).join


### PR DESCRIPTION
#2482 asserted that an ERB tag compiles to the line it was written on, and started from an allowlist of the 43 tests where it did not. #2483, #2484, #2486, #2487, #2488 and #2489 worked that list down to nothing, and #2489 deleted the file.

What is left is the machinery that read it. There is nothing to read, so it goes too, and the assertion says what it always meant to say.

```ruby
def assert_erb_tags_keep_their_line(source, compiled)
  off = erb_tags_off_their_line(source, compiled)

  assert off.empty?, <<~MESSAGE
    An ERB tag compiles to a line other than the one it was written on, so a
    backtrace from this template would name the wrong line:
    ...
  MESSAGE
end
```

Gone with it are the allowlist reader, the two sets that tracked which entries a run actually needed, the `after_teardown` hook that noticed when a run had already failed, the `Minitest.after_run` check that failed a green run holding an entry it no longer needed, and `UPDATE_LINE_FIDELITY_ALLOWLIST`.

That staleness check did its job. 