### PR TITLE
Engine: Keep the line a multi-line control tag's code starts on

### DIFF
--- a/lib/herb/engine/compiler.rb
+++ b/lib/herb/engine/compiler.rb
@@ -235,7 +235,10 @@ module Herb
 
       def visit_erb_control_node(node, &)
         if node.content
+          code_index = @tokens.length
+
           apply_trim(node, node.content.value.strip)
+          keep_line_count(node, at: code_index)
         end
 
         yield if block_given?

--- a/test/engine/whitespace_trimming_test.rb
+++ b/test/engine/whitespace_trimming_test.rb
@@ -466,5 +466,11 @@ module Engine
 
       assert_includes engine.src, "'\nafter\n'"
     end
+
+    test "a multi-line control tag keeps the line its code starts on" do
+      template = "<%\n  if true %>\n<%= \"text\" %>\n<% end %>\n"
+
+      assert_compiled_snapshot(template)
+    end
   end
 end

--- a/test/snapshots/engine/whitespace_trimming_test/test_0058_a_multi-line_control_tag_keeps_the_line_its_code_starts_on_3e244deacf6f5b706343e159308fc57d.txt
+++ b/test/snapshots/engine/whitespace_trimming_test/test_0058_a_multi-line_control_tag_keeps_the_line_its_code_starts_on_3e244deacf6f5b706343e159308fc57d.txt
@@ -1,0 +1,9 @@
+---
+source: "Engine::WhitespaceTrimmingTest#test_0058_a multi-line control tag keeps the line its code starts on"
+input: "{source: \"<%\\n  if true %>\\n<%= \\\"text\\\" %>\\n<% end %>\\n\", options: {}}"
+---
+_buf = ::String.new; 
+ if true 
+ _buf << ("text").to_s; _buf << '
+'.freeze; end 
+_buf.to_s


### PR DESCRIPTION
#2486 taught the compiler to pad for the newlines a tag carries before its code, so that a tag written across lines compiles onto the line its code starts on. 

That landed in `process_erb_tag`, which a control tag never reaches. `visit_erb_control_node` calls `apply_trim` directly and counted nothing, so `if`, `unless`, `case`, `when`, `else`, `end` and the rest lost every newline written between their `<%` and their code.

```erb
<%
  if true %>
<%= "text" %>
<% end %>
```

`"text"` is written on line 3 and compiled to line 2. It now compiles to line 3.

A control tag written on one line carries no newlines, so it pads nothing and compiles exactly as before. That is every control tag in the suite, which is why no snapshot moves and why the gap survived #2486.

This one came from a corpus run. Of 3894 templates from `herb-corpus` that compile, 24 still had a tag that did not compile to the line it was written on, and 5 of those were a control tag opened on one line with its condition on the next. 