### PR TITLE
Engine: Add per-pass toggles to `OptimizeVisitor`

### DIFF
--- a/docs/docs/projects/engine.md
+++ b/docs/docs/projects/engine.md
@@ -847,6 +847,14 @@ The conditions compile onto the lines they were written on, so backtraces stay r
 
 The `herb compile --optimize` and `herb render --optimize` commands wire the visitor up from the command line. The engine keeps the buffer when the caller drives it through `preamble`, `postamble`, `bufval`, or `ensure`, and when a visitor recorded a diagnostic the compiled template still has to report.
 
+Every pass is on by default, and each can be left off on its own. `helpers: false` stops asking the parser to resolve helpers, `conditionals: false` stops asking it to unroll the postfix conditionals and ternaries it would have, `literals: false` keeps literal outputs dynamic, and `collapse: false` keeps the buffer for a template either collapse would have compiled without one:
+
+```ruby
+Herb::Engine::OptimizeVisitor.new(literals: false, collapse: false)
+```
+
+Turning a parser-side pass off only withdraws the visitor's request for the parser option behind it. A caller that asks for `action_view_helpers: true` through `parser_options` still gets the resolution the parser was asked for directly. Unrolling is also part of how the parser resolves helpers, since a helper behind a modifier has to come out of it first, so a modifier keeps its written shape only once `helpers` is off too.
+
 Replacing a helper call with its markup is the same thing as calling it only while the helper is the one it was resolved against. An application that defines its own `content_tag` gets the stock markup everywhere instead of its own, with nothing at the call site to say so. `verify` compiles a check into the template that reports a helper that has since been overwritten:
 
 ```ruby

--- a/lib/herb/engine/visitors/optimize_visitor.rb
+++ b/lib/herb/engine/visitors/optimize_visitor.rb
@@ -56,6 +56,21 @@ module Herb
     # would hold more than `DUPLICATION_LIMIT` times the template's static bytes, and the buffer
     # stays. A chain that sits beside another in the same scope keeps the buffer too.
     #
+    # Every pass is on by default, and each can be left off on its own. `helpers: false` stops
+    # asking the parser to resolve helpers, `conditionals: false` stops asking it to unroll the
+    # postfix conditionals and ternaries it would have, `literals: false` keeps literal outputs
+    # dynamic, and `collapse: false` keeps the buffer for a template either collapse above would
+    # have compiled without one:
+    #
+    #     Herb::Engine::OptimizeVisitor.new(literals: false, collapse: false)
+    #
+    # Turning a parser-side pass off only withdraws this visitor's request for the parser option
+    # behind it. A caller that asks for `action_view_helpers: true` through `parser_options` still
+    # gets the resolution the parser was asked for directly, and `verify` below still covers what
+    # it resolved. Unrolling is also part of how the parser resolves helpers, since a helper
+    # behind a modifier has to come out of it first, so a modifier keeps its written shape only
+    # once `helpers` is off too.
+    #
     # Replacing a helper call with its markup is only the same thing as calling it while the helper
     # is the one it was resolved against. An application that defines its own `content_tag` gets the
     # stock markup instead, everywhere, with nothing at the call site to say so. `verify` compiles a
@@ -93,10 +108,14 @@ module Herb
         true
       end
 
-      #: (?verify: bool) -> void
-      def initialize(verify: false)
+      #: (?helpers: bool, ?conditionals: bool, ?literals: bool, ?collapse: bool, ?verify: bool) -> void
+      def initialize(helpers: true, conditionals: true, literals: true, collapse: true, verify: false)
         super()
 
+        @helpers = helpers
+        @conditionals = conditionals
+        @literals = literals
+        @collapse = collapse
         @verify = verify
         @sources = {} #: Hash[String, Herb::Location?]
         @output_contexts = [] #: Array[Symbol]
@@ -104,9 +123,13 @@ module Herb
 
       #: () -> Hash[Symbol, untyped]
       def required_parser_options
-        return super unless @verify
+        options = super
 
-        super.merge(track_locations: true)
+        options.delete(:action_view_helpers) unless @helpers
+        options.delete(:transform_conditionals) unless @conditionals
+        options[:track_locations] = true if @verify
+
+        options
       end
 
       #: (Herb::AST::DocumentNode) -> void
@@ -124,6 +147,8 @@ module Herb
 
       #: (Herb::AST::Node) -> void
       def visit_node(node)
+        return unless @literals
+
         CHILD_LISTS.each do |name|
           next unless node.respond_to?(name)
 
@@ -156,6 +181,8 @@ module Herb
 
       #: (Herb::Engine, untyped) -> String?
       def compile_static_body(engine, compiler)
+        return unless @collapse
+
         text = compiler.static_template_text
 
         return engine.string_literal(text) if text
@@ -165,12 +192,27 @@ module Herb
 
       #: () -> String
       def inspect
-        return "#<#{self.class.name}>" unless @verify
+        toggles = non_default_toggles
 
-        "#<#{self.class.name} verify=true>"
+        return "#<#{self.class.name}>" if toggles.empty?
+
+        "#<#{self.class.name} #{toggles.join(" ")}>"
       end
 
       private
+
+      #: () -> Array[String]
+      def non_default_toggles
+        toggles = [] #: Array[String]
+
+        toggles << "helpers=false" unless @helpers
+        toggles << "conditionals=false" unless @conditionals
+        toggles << "literals=false" unless @literals
+        toggles << "collapse=false" unless @collapse
+        toggles << "verify=true" if @verify
+
+        toggles
+      end
 
       #: ((Herb::AST::HTMLElementNode | Herb::AST::HTMLConditionalElementNode)) -> Symbol?
       def element_output_context(node)

--- a/sig/herb/engine/visitors/optimize_visitor.rbs
+++ b/sig/herb/engine/visitors/optimize_visitor.rbs
@@ -49,6 +49,21 @@ module Herb
     # would hold more than `DUPLICATION_LIMIT` times the template's static bytes, and the buffer
     # stays. A chain that sits beside another in the same scope keeps the buffer too.
     #
+    # Every pass is on by default, and each can be left off on its own. `helpers: false` stops
+    # asking the parser to resolve helpers, `conditionals: false` stops asking it to unroll the
+    # postfix conditionals and ternaries it would have, `literals: false` keeps literal outputs
+    # dynamic, and `collapse: false` keeps the buffer for a template either collapse above would
+    # have compiled without one:
+    #
+    #     Herb::Engine::OptimizeVisitor.new(literals: false, collapse: false)
+    #
+    # Turning a parser-side pass off only withdraws this visitor's request for the parser option
+    # behind it. A caller that asks for `action_view_helpers: true` through `parser_options` still
+    # gets the resolution the parser was asked for directly, and `verify` below still covers what
+    # it resolved. Unrolling is also part of how the parser resolves helpers, since a helper
+    # behind a modifier has to come out of it first, so a modifier keeps its written shape only
+    # once `helpers` is off too.
+    #
     # Replacing a helper call with its markup is only the same thing as calling it while the helper
     # is the one it was resolved against. An application that defines its own `content_tag` gets the
     # stock markup instead, everywhere, with nothing at the call site to say so. `verify` compiles a
@@ -83,8 +98,8 @@ module Herb
       # : () -> bool
       def self.rewrites_erb_source?: () -> bool
 
-      # : (?verify: bool) -> void
-      def initialize: (?verify: bool) -> void
+      # : (?helpers: bool, ?conditionals: bool, ?literals: bool, ?collapse: bool, ?verify: bool) -> void
+      def initialize: (?helpers: bool, ?conditionals: bool, ?literals: bool, ?collapse: bool, ?verify: bool) -> void
 
       # : () -> Hash[Symbol, untyped]
       def required_parser_options: () -> Hash[Symbol, untyped]
@@ -111,6 +126,9 @@ module Herb
       def inspect: () -> String
 
       private
+
+      # : () -> Array[String]
+      def non_default_toggles: () -> Array[String]
 
       # : ((Herb::AST::HTMLElementNode | Herb::AST::HTMLConditionalElementNode)) -> Symbol?
       def element_output_context: (Herb::AST::HTMLElementNode | Herb::AST::HTMLConditionalElementNode) -> Symbol?

--- a/test/engine/optimize_toggles_test.rb
+++ b/test/engine/optimize_toggles_test.rb
@@ -1,0 +1,119 @@
+# frozen_string_literal: true
+
+require_relative "../test_helper"
+require_relative "../snapshot_utils"
+require "herb/engine/visitors/optimize_visitor"
+
+module Engine
+  class OptimizeTogglesTest < Minitest::Spec
+    include SnapshotUtils
+
+    def optimize_options(toggles = {}, **options)
+      { visitors: [Herb::Engine::OptimizeVisitor.new(**toggles)], **options }
+    end
+
+    describe "the helpers pass" do
+      test "left off, a helper call stays for the renderer to make" do
+        assert_compiled_snapshot("<p><%= tag.br %></p>", optimize_options({ helpers: false }))
+      end
+
+      test "left off, it does not stand between the caller and the parser option" do
+        assert_compiled_snapshot(
+          "<p><%= tag.br %></p>",
+          optimize_options({ helpers: false }, parser_options: { action_view_helpers: true })
+        )
+      end
+
+      test "left off, verify finds nothing to guard" do
+        assert_compiled_snapshot("<p><%= tag.br %></p>", optimize_options({ helpers: false, verify: true }))
+      end
+    end
+
+    describe "the conditionals pass" do
+      test "left off alone, helpers still bring the unroll with them" do
+        assert_compiled_snapshot(%(<p><%= "yes" if flag %></p>), optimize_options({ conditionals: false }))
+      end
+
+      test "left off with helpers, a statement modifier stays the expression it was written as" do
+        assert_compiled_snapshot(%(<p><%= "yes" if flag %></p>), optimize_options({ helpers: false, conditionals: false }))
+      end
+    end
+
+    describe "the literals pass" do
+      test "left off, a literal output stays dynamic" do
+        assert_compiled_snapshot(%(<h1><%= "hello" %></h1>), optimize_options({ literals: false }))
+      end
+
+      test "left off, helpers still resolve" do
+        assert_compiled_snapshot(%(<p><%= tag.br %><%= "text" %></p>), optimize_options({ literals: false }))
+      end
+
+      test "left off, a template the helpers made static still collapses" do
+        assert_compiled_snapshot("<p><%= tag.br %></p>", optimize_options({ literals: false }))
+      end
+    end
+
+    describe "the collapse pass" do
+      test "left off, an HTML-only template keeps the buffer" do
+        assert_compiled_snapshot("<div>Static</div>", optimize_options({ collapse: false }))
+      end
+
+      test "left off, a conditional chain keeps the buffer" do
+        assert_compiled_snapshot(
+          "<% if signed_in? %><p>Hello</p><% else %><p>Bye</p><% end %>",
+          optimize_options({ collapse: false })
+        )
+      end
+
+      test "left off, literals still fold into the text around them" do
+        assert_compiled_snapshot(%(<h1><%= "hello" %></h1>), optimize_options({ collapse: false }))
+      end
+    end
+
+    describe "what inspect names" do
+      test "default construction names no toggles" do
+        assert_equal "#<Herb::Engine::OptimizeVisitor>", Herb::Engine::OptimizeVisitor.new.inspect
+      end
+
+      test "verify keeps the inspect it had" do
+        assert_equal "#<Herb::Engine::OptimizeVisitor verify=true>", Herb::Engine::OptimizeVisitor.new(verify: true).inspect
+      end
+
+      test "a pass left off is named" do
+        assert_equal "#<Herb::Engine::OptimizeVisitor helpers=false>", Herb::Engine::OptimizeVisitor.new(helpers: false).inspect
+      end
+
+      test "every non-default toggle is named" do
+        visitor = Herb::Engine::OptimizeVisitor.new(helpers: false, conditionals: false, literals: false, collapse: false, verify: true)
+
+        assert_equal "#<Herb::Engine::OptimizeVisitor helpers=false conditionals=false literals=false collapse=false verify=true>", visitor.inspect
+      end
+    end
+
+    describe "what the parser is asked for" do
+      test "every pass on requires both parser options" do
+        options = Herb::Engine::OptimizeVisitor.new.required_parser_options
+
+        assert_equal({ action_view_helpers: true, transform_conditionals: true }, options)
+      end
+
+      test "helpers left off drops its parser option" do
+        options = Herb::Engine::OptimizeVisitor.new(helpers: false).required_parser_options
+
+        assert_equal({ transform_conditionals: true }, options)
+      end
+
+      test "conditionals left off drops its parser option" do
+        options = Herb::Engine::OptimizeVisitor.new(conditionals: false).required_parser_options
+
+        assert_equal({ action_view_helpers: true }, options)
+      end
+
+      test "verify keeps requiring locations with the parser passes off" do
+        options = Herb::Engine::OptimizeVisitor.new(helpers: false, conditionals: false, verify: true).required_parser_options
+
+        assert_equal({ track_locations: true }, options)
+      end
+    end
+  end
+end

--- a/test/snapshots/engine/optimize_toggles_test/the_collapse_pass/test_0001_left_off,_an_HTML-only_template_keeps_the_buffer_c20e7fc7f2b8838aec5f947ae7d383b0.txt
+++ b/test/snapshots/engine/optimize_toggles_test/the_collapse_pass/test_0001_left_off,_an_HTML-only_template_keeps_the_buffer_c20e7fc7f2b8838aec5f947ae7d383b0.txt
@@ -1,0 +1,6 @@
+---
+source: "Engine::OptimizeTogglesTest::the collapse pass#test_0001_left off, an HTML-only template keeps the buffer"
+input: "{source: \"<div>Static</div>\", options: {visitors: [#<Herb::Engine::OptimizeVisitor collapse=false>]}}"
+---
+_buf = ::String.new; _buf << '<div>Static</div>'.freeze;
+_buf.to_s

--- a/test/snapshots/engine/optimize_toggles_test/the_collapse_pass/test_0002_left_off,_a_conditional_chain_keeps_the_buffer_16ba90743efb7e273be0b3504db1a85d.txt
+++ b/test/snapshots/engine/optimize_toggles_test/the_collapse_pass/test_0002_left_off,_a_conditional_chain_keeps_the_buffer_16ba90743efb7e273be0b3504db1a85d.txt
@@ -1,0 +1,6 @@
+---
+source: "Engine::OptimizeTogglesTest::the collapse pass#test_0002_left off, a conditional chain keeps the buffer"
+input: "{source: \"<% if signed_in? %><p>Hello</p><% else %><p>Bye</p><% end %>\", options: {visitors: [#<Herb::Engine::OptimizeVisitor collapse=false>]}}"
+---
+_buf = ::String.new; if signed_in? ; _buf << '<p>Hello</p>'.freeze; else; _buf << '<p>Bye</p>'.freeze; end;
+_buf.to_s

--- a/test/snapshots/engine/optimize_toggles_test/the_collapse_pass/test_0003_left_off,_literals_still_fold_into_the_text_around_them_a95380e7e4d1ec3fd3df6df7b1b0844f.txt
+++ b/test/snapshots/engine/optimize_toggles_test/the_collapse_pass/test_0003_left_off,_literals_still_fold_into_the_text_around_them_a95380e7e4d1ec3fd3df6df7b1b0844f.txt
@@ -1,0 +1,6 @@
+---
+source: "Engine::OptimizeTogglesTest::the collapse pass#test_0003_left off, literals still fold into the text around them"
+input: "{source: \"<h1><%= \\\"hello\\\" %></h1>\", options: {visitors: [#<Herb::Engine::OptimizeVisitor collapse=false>]}}"
+---
+_buf = ::String.new; _buf << '<h1>hello</h1>'.freeze;
+_buf.to_s

--- a/test/snapshots/engine/optimize_toggles_test/the_conditionals_pass/test_0001_left_off_alone,_helpers_still_bring_the_unroll_with_them_91237b15856861ec5d87d2d7709151b8.txt
+++ b/test/snapshots/engine/optimize_toggles_test/the_conditionals_pass/test_0001_left_off_alone,_helpers_still_bring_the_unroll_with_them_91237b15856861ec5d87d2d7709151b8.txt
@@ -1,0 +1,5 @@
+---
+source: "Engine::OptimizeTogglesTest::the conditionals pass#test_0001_left off alone, helpers still bring the unroll with them"
+input: "{source: \"<p><%= \\\"yes\\\" if flag %></p>\", options: {visitors: [#<Herb::Engine::OptimizeVisitor conditionals=false>]}}"
+---
+if flag; "<p>yes</p>".freeze; else "<p></p>".freeze;end;

--- a/test/snapshots/engine/optimize_toggles_test/the_conditionals_pass/test_0002_left_off_with_helpers,_a_statement_modifier_stays_the_expression_it_was_written_as_df15eb89eb665e8705f0929b4d0b62d4.txt
+++ b/test/snapshots/engine/optimize_toggles_test/the_conditionals_pass/test_0002_left_off_with_helpers,_a_statement_modifier_stays_the_expression_it_was_written_as_df15eb89eb665e8705f0929b4d0b62d4.txt
@@ -1,0 +1,6 @@
+---
+source: "Engine::OptimizeTogglesTest::the conditionals pass#test_0002_left off with helpers, a statement modifier stays the expression it was written as"
+input: "{source: \"<p><%= \\\"yes\\\" if flag %></p>\", options: {visitors: [#<Herb::Engine::OptimizeVisitor helpers=false conditionals=false>]}}"
+---
+_buf = ::String.new; _buf << '<p>'.freeze; _buf << ("yes" if flag).to_s; _buf << '</p>'.freeze;
+_buf.to_s

--- a/test/snapshots/engine/optimize_toggles_test/the_helpers_pass/test_0001_left_off,_a_helper_call_stays_for_the_renderer_to_make_b60dd29f98e97c321fa21e07d6b2beab.txt
+++ b/test/snapshots/engine/optimize_toggles_test/the_helpers_pass/test_0001_left_off,_a_helper_call_stays_for_the_renderer_to_make_b60dd29f98e97c321fa21e07d6b2beab.txt
@@ -1,0 +1,6 @@
+---
+source: "Engine::OptimizeTogglesTest::the helpers pass#test_0001_left off, a helper call stays for the renderer to make"
+input: "{source: \"<p><%= tag.br %></p>\", options: {visitors: [#<Herb::Engine::OptimizeVisitor helpers=false>]}}"
+---
+_buf = ::String.new; _buf << '<p>'.freeze; _buf << (tag.br).to_s; _buf << '</p>'.freeze;
+_buf.to_s

--- a/test/snapshots/engine/optimize_toggles_test/the_helpers_pass/test_0002_left_off,_it_does_not_stand_between_the_caller_and_the_parser_option_22a13014cc6c8bc7e7ce3d73f96e2425.txt
+++ b/test/snapshots/engine/optimize_toggles_test/the_helpers_pass/test_0002_left_off,_it_does_not_stand_between_the_caller_and_the_parser_option_22a13014cc6c8bc7e7ce3d73f96e2425.txt
@@ -1,0 +1,5 @@
+---
+source: "Engine::OptimizeTogglesTest::the helpers pass#test_0002_left off, it does not stand between the caller and the parser option"
+input: "{source: \"<p><%= tag.br %></p>\", options: {visitors: [#<Herb::Engine::OptimizeVisitor helpers=false>], parser_options: {action_view_helpers: true}}}"
+---
+'<p><br></p>'.freeze

--- a/test/snapshots/engine/optimize_toggles_test/the_helpers_pass/test_0003_left_off,_verify_finds_nothing_to_guard_a3236bb53347e3a6b7dd668c8ff3d98f.txt
+++ b/test/snapshots/engine/optimize_toggles_test/the_helpers_pass/test_0003_left_off,_verify_finds_nothing_to_guard_a3236bb53347e3a6b7dd668c8ff3d98f.txt
@@ -1,0 +1,6 @@
+---
+source: "Engine::OptimizeTogglesTest::the helpers pass#test_0003_left off, verify finds nothing to guard"
+input: "{source: \"<p><%= tag.br %></p>\", options: {visitors: [#<Herb::Engine::OptimizeVisitor helpers=false verify=true>]}}"
+---
+_buf = ::String.new; _buf << '<p>'.freeze; _buf << (tag.br).to_s; _buf << '</p>'.freeze;
+_buf.to_s

--- a/test/snapshots/engine/optimize_toggles_test/the_literals_pass/test_0001_left_off,_a_literal_output_stays_dynamic_c728de8ff24f6e606ef271b7a248edab.txt
+++ b/test/snapshots/engine/optimize_toggles_test/the_literals_pass/test_0001_left_off,_a_literal_output_stays_dynamic_c728de8ff24f6e606ef271b7a248edab.txt
@@ -1,0 +1,6 @@
+---
+source: "Engine::OptimizeTogglesTest::the literals pass#test_0001_left off, a literal output stays dynamic"
+input: "{source: \"<h1><%= \\\"hello\\\" %></h1>\", options: {visitors: [#<Herb::Engine::OptimizeVisitor literals=false>]}}"
+---
+_buf = ::String.new; _buf << '<h1>'.freeze; _buf << ("hello").to_s; _buf << '</h1>'.freeze;
+_buf.to_s

--- a/test/snapshots/engine/optimize_toggles_test/the_literals_pass/test_0002_left_off,_helpers_still_resolve_ba509d86af9c2cdf2d3667c7a87c76f3.txt
+++ b/test/snapshots/engine/optimize_toggles_test/the_literals_pass/test_0002_left_off,_helpers_still_resolve_ba509d86af9c2cdf2d3667c7a87c76f3.txt
@@ -1,0 +1,6 @@
+---
+source: "Engine::OptimizeTogglesTest::the literals pass#test_0002_left off, helpers still resolve"
+input: "{source: \"<p><%= tag.br %><%= \\\"text\\\" %></p>\", options: {visitors: [#<Herb::Engine::OptimizeVisitor literals=false>]}}"
+---
+_buf = ::String.new; _buf << '<p><br>'.freeze; _buf << ("text").to_s; _buf << '</p>'.freeze;
+_buf.to_s

--- a/test/snapshots/engine/optimize_toggles_test/the_literals_pass/test_0003_left_off,_a_template_the_helpers_made_static_still_collapses_013594651bbec5816ea1635763f62fd9.txt
+++ b/test/snapshots/engine/optimize_toggles_test/the_literals_pass/test_0003_left_off,_a_template_the_helpers_made_static_still_collapses_013594651bbec5816ea1635763f62fd9.txt
@@ -1,0 +1,5 @@
+---
+source: "Engine::OptimizeTogglesTest::the literals pass#test_0003_left off, a template the helpers made static still collapses"
+input: "{source: \"<p><%= tag.br %></p>\", options: {visitors: [#<Herb::Engine::OptimizeVisitor literals=false>]}}"
+---
+'<p><br></p>'.freeze


### PR DESCRIPTION
Follow up on #2494 and #2497.

This pull request adds constructor keywords to `Herb::Engine::OptimizeVisitor` so each of its optimization passes can be left off on its own. Every pass stays on by default, so `OptimizeVisitor.new` compiles exactly what it did before.

```ruby
Herb::Engine.new(source, visitors: [
  Herb::Engine::OptimizeVisitor.new(literals: false, collapse: false)
])
```

The parser-side toggles work through the instance-level `required_parser_options` override that `verify` already used for `track_locations`. Turning one off deletes the option from what the visitor requires, and nothing more. A caller that asks for `action_view_helpers: true` through `parser_options` still gets the resolution the parser was asked for directly, and `verify` still guards whatever it resolved, since collection keys off the `element_source` the parser stamps.

One coupling falls out of the parser, not this visitor. The conditional unroll runs when either `transform_conditionals` or `action_view_helpers` is set, because resolving a helper behind a statement modifier needs the unroll first. So `conditionals: false` on its own still compiles an unrolled template while `helpers` stays on, and a modifier keeps its written shape only once both are off. The docs state this and a snapshot pins it down.