### PR TITLE
Engine: Refuse `herb:state` conditions that are always true or false

### DIFF
--- a/config/state/kind.yml
+++ b/config/state/kind.yml
@@ -35,6 +35,7 @@ kinds:
     literal: true
     value: true
     falsy: true
+    nilable: true
 
   - name: "array"
     article: "an Array"
@@ -54,6 +55,7 @@ kinds:
     value: true
     unknown: true
     falsy: true
+    nilable: true
 
   - name: "missing"
     article: "a value"

--- a/javascript/packages/client/src/directives.ts
+++ b/javascript/packages/client/src/directives.ts
@@ -12,10 +12,11 @@ export { ACTION_SCHEMA, ACTION_NAMES, HERB_ATTRIBUTES } from "./grammar/attribut
 export { STATE_PREDICATES, STATE_PREDICATE_NAMES } from "./state-predicates"
 export { STATE_TRANSFORMS, STATE_TRANSFORM_NAMES } from "./state-transforms"
 export { MIRRORED_COMPARISONS, NEGATED_COMPARISONS, ORDERED_COMPARISONS, COMPARISON_OPERATORS } from "./state-operators"
-export { STATE_DEFAULT_KINDS, LITERAL_STATE_KINDS, UNKNOWN_STATE_KINDS, FALSY_STATE_KINDS, PRISM_LITERAL_KINDS, stateKindArticle } from "./state-kinds"
+export { STATE_DEFAULT_KINDS, LITERAL_STATE_KINDS, UNKNOWN_STATE_KINDS, FALSY_STATE_KINDS, NILABLE_STATE_KINDS, PRISM_LITERAL_KINDS } from "./state-kinds"
 
-export { clauses, names, balancedQuotes, splitOutsideQuotes, unquote } from "./grammar/parsing"
+export { stateKindArticle } from "./state-kinds"
 export { isMarker, parseMarker } from "./markup/markers"
+export { clauses, names, balancedQuotes, splitOutsideQuotes, unquote } from "./grammar/parsing"
 
 export type { Clause } from "./grammar/parsing"
 export type { StatePredicate } from "./state-predicates"

--- a/javascript/packages/linter/src/rules/herb-state-valid-reads.ts
+++ b/javascript/packages/linter/src/rules/herb-state-valid-reads.ts
@@ -2,7 +2,7 @@ import { ParserRule } from "../types.js"
 import { BaseRuleVisitor } from "../utils/rule-utils.js"
 import { StateScopeMap } from "../utils/state-directives-utils.js"
 
-import { COMPARISON_OPERATORS, FALSY_STATE_KINDS, PRISM_LITERAL_KINDS, STATE_PREDICATES, STATE_TRANSFORMS } from "@herb-tools/client/directives"
+import { COMPARISON_OPERATORS, FALSY_STATE_KINDS, NILABLE_STATE_KINDS, PRISM_LITERAL_KINDS, STATE_PREDICATES, STATE_TRANSFORMS } from "@herb-tools/client/directives"
 
 import { declaredKind, defaultExample, kindWithArticle, predicateAdvice } from "../utils/state-directives-utils.js"
 import { bareReadName, classifyDerivedDefault, mentionsAnyState, predicateAnswers, transformApplies } from "@herb-tools/client/directives"
@@ -380,6 +380,12 @@ class StateValidReadsVisitor extends BaseRuleVisitor {
         return "reported"
       }
 
+      if (STATE_PREDICATES[call.predicate].comparand === "nil" && !NILABLE_STATE_KINDS.has(kind)) {
+        this.nilCheckOffense(predicate, declaration, kind, "can never match")
+
+        return "reported"
+      }
+
       return "state"
     }
 
@@ -551,6 +557,12 @@ class StateValidReadsVisitor extends BaseRuleVisitor {
           return "reported"
         }
 
