### PR TITLE
Engine: Scan for trailing whitespace instead of matching it

### DIFF
--- a/lib/herb/engine/compiler.rb
+++ b/lib/herb/engine/compiler.rb
@@ -6,16 +6,9 @@ module Herb
   class Engine
     class Compiler < ::Herb::Visitor
       PADDING_NEWLINES = Array.new(17) { |count| ("\n" * count).freeze }.freeze #: Array[String]
-
-      EXPRESSION_TOKEN_TYPES = [:expr, :expr_escaped, :expr_block, :expr_block_escaped].freeze
-
-      TRAILING_WHITESPACE = /[ \t]+\z/
-      TRAILING_INDENTATION = /\n[ \t]+\z/
-      TRAILING_INDENTATION_CAPTURE = /\n([ \t]+)\z/
-      WHITESPACE_ONLY = /\A[ \t]+\z/
-      WHITESPACE_ONLY_CAPTURE = /\A([ \t]+)\z/
-
-      RAW_TEXT_ELEMENTS = ["script", "style"].freeze
+      EXPRESSION_TOKEN_TYPES = [:expr, :expr_escaped, :expr_block, :expr_block_escaped].freeze #: Array[Symbol]
+      HORIZONTAL_SPACE = [" ", "\t"].freeze #: Array[String]
+      RAW_TEXT_ELEMENTS = ["script", "style"].freeze #: Array[String]
 
       attr_reader :tokens
 
@@ -652,6 +645,36 @@ module Herb
         end
       end
 
+      #: (String) -> Integer
+      def trailing_space_length(text)
+        count = 0
+        count += 1 while count < text.length && HORIZONTAL_SPACE.include?(text[text.length - 1 - count])
+
+        count
+      end
+
+      #: (String) -> String
+      def trailing_spaces(text)
+        text[text.length - trailing_space_length(text), text.length].to_s
+      end
+
+      #: (String) -> void
+      def remove_trailing_spaces!(text)
+        text.replace(text[0, text.length - trailing_space_length(text)].to_s)
+      end
+
+      #: (String) -> bool
+      def whitespace_only?(text)
+        !text.empty? && trailing_space_length(text) == text.length
+      end
+
+      #: (String) -> bool
+      def trailing_indentation?(text)
+        spaces = trailing_space_length(text)
+
+        spaces.positive? && text[text.length - spaces - 1] == "\n"
+      end
+
       def at_line_start?
         return true if @tokens.empty?
 
@@ -659,7 +682,7 @@ module Herb
         last_value = @tokens.last[1]
 
         if last_type == :text
-          last_value.empty? || last_value.end_with?("\n") || (last_value.match?(WHITESPACE_ONLY) && preceding_token_ends_with_newline?) || last_value.match?(TRAILING_INDENTATION)
+          last_value.empty? || last_value.end_with?("\n") || (whitespace_only?(last_value) && preceding_token_ends_with_newline?) || trailing_indentation?(last_value)
         elsif EXPRESSION_TOKEN_TYPES.include?(last_type)
           @last_trim_consumed_newline
         else
@@ -715,7 +738,7 @@ module Herb
 
         text = token[1]
 
-        return Regexp.last_match(1) if text =~ TRAILING_INDENTATION_CAPTURE || text =~ WHITESPACE_ONLY_CAPTURE
+        return trailing_spaces(text) if trailing_indentation?(text) || whitespace_only?(text)
 
         ""
       end
@@ -726,9 +749,9 @@ module Herb
 
         text = token[1]
 
-        return true if text.match?(TRAILING_INDENTATION)
+        return true if trailing_indentation?(text)
 
-        text.match?(WHITESPACE_ONLY) && (preceding_text_ends_with_newline? || @last_trim_consumed_newline)
+        whitespace_only?(text) && (preceding_text_ends_with_newline? || @last_trim_consumed_newline)
       end
 
       def preceding_text_ends_with_newline?
