### PR TITLE
Engine: Keep the line a multi-line block opening's body starts on

### DIFF
--- a/lib/herb/engine/compiler.rb
+++ b/lib/herb/engine/compiler.rb
@@ -316,12 +316,15 @@ module Herb
         if opening.include?("=")
           should_escape = should_escape_output?(opening)
           code = ::Herb::Engine::Helpers.strip_trailing_comment(node.content.value.strip)
+          code_index = @tokens.length
 
           @tokens << if should_escape
                        [:expr_block_escaped, code, current_context]
                      else
                        [:expr_block, code, current_context]
                      end
+
+          keep_line_count(node, at: code_index)
 
           @last_trim_consumed_newline = false
           @trim_next_whitespace = true if right_trim?(node)

--- a/test/engine/engine_block_test.rb
+++ b/test/engine/engine_block_test.rb
@@ -155,5 +155,11 @@ module Engine
 
       assert_compiled_snapshot(template)
     end
+
+    test "a multi-line block opening keeps the line its body starts on" do
+      template = "<%=\n  render(\n    x\n  ) do |c|\n%>\n  <%= c %>\n<% end %>\n"
+
+      assert_compiled_snapshot(template)
+    end
   end
 end

--- a/test/snapshots/engine/engine_block_test/test_0018_a_multi-line_block_opening_keeps_the_line_its_body_starts_on_9b1895e929e72ae1e0045cfc87aa1c40.txt
+++ b/test/snapshots/engine/engine_block_test/test_0018_a_multi-line_block_opening_keeps_the_line_its_body_starts_on_9b1895e929e72ae1e0045cfc87aa1c40.txt
@@ -1,0 +1,12 @@
+---
+source: "Engine::EngineBlockTest#test_0018_a multi-line block opening keeps the line its body starts on"
+input: "{source: \"<%=\\n  render(\\n    x\\n  ) do |c|\\n%>\\n  <%= c %>\\n<% end %>\\n\", options: {}}"
+---
+_buf = ::String.new; 
+ _buf << (render(
+    x
+  ) do |c|; _buf << '
+  '.freeze; 
+ _buf << (c).to_s; _buf << '
+'.freeze; end )
+_buf.to_s


### PR DESCRIPTION
#2486 taught the compiler to pad for the newlines a tag carries before its code. #2496 gave that to control tags, which reach the compiler through `visit_erb_control_node` instead of `process_erb_tag` and were counting nothing. A block opening is the third way a tag reaches the compiler, through `visit_erb_block_node`, and it was counting nothing either.

```erb
<%=
  render(
    x
  ) do |c|
%>
  <%= c %>
<% end %>
```

`c` is written on line 6 and compiled to line 2. It now compiles to line 6.

```ruby
code_index = @tokens.length

@tokens << if should_escape
             [:expr_block_escaped, code, current_context]
           else
             [:expr_block, code, current_context]
           end

keep_line_count(node, at: code_index)
```

A block opening written on one line carries no newlines, so it pads nothing and compiles exactly as before. That is every block opening in the suite, which is why no snapshot moves and why the gap survived both earlier fixes.

Of 3894 templates from `herb-corpus` that compile, 11 had a tag that did not compile to the line it was written on and no explicit `-%>` to explain it. 8 do now. What is left needs the tag's surroundings to reproduce, multi-line HTML tags and attributes split across lines, rather than a shape that can be written down on its own.
