### PR TITLE
Engine: Only break the line after a heredoc that ends the tag

### DIFF
--- a/lib/herb/engine.rb
+++ b/lib/herb/engine.rb
@@ -321,7 +321,7 @@ module Herb
 
     def trailing_newline(code)
       return "\n" if Helpers.comment?(code)
-      return "\n" if Helpers.heredoc?(code)
+      return "\n" if Helpers.ends_on_heredoc_terminator?(code)
 
       ""
     end

--- a/lib/herb/engine/helpers.rb
+++ b/lib/herb/engine/helpers.rb
@@ -25,6 +25,15 @@ module Herb
       end
 
       #: (String) -> bool
+      def self.ends_on_heredoc_terminator?(code)
+        return false unless heredoc?(code)
+
+        terminators = code.scan(/<<[~-]?\s*['"`]?(\w+)/).flatten
+
+        terminators.any? && terminators.include?(code.lines.last.to_s.strip)
+      end
+
+      #: (String) -> bool
       def self.heredoc?(code)
         code.match?(/<<[~-]?\s*['"`]?\w/)
       end

--- a/sig/herb/engine/helpers.rbs
+++ b/sig/herb/engine/helpers.rbs
@@ -10,6 +10,9 @@ module Herb
       def self.without_trailing_spaces: (String) -> String
 
       # : (String) -> bool
+      def self.ends_on_heredoc_terminator?: (String) -> bool
+
+      # : (String) -> bool
       def self.heredoc?: (String) -> bool
 
       # : (String) -> String

--- a/test/engine/engine_test.rb
+++ b/test/engine/engine_test.rb
@@ -343,5 +343,11 @@ module Engine
     test "compilation with parser_options strict false" do
       assert_compiled_snapshot("<div>Hello</div>", parser_options: { strict: false })
     end
+
+    test "heredoc closed before the end of an output tag keeps the following line" do
+      template = "<%= part(\n  y: [<<-D]\n    text\n  D\n) %>\n<%= z %>\n"
+
+      assert_compiled_snapshot(template)
+    end
   end
 end

--- a/test/snapshots/engine/engine_test/test_0040_heredoc_closed_before_the_end_of_an_output_tag_keeps_the_following_line_649b70821c0feeb4ee8073f8504e6c2d.txt
+++ b/test/snapshots/engine/engine_test/test_0040_heredoc_closed_before_the_end_of_an_output_tag_keeps_the_following_line_649b70821c0feeb4ee8073f8504e6c2d.txt
@@ -1,0 +1,12 @@
+---
+source: "Engine::EngineTest#test_0040_heredoc closed before the end of an output tag keeps the following line"
+input: "{source: \"<%= part(\\n  y: [<<-D]\\n    text\\n  D\\n) %>\\n<%= z %>\\n\", options: {}}"
+---
+_buf = ::String.new; _buf << (part(
+  y: [<<-D]
+    text
+  D
+)).to_s; _buf << '
+'.freeze; _buf << (z).to_s; _buf << '
+'.freeze;
+_buf.to_s


### PR DESCRIPTION
An output tag whose code opens a heredoc is compiled with a newline before its closing paren, so that a heredoc terminator is never followed by `).to_s` on the same line.

```ruby
_buf << (<<~SQL
  select 1
SQL
).to_s
```

That newline was written for any code containing a heredoc, whether or not the heredoc was still open at the end of it. A tag that closes its heredoc and carries on compiled a line longer than it was written, and every tag below it followed.

```erb
<%= part(
  y: [<<-D]
    text
  D
) %>
<%= z %>
```

`z` is written on line 6 and compiled to line 7. It now compiles to line 6.

The newline is emitted when the code's last line is one of the terminators the code opened.

```ruby
def self.ends_on_heredoc_terminator?(code)
  return false unless heredoc?(code)

  terminators = code.scan(/<<[~-]?\s*['"`]?(\w+)/).flatten

  terminators.any? && terminators.include?(code.lines.last.to_s.strip)
end
```

A tag that ends on its terminator still gets the newline and still compiles to valid Ruby, escaped or not, as does a heredoc in a statement tag and a heredoc closed early. Those four shapes are checked against `RubyVM::InstructionSequence.compile`.

This came out of a corpus run. Of 3894 templates from `herb-corpus` that compile, 18 had a tag that did not compile to the line it was written on and no explicit `-%>` to explain it. Three were this, and 15 are left, all of them a block tag whose `<% end %>` shares a line with its opening.
