### PR TITLE
Engine: Take back the whitespace trim along with the newline

### DIFF
--- a/lib/herb/engine/compiler.rb
+++ b/lib/herb/engine/compiler.rb
@@ -26,6 +26,7 @@ module Herb
         @trim_next_whitespace = false
         @last_trim_consumed_newline = false
         @pending_trim_newline_index = nil #: Integer?
+        @pending_trim_owns_next_whitespace = false
         @pending_leading_whitespace = nil
         @pending_leading_whitespace_insert_index = 0
         @current_element_source = nil
@@ -611,14 +612,14 @@ module Herb
       end
 
       def process_erb_output(node, opening, code)
-        settle_pending_trim_newline!(false)
-
         if @trim_next_whitespace && @pending_leading_whitespace
           restore_pending_leading_whitespace!
           @pending_leading_whitespace = nil
           @trim_next_whitespace = false
           @last_trim_consumed_newline = false
         end
+
+        settle_pending_trim_newline!(false)
 
         should_escape = should_escape_output?(opening)
         add_expression_with_escaping(code, should_escape)
@@ -802,8 +803,12 @@ module Herb
           @pending_leading_whitespace_insert_index = @tokens.length
           @pending_leading_whitespace = effective_leading_space if !effective_leading_space.empty? && follows_newline
           @tokens << [:code, "#{effective_leading_space}#{code}#{right_space}", current_context]
-          @pending_trim_newline_index = @tokens.length - 1 if right_space.end_with?(" \n")
           @trim_next_whitespace = true
+
+          if right_space.end_with?(" \n")
+            @pending_trim_newline_index = @tokens.length - 1
+            @pending_trim_owns_next_whitespace = true
+          end
         else
           @tokens << [:code, code, current_context]
         end
@@ -822,11 +827,15 @@ module Herb
 
         return unless index
 
+        owned = @pending_trim_owns_next_whitespace
+
         @pending_trim_newline_index = nil
+        @pending_trim_owns_next_whitespace = false
 
         return if keep
 
         @tokens[index][1] = @tokens[index][1].chomp
+        @trim_next_whitespace = false if owned
       end
 
       def save_pending_leading_whitespace!(whitespace)
@@ -838,6 +847,11 @@ module Herb
         return unless @pending_leading_whitespace
 
         @tokens.insert(@pending_leading_whitespace_insert_index, [:text, @pending_leading_whitespace, current_context])
+
+        return unless @pending_trim_newline_index
+        return if @pending_trim_newline_index < @pending_leading_whitespace_insert_index
+
+        @pending_trim_newline_index += 1
       end
 
       def remove_trailing_whitespace_from_last_token!

--- a/test/engine/whitespace_trimming_test.rb
+++ b/test/engine/whitespace_trimming_test.rb
@@ -472,5 +472,11 @@ module Engine
 
       assert_compiled_snapshot(template)
     end
+
+    test "a block tag closed on its own line keeps the blank line after it" do
+      template = "<% a = 1 %>\n\n<% provide :t do %><%= x %><% end %>\n\n<% b = 2 %>\n"
+
+      assert_compiled_snapshot(template)
+    end
   end
 end

--- a/test/snapshots/engine/whitespace_trimming_test/test_0059_a_block_tag_closed_on_its_own_line_keeps_the_blank_line_after_it_dc68f4b85df3f6d1d8faa0961cc64844.txt
+++ b/test/snapshots/engine/whitespace_trimming_test/test_0059_a_block_tag_closed_on_its_own_line_keeps_the_blank_line_after_it_dc68f4b85df3f6d1d8faa0961cc64844.txt
@@ -1,0 +1,10 @@
+---
+source: "Engine::WhitespaceTrimmingTest#test_0059_a block tag closed on its own line keeps the blank line after it"
+input: "{source: \"<% a = 1 %>\\n\\n<% provide :t do %><%= x %><% end %>\\n\\n<% b = 2 %>\\n\", options: {}}"
+---
+_buf = ::String.new; a = 1 
+ _buf << '
+'.freeze; provide :t do ; _buf << (x).to_s; end; _buf << '
+
+'.freeze; b = 2 
+_buf.to_s


### PR DESCRIPTION
Follow up on #2489.

#2489 has the compiler emit the newline after a trimmed statement tag and take it back once something shows the tag did not end its line. Emitting the newline is only half of what that tag did. It also set `@trim_next_whitespace`, so that the newline it was about to swallow would be swallowed. Taking the newline back left that standing, and the swallow happened anyway, several tokens later.

```erb
<% a = 1 %>

<% provide :t do %><%= x %><% end %>

<% b = 2 %>
```

The `do` tag begins a line, so it emits a newline and arms the trim. The expression that follows shows it did not end its line, so the newline is taken back, but the armed trim survives the expression and the `end` and eats one of the two newlines below them. `b = 2` is written on line 5 and compiled to line 4.

The trim is now retracted with the newline that armed it.

```ruby
if right_space.end_with?(" \n")
  @pending_trim_newline_index = @tokens.length - 1
  @pending_trim_owns_next_whitespace = true
end
```

Only a trim the pending tag armed itself is taken back. A trim armed by an earlier tag, by a right trim, or by a comment is left alone, which is what keeps `<% end %>` and the `unless` below it on separate lines.

Two orderings matter and both took a wrong turn first.

`process_erb_output` restores the leading whitespace it swallowed before retracting the newline, not after. Retracting first clears the armed trim, and the restore is written to run only while that trim is armed, so the indentation was dropped and the tag merged onto the line above.

`restore_pending_leading_whitespace!` inserts that whitespace at the index the pending tag sits on, so the pending index has to move with it. Without that, the retraction chomps the inserted whitespace and leaves the tag's newline in place.

This is the last shape the corpus reported. Of 3894 templates from `herb-corpus` that compile, 88 had a tag that did not compile to the line it was written on when this run started. 11 do now, and 35 more are an explicit `-%>` removing a newline the author asked it to remove.
