### PR TITLE
Engine: Fold literal output into static text in `OptimizeVisitor`

### DIFF
--- a/docs/docs/projects/engine.md
+++ b/docs/docs/projects/engine.md
@@ -250,7 +250,7 @@ Herb ships the following transform visitors:
 | `HTMLSafeAssertionsVisitor`   | Checks every `.html_safe` call at runtime                                    |
 | `InlineRender::Visitor`       | Replaces a `render` of a static partial with the partial (experimental)      |
 | `InstrumentationVisitor`      | Frames every ERB tag so a render can be attributed to it (experimental)      |
-| `OptimizeVisitor`             | Compile-time optimizations for Action View helpers (experimental)            |
+| `OptimizeVisitor`             | Compile-time optimizations for helpers and literal output (experimental)     |
 | `RemoveCommentsVisitor`       | Removes comments, so the output never contains one                           |
 | `ScopedStyle::Visitor`        | Scopes a `<style scoped>` block to the file it was written in (experimental) |
 | `SourceAttributionVisitor`    | Stamps every element with the template and position it was written at        |
@@ -799,7 +799,9 @@ Herb::Engine.new(source, visitors: [Herb::Engine::OptimizeVisitor.new])
 
 `<%= tag.div do %>Content<% end %>` compiles to `<div>Content</div>` with no helper call left at all. Only the helpers the registry marks supported are resolved.
 
-Its presence also collapses a template that carries no Ruby into the single string literal it renders, with none of the buffer the compiler would otherwise build up. `<div>Static</div>` compiles to `'<div>Static</div>'`. A template written as HTML qualifies on its own, and one left fully static once its helpers resolved to markup qualifies too, so `<%= tag.br %>` compiles to `'<br>'`. The engine keeps the buffer when the caller drives it through `preamble`, `postamble`, `bufval`, or `ensure`, and when a visitor recorded a diagnostic the compiled template still has to report.
+An output tag that carries only a string, integer, or float literal renders the same text every time, so the visitor folds it into the template text around it, with the escaping the renderer would have applied already applied. `<%= "hello" %>` compiles to the text `hello`, and with `escape: true`, `<%= "it's" %>` compiles to `it&#39;s`. The fold follows the tag's position, so a literal in an attribute value takes the attribute escape, and one inside `<script>` or `<style>` takes the JavaScript or CSS escape. A literal that spans lines, sits in a trimming tag, or renders nothing stays dynamic, and so does one whose escape function the caller swapped out through `escapefunc`, `attrfunc`, `jsfunc`, or `cssfunc`, unless the stock function leaves the value untouched.
+
+Its presence also collapses a template that carries no Ruby into the single string literal it renders, with none of the buffer the compiler would otherwise build up. `<div>Static</div>` compiles to `'<div>Static</div>'`. A template written as HTML qualifies on its own, and one left fully static once its helpers resolved to markup and its literals folded into text qualifies too, so `<%= tag.br %>` compiles to `'<br>'` and `<h1><%= "hello" %></h1>` to `'<h1>hello</h1>'`. The engine keeps the buffer when the caller drives it through `preamble`, `postamble`, `bufval`, or `ensure`, and when a visitor recorded a diagnostic the compiled template still has to report.
 
 Replacing a helper call with its markup is the same thing as calling it only while the helper is the one it was resolved against. An application that defines its own `content_tag` gets the stock markup everywhere instead of its own, with nothing at the call site to say so. `verify` compiles a check into the template that reports a helper that has since been overwritten:
 

--- a/lib/herb/engine/visitors/optimize_visitor.rb
+++ b/lib/herb/engine/visitors/optimize_visitor.rb
@@ -4,27 +4,41 @@
 require_relative "../../visitor"
 require_relative "../../visitor/experimental"
 require_relative "../../visitor/context_aware"
+require_relative "../helpers"
 require_relative "../../action_view/helper_registry"
 
 module Herb
   class Engine
     # Asks the parser to resolve Action View helpers into the markup they produce, so the compiler
-    # emits that markup directly instead of a call the renderer has to make.
-    #
-    # It rewrites nothing itself. The work happens in the parser, and this says the template wants
-    # it done:
+    # emits that markup directly instead of a call the renderer has to make. Passing it is the
+    # whole opt-in:
     #
     #     Herb::Engine.new(source, visitors: [Herb::Engine::OptimizeVisitor.new])
     #
-    # Inserting it is the whole opt-in. There is no check first for whether a template looks like
-    # it contains helpers, because a caller that added this has already answered that question.
+    # There is no check first for whether a template looks like it contains helpers, because a
+    # caller that added this has already answered that question.
+    #
+    # An output tag whose Ruby is a single string, integer, or float literal renders the same text
+    # every time, so the visitor folds it into the template text around it. `<%= "hello" %>`
+    # compiles to the text `hello`, with nothing left to evaluate when the template renders. The
+    # escaping the compiler would have arranged at render time is applied once here instead, by the
+    # same functions it would have called, so the fold produces byte for byte what the expression
+    # would have, in an attribute value and inside `<script>` or `<style>` just as in plain
+    # content. A caller that swapped one of those functions out through `escapefunc`, `attrfunc`,
+    # `jsfunc`, or `cssfunc` gets the fold only when the stock function leaves the value untouched,
+    # on the grounds that an escape function has nothing to do there either.
+    #
+    # A literal that spans lines, sits in a trimming tag, or renders nothing at all stays dynamic,
+    # so folding never moves another tag off the line it was written on and never changes how the
+    # whitespace around the tag is handled.
     #
     # Its presence also lets the engine collapse a template that carries no Ruby into the single
     # string literal it renders, skipping the buffer the compiler would otherwise build up. A
     # template that was HTML to begin with qualifies, and so does one left fully static once the