+        if (!ordered && comparandKind === "nil" && !NILABLE_STATE_KINDS.has(kind)) {
+          this.nilCheckOffense(predicate, declaration, kind, operator === "!=" ? "always matches" : "can never match")
+
+          return "reported"
+        }
+
         if (!ordered && kind !== "seeded" && comparandKind !== "nil" && comparandKind !== kind) {
           const consequence = operator === "==" ? "so it can never match" : "so it always matches"
 
@@ -578,6 +590,13 @@ class StateValidReadsVisitor extends BaseRuleVisitor {
     }
 
     return "other"
+  }
+
+  private nilCheckOffense(predicate: PrismNode, declaration: StateDeclaration, kind: string, consequence: string): void {
+    this.addOffense(
+      `\`${this.sliceOf(predicate)}\` reads the ${capitalize(kind)} state \`${declaration.name}\` as a nil check. Only a Nil state can be nil, so it ${consequence}. ${predicateAdvice(kind, declaration.name)}compare it to a literal${defaultExample(declaration, `${declaration.name} == `)}, or declare it with a \`nil\` default.`,
+      this.locationOf(predicate),
+    )
   }
 
   private checkNeverFalsy(predicate: PrismNode, spelled: string, answer: string): boolean {

--- a/javascript/packages/linter/src/rules/herb-state-valid-reads.ts
+++ b/javascript/packages/linter/src/rules/herb-state-valid-reads.ts
@@ -4,7 +4,7 @@ import { StateScopeMap } from "../utils/state-directives-utils.js"
 
 import { COMPARISON_OPERATORS, FALSY_STATE_KINDS, PRISM_LITERAL_KINDS, STATE_PREDICATES, STATE_TRANSFORMS } from "@herb-tools/client/directives"
 
-import { declaredKind, kindWithArticle } from "../utils/state-directives-utils.js"
+import { declaredKind, defaultExample, kindWithArticle, predicateAdvice } from "../utils/state-directives-utils.js"
 import { bareReadName, classifyDerivedDefault, mentionsAnyState, predicateAnswers, transformApplies } from "@herb-tools/client/directives"
 import { isBooleanAttribute, locationFromByteOffset, substringFromByteOffset } from "@herb-tools/core"
 import { getAttributeName, getAttributeValueNodes, isERBContentNode } from "@herb-tools/core"
@@ -227,7 +227,7 @@ class StateValidReadsVisitor extends BaseRuleVisitor {
     if (prismType(prism) === "UnlessNode" && prism.predicate) {
       const names = this.states.namesIn(this.stack)
 
-      if (names.length > 0) {
+      if (names.length > 0 && !this.checkNeverFalsy(prism.predicate, `unless ${this.sliceOf(prism.predicate)}`, "false")) {
         this.classifyPredicate(prism.predicate, names)
       }
     }
@@ -265,6 +265,8 @@ class StateValidReadsVisitor extends BaseRuleVisitor {
     while (prismType(current) === "IfNode") {
       const predicate = current.predicate
       if (!predicate) return
+
+      if (this.checkNeverFalsy(predicate, this.sliceOf(predicate), "true")) return
 
       const read = this.classifyPredicate(predicate, names)
       if (read === "reported") return
@@ -351,7 +353,7 @@ class StateValidReadsVisitor extends BaseRuleVisitor {
 
       if (!transformApplies(transformCall.transform, kind)) {
         this.addOffense(
-          `\`${this.sliceOf(predicate)}\` reads the ${capitalize(kind)} state \`${transformCall.name}\` with \`${transformCall.transform}\`. Only ${STATE_TRANSFORMS[transformCall.transform].only} can be read with \`${transformCall.transform}\`. Compare \`${transformCall.name}\` itself instead, like \`${transformCall.name} == ${declaration.defaultSource}\`.`,
+          `\`${this.sliceOf(predicate)}\` reads the ${capitalize(kind)} state \`${transformCall.name}\` with \`${transformCall.transform}\`. Only ${STATE_TRANSFORMS[transformCall.transform].only} can be read with \`${transformCall.transform}\`. Compare \`${transformCall.name}\` itself instead${defaultExample(declaration, `${transformCall.name} == `)}.`,
           this.locationOf(predicate),
         )
 
@@ -400,7 +402,7 @@ class StateValidReadsVisitor extends BaseRuleVisitor {
 
         if (!transformApplies(call.transform, kind)) {
           this.addOffense(
-            `\`${this.sliceOf(side)}\` reads the ${capitalize(kind)} state \`${call.name}\` with \`${call.transform}\`. Only ${STATE_TRANSFORMS[call.transform].only} can be read with \`${call.transform}\`. Compare \`${call.name}\` itself instead, like \`${call.name} == ${declaration.defaultSource}\`.`,
+            `\`${this.sliceOf(side)}\` reads the ${capitalize(kind)} state \`${call.name}\` with \`${call.transform}\`. Only ${STATE_TRANSFORMS[call.transform].only} can be read with \`${call.transform}\`. Compare \`${call.name}\` itself instead${defaultExample(declaration, `${call.name} == `)}.`,
             this.locationOf(side),
           )
 
@@ -519,7 +521,7 @@ class StateValidReadsVisitor extends BaseRuleVisitor {
         const kind = declaredKind(declaration)
 
         if (!comparandKind) {
-          const example = kind === "seeded" ? "" : `, like \`${declaration.name} == ${declaration.defaultSource}\``
+          const example = defaultExample(declaration, `${declaration.name} == `)
 
           this.addOffense(
             `\`${this.sliceOf(predicate)}\` compares the state \`${declaration.name}\` against \`${this.sliceOf(comparand)}\`, which is not a literal. The client resolves a comparison by looking the state up, so it has no value for the other side. Compare \`${declaration.name}\` to a literal${example}, or declare a state for \`${this.sliceOf(comparand)}\` and set it from app code.`,
@@ -553,7 +555,7 @@ class StateValidReadsVisitor extends BaseRuleVisitor {
           const consequence = operator === "==" ? "so it can never match" : "so it always matches"
 
           this.addOffense(
-            `\`${this.sliceOf(predicate)}\` compares the ${capitalize(kind)} state \`${declaration.name}\` against ${kindWithArticle(comparandKind)} literal, ${consequence}. Compare it against ${kindWithArticle(kind)} literal, like \`${declaration.name} == ${declaration.defaultSource}\`.`,
+            `\`${this.sliceOf(predicate)}\` compares the ${capitalize(kind)} state \`${declaration.name}\` against ${kindWithArticle(comparandKind)} literal, ${consequence}. Compare it against ${kindWithArticle(kind)} literal${defaultExample(declaration, `${declaration.name} == `)}.`,
             this.locationOf(predicate),
           )
 
@@ -578,6 +580,28 @@ class StateValidReadsVisitor extends BaseRuleVisitor {
     return "other"
   }
 
+  private checkNeverFalsy(predicate: PrismNode, spelled: string, answer: string): boolean {
+    const bare = prismBareRead(predicate)
+    const declaration = bare ? this.resolve(bare.name) : null
+
+    if (!declaration) {
+      return false
+    }
+
+    const kind = declaredKind(declaration)
+
+    if (FALSY_STATE_KINDS.has(kind)) {
+      return false
+    }
+
+    this.addOffense(
+      `\`${spelled}\` reads the ${capitalize(kind)} state \`${bare!.name}\` as a presence. Only \`nil\` and \`false\` are falsy in Ruby, so the condition is always ${answer}. ${predicateAdvice(kind, bare!.name)}compare it to a literal${defaultExample(declaration, `${bare!.name} == `)}, or declare it as a boolean.`,
+      this.locationOf(predicate),
+    )
+
+    return true
+  }
+
   private checkPresenceRead(expression: string, node: ERBContentNode): boolean {
     const bare = bareReadName(expression)
     const declaration = bare ? this.resolve(bare) : null
@@ -589,7 +613,7 @@ class StateValidReadsVisitor extends BaseRuleVisitor {
     if (FALSY_STATE_KINDS.has(kind)) return false
 
     this.addOffense(
-      `\`${this.attributeName}="<%= ${expression} %>"\` reads the ${capitalize(kind)} state \`${bare}\` as a presence. Only \`nil\` and \`false\` are falsy in Ruby, so the attribute could never turn off. Compare \`${bare}\` to a literal, like \`${bare} == ${declaration.defaultSource}\`, or declare it as a boolean.`,
+      `\`${this.attributeName}="<%= ${expression} %>"\` reads the ${capitalize(kind)} state \`${bare}\` as a presence. Only \`nil\` and \`false\` are falsy in Ruby, so the attribute could never turn off. ${predicateAdvice(kind, bare!)}compare it to a literal${defaultExample(declaration, `${bare} == `)}, or declare it as a boolean.`,
       node.location,
     )
 
@@ -638,7 +662,7 @@ class StateValidReadsVisitor extends BaseRuleVisitor {
 
         if (!comparandKind) {
           this.addOffense(
-            `\`when ${list}\` on the state \`${declaration.name}\` has a comparand that is not a literal. The client resolves a \`when\` by lookup. List literals instead, like \`when ${declaration.defaultSource}\`.`,
+            `\`when ${list}\` on the state \`${declaration.name}\` has a comparand that is not a literal. The client resolves a \`when\` by lookup. List literals instead${defaultExample(declaration, "when ")}.`,
             this.locationOf(condition),
           )
 
@@ -647,7 +671,7 @@ class StateValidReadsVisitor extends BaseRuleVisitor {
 
         if (kind !== "seeded" && comparandKind !== "nil" && comparandKind !== kind) {
           this.addOffense(
-            `\`when ${list}\` compares the ${capitalize(kind)} state \`${declaration.name}\` against a literal of another type, so it can never match. Use ${kindWithArticle(kind)} literal in every arm, like \`when ${declaration.defaultSource}\`.`,
+            `\`when ${list}\` compares the ${capitalize(kind)} state \`${declaration.name}\` against a literal of another type, so it can never match. Use ${kindWithArticle(kind)} literal in every arm${defaultExample(declaration, "when ")}.`,
             this.locationOf(condition),
           )
 
@@ -667,7 +691,7 @@ class StateValidReadsVisitor extends BaseRuleVisitor {
       return `Read \`${name}\` bare, like \`<% if ${name} %>\`, or as \`${name}?\`.`
     }
 
-    return `Read \`${name}\` bare, like \`<% if ${name} %>\`, or compare it to a literal, like \`${name} == ${declaration.defaultSource}\`.`
+    return `Read \`${name}\` bare, like \`<% if ${name} %>\`, or compare it to a literal${defaultExample(declaration, `${name} == `)}.`
   }
 
   private resolve(name: string): StateDeclaration | undefined {

--- a/javascript/packages/linter/src/utils/state-directives-utils.ts
+++ b/javascript/packages/linter/src/utils/state-directives-utils.ts
@@ -1,6 +1,9 @@
-import { Visitor } from "@herb-tools/core"
-import { isStateDirectiveContent, mentionsAnyState, parseStateDirective, slotsDirectiveModeOf } from "@herb-tools/client/directives"
+import { LITERAL_STATE_KINDS, STATE_PREDICATES } from "@herb-tools/client/directives"
 import { ACTION_NAMES, ACTION_SCHEMA, HERB_ATTRIBUTES } from "@herb-tools/client/directives"
+
+import { Visitor } from "@herb-tools/core"
+
+import { isStateDirectiveContent, mentionsAnyState, parseStateDirective, slotsDirectiveModeOf } from "@herb-tools/client/directives"
 
 import type { ERBBlockNode, ERBContentNode, ERBIfNode, Node } from "@herb-tools/core"
 import type { ActionName, ActionSchema, Clause, StateDeclaration, StateSignature } from "@herb-tools/client/directives"
@@ -63,6 +66,29 @@ export function declaredKind(declaration: StateDeclaration): "boolean" | "intege
     default:
       return "seeded"
   }
+}
+
+export function predicateAdvice(kind: string, name: string): string {
+  const spellings = Object.entries(STATE_PREDICATES).filter(([, entry]) => entry.kinds?.includes(kind)).map(([predicate]) => predicate)
+
+  if (spellings.length === 0) return ""
+
+  const listed = spellings.map((predicate, index) => index === 0 ? `\`${name}.${predicate}\`` : `\`.${predicate}\``)
+  const last = listed[listed.length - 1]
+
+  return `Ask ${listed.length === 1 ? last : `${listed.slice(0, -1).join(", ")} or ${last}`}, `
+}
+
+export function literalDefault(declaration: StateDeclaration): boolean {
+  if (declaration.derived !== undefined && declaration.derived !== null) return false
+
+  return LITERAL_STATE_KINDS.has(declaration.kind)
+}
+
+export function defaultExample(declaration: StateDeclaration, spelling: string): string {
+  if (!literalDefault(declaration)) return ""
+
+  return `, like \`${spelling}${declaration.defaultSource}\``
 }
 
 export { stateKindArticle as kindWithArticle } from "@herb-tools/client/directives"

--- a/javascript/packages/linter/test/rules/herb-state-valid-reads.test.ts
+++ b/javascript/packages/linter/test/rules/herb-state-valid-reads.test.ts
@@ -161,13 +161,39 @@ describe("HerbStateValidReadsRule", () => {
     `)
   })
 
-  test("allows the `?` spelling on a state of any kind", () => {
+  test("allows the `?` spelling on a state that can be falsy", () => {
     expectNoOffenses(dedent`
-      <%# herb:state (attempts: 0, draft: "", tab: :first, shown: draft?) %>
-      <% if attempts? %>Tried<% end %>
-      <% if draft? %>Drafted<% end %>
-      <% if tab? %>Tabbed<% end %>
+      <%# herb:state (pending: false, missing: nil, draft: "", shown: draft?) %>
+      <% if pending? %>Sending<% end %>
+      <% if missing? %>Missing<% end %>
       <% if shown %>Shown<% end %>
+    `)
+  })
+
+  test("flags a bare condition on a state that can never be falsy", () => {
+    expectError('`draft` reads the String state `draft` as a presence. Only `nil` and `false` are falsy in Ruby, so the condition is always true. Ask `draft.empty?`, `.blank?` or `.present?`, compare it to a literal, like `draft == ""`, or declare it as a boolean.')
+
+    assertOffenses(dedent`
+      <%# herb:state (draft: "") %>
+      <% if draft %>Drafted<% else %>Empty<% end %>
+    `)
+  })
+
+  test("flags the `?` spelling of that condition the same way", () => {
+    expectError("`attempts?` reads the Integer state `attempts` as a presence. Only `nil` and `false` are falsy in Ruby, so the condition is always true. Ask `attempts.zero?`, `.one?` or `.positive?`, compare it to a literal, like `attempts == 0`, or declare it as a boolean.")
+
+    assertOffenses(dedent`
+      <%# herb:state (attempts: 0) %>
+      <% if attempts? %>Tried<% end %>
+    `)
+  })
+
+  test("flags an `unless` on a state that can never be falsy", () => {
+    expectError("`unless tab` reads the Symbol state `tab` as a presence. Only `nil` and `false` are falsy in Ruby, so the condition is always false. Ask `tab.empty?`, compare it to a literal, like `tab == :first`, or declare it as a boolean.")
+
+    assertOffenses(dedent`
+      <%# herb:state (tab: :first) %>
+      <% unless tab %>Tabbed<% end %>
     `)
   })
 
@@ -266,7 +292,7 @@ describe("HerbStateValidReadsRule", () => {
   })
 
   test("flags a comparison against a derived state's inferred kind", () => {
-    expectError("`busy == 3` compares the Boolean state `busy` against an Integer literal, so it can never match. Compare it against a Boolean literal, like `busy == pending || failed`.")
+    expectError("`busy == 3` compares the Boolean state `busy` against an Integer literal, so it can never match. Compare it against a Boolean literal.")
 
     assertOffenses(dedent`
       <%# herb:state (pending: false, failed: false, busy: pending || failed) %>
@@ -354,7 +380,7 @@ describe("HerbStateValidReadsRule", () => {
   })
 
   test("flags a presence read of a state that is never falsy", () => {
-    expectError('`disabled="<%= draft %>"` reads the String state `draft` as a presence. Only `nil` and `false` are falsy in Ruby, so the attribute could never turn off. Compare `draft` to a literal, like `draft == ""`, or declare it as a boolean.')
+    expectError('`disabled="<%= draft %>"` reads the String state `draft` as a presence. Only `nil` and `false` are falsy in Ruby, so the attribute could never turn off. Ask `draft.empty?`, `.blank?` or `.present?`, compare it to a literal, like `draft == ""`, or declare it as a boolean.')
 
     assertOffenses(dedent`
       <%# herb:state (draft: "") %>
@@ -364,7 +390,7 @@ describe("HerbStateValidReadsRule", () => {
   })
 
   test("flags the predicate spelling of a presence read the same way", () => {
-    expectError('`disabled="<%= draft? %>"` reads the String state `draft` as a presence. Only `nil` and `false` are falsy in Ruby, so the attribute could never turn off. Compare `draft` to a literal, like `draft == ""`, or declare it as a boolean.')
+    expectError('`disabled="<%= draft? %>"` reads the String state `draft` as a presence. Only `nil` and `false` are falsy in Ruby, so the attribute could never turn off. Ask `draft.empty?`, `.blank?` or `.present?`, compare it to a literal, like `draft == ""`, or declare it as a boolean.')
 
     assertOffenses(dedent`
       <%# herb:state (draft: "") %>

--- a/javascript/packages/linter/test/rules/herb-state-valid-reads.test.ts
+++ b/javascript/packages/linter/test/rules/herb-state-valid-reads.test.ts
@@ -170,6 +170,32 @@ describe("HerbStateValidReadsRule", () => {
     `)
   })
 
+  test("flags a nil check on a state that can never be nil", () => {
+    expectError('`draft.nil?` reads the String state `draft` as a nil check. Only a Nil state can be nil, so it can never match. Ask `draft.empty?`, `.blank?` or `.present?`, compare it to a literal, like `draft == ""`, or declare it with a `nil` default.')
+
+    assertOffenses(dedent`
+      <%# herb:state (draft: "") %>
+      <% if draft.nil? %>x<% end %>
+    `)
+  })
+
+  test("flags the same nil check written as a comparison", () => {
+    expectError('`draft != nil` reads the String state `draft` as a nil check. Only a Nil state can be nil, so it always matches. Ask `draft.empty?`, `.blank?` or `.present?`, compare it to a literal, like `draft == ""`, or declare it with a `nil` default.')
+
+    assertOffenses(dedent`
+      <%# herb:state (draft: "") %>
+      <% if draft != nil %>x<% end %>
+    `)
+  })
+
+  test("allows a nil check on the kinds that really can be nil", () => {
+    expectNoOffenses(dedent`
+      <%# herb:state (missing: nil, thing: @thing) %>
+      <% if missing.nil? %>x<% end %>
+      <% if thing.nil? %>y<% end %>
+    `)
+  })
+
   test("flags a bare condition on a state that can never be falsy", () => {
     expectError('`draft` reads the String state `draft` as a presence. Only `nil` and `false` are falsy in Ruby, so the condition is always true. Ask `draft.empty?`, `.blank?` or `.present?`, compare it to a literal, like `draft == ""`, or declare it as a boolean.')
 
@@ -215,10 +241,10 @@ describe("HerbStateValidReadsRule", () => {
     `)
   })
 
-  test("allows a comparison against nil for any kind", () => {
+  test("allows a comparison against nil on a state that can hold one", () => {
     expectNoOffenses(dedent`
       <%# herb:state (error: nil, sort: "name") %>
-      <% if sort == nil %>Unset<% end %>
+      <% if error == nil %>Unset<% end %>
     `)
   })
 
@@ -567,7 +593,7 @@ describe("HerbStateValidReadsRule", () => {
       <% if draft.empty? %>Empty<% end %>
       <% if count.zero? %>None<% end %>
       <% if count.one? %>One<% end %>
-      <% if open.nil? %>Unset<% end %>
+      <% if note.nil? %>Unset<% end %>
       <% if note.blank? %>No note<% end %>
     `)
   })

--- a/lib/herb/engine/slots/state_compiler.rb
+++ b/lib/herb/engine/slots/state_compiler.rb
@@ -774,10 +774,14 @@ module Herb
 
           read = StateDirectives.condition_read(expression, states, @visitor, condition_anchor(node, expression))
 
+          return :reported if read == :reported
+
           return nil unless read.is_a?(StateDirectives::Read) || read.is_a?(StateDirectives::Combo)
 
           if read.is_a?(StateDirectives::Read) && read.comparand.nil? && read.against.nil? && read.operator.nil? && !StateKinds::FALSY.include?(read.kind)
-            return @visitor.slot_error("`#{slot.attribute}=\"<%= #{expression} %>\"` reads #{StateDirectives.subject_phrase(read)} as a presence. Only `nil` and `false` are falsy in Ruby, so the attribute could never turn off.", condition_anchor(node, expression).location, :read, suggestion: "#{StateDirectives.predicate_advice(read.kind, read.name)}compare it to a literal#{StateDirectives.default_example(states.fetch(read.name), "#{read.name} == ")}, or declare it as a boolean.")
+            @visitor.slot_error("`#{slot.attribute}=\"<%= #{expression} %>\"` reads #{StateDirectives.subject_phrase(read)} as a presence. Only `nil` and `false` are falsy in Ruby, so the attribute could never turn off.", condition_anchor(node, expression).location, :read, suggestion: "#{StateDirectives.predicate_advice(read.kind, read.name)}compare it to a literal#{StateDirectives.default_example(states.fetch(read.name), "#{read.name} == ")}, or declare it as a boolean.")
+
+            return :reported
           end
 
           open_tag = @visitor.open_tag_for(node)

--- a/lib/herb/engine/slots/state_compiler.rb
+++ b/lib/herb/engine/slots/state_compiler.rb
@@ -389,6 +389,10 @@ module Herb
               return @visitor.slot_error("`#{expression}` sits in a state-driven conditional but reads no state. The client resolves every arm, so an arm it cannot answer would never be chosen.", condition_anchor(arm, expression).location, :conditional, suggestion: "Read a state in this arm, or move this branch into its own conditional.")
             end
 
+            dead = StateDirectives.never_falsy_read(read)
+
+            return presence_error(expression, dead, states, condition_anchor(arm, expression), "true") if dead
+
             StateDirectives.read_names(read).each { |name| rewrite_predicate(arm, name) }
 
             arms << arm_entry(read, branch)
@@ -423,6 +427,10 @@ module Herb
 
           return nil unless read.is_a?(StateDirectives::Read) || read.is_a?(StateDirectives::Combo)
 
+          dead = StateDirectives.never_falsy_read(read)
+
+          return presence_error("unless #{expression}", dead, states, condition_anchor(node, expression), "false") if dead
+
           chain = @visitor.conditional_chain(node)
           else_position = chain.index { |arm| arm.is_a?(Herb::AST::ERBElseNode) }
 
@@ -433,6 +441,18 @@ module Herb
             else: 0,
             signature: signature_of(["!#{StateDirectives.condition_source(read)}@#{else_position}"], 0),
           }
+        end
+
+        #: (String, StateDirectives::Read, Hash[String, StateDirectives::Declaration], StateAnchor, String) -> nil
+        def presence_error(spelled, read, states, anchor, answer)
+          declaration = states.fetch(read.name)
+
+          @visitor.slot_error(
+            "`#{spelled}` reads #{StateDirectives.subject_phrase(read)} as a presence. Only `nil` and `false` are falsy in Ruby, so the condition is always #{answer}.",
+            anchor.location,
+            :read,
+            suggestion: "#{StateDirectives.predicate_advice(read.kind, read.name)}compare it to a literal#{StateDirectives.default_example(declaration, "#{read.name} == ")}, or declare it as a boolean."
+          )
         end
 
         #: (untyped, Hash[String, StateDirectives::Declaration]) -> Hash[Symbol, untyped]?
@@ -457,11 +477,11 @@ module Herb
             comparands = StateDirectives.when_comparands(list, declaration)
 
             if comparands == :computed
-              return @visitor.slot_error("`when #{list}` on the state `#{read.name}` has a comparand that is not a literal. The client resolves a `when` by lookup.", condition_anchor(arm, list).location, :conditional, suggestion: "List literals instead, like `when #{declaration.default}`.")
+              return @visitor.slot_error("`when #{list}` on the state `#{read.name}` has a comparand that is not a literal. The client resolves a `when` by lookup.", condition_anchor(arm, list).location, :conditional, suggestion: "List literals instead#{StateDirectives.default_example(declaration, "when ")}.")
             end
 
             if comparands == :mismatched
-              return @visitor.slot_error("`when #{list}` compares the #{declaration.kind.to_s.capitalize} state `#{read.name}` against a literal of another type, so it can never match.", condition_anchor(arm, list).location, :compare, suggestion: "Use #{StateDirectives.kind_article(declaration.kind)} literal in every arm, like `when #{declaration.default}`.")
+              return @visitor.slot_error("`when #{list}` compares the #{declaration.kind.to_s.capitalize} state `#{read.name}` against a literal of another type, so it can never match.", condition_anchor(arm, list).location, :compare, suggestion: "Use #{StateDirectives.kind_article(declaration.kind)} literal in every arm#{StateDirectives.default_example(declaration, "when ")}.")
             end
 
             next unless comparands.is_a?(Array)
@@ -490,7 +510,7 @@ module Herb
 
           return "Read `#{name}` bare, like `<% if #{name} %>`, or as `#{name}?`." if declaration.kind == :boolean
 
-          "Read `#{name}` bare, like `<% if #{name} %>`, or compare it to a literal, like `#{name} == #{declaration.default}`."
+          "Read `#{name}` bare, like `<% if #{name} %>`, or compare it to a literal#{StateDirectives.default_example(declaration, "#{name} == ")}."
         end
 
         #: (untyped, String) -> StateAnchor
@@ -757,7 +777,7 @@ module Herb
           return nil unless read.is_a?(StateDirectives::Read) || read.is_a?(StateDirectives::Combo)
 
           if read.is_a?(StateDirectives::Read) && read.comparand.nil? && read.against.nil? && read.operator.nil? && !StateKinds::FALSY.include?(read.kind)
-            return @visitor.slot_error("`#{slot.attribute}=\"<%= #{expression} %>\"` reads #{StateDirectives.subject_phrase(read)} as a presence. Only `nil` and `false` are falsy in Ruby, so the attribute could never turn off.", condition_anchor(node, expression).location, :read, suggestion: "Compare `#{read.name}` to a literal, like `#{read.name} == #{states.fetch(read.name).default}`, or declare it as a boolean.")
+            return @visitor.slot_error("`#{slot.attribute}=\"<%= #{expression} %>\"` reads #{StateDirectives.subject_phrase(read)} as a presence. Only `nil` and `false` are falsy in Ruby, so the attribute could never turn off.", condition_anchor(node, expression).location, :read, suggestion: "#{StateDirectives.predicate_advice(read.kind, read.name)}compare it to a literal#{StateDirectives.default_example(states.fetch(read.name), "#{read.name} == ")}, or declare it as a boolean.")
           end
 
           open_tag = @visitor.open_tag_for(node)

--- a/lib/herb/engine/slots/state_directives.rb
+++ b/lib/herb/engine/slots/state_directives.rb
@@ -374,6 +374,43 @@ module Herb
             }
           end
 
+          #: (Symbol?, String) -> String
+          def predicate_advice(kind, name)
+            spellings = PREDICATES.filter_map { |predicate, entry| predicate if entry[:kinds]&.include?(kind) }
+
+            return "" if spellings.empty?
+
+            listed = spellings.each_with_index.map { |predicate, index| index.zero? ? "`#{name}.#{predicate}`" : "`.#{predicate}`" }
+            leading = listed[0..-2] #: Array[String]
+
+            "Ask #{listed.one? ? listed.last : "#{leading.join(", ")} or #{listed.last}"}, "
+          end
+
+          #: ((Read | Combo)) -> Read?
+          def never_falsy_read(read)
+            return nil unless read.is_a?(Read)
+            return nil unless read.operator.nil? && read.comparand.nil? && read.against.nil? && read.transform.nil?
+            return nil if StateKinds::FALSY.include?(read.kind)
+
+            read
+          end
+
+          #: (Declaration) -> bool
+          def literal_default?(declaration)
+            return false if declaration.derived
+
+            node = expression_node(declaration.default)
+
+            !node.nil? && KINDS.key?(node.class.name)
+          end
+
+          #: (Declaration, String) -> String
+          def default_example(declaration, spelling)
+            return "" unless literal_default?(declaration)
+
+            ", like `#{spelling}#{declaration.default}`"
+          end
+
           #: (Declaration) -> bool
           def seeded?(declaration)
             return false if declaration.derived
@@ -594,7 +631,7 @@ module Herb
             kinds = transform.fetch(:kinds)
 
             if kinds && read.kind != :seeded && !kinds.include?(read.kind)
-              return visitor.slot_error("`#{node.slice}` reads the #{read.kind.to_s.capitalize} state `#{read.name}` with `#{node.name}`. Only #{transform.fetch(:only)} can be read with `#{node.name}`.", anchor.locate(node), :read, suggestion: "Compare `#{read.name}` itself instead, like `#{read.name} == #{states.fetch(read.name).default}`.")
+              return visitor.slot_error("`#{node.slice}` reads the #{read.kind.to_s.capitalize} state `#{read.name}` with `#{node.name}`. Only #{transform.fetch(:only)} can be read with `#{node.name}`.", anchor.locate(node), :read, suggestion: "Compare `#{read.name}` itself instead#{default_example(states.fetch(read.name), "#{read.name} == ")}.")
             end
 
             Read.new(name: read.name, comparand: nil, kind: transform.fetch(:returns), operator: nil, against: nil, transform: transform.fetch(:operation), against_transform: nil)
@@ -673,7 +710,7 @@ module Herb
             kind = KINDS[literal.class.name]
 
             unless kind
-              return visitor.slot_error("`#{node.slice}` compares the state `#{read.name}` against `#{literal.slice}`, which is not a literal. The client resolves a comparison by looking the state up, so it has no value for the other side.", anchor.locate(literal), :compare, suggestion: "Compare `#{read.name}` to a literal, like `#{read.name} == #{states.fetch(read.name).default}`, or declare a state for `#{literal.slice}` and set it from app code.")
+              return visitor.slot_error("`#{node.slice}` compares the state `#{read.name}` against `#{literal.slice}`, which is not a literal. The client resolves a comparison by looking the state up, so it has no value for the other side.", anchor.locate(literal), :compare, suggestion: "Compare `#{read.name}` to a literal#{default_example(states.fetch(read.name), "#{read.name} == ")}, or declare a state for `#{literal.slice}` and set it from app code.")
             end
 
             operator = node.name == :== ? nil : node.name.to_s
@@ -691,7 +728,7 @@ module Herb
             unless ordered || kind == read.kind || kind == :nil || read.kind == :seeded
               consequence = operator == "!=" ? "so it always matches" : "so it can never match"
 
-              return visitor.slot_error("`#{node.slice}` compares #{subject_phrase(read)} against #{kind_article(kind)} literal, #{consequence}.", anchor.locate(literal), :compare, suggestion: "Compare it against #{kind_article(read.kind)} literal, like `#{read.name} == #{states.fetch(read.name).default}`.")
+              return visitor.slot_error("`#{node.slice}` compares #{subject_phrase(read)} against #{kind_article(kind)} literal, #{consequence}.", anchor.locate(literal), :compare, suggestion: "Compare it against #{kind_article(read.kind)} literal#{default_example(states.fetch(read.name), "#{read.name} == ")}.")
             end
 
             Read.new(name: read.name, comparand: literal.slice, kind: read.kind, operator: operator, against: nil, transform: read.transform, against_transform: nil)

--- a/lib/herb/engine/slots/state_directives.rb
+++ b/lib/herb/engine/slots/state_directives.rb
@@ -660,7 +660,24 @@ module Herb
               return visitor.slot_error("`#{node.slice}` reads the #{read.kind.to_s.capitalize} state `#{read.name}` with `#{node.name}`. Only #{predicate.fetch(:only)} can be read with `#{node.name}`.", anchor.locate(node), :read, suggestion: "Compare `#{read.name}` to a literal instead, or declare it as #{kind_article(predicate.fetch(:kinds)&.first)} state.")
             end
 
+            if predicate[:comparand] == "nil" && !StateKinds::NILABLE.include?(read.kind)
+              return nil_check_error(node, read, visitor, anchor, consequence: "can never match", example: default_example(states.fetch(read.name), "#{read.name} == "))
+            end
+
             Read.new(name: read.name, comparand: predicate[:comparand], kind: read.kind, operator: predicate[:operator], against: nil, transform: nil, against_transform: nil)
+          end
+
+          #: (untyped, Read, untyped, StateAnchor, **untyped) -> nil
+          def nil_check_error(node, read, visitor, anchor, **options)
+            consequence = options.fetch(:consequence) #: String
+            example = options.fetch(:example) #: String
+
+            visitor.slot_error(
+              "`#{node.slice}` reads #{subject_phrase(read)} as a nil check. Only a Nil state can be nil, so it #{consequence}.",
+              anchor.locate(node),
+              :compare,
+              suggestion: "#{predicate_advice(read.kind, read.name)}compare it to a literal#{example}, or declare it with a `nil` default."
+            )
           end
 
           #: (untyped, Hash[String, Declaration], untyped, StateAnchor) -> (Read | Combo)?
@@ -723,6 +740,10 @@ module Herb
 
             if ordered && kind != :integer
               return visitor.slot_error("`#{node.slice}` orders the state `#{read.name}` against #{kind_article(kind)} literal. Ordering compares numbers.", anchor.locate(literal), :compare, suggestion: "Compare `#{read.name}` against an Integer literal, like `#{read.name} > 0`.")
+            end
+
+            if !ordered && kind == :nil && !StateKinds::NILABLE.include?(read.kind)
+              return nil_check_error(node, read, visitor, anchor, consequence: operator == "!=" ? "always matches" : "can never match", example: default_example(states.fetch(read.name), "#{read.name} == "))
             end
 
             unless ordered || kind == read.kind || kind == :nil || read.kind == :seeded

--- a/sig/herb/engine/slots/state_compiler.rbs
+++ b/sig/herb/engine/slots/state_compiler.rbs
@@ -93,6 +93,9 @@ module Herb
         # : (untyped, Hash[String, StateDirectives::Declaration]) -> Hash[Symbol, untyped]?
         def state_unless_for: (untyped, Hash[String, StateDirectives::Declaration]) -> Hash[Symbol, untyped]?
 
+        # : (String, StateDirectives::Read, Hash[String, StateDirectives::Declaration], StateAnchor, String) -> nil
+        def presence_error: (String, StateDirectives::Read, Hash[String, StateDirectives::Declaration], StateAnchor, String) -> nil
+
         # : (untyped, Hash[String, StateDirectives::Declaration]) -> Hash[Symbol, untyped]?
         def state_case_for: (untyped, Hash[String, StateDirectives::Declaration]) -> Hash[Symbol, untyped]?
 

--- a/sig/herb/engine/slots/state_directives.rbs
+++ b/sig/herb/engine/slots/state_directives.rbs
@@ -177,6 +177,18 @@ module Herb
         # : (String, Declaration) -> (Array[String] | Symbol)
         def self.when_comparands: (String, Declaration) -> (Array[String] | Symbol)
 
+        # : (Symbol?, String) -> String
+        def self.predicate_advice: (Symbol?, String) -> String
+
+        # : ((Read | Combo)) -> Read?
+        def self.never_falsy_read: (Read | Combo) -> Read?
+
+        # : (Declaration) -> bool
+        def self.literal_default?: (Declaration) -> bool
+
+        # : (Declaration, String) -> String
+        def self.default_example: (Declaration, String) -> String
+
         # : (Declaration) -> bool
         def self.seeded?: (Declaration) -> bool
 

--- a/sig/herb/engine/slots/state_directives.rbs
+++ b/sig/herb/engine/slots/state_directives.rbs
@@ -237,6 +237,9 @@ module Herb
         # : (untyped, Hash[String, Declaration], untyped, StateAnchor) -> Read?
         private def self.predicate_read: (untyped, Hash[String, Declaration], untyped, StateAnchor) -> Read?
 
+        # : (untyped, Read, untyped, StateAnchor, **untyped) -> nil
+        private def self.nil_check_error: (untyped, Read, untyped, StateAnchor, **untyped) -> nil
+
         # : (untyped, Hash[String, Declaration], untyped, StateAnchor) -> (Read | Combo)?
         private def self.negated_read: (untyped, Hash[String, Declaration], untyped, StateAnchor) -> (Read | Combo)?
 

--- a/sig/herb/engine/slots/state_kinds.rbs
+++ b/sig/herb/engine/slots/state_kinds.rbs
@@ -15,6 +15,8 @@ module Herb
 
         FALSY: Array[Symbol]
 
+        NILABLE: Array[Symbol]
+
         ARTICLES: Hash[String, String]
       end
     end

--- a/templates/javascript/packages/client/src/state-kinds.ts.erb
+++ b/templates/javascript/packages/client/src/state-kinds.ts.erb
@@ -16,6 +16,8 @@ export const UNKNOWN_STATE_KINDS: ReadonlySet<string> = new Set([<%= state_kinds
 
 export const FALSY_STATE_KINDS: ReadonlySet<string> = new Set([<%= state_kinds.select(&:falsy?).map { |kind| kind.name.inspect }.join(", ") %>])
 
+export const NILABLE_STATE_KINDS: ReadonlySet<string> = new Set([<%= state_kinds.select(&:nilable?).map { |kind| kind.name.inspect }.join(", ") %>])
+
 export const PRISM_LITERAL_KINDS: Record<string, StateDefaultKind> = {
 <%- state_kinds.select(&:literal?).each do |kind| -%>
 <%- kind.prism_nodes.each do |node| -%>

--- a/templates/lib/herb/engine/slots/state_kinds.rb.erb
+++ b/templates/lib/herb/engine/slots/state_kinds.rb.erb
@@ -24,6 +24,8 @@ module Herb
 
         FALSY = [<%= state_kinds.select(&:falsy?).map { |kind| ":#{kind.name}" }.join(", ") %>].freeze #: Array[Symbol]
 
+        NILABLE = [<%= state_kinds.select(&:nilable?).map { |kind| ":#{kind.name}" }.join(", ") %>].freeze #: Array[Symbol]
+
         ARTICLES = {
 <%- state_kinds.each do |kind| -%>
           <%= kind.name.inspect %> => <%= kind.article.inspect %>,

--- a/templates/template.rb
+++ b/templates/template.rb
@@ -692,6 +692,7 @@ module Herb
         @value = config.fetch("value", false)
         @unknown = config.fetch("unknown", false)
         @falsy = config.fetch("falsy", false)
+        @nilable = config.fetch("nilable", false)
       end
 
       def literal?
@@ -708,6 +709,10 @@ module Herb
 
       def falsy?
         @falsy
+      end
+
+      def nilable?
+        @nilable
       end
 
       def prism_constants

--- a/test/engine/slots/states_test.rb
+++ b/test/engine/slots/states_test.rb
@@ -304,6 +304,19 @@ module Engine
         )
       end
 
+      test "a mistake inside a boolean attribute is reported once" do
+        [
+          %(<%# herb:state (draft: "") %><div><button disabled="<%= draft == 3 %>">x</button></div>),
+          %(<%# herb:state (draft: "") %><div><button disabled="<%= draft.nil? %>">x</button></div>),
+          %(<%# herb:state (draft: "") %><div><button disabled="<%= draft %>">x</button></div>),
+          %(<%# herb:state (count: 0) %><div><button disabled="<%= count.empty? %>">x</button></div>)
+        ].each do |template|
+          error = assert_raises(Herb::Engine::CompilationError) { compile(template) }
+
+          assert_equal 1, error.diagnostics.size
+        end
+      end
+
       test "a nil check on a state that can never be nil is refused, in either spelling" do
         refuse(
           %(<%# herb:state (draft: "") %><div><% if draft.nil? %>x<% end %></div>),

--- a/test/engine/slots/states_test.rb
+++ b/test/engine/slots/states_test.rb
@@ -304,6 +304,34 @@ module Engine
         )
       end
 
+      test "a nil check on a state that can never be nil is refused, in either spelling" do
+        refuse(
+          %(<%# herb:state (draft: "") %><div><% if draft.nil? %>x<% end %></div>),
+          "`draft.nil?` reads the String state `draft` as a nil check. Only a Nil state can be nil, so it can never match."
+        )
+
+        refuse(
+          %(<%# herb:state (draft: "") %><div><% if draft == nil %>x<% end %></div>),
+          "`draft == nil` reads the String state `draft` as a nil check. Only a Nil state can be nil, so it can never match."
+        )
+
+        refuse(
+          %(<%# herb:state (draft: "") %><div><% if draft != nil %>x<% end %></div>),
+          "`draft != nil` reads the String state `draft` as a nil check. Only a Nil state can be nil, so it always matches."
+        )
+      end
+
+      test "a nil check compiles for the kinds that really can be nil" do
+        {
+          %(<%# herb:state (missing: nil) %><div><% if missing.nil? %>x<% end %></div>) => ["missing", { "value" => nil }],
+          %(<%# herb:state (thing: @thing) %><div><% if thing.nil? %>x<% end %></div>) => ["thing", { "value" => nil }],
+        }.each do |template, condition|
+          visitor, = compile(template)
+
+          assert_equal({ arms: [arm(0, condition)], else: nil }, visitor.state_conditional_entries.fetch(0))
+        end
+      end
+
       test "the way out names the predicates that can answer false for the state's kind" do
         assert_equal(
           "Ask `draft.empty?`, `.blank?` or `.present?`, compare it to a literal, like `draft == \"\"`, or declare it as a boolean.",
@@ -373,7 +401,7 @@ module Engine
       test "a predicate compiles into the comparison it stands for" do
         {
           %(<%# herb:state (draft: "") %><div><% if draft.empty? %>x<% end %></div>) => ["draft", { "value" => "" }],
-          %(<%# herb:state (draft: "") %><div><% if draft.nil? %>x<% end %></div>) => ["draft", { "value" => nil }],
+          %(<%# herb:state (missing: nil) %><div><% if missing.nil? %>x<% end %></div>) => ["missing", { "value" => nil }],
           %(<%# herb:state (count: 0) %><div><% if count.zero? %>x<% end %></div>) => ["count", { "value" => 0 }],
           %(<%# herb:state (count: 0) %><div><% if count.one? %>x<% end %></div>) => ["count", { "value" => 1 }],
           %(<%# herb:state (count: 0) %><div><% if count.positive? %>x<% end %></div>) => ["count", { "value" => 0 }, ">"],

--- a/test/engine/slots/states_test.rb
+++ b/test/engine/slots/states_test.rb
@@ -281,11 +281,10 @@ module Engine
         assert_includes rendered, "false</textarea>"
       end
 
-      test "the `?` spelling reads any state for its truth, the way the bare name does" do
+      test "the `?` spelling reads a state for its truth, the way the bare name does" do
         {
-          %(<%# herb:state (message: "hi") %><div><% if message? %>x<% end %></div>) => ["message", nil],
-          %(<%# herb:state (attempts: 0) %><div><% if attempts? %>x<% end %></div>) => ["attempts", nil],
-          %(<%# herb:state (tab: :first) %><div><% if tab? %>x<% end %></div>) => ["tab", nil],
+          %(<%# herb:state (pending: false) %><div><% if pending? %>x<% end %></div>) => ["pending", nil],
+          %(<%# herb:state (missing: nil) %><div><% if missing? %>x<% end %></div>) => ["missing", nil],
         }.each do |template, condition|
           visitor, = compile(template)
 
@@ -293,8 +292,44 @@ module Engine
         end
       end
 
+      test "a state that can never be falsy is refused as a condition, in either spelling" do
+        refuse(
+          %(<%# herb:state (message: "hi") %><div><% if message %>x<% end %></div>),
+          "`message` reads the String state `message` as a presence. Only `nil` and `false` are falsy in Ruby, so the condition is always true."
+        )
+
+        refuse(
+          %(<%# herb:state (attempts: 0) %><div><% if attempts? %>x<% end %></div>),
+          "`attempts?` reads the Integer state `attempts` as a presence. Only `nil` and `false` are falsy in Ruby, so the condition is always true."
+        )
+      end
+
+      test "the way out names the predicates that can answer false for the state's kind" do
+        assert_equal(
+          "Ask `draft.empty?`, `.blank?` or `.present?`, compare it to a literal, like `draft == \"\"`, or declare it as a boolean.",
+          diagnostic_for(%(<%# herb:state (draft: "") %><div><% if draft %>x<% end %></div>)).suggestion
+        )
+
+        assert_equal(
+          "Ask `attempts.zero?`, `.one?` or `.positive?`, compare it to a literal, like `attempts == 0`, or declare it as a boolean.",
+          diagnostic_for(%(<%# herb:state (attempts: 0) %><div><% if attempts %>x<% end %></div>)).suggestion
+        )
+
+        assert_equal(
+          "Ask `tab.empty?`, compare it to a literal, like `tab == :first`, or declare it as a boolean.",
+          diagnostic_for(%(<%# herb:state (tab: :first) %><div><% if tab %>x<% end %></div>)).suggestion
+        )
+      end
+
+      test "an `unless` on a state that can never be falsy is refused the other way around" do
+        refuse(
+          %(<%# herb:state (tab: :first) %><div><% unless tab %>x<% end %></div>),
+          "`unless tab` reads the Symbol state `tab` as a presence. Only `nil` and `false` are falsy in Ruby, so the condition is always false."
+        )
+      end
+
       test "the `?` spelling drops off the source the server runs" do
-        rendered = render(%(<%# herb:state (message: "hi") %><div><% if message? %>Present<% else %>None<% end %></div>))
+        rendered = render(%(<%# herb:state (pending: true) %><div><% if pending? %>Present<% else %>None<% end %></div>))
 
         assert_includes rendered, "Present"
       end


### PR DESCRIPTION
Follow up on #2470

A `herb:state` condition parks a branch for the client to resolve, so a condition whose answer is fixed before the page renders parks a branch that can never be chosen. The compiler already knew this in one place and not the others.

```erb
<%# herb:state (draft: "") %>

<button disabled="<%= draft %>">Send</button>   <%# refused %>
<% if draft %>Drafted<% else %>Empty<% end %>   <%# accepted, and the else is dead %>
```

Only `nil` and `false` are falsy in Ruby, so a String state answers a bare read the same way forever. The attribute form said so. The conditional compiled, and the `else` sat there unreachable.

#### A bare read the client can never answer differently

`StateDirectives.never_falsy_read` catches a condition that resolves to a bare truthiness read of a state whose kind is not in `StateKinds::FALSY`, which is to say anything but a Boolean, a Nil or a seeded state.

```erb
<%# herb:state (draft: "") %>
<% if draft %>Drafted<% else %>Empty<% end %>
```

> `draft` reads the String state `draft` as a presence. Only `nil` and `false` are falsy in Ruby, so the condition is always true.
>
> Suggestion: Ask `draft.empty?`, `.blank?` or `.present?`, compare it to a literal, like `draft == ""`, or declare it as a boolean.

`unless` reports the same thing the other way around, and the `draft?` spelling reports it too, since it asks the same question.

#### A nil check on a state that is never nil

```erb
<%# herb:state (draft: "") %>
<% if draft.nil? %>Unset<% end %>
```

> `draft.nil?` reads the String state `draft` as a nil check. Only a Nil state can be nil, so it can never match.

The `draft == nil` and `draft != nil` spellings reach the same place, the second one reporting that it always matches instead. `.nil?` needed its own path, since it is the one predicate with no `kinds` in `config/state/predicates.yml` and so was gated by nothing, while the comparison form was let through by a blanket exemption for nil comparands.

Nil-ness turned out to be narrower than falsiness, so `FALSY` was the wrong list to reuse. A Boolean state holds `false` sometimes but never `nil`, and `pending.nil?` is as dead as `draft.nil?`. `config/state/kind.yml` gained a `nilable` flag, generating `StateKinds::NILABLE` and `NILABLE_STATE_KINDS` for the two kinds that can really hold one.

#### The way out names the predicates that fit the kind

A bare read is usually someone reaching for a question Ruby already has a word for, so the suggestion offers the ones registered for that state's kind, read out of `config/state/predicates.yml`.

```
Ask `draft.empty?`, `.blank?` or `.present?`, ...
Ask `attempts.zero?`, `.one?` or `.positive?`, ...
Ask `tab.empty?`, ...
```

#### An example only when there is one to give

Every suggestion that spelled out a state's default assumed the default was a literal, which a derived or a bare one is not.

```erb
<%# herb:state (pending: false, failed: false, busy: pending || failed) %>
<% if busy == 3 %>x<% end %>
```

**Before**

> Compare it against a Boolean literal, like `busy == pending || failed`.

**After**

> Compare it against a Boolean literal.

#### One diagnostic per attribute

A mistake inside a boolean attribute was reported twice, and had been since these diagnostics existed.

```erb
<%# herb:state (draft: "") %>
<button disabled="<%= draft == 3 %>">Send</button>
```