### PR TITLE
Engine: Keep the lines a stripped trailing comment sat on

### DIFF
--- a/lib/herb/engine/helpers.rb
+++ b/lib/herb/engine/helpers.rb
@@ -16,6 +16,14 @@ module Herb
         true
       end
 
+      #: (String) -> String
+      def self.without_trailing_spaces(code)
+        cut = code.length
+        cut -= 1 while cut.positive? && [" ", "\t"].include?(code[cut - 1])
+
+        code[0, cut].to_s
+      end
+
       #: (String) -> bool
       def self.heredoc?(code)
         code.match?(/<<[~-]?\s*['"`]?\w/)
@@ -30,7 +38,7 @@ module Herb
 
         return code unless comment
 
-        code.byteslice(0, comment.location.start_offset).to_s.rstrip
+        without_trailing_spaces(code.byteslice(0, comment.location.start_offset).to_s)
       rescue StandardError
         code
       end

--- a/sig/herb/engine/helpers.rbs
+++ b/sig/herb/engine/helpers.rbs
@@ -6,6 +6,9 @@ module Herb
       # : (String) -> bool
       def self.comment?: (String) -> bool
 
+      # : (String) -> String
+      def self.without_trailing_spaces: (String) -> String
+
       # : (String) -> bool
       def self.heredoc?: (String) -> bool
 

--- a/test/engine/erb_comments_test.rb
+++ b/test/engine/erb_comments_test.rb
@@ -133,5 +133,11 @@ module Engine
 
       assert_evaluated_snapshot(template, enforce_erubi_equality: true)
     end
+
+    test "a tag whose content is only comments keeps every line" do
+      template = "<%\n  # a\n  # b\n%>\n<%= x %>\n"
+
+      assert_compiled_snapshot(template)
+    end
   end
 end

--- a/test/snapshots/engine/erb_comments_test/test_0022_a_tag_whose_content_is_only_comments_keeps_every_line_b28547ad6a08a60b5c4e2b5421b94789.txt
+++ b/test/snapshots/engine/erb_comments_test/test_0022_a_tag_whose_content_is_only_comments_keeps_every_line_b28547ad6a08a60b5c4e2b5421b94789.txt
@@ -1,0 +1,11 @@
+---
+source: "Engine::ERBCommentsTest#test_0022_a tag whose content is only comments keeps every line"
+input: "{source: \"<%\\n  # a\\n  # b\\n%>\\n<%= x %>\\n\", options: {}}"
+---
+_buf = ::String.new; 
+ # a
+ 
+ 
+ _buf << (x).to_s; _buf << '
+'.freeze;
+_buf.to_s


### PR DESCRIPTION
#2480 splices a trailing comment out of the code a tag emits, so that the comment cannot swallow the `;` or the `)` the compiler appends after it. The splice cut the comment and the newline in front of it, so a tag whose content is only comments lost a line of that content.

```erb
<%
  # a
  # b
%>
<%= x %>
```

**Before**

```ruby
1 | _buf = ::String.new; 
2 |  # a
3 |  
4 |  _buf << (x).to_s; _buf << '
```

**After**

```ruby
1 | _buf = ::String.new; 
2 |  # a
3 |  
4 |  
5 |  _buf << (x).to_s; _buf << '
```

`# b` was gone from the compiled template altogether, and `x`, written on line 5, compiled to line 4.

The splice now takes the spaces and tabs before the comment and leaves the newlines alone.

```ruby
code.byteslice(0, comment.location.start_offset).to_s.sub(/[ \t]*\z/, "")
```

A tag written on one line is unaffected, since `x = 1 # note` has no newline to keep, and that is every comment tag in the suite. This one came out of a corpus run instead: license headers written as `<%` with a block of `#` lines are common in real templates, and each one was losing its last line and taking every tag below it up with it.