-    # helpers above resolved to markup. The collapse is held back when the caller drives the buffer
-    # itself through `preamble`, `postamble`, `bufval`, or `ensure`, and when a visitor recorded a
-    # diagnostic that the compiled template still needs to report.
+    # helpers above resolved to markup and the literal outputs folded into text. The collapse is
+    # held back when the caller drives the buffer itself through `preamble`, `postamble`, `bufval`,
+    # or `ensure`, and when a visitor recorded a diagnostic that the compiled template still needs
+    # to report.
     #
     # Replacing a helper call with its markup is only the same thing as calling it while the helper
     # is the one it was resolved against. An application that defines its own `content_tag` gets the
@@ -46,6 +60,9 @@ module Herb
       CODE = "overwritten-helper" #: String
       ORIGIN = "Herb Engine" #: String
 
+      OUTPUT_OPENINGS = ["<%=", "<%=="].freeze #: Array[String]
+      CHILD_LISTS = [:children, :body, :statements].freeze #: Array[Symbol]
+
       required_parser_option action_view_helpers: true, transform_conditionals: true
       experimental "Compile-time optimizations are experimental. Output may differ from standard Action View rendering."
 
@@ -60,6 +77,7 @@ module Herb
 
         @verify = verify
         @sources = {} #: Hash[String, Herb::Location?]
+        @output_contexts = [] #: Array[Symbol]
       end
 
       #: () -> Hash[Symbol, untyped]
@@ -72,6 +90,7 @@ module Herb
       #: (Herb::AST::DocumentNode) -> void
       def visit_document_node(node)
         @sources = {} #: Hash[String, Herb::Location?]
+        @output_contexts = [] #: Array[Symbol]
 
         super
 
@@ -81,18 +100,36 @@ module Herb
         node.children << check_node(node)
       end
 
+      #: (Herb::AST::Node) -> void
+      def visit_node(node)
+        CHILD_LISTS.each do |name|
+          next unless node.respond_to?(name)
+
+          children = node.public_send(name)
+
+          next unless children.is_a?(Array)
+
+          children.map! { |child| folded_literal(child) || child }
+        end
+      end
+
       #: (Herb::AST::HTMLElementNode) -> void
       def visit_html_element_node(node)
         collect(node.element_source, node.location)
 
-        super
+        with_output_context(element_output_context(node)) { super }
       end
 
       #: (Herb::AST::HTMLConditionalElementNode) -> void
       def visit_html_conditional_element_node(node)
         collect(node.element_source, node.location)
 
-        super
+        with_output_context(element_output_context(node)) { super }
+      end
+
+      #: (Herb::AST::HTMLAttributeValueNode) -> void
+      def visit_html_attribute_value_node(node)
+        with_output_context(:attribute_value) { super }
       end
 
       #: (Herb::Engine, untyped) -> String?
@@ -112,6 +149,108 @@ module Herb
       end
 
       private
+
+      #: ((Herb::AST::HTMLElementNode | Herb::AST::HTMLConditionalElementNode)) -> Symbol?
+      def element_output_context(node)
+        case node.tag_name&.value&.downcase
+        when "script" then :script_content
+        when "style" then :style_content
+        end
+      end
+
+      #: (Symbol?) { () -> void } -> void
+      def with_output_context(output_context)
+        return yield unless output_context
+
+        @output_contexts.push(output_context)
+
+        begin
+          yield
+        ensure
+          @output_contexts.pop
+        end
+      end
+
+      #: () -> Symbol
+      def current_output_context
+        @output_contexts.last || :html_content
+      end
+
+      #: (Herb::AST::Node?) -> Herb::AST::LiteralNode?
+      def folded_literal(node)
+        return unless node.is_a?(Herb::AST::ERBContentNode)
+
+        opening = node.tag_opening&.value
+
+        return unless opening
+        return unless OUTPUT_OPENINGS.include?(opening)
+        return unless node.tag_closing&.value == "%>"
+
+        code = node.content&.value
+
+        return unless code
+        return if code.include?("\n")
+
+        value = literal_value(code)
+
+        return unless value
+
+        text = output_text(value, opening)
+
+        return unless text
+        return if text.empty? || text.include?("\n")
+
+        Herb::AST::LiteralNode.build(content: +text, location: node.location)
+      end
+
+      #: (String) -> String?
+      def literal_value(code)
+        return unless Helpers.prism_available?
+
+        result = Prism.parse(code)
+
+        return unless result.success?
+
+        statements = result.value.statements.body
+
+        return unless statements.length == 1
+
+        case (statement = statements.first)
+        when Prism::StringNode then statement.unescaped
+        when Prism::IntegerNode, Prism::FloatNode then statement.value.to_s
+        end
+      end
+
+      #: (String, String) -> String?
+      def output_text(value, opening)
+        case current_output_context
+        when :attribute_value then escaped_output(value, :attrfunc) { Engine.attr(value) }
+        when :script_content then escaped_output(value, :jsfunc) { Engine.js(value) }
+        when :style_content then escaped_output(value, :cssfunc) { Engine.css(value) }
+        else
+          return value unless escape_output?(opening)
+
+          escaped_output(value, :escapefunc) { Engine.h(value) }
+        end
+      end
+
+      #: (String, Symbol) { () -> String } -> String?
+      def escaped_output(value, option)
+        escaped = yield
+
+        return escaped unless context.options.key?(option)
+        return value if escaped == value
+
+        nil
+      end
+
+      #: (String) -> bool
+      def escape_output?(opening)
+        options = context.options
+        escape = options.fetch(:escape) { options.fetch(:escape_html, false) }
+
+        opening == "<%==" ? !escape : !!escape
+      end
 
       #: (String?, Herb::Location?) -> void
       def collect(source, location)