@@ -745,9 +768,9 @@ module Herb
 
         text = @tokens.last[1]
 
-        if text.match?(TRAILING_INDENTATION)
-          text.sub!(TRAILING_WHITESPACE, "")
-        elsif text.match?(WHITESPACE_ONLY)
+        if trailing_indentation?(text)
+          remove_trailing_spaces!(text)
+        elsif whitespace_only?(text)
           text.replace("")
         end
 
@@ -819,12 +842,12 @@ module Herb
         return "" unless token
 
         text = token[1]
-        removed = text[TRAILING_WHITESPACE] || ""
+        removed = trailing_spaces(text)
 
-        if text.match?(TRAILING_INDENTATION)
-          text.sub!(TRAILING_WHITESPACE, "")
+        if trailing_indentation?(text)
+          remove_trailing_spaces!(text)
           token[1] = text
-        elsif text.match?(WHITESPACE_ONLY)
+        elsif whitespace_only?(text)
           text.replace("")
           token[1] = text
         end

--- a/sig/herb/engine/compiler.rbs
+++ b/sig/herb/engine/compiler.rbs
@@ -5,19 +5,11 @@ module Herb
     class Compiler < ::Herb::Visitor
       PADDING_NEWLINES: Array[String]
 
-      EXPRESSION_TOKEN_TYPES: untyped
+      EXPRESSION_TOKEN_TYPES: Array[Symbol]
 
-      TRAILING_WHITESPACE: ::Regexp
+      HORIZONTAL_SPACE: Array[String]
 
-      TRAILING_INDENTATION: ::Regexp
-
-      TRAILING_INDENTATION_CAPTURE: ::Regexp
-
-      WHITESPACE_ONLY: ::Regexp
-
-      WHITESPACE_ONLY_CAPTURE: ::Regexp
-
-      RAW_TEXT_ELEMENTS: untyped
+      RAW_TEXT_ELEMENTS: Array[String]
 
       attr_reader tokens: untyped
 
@@ -156,6 +148,21 @@ module Herb
       def should_escape_output?: (untyped opening) -> untyped
 
       def add_expression_with_escaping: (untyped code, untyped should_escape) -> untyped
+
+      # : (String) -> Integer
+      def trailing_space_length: (String) -> Integer
+
+      # : (String) -> String
+      def trailing_spaces: (String) -> String
+
+      # : (String) -> void
+      def remove_trailing_spaces!: (String) -> void
+
+      # : (String) -> bool
+      def whitespace_only?: (String) -> bool
+
+      # : (String) -> bool
+      def trailing_indentation?: (String) -> bool
 
       def at_line_start?: () -> untyped
 


### PR DESCRIPTION
CodeQL reports three high severity alerts on `lib/herb/engine/compiler.rb`, one for each of the regular expressions the compiler uses to find trailing whitespace in a token.

```
Polynomial regular expression used on uncontrolled data
This regular expression that depends on a library input may run slow on
strings with many repetitions of '\t'.
```

The alerts are wrong. Onigmo optimises an anchored match, so none of these degrade, measured on the shape the rule is worried about, a long run of tabs that is never followed by the end of the string.

| tabs | `sub`, `match?`, `match?` |
|---|---|
| 32,000 | 0.0015s |
| 128,000 | 0.0078s |
| 512,000 | 0.0348s |

Four times the input for four and a half times the work, at every size. Half a million tabs takes 35 ms.

They are still worth removing. The rule cannot see what Onigmo does, so it will keep failing the check on every pull request, and what these expressions ask for is simpler to say directly than to read out of a pattern.

```ruby
def trailing_space_length(text)
  count = 0
  count += 1 while count < text.length && HORIZONTAL_SPACE.include?(text[text.length - 1 - count])

  count
end
```

`trailing_spaces`, `remove_trailing_spaces!`, `whitespace_only?` and `trailing_indentation?` are written on top of it, and the five regular expressions are gone.