--- a/sig/herb/engine/visitors/optimize_visitor.rbs
+++ b/sig/herb/engine/visitors/optimize_visitor.rbs
@@ -3,22 +3,35 @@
 module Herb
   class Engine
     # Asks the parser to resolve Action View helpers into the markup they produce, so the compiler
-    # emits that markup directly instead of a call the renderer has to make.
-    #
-    # It rewrites nothing itself. The work happens in the parser, and this says the template wants
-    # it done:
+    # emits that markup directly instead of a call the renderer has to make. Passing it is the
+    # whole opt-in:
     #
     #     Herb::Engine.new(source, visitors: [Herb::Engine::OptimizeVisitor.new])
     #
-    # Inserting it is the whole opt-in. There is no check first for whether a template looks like
-    # it contains helpers, because a caller that added this has already answered that question.
+    # There is no check first for whether a template looks like it contains helpers, because a
+    # caller that added this has already answered that question.
+    #
+    # An output tag whose Ruby is a single string, integer, or float literal renders the same text
+    # every time, so the visitor folds it into the template text around it. `<%= "hello" %>`
+    # compiles to the text `hello`, with nothing left to evaluate when the template renders. The
+    # escaping the compiler would have arranged at render time is applied once here instead, by the
+    # same functions it would have called, so the fold produces byte for byte what the expression
+    # would have, in an attribute value and inside `<script>` or `<style>` just as in plain
+    # content. A caller that swapped one of those functions out through `escapefunc`, `attrfunc`,
+    # `jsfunc`, or `cssfunc` gets the fold only when the stock function leaves the value untouched,
+    # on the grounds that an escape function has nothing to do there either.
+    #
+    # A literal that spans lines, sits in a trimming tag, or renders nothing at all stays dynamic,
+    # so folding never moves another tag off the line it was written on and never changes how the
+    # whitespace around the tag is handled.
     #
     # Its presence also lets the engine collapse a template that carries no Ruby into the single
     # string literal it renders, skipping the buffer the compiler would otherwise build up. A
     # template that was HTML to begin with qualifies, and so does one left fully static once the
-    # helpers above resolved to markup. The collapse is held back when the caller drives the buffer
-    # itself through `preamble`, `postamble`, `bufval`, or `ensure`, and when a visitor recorded a
-    # diagnostic that the compiled template still needs to report.
+    # helpers above resolved to markup and the literal outputs folded into text. The collapse is
+    # held back when the caller drives the buffer itself through `preamble`, `postamble`, `bufval`,
+    # or `ensure`, and when a visitor recorded a diagnostic that the compiled template still needs
+    # to report.
     #
     # Replacing a helper call with its markup is only the same thing as calling it while the helper
     # is the one it was resolved against. An application that defines its own `content_tag` gets the
@@ -42,6 +55,10 @@ module Herb
 
       ORIGIN: String
 
+      OUTPUT_OPENINGS: Array[String]
+
+      CHILD_LISTS: Array[Symbol]
+
       # : () -> Array[String]
       def self.helper_sources: () -> Array[String]
 
@@ -54,11 +71,17 @@ module Herb
       # : (Herb::AST::DocumentNode) -> void
       def visit_document_node: (Herb::AST::DocumentNode) -> void
 
+      # : (Herb::AST::Node) -> void
+      def visit_node: (Herb::AST::Node) -> void
+
       # : (Herb::AST::HTMLElementNode) -> void
       def visit_html_element_node: (Herb::AST::HTMLElementNode) -> void
 
       # : (Herb::AST::HTMLConditionalElementNode) -> void
       def visit_html_conditional_element_node: (Herb::AST::HTMLConditionalElementNode) -> void
+
+      # : (Herb::AST::HTMLAttributeValueNode) -> void
+      def visit_html_attribute_value_node: (Herb::AST::HTMLAttributeValueNode) -> void
 
       # : (Herb::Engine, untyped) -> String?
       def compile_static_body: (Herb::Engine, untyped) -> String?
@@ -67,6 +90,30 @@ module Herb
       def inspect: () -> String
 
       private
+
+      # : ((Herb::AST::HTMLElementNode | Herb::AST::HTMLConditionalElementNode)) -> Symbol?
+      def element_output_context: (Herb::AST::HTMLElementNode | Herb::AST::HTMLConditionalElementNode) -> Symbol?
+
+      # : (Symbol?) { () -> void } -> void
+      def with_output_context: (Symbol?) { () -> void } -> void
+
+      # : () -> Symbol
+      def current_output_context: () -> Symbol
+
+      # : (Herb::AST::Node?) -> Herb::AST::LiteralNode?
+      def folded_literal: (Herb::AST::Node?) -> Herb::AST::LiteralNode?
+
+      # : (String) -> String?
+      def literal_value: (String) -> String?
+
+      # : (String, String) -> String?
+      def output_text: (String, String) -> String?
+
+      # : (String, Symbol) { () -> String } -> String?
+      def escaped_output: (String, Symbol) { () -> String } -> String?
+
+      # : (String) -> bool
+      def escape_output?: (String) -> bool
 
       # : (String?, Herb::Location?) -> void
       def collect: (String?, Herb::Location?) -> void

--- a/test/engine/optimized_literals_test.rb
+++ b/test/engine/optimized_literals_test.rb
@@ -1,0 +1,125 @@
+# frozen_string_literal: true
+
+require_relative "../test_helper"
+require_relative "../snapshot_utils"
+require "herb/engine/visitors/optimize_visitor"
+
+module Engine
+  class OptimizedLiteralsTest < Minitest::Spec
+    include SnapshotUtils
+
+    def optimize_options(**options)
+      { visitors: [Herb::Engine::OptimizeVisitor.new], **options }
+    end
+
+    describe "what folds into text" do
+      test "a string literal" do
+        assert_compiled_snapshot(%(<p><%= "Total" %>: <%= count %></p>), optimize_options)
+      end
+
+      test "an integer literal" do
+        assert_compiled_snapshot("<p><%= 1 %> of <%= count %></p>", optimize_options)
+      end
+
+      test "a float literal" do
+        assert_compiled_snapshot("<p><%= 1.5 %> of <%= count %></p>", optimize_options)
+      end
+
+      test "a literal in a branch" do
+        assert_compiled_snapshot(%(<% if flag %><%= "yes" %><% end %>), optimize_options)
+      end
+
+      test "a literal behind a statement modifier, inside the branch the parser unrolls it into" do
+        assert_compiled_snapshot(%(<p><%= "yes" if flag %></p>), optimize_options)
+      end
+
+      test "a template left fully static collapses to the string it renders" do
+        assert_compiled_snapshot(%(<h1><%= "hello" %></h1>), optimize_options)
+      end
+
+      test "a fully static template collapses with verify on, because a literal leaves nothing to verify" do
+        assert_compiled_snapshot(%(<h1><%= "hello" %></h1>), visitors: [Herb::Engine::OptimizeVisitor.new(verify: true)])
+      end
+    end
+
+    describe "how it escapes" do
+      test "applies at compile time the escaping the renderer would have applied" do
+        assert_compiled_snapshot(%(<p><%= "it's" %></p>), optimize_options(escape: true))
+      end
+
+      test "leaves raw output raw" do
+        assert_compiled_snapshot(%(<p><%= "<b>bold</b>" %></p>), optimize_options)
+      end
+
+      test "honors the double equals indicator escaping when the engine does not" do
+        assert_compiled_snapshot(%(<p><%== "<b>bold</b>" %></p>), optimize_options)
+      end
+
+      test "honors the double equals indicator staying raw when the engine escapes" do
+        assert_compiled_snapshot(%(<p><%== "<b>bold</b>" %></p>), optimize_options(escape: true))
+      end
+
+      test "applies the attribute escape inside an attribute value" do
+        assert_compiled_snapshot(%(<img alt="<%= "Herb's logo" %>">), optimize_options)
+      end
+
+      test "applies the JavaScript escape inside a script element" do
+        assert_compiled_snapshot(%(<script>let text = "<%= "line\\nbreak" %>";</script>), optimize_options)
+      end
+
+      test "applies the CSS escape inside a style element" do
+        assert_compiled_snapshot(%(<style>.a { color: <%= "red" %>; }</style>), optimize_options)
+      end
+    end
+
+    describe "what stays dynamic" do
+      test "an expression" do
+        assert_compiled_snapshot("<p><%= greeting %></p>", optimize_options)
+      end
+
+      test "a string with interpolation" do
+        assert_compiled_snapshot(%(<p><%= "a\#{b}" %></p>), optimize_options)
+      end
+
+      test "a literal in a trimming tag" do
+        assert_compiled_snapshot(%(<p><%= "hi" -%>\ntail</p>), optimize_options)
+      end
+
+      test "a literal in a tag that spans lines" do
+        assert_compiled_snapshot(%(<p><%=\n"hello" %></p>), optimize_options)
+      end
+
+      test "a literal that renders nothing" do
+        assert_compiled_snapshot(%(<p><%= "" %></p>), optimize_options)
+      end
+
+      test "a value a swapped-out escape function might treat differently" do
+        assert_compiled_snapshot(%(<p><%= "it's" %></p>), optimize_options(escape: true, escapefunc: "::CGI.escapeHTML"))
+      end
+    end
+
+    describe "with a swapped-out escape function" do
+      test "a value the stock function leaves untouched still folds" do
+        assert_compiled_snapshot(%(<p><%= "hello" %></p>), optimize_options(escape: true, escapefunc: "::CGI.escapeHTML"))
+      end
+    end
+
+    describe "what it renders" do
+      test "renders what the expressions would have rendered" do
+        assert_evaluated_snapshot(
+          %(<p><%= "Total" %>: <%= count %> <%= "item" %><%= "s" if count != 1 %></p>),
+          { count: 2 },
+          optimize_options
+        )
+      end
+
+      test "renders escaped text the way the renderer would have" do
+        assert_evaluated_snapshot(
+          %(<img alt="<%= "Herb's logo" %>" title="<%= title %>">),
+          { title: "Herb" },
+          optimize_options(escape: true)
+        )
+      end
+    end
+  end
+end

--- a/test/snapshots/engine/action_view/postfix_conditional_test/test_0007_string_literal_that_would_be_HTML-escaped_with_postfix_if_condition_639727d9a71015c2fb9b57f5503a29cf.txt
+++ b/test/snapshots/engine/action_view/postfix_conditional_test/test_0007_string_literal_that_would_be_HTML-escaped_with_postfix_if_condition_639727d9a71015c2fb9b57f5503a29cf.txt
@@ -2,5 +2,5 @@
 source: "Engine::ActionView::PostfixConditionalTest#test_0007_string literal that would be HTML-escaped with postfix if condition"
 input: "{source: \"<%= \\\"5 > 3\\\" if condition %>\", options: {escape: true, visitors: [#<Herb::Engine::OptimizeVisitor>]}}"
 ---
-__herb = ::Herb::Engine; _buf = ::String.new; if condition ; _buf << __herb.h(("5 > 3")); end;
+_buf = ::String.new; if condition ; _buf << '5 &gt; 3'.freeze; end;
 _buf.to_s

--- a/test/snapshots/engine/action_view/ternary_conditional_test/test_0008_ternary_with_literals_that_would_be_HTML-escaped_8321c6d088528bc271f6ae3d11a80181.txt
+++ b/test/snapshots/engine/action_view/ternary_conditional_test/test_0008_ternary_with_literals_that_would_be_HTML-escaped_8321c6d088528bc271f6ae3d11a80181.txt
@@ -2,5 +2,5 @@
 source: "Engine::ActionView::TernaryConditionalTest#test_0008_ternary with literals that would be HTML-escaped"
 input: "{source: \"<%= active ? \\\"5 > 3\\\" : \\\"a & b\\\" %>\", options: {escape: true, visitors: [#<Herb::Engine::OptimizeVisitor>]}}"
 ---
-__herb = ::Herb::Engine; _buf = ::String.new; if active ; _buf << __herb.h(("5 > 3")); else; _buf << __herb.h(("a & b")); end;
+_buf = ::String.new; if active ; _buf << '5 &gt; 3'.freeze; else; _buf << 'a &amp; b'.freeze; end;
 _buf.to_s

--- a/test/snapshots/engine/optimized_literals_test/how_it_escapes/test_0001_applies_at_compile_time_the_escaping_the_renderer_would_have_applied_31c56b2e8b54c1c777d848f3f3054405.txt
+++ b/test/snapshots/engine/optimized_literals_test/how_it_escapes/test_0001_applies_at_compile_time_the_escaping_the_renderer_would_have_applied_31c56b2e8b54c1c777d848f3f3054405.txt
@@ -1,0 +1,5 @@
+---
+source: "Engine::OptimizedLiteralsTest::how it escapes#test_0001_applies at compile time the escaping the renderer would have applied"
+input: "{source: \"<p><%= \\\"it's\\\" %></p>\", options: {visitors: [#<Herb::Engine::OptimizeVisitor>], escape: true}}"
+---
+'<p>it&#39;s</p>'.freeze

--- a/test/snapshots/engine/optimized_literals_test/how_it_escapes/test_0002_leaves_raw_output_raw_eb139b2bac6230b9966061d63de1e60a.txt
+++ b/test/snapshots/engine/optimized_literals_test/how_it_escapes/test_0002_leaves_raw_output_raw_eb139b2bac6230b9966061d63de1e60a.txt
@@ -1,0 +1,5 @@
+---
+source: "Engine::OptimizedLiteralsTest::how it escapes#test_0002_leaves raw output raw"
+input: "{source: \"<p><%= \\\"<b>bold</b>\\\" %></p>\", options: {visitors: [#<Herb::Engine::OptimizeVisitor>]}}"
+---
+'<p><b>bold</b></p>'.freeze

--- a/test/snapshots/engine/optimized_literals_test/how_it_escapes/test_0003_honors_the_double_equals_indicator_escaping_when_the_engine_does_not_f42f006313810d7ebb1d0cf36421d049.txt
+++ b/test/snapshots/engine/optimized_literals_test/how_it_escapes/test_0003_honors_the_double_equals_indicator_escaping_when_the_engine_does_not_f42f006313810d7ebb1d0cf36421d049.txt
@@ -1,0 +1,5 @@
+---
+source: "Engine::OptimizedLiteralsTest::how it escapes#test_0003_honors the double equals indicator escaping when the engine does not"
+input: "{source: \"<p><%== \\\"<b>bold</b>\\\" %></p>\", options: {visitors: [#<Herb::Engine::OptimizeVisitor>]}}"
+---
+'<p>&lt;b&gt;bold&lt;/b&gt;</p>'.freeze

--- a/test/snapshots/engine/optimized_literals_test/how_it_escapes/test_0004_honors_the_double_equals_indicator_staying_raw_when_the_engine_escapes_20cc8066e6b927c2565bff6d5e1bc7b2.txt
+++ b/test/snapshots/engine/optimized_literals_test/how_it_escapes/test_0004_honors_the_double_equals_indicator_staying_raw_when_the_engine_escapes_20cc8066e6b927c2565bff6d5e1bc7b2.txt
@@ -1,0 +1,5 @@
+---
+source: "Engine::OptimizedLiteralsTest::how it escapes#test_0004_honors the double equals indicator staying raw when the engine escapes"
+input: "{source: \"<p><%== \\\"<b>bold</b>\\\" %></p>\", options: {visitors: [#<Herb::Engine::OptimizeVisitor>], escape: true}}"
+---
+'<p><b>bold</b></p>'.freeze

--- a/test/snapshots/engine/optimized_literals_test/how_it_escapes/test_0005_applies_the_attribute_escape_inside_an_attribute_value_24880894d113b4fd4a243ca35f91256b.txt
+++ b/test/snapshots/engine/optimized_literals_test/how_it_escapes/test_0005_applies_the_attribute_escape_inside_an_attribute_value_24880894d113b4fd4a243ca35f91256b.txt
@@ -1,0 +1,5 @@
+---
+source: "Engine::OptimizedLiteralsTest::how it escapes#test_0005_applies the attribute escape inside an attribute value"
+input: "{source: \"<img alt=\\\"<%= \\\"Herb's logo\\\" %>\\\">\", options: {visitors: [#<Herb::Engine::OptimizeVisitor>]}}"
+---
+'<img alt="Herb&#39;s logo">'.freeze

--- a/test/snapshots/engine/optimized_literals_test/how_it_escapes/test_0006_applies_the_JavaScript_escape_inside_a_script_element_c38557dc5f187c84a05e4c291c9ca15f.txt
+++ b/test/snapshots/engine/optimized_literals_test/how_it_escapes/test_0006_applies_the_JavaScript_escape_inside_a_script_element_c38557dc5f187c84a05e4c291c9ca15f.txt
@@ -1,0 +1,5 @@
+---
+source: "Engine::OptimizedLiteralsTest::how it escapes#test_0006_applies the JavaScript escape inside a script element"
+input: "{source: \"<script>let text = \\\"<%= \\\"line\\\\nbreak\\\" %>\\\";</script>\", options: {visitors: [#<Herb::Engine::OptimizeVisitor>]}}"
+---
+'<script>let text = "line\\nbreak";</script>'.freeze

--- a/test/snapshots/engine/optimized_literals_test/how_it_escapes/test_0007_applies_the_CSS_escape_inside_a_style_element_a864450a74ee5c8586924386f5d7813f.txt
+++ b/test/snapshots/engine/optimized_literals_test/how_it_escapes/test_0007_applies_the_CSS_escape_inside_a_style_element_a864450a74ee5c8586924386f5d7813f.txt
@@ -1,0 +1,5 @@
+---
+source: "Engine::OptimizedLiteralsTest::how it escapes#test_0007_applies the CSS escape inside a style element"
+input: "{source: \"<style>.a { color: <%= \\\"red\\\" %>; }</style>\", options: {visitors: [#<Herb::Engine::OptimizeVisitor>]}}"
+---
+'<style>.a { color: red; }</style>'.freeze

--- a/test/snapshots/engine/optimized_literals_test/what_folds_into_text/test_0001_a_string_literal_a08e69f9d48de2bc4be5d4c7c8027d83.txt
+++ b/test/snapshots/engine/optimized_literals_test/what_folds_into_text/test_0001_a_string_literal_a08e69f9d48de2bc4be5d4c7c8027d83.txt
@@ -1,0 +1,6 @@
+---
+source: "Engine::OptimizedLiteralsTest::what folds into text#test_0001_a string literal"
+input: "{source: \"<p><%= \\\"Total\\\" %>: <%= count %></p>\", options: {visitors: [#<Herb::Engine::OptimizeVisitor>]}}"
+---
+_buf = ::String.new; _buf << '<p>Total: '.freeze; _buf << (count).to_s; _buf << '</p>'.freeze;
+_buf.to_s

--- a/test/snapshots/engine/optimized_literals_test/what_folds_into_text/test_0002_an_integer_literal_5ba0e1d1911f35f46ca29ad8c689be29.txt
+++ b/test/snapshots/engine/optimized_literals_test/what_folds_into_text/test_0002_an_integer_literal_5ba0e1d1911f35f46ca29ad8c689be29.txt
@@ -1,0 +1,6 @@
+---
+source: "Engine::OptimizedLiteralsTest::what folds into text#test_0002_an integer literal"
+input: "{source: \"<p><%= 1 %> of <%= count %></p>\", options: {visitors: [#<Herb::Engine::OptimizeVisitor>]}}"
+---
+_buf = ::String.new; _buf << '<p>1 of '.freeze; _buf << (count).to_s; _buf << '</p>'.freeze;
+_buf.to_s

--- a/test/snapshots/engine/optimized_literals_test/what_folds_into_text/test_0003_a_float_literal_465dd0eae5614c73326d1d32b1aa9240.txt
+++ b/test/snapshots/engine/optimized_literals_test/what_folds_into_text/test_0003_a_float_literal_465dd0eae5614c73326d1d32b1aa9240.txt
@@ -1,0 +1,6 @@
+---
+source: "Engine::OptimizedLiteralsTest::what folds into text#test_0003_a float literal"
+input: "{source: \"<p><%= 1.5 %> of <%= count %></p>\", options: {visitors: [#<Herb::Engine::OptimizeVisitor>]}}"
+---
+_buf = ::String.new; _buf << '<p>1.5 of '.freeze; _buf << (count).to_s; _buf << '</p>'.freeze;
+_buf.to_s

--- a/test/snapshots/engine/optimized_literals_test/what_folds_into_text/test_0004_a_literal_in_a_branch_1c28a73431439f45ce2a15c337d3eef4.txt
+++ b/test/snapshots/engine/optimized_literals_test/what_folds_into_text/test_0004_a_literal_in_a_branch_1c28a73431439f45ce2a15c337d3eef4.txt
@@ -1,0 +1,6 @@
+---
+source: "Engine::OptimizedLiteralsTest::what folds into text#test_0004_a literal in a branch"
+input: "{source: \"<% if flag %><%= \\\"yes\\\" %><% end %>\", options: {visitors: [#<Herb::Engine::OptimizeVisitor>]}}"
+---
+_buf = ::String.new; if flag ; _buf << 'yes'.freeze; end;
+_buf.to_s

--- a/test/snapshots/engine/optimized_literals_test/what_folds_into_text/test_0005_a_literal_behind_a_statement_modifier,_inside_the_branch_the_parser_unrolls_it_into_5327724a32924930f4edda42f8f0a100.txt
+++ b/test/snapshots/engine/optimized_literals_test/what_folds_into_text/test_0005_a_literal_behind_a_statement_modifier,_inside_the_branch_the_parser_unrolls_it_into_5327724a32924930f4edda42f8f0a100.txt
@@ -1,0 +1,6 @@
+---
+source: "Engine::OptimizedLiteralsTest::what folds into text#test_0005_a literal behind a statement modifier, inside the branch the parser unrolls it into"
+input: "{source: \"<p><%= \\\"yes\\\" if flag %></p>\", options: {visitors: [#<Herb::Engine::OptimizeVisitor>]}}"
+---
+_buf = ::String.new; _buf << '<p>'.freeze; if flag; _buf << 'yes'.freeze; end; _buf << '</p>'.freeze;
+_buf.to_s

--- a/test/snapshots/engine/optimized_literals_test/what_folds_into_text/test_0006_a_template_left_fully_static_collapses_to_the_string_it_renders_f9393cedc865b7134a394d4c7343dad9.txt
+++ b/test/snapshots/engine/optimized_literals_test/what_folds_into_text/test_0006_a_template_left_fully_static_collapses_to_the_string_it_renders_f9393cedc865b7134a394d4c7343dad9.txt
@@ -1,0 +1,5 @@
+---
+source: "Engine::OptimizedLiteralsTest::what folds into text#test_0006_a template left fully static collapses to the string it renders"
+input: "{source: \"<h1><%= \\\"hello\\\" %></h1>\", options: {visitors: [#<Herb::Engine::OptimizeVisitor>]}}"
+---
+'<h1>hello</h1>'.freeze

--- a/test/snapshots/engine/optimized_literals_test/what_folds_into_text/test_0007_a_fully_static_template_collapses_with_verify_on,_because_a_literal_leaves_nothing_to_verify_e5cb32e15cccbf71fc0a0c969187651b.txt
+++ b/test/snapshots/engine/optimized_literals_test/what_folds_into_text/test_0007_a_fully_static_template_collapses_with_verify_on,_because_a_literal_leaves_nothing_to_verify_e5cb32e15cccbf71fc0a0c969187651b.txt
@@ -1,0 +1,5 @@
+---
+source: "Engine::OptimizedLiteralsTest::what folds into text#test_0007_a fully static template collapses with verify on, because a literal leaves nothing to verify"
+input: "{source: \"<h1><%= \\\"hello\\\" %></h1>\", options: {visitors: [#<Herb::Engine::OptimizeVisitor verify=true>]}}"
+---
+'<h1>hello</h1>'.freeze

--- a/test/snapshots/engine/optimized_literals_test/what_it_renders/test_0001_renders_what_the_expressions_would_have_rendered_74896f9e9c76ff203e6754e331195800.txt
+++ b/test/snapshots/engine/optimized_literals_test/what_it_renders/test_0001_renders_what_the_expressions_would_have_rendered_74896f9e9c76ff203e6754e331195800.txt
@@ -1,0 +1,5 @@
+---
+source: "Engine::OptimizedLiteralsTest::what it renders#test_0001_renders what the expressions would have rendered"
+input: "{source: \"<p><%= \\\"Total\\\" %>: <%= count %> <%= \\\"item\\\" %><%= \\\"s\\\" if count != 1 %></p>\", locals: {count: 2}, options: {visitors: [#<Herb::Engine::OptimizeVisitor>]}}"
+---
+<p>Total: 2 items</p>

--- a/test/snapshots/engine/optimized_literals_test/what_it_renders/test_0002_renders_escaped_text_the_way_the_renderer_would_have_d7f9fc8081104a12948833412ecfb31a.txt
+++ b/test/snapshots/engine/optimized_literals_test/what_it_renders/test_0002_renders_escaped_text_the_way_the_renderer_would_have_d7f9fc8081104a12948833412ecfb31a.txt
@@ -1,0 +1,5 @@
+---
+source: "Engine::OptimizedLiteralsTest::what it renders#test_0002_renders escaped text the way the renderer would have"
+input: "{source: \"<img alt=\\\"<%= \\\"Herb's logo\\\" %>\\\" title=\\\"<%= title %>\\\">\", locals: {title: \"Herb\"}, options: {visitors: [#<Herb::Engine::OptimizeVisitor>], escape: true}}"
+---
+<img alt="Herb&#39;s logo" title="Herb">

--- a/test/snapshots/engine/optimized_literals_test/what_stays_dynamic/test_0001_an_expression_fa53b475af1effefc69c931962bd3cb1.txt
+++ b/test/snapshots/engine/optimized_literals_test/what_stays_dynamic/test_0001_an_expression_fa53b475af1effefc69c931962bd3cb1.txt
@@ -1,0 +1,6 @@
+---
+source: "Engine::OptimizedLiteralsTest::what stays dynamic#test_0001_an expression"
+input: "{source: \"<p><%= greeting %></p>\", options: {visitors: [#<Herb::Engine::OptimizeVisitor>]}}"
+---
+_buf = ::String.new; _buf << '<p>'.freeze; _buf << (greeting).to_s; _buf << '</p>'.freeze;
+_buf.to_s

--- a/test/snapshots/engine/optimized_literals_test/what_stays_dynamic/test_0002_a_string_with_interpolation_5276cd2ec219e510e543e0ebddc2d86f.txt
+++ b/test/snapshots/engine/optimized_literals_test/what_stays_dynamic/test_0002_a_string_with_interpolation_5276cd2ec219e510e543e0ebddc2d86f.txt
@@ -1,0 +1,6 @@
+---
+source: "Engine::OptimizedLiteralsTest::what stays dynamic#test_0002_a string with interpolation"
+input: "{source: \"<p><%= \\\"a\\\#{b}\\\" %></p>\", options: {visitors: [#<Herb::Engine::OptimizeVisitor>]}}"
+---
+_buf = ::String.new; _buf << '<p>'.freeze; _buf << ("a#{b}").to_s; _buf << '</p>'.freeze;
+_buf.to_s

--- a/test/snapshots/engine/optimized_literals_test/what_stays_dynamic/test_0003_a_literal_in_a_trimming_tag_1d78fefe08fe52f6623c26a063893fdf.txt
+++ b/test/snapshots/engine/optimized_literals_test/what_stays_dynamic/test_0003_a_literal_in_a_trimming_tag_1d78fefe08fe52f6623c26a063893fdf.txt
@@ -1,0 +1,6 @@
+---
+source: "Engine::OptimizedLiteralsTest::what stays dynamic#test_0003_a literal in a trimming tag"
+input: "{source: \"<p><%= \\\"hi\\\" -%>\\ntail</p>\", options: {visitors: [#<Herb::Engine::OptimizeVisitor>]}}"
+---
+_buf = ::String.new; _buf << '<p>'.freeze; _buf << ("hi").to_s; _buf << 'tail</p>'.freeze;
+_buf.to_s

--- a/test/snapshots/engine/optimized_literals_test/what_stays_dynamic/test_0004_a_literal_in_a_tag_that_spans_lines_bcc977fb56e9f839d3d2e00911649411.txt
+++ b/test/snapshots/engine/optimized_literals_test/what_stays_dynamic/test_0004_a_literal_in_a_tag_that_spans_lines_bcc977fb56e9f839d3d2e00911649411.txt
@@ -1,0 +1,7 @@
+---
+source: "Engine::OptimizedLiteralsTest::what stays dynamic#test_0004_a literal in a tag that spans lines"
+input: "{source: \"<p><%=\\n\\\"hello\\\" %></p>\", options: {visitors: [#<Herb::Engine::OptimizeVisitor>]}}"
+---
+_buf = ::String.new; _buf << '<p>'.freeze; 
+ _buf << ("hello").to_s; _buf << '</p>'.freeze;
+_buf.to_s

--- a/test/snapshots/engine/optimized_literals_test/what_stays_dynamic/test_0005_a_literal_that_renders_nothing_0589f719543124723553b9592dba80dc.txt
+++ b/test/snapshots/engine/optimized_literals_test/what_stays_dynamic/test_0005_a_literal_that_renders_nothing_0589f719543124723553b9592dba80dc.txt
@@ -1,0 +1,6 @@
+---
+source: "Engine::OptimizedLiteralsTest::what stays dynamic#test_0005_a literal that renders nothing"
+input: "{source: \"<p><%= \\\"\\\" %></p>\", options: {visitors: [#<Herb::Engine::OptimizeVisitor>]}}"
+---
+_buf = ::String.new; _buf << '<p>'.freeze; _buf << ("").to_s; _buf << '</p>'.freeze;
+_buf.to_s

--- a/test/snapshots/engine/optimized_literals_test/what_stays_dynamic/test_0006_a_value_a_swapped-out_escape_function_might_treat_differently_4397ecbde386b6a521e8fae5c3dbb238.txt
+++ b/test/snapshots/engine/optimized_literals_test/what_stays_dynamic/test_0006_a_value_a_swapped-out_escape_function_might_treat_differently_4397ecbde386b6a521e8fae5c3dbb238.txt
@@ -1,0 +1,6 @@
+---
+source: "Engine::OptimizedLiteralsTest::what stays dynamic#test_0006_a value a swapped-out escape function might treat differently"
+input: "{source: \"<p><%= \\\"it's\\\" %></p>\", options: {visitors: [#<Herb::Engine::OptimizeVisitor>], escape: true, escapefunc: \"::CGI.escapeHTML\"}}"
+---
+_buf = ::String.new; _buf << '<p>'.freeze; _buf << ::CGI.escapeHTML(("it's")); _buf << '</p>'.freeze;
+_buf.to_s

--- a/test/snapshots/engine/optimized_literals_test/with_a_swapped_out_escape_function/test_0001_a_value_the_stock_function_leaves_untouched_still_folds_c858344f066c0e46b06040cd28dd7e27.txt
+++ b/test/snapshots/engine/optimized_literals_test/with_a_swapped_out_escape_function/test_0001_a_value_the_stock_function_leaves_untouched_still_folds_c858344f066c0e46b06040cd28dd7e27.txt
@@ -1,0 +1,5 @@
+---
+source: "Engine::OptimizedLiteralsTest::with a swapped-out escape function#test_0001_a value the stock function leaves untouched still folds"
+input: "{source: \"<p><%= \\\"hello\\\" %></p>\", options: {visitors: [#<Herb::Engine::OptimizeVisitor>], escape: true, escapefunc: \"::CGI.escapeHTML\"}}"
+---
+'<p>hello</p>'.freeze


### PR DESCRIPTION
This pull request teaches `OptimizeVisitor` to fold output tags that carry only a literal into the static text around them, so the compiled template ships the text instead of an expression the renderer has to evaluate.

An output tag whose Ruby is a single string, integer, or float literal renders the same text on every render. With the visitor in the stack, `<%= "hello" %>` now compiles to the text `hello`, and a template the fold leaves fully static collapses into the single string literal it renders:

```erb
<h1><%= "hello" %></h1>
```

**Before**

```ruby
_buf = ::String.new; _buf << '<h1>'.freeze; _buf << ("hello").to_s; _buf << '</h1>'.freeze;
_buf.to_s
```

**After**

```ruby
'<h1>hello</h1>'.freeze
```

The escaping the compiler would have arranged at render time is applied once at compile time instead, by the same functions it would have called, so the fold produces byte for byte what the expression would have. The visitor mirrors the compiler's context stack to pick the function. Plain content honors `escape` and the `<%==` indicator, an attribute value takes the attribute escape, and `<script>` and `<style>` take the JavaScript and CSS escapes, so with `escape: true`, `<%= "it's" %>` compiles to the text `it&#39;s`, and an attribute value escapes even without it:

```erb
<img alt="<%= "Herb's logo" %>">
```

```ruby
'<img alt="Herb&#39;s logo">'.freeze
```

A caller that swapped an escape function out through `escapefunc`, `attrfunc`, `jsfunc`, or `cssfunc` gets the fold only when the stock function leaves the value untouched, on the grounds that an escape function has nothing to do there either.

A literal stays dynamic whenever folding could change the output or the compiled source's line fidelity. A tag with a `-%>` closing keeps its trim, a tag or value that spans lines keeps the template's line mapping intact, an empty string keeps the compiler's whitespace bookkeeping identical, and interpolation and multi-statement tags are not literals to begin with.

The parser's `transform_conditionals` pass already folded string literals inside the branches it unrolls, but only escape-neutral ones, since the parser cannot know the engine's escape setting. The visitor closes that gap, which is why the two "would be HTML-escaped" snapshots now show compile-time-escaped static text:

```diff
-__herb = ::Herb::Engine; _buf = ::String.new; if active 
- _buf << __herb.h(("5 > 3")); else; _buf << __herb.h(("a & b")); end;
+_buf = ::String.new; if active 
+ _buf << '5 &gt; 3'.freeze; else; _buf << 'a &amp; b'.freeze; end;
 _buf.to_s
```
