### PR TITLE
Engine: Resolve `herb:state` reads from Prism nodes

### DIFF
--- a/lib/herb.rb
+++ b/lib/herb.rb
@@ -28,8 +28,6 @@ require_relative "herb/diagnostic"
 
 require_relative "herb/version"
 require_relative "herb/visitor"
-require_relative "herb/locate"
-require_relative "herb/source_path"
 
 begin
   major, minor, _patch = RUBY_VERSION.split(".") #: [String, String, String]

--- a/lib/herb/analysis/ruby_locals_index/offset_table.rb
+++ b/lib/herb/analysis/ruby_locals_index/offset_table.rb
@@ -4,13 +4,17 @@ module Herb
   module Analysis
     class RubyLocalsIndex
       # Prism reports byte offsets into the whole template while the Herb AST
-      # reports lines and columns, so one of them has to be translated.
+      # reports lines and 0-based character columns, so one of them has to be
+      # translated. The line table stays in bytes to index into the source, and
+      # only the column is counted in characters.
+      #
       class OffsetTable
-        # @rbs!
-        #   @line_starts: Array[Integer]
+        attr_reader :source #: String
+        attr_reader :line_starts #: Array[Integer]
 
         #: (String) -> void
         def initialize(source)
+          @source = source
           @line_starts = [0]
 
           source.each_byte.with_index do |byte, index|
@@ -29,10 +33,10 @@ module Herb
         #: (Integer) -> [Integer, Integer]
         def position_at(offset)
           following = @line_starts.bsearch_index { |start| start > offset }
-          index = following ? following - 1 : @line_starts.length - 1
+          index = following ? following - 1 : line_starts.length - 1
           start = @line_starts[index] || 0
 
-          [index + 1, offset - start]
+          [index + 1, source.byteslice(start, offset - start).to_s.length]
         end
       end
     end

--- a/lib/herb/ast/node.rb
+++ b/lib/herb/ast/node.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 # typed: true
 
+require_relative "../locate"
+
 module Herb
   #: type serialized_node = {
   #|  type: String,

--- a/lib/herb/engine/slots/state_anchor.rb
+++ b/lib/herb/engine/slots/state_anchor.rb
@@ -12,15 +12,24 @@ module Herb
       # has nothing to work with it answers the whole node's location, which is what every
       # diagnostic used before.
       #
+      # A node resolved out of the template's whole Prism program counts from the start of the
+      # template instead, so `rebased` takes the offset those nodes count from.
+      #
       class StateAnchor
         attr_reader :location #: Herb::Location?
 
-        #: (Herb::Location?, ?token: Herb::Token?, ?expression: String?, ?context: Symbol) -> void
-        def initialize(location, token: nil, expression: nil, context: :condition)
+        #: (Herb::Location?, ?token: Herb::Token?, ?expression: String?, ?context: Symbol, ?base: Integer) -> void
+        def initialize(location, token: nil, expression: nil, context: :condition, base: 0)
           @location = location #: Herb::Location?
           @token = token #: Herb::Token?
           @expression = expression #: String?
           @context = context #: Symbol
+          @base = base #: Integer
+        end
+
+        #: (Integer) -> StateAnchor
+        def rebased(base)
+          StateAnchor.new(@location, token: @token, expression: @expression, context: @context, base: base)
         end
 
         #: () -> bool
@@ -56,7 +65,10 @@ module Herb
 
           return nil unless within
 
-          bytes = node.location.start_offset
+          bytes = node.location.start_offset - @base
+
+          return nil if bytes.negative?
+
           prefix = expression.byteslice(0, bytes)
 
           return nil unless prefix

--- a/lib/herb/engine/slots/state_compiler.rb
+++ b/lib/herb/engine/slots/state_compiler.rb
@@ -375,7 +375,7 @@ module Herb
 
           conditions.each_with_index do |arm, branch|
             expression = condition_expression(arm)
-            read = StateDirectives.condition_read(expression, states, @visitor, condition_anchor(arm, expression))
+            read = StateDirectives.condition_read(expression, states, @visitor, condition_anchor(arm, expression), resolved_ruby(arm))
 
             return nil if read == :reported
 
@@ -417,7 +417,7 @@ module Herb
         #: (untyped, Hash[String, StateDirectives::Declaration]) -> Hash[Symbol, untyped]?
         def state_unless_for(node, states)
           expression = condition_expression(node)
-          read = StateDirectives.condition_read(expression, states, @visitor, condition_anchor(node, expression))
+          read = StateDirectives.condition_read(expression, states, @visitor, condition_anchor(node, expression), resolved_ruby(node))
 
           return nil if read.nil? || read == :reported
 
@@ -458,7 +458,7 @@ module Herb
         #: (untyped, Hash[String, StateDirectives::Declaration]) -> Hash[Symbol, untyped]?
         def state_case_for(node, states)
           subject_source = condition_expression(node)
-          read = StateDirectives.condition_read(subject_source, states, @visitor, condition_anchor(node, subject_source))
+          read = StateDirectives.condition_read(subject_source, states, @visitor, condition_anchor(node, subject_source), resolved_ruby(node))
 
           return nil if read.nil? || read == :reported
 
@@ -531,6 +531,11 @@ module Herb
         end
 
         #: (untyped) -> untyped
+        def resolved_ruby(node)
+          @visitor.ruby_at(node.content&.location) if node.respond_to?(:content) && node.content.is_a?(Herb::Token)
+        end
+
+        #: (untyped) -> untyped
         def register_count_fold(node)
           return nil if @visitor.continuation?(node)
           return nil unless node.respond_to?(:subsequent) && node.subsequent.nil?
@@ -560,7 +565,7 @@ module Herb
 
           return nil unless increment && states.key?(increment.name)
 
-          read = StateDirectives.condition_read(condition_expression(node), states, @visitor, condition_anchor(node, condition_expression(node)))
+          read = StateDirectives.condition_read(condition_expression(node), states, @visitor, condition_anchor(node, condition_expression(node)), resolved_ruby(node))
 
           return nil unless read.is_a?(StateDirectives::Read) || read.is_a?(StateDirectives::Combo)
 
@@ -663,7 +668,7 @@ module Herb
 
           return unless token
 
-          token.value.replace(StateDirectives.rewrite_reads(token.value, name))
+          token.value.replace(StateDirectives.rewrite_reads(token.value, name, @visitor.ruby_at(token.location)))
         rescue FrozenError
           nil
         end
@@ -681,7 +686,7 @@ module Herb
           return nil unless position
 
           literal = children.fetch(position) #: untyped
-          rewritten = StateDirectives.rewrite_reads(literal.content.to_s, name)
+          rewritten = StateDirectives.rewrite_reads(literal.content.to_s, name, @visitor.ruby_at(literal.location))
           replacement = Herb::AST::RubyLiteralNode.build(content: rewritten, location: literal.location)
 
           children[position] = replacement
@@ -754,7 +759,7 @@ module Herb
 
         #: (untyped, Integer, untyped, String, Hash[String, StateDirectives::Declaration]) -> void
         def register_state_value(node, index, slot, expression, states)
-          read = slot.valued? ? StateDirectives.condition_read(expression, states, @visitor, condition_anchor(node, expression)) : nil
+          read = slot.valued? ? StateDirectives.condition_read(expression, states, @visitor, condition_anchor(node, expression), resolved_ruby(node)) : nil
 
           return if read == :reported
 
@@ -772,7 +777,7 @@ module Herb
           return nil unless slot.type == :attribute || (slot.type == :boolean_attribute && !@state_presence.key?(index))
           return nil unless slot.attribute && Herb::HTML::Util.boolean_attribute?(slot.attribute)
 
-          read = StateDirectives.condition_read(expression, states, @visitor, condition_anchor(node, expression))
+          read = StateDirectives.condition_read(expression, states, @visitor, condition_anchor(node, expression), resolved_ruby(node))
 
           return :reported if read == :reported
 

--- a/lib/herb/engine/slots/state_directives.rb
+++ b/lib/herb/engine/slots/state_directives.rb
@@ -114,11 +114,13 @@ module Herb
             }
           end
 
-          #: (String, Hash[String, Declaration], untyped, (StateAnchor | Herb::Location)?) -> (Read | Combo | Symbol)?
-          def condition_read(expression, states, visitor, anchor)
+          #: (String, Hash[String, Declaration], untyped, (StateAnchor | Herb::Location)?, ?untyped) -> (Read | Combo | Symbol)?
+          def condition_read(expression, states, visitor, anchor, resolved = nil)
             anchor = StateAnchor.new(anchor) unless anchor.is_a?(StateAnchor)
             source = expression.strip
-            parsed = expression_node(source)
+            resolved_node = resolved_expression(resolved, source)
+            parsed = resolved_node || expression_node(source)
+            anchor = anchor.rebased(resolved_node.location.start_offset) if resolved_node
 
             return mentions_any?(source, states) ? :computed : nil if parsed.nil?
 
@@ -128,7 +130,7 @@ module Herb
             return :reported if visitor.diagnostic_count > said
             return read if read
 
-            mentions_any?(source, states) ? :computed : nil
+            mentions?(parsed, states) ? :computed : nil
           end
 
           #: (untyped, Hash[String, Declaration], untyped, (StateAnchor | Herb::Location)?) -> (Read | Combo | Symbol)?
@@ -331,8 +333,6 @@ module Herb
 
           #: (String, Hash[String, Declaration]) -> Array[String]
           def assigned_state_names(source, states)
-            return [] unless mentions_any?(source, states)
-
             result = Prism.parse(source)
 
             return [] if result.failure?
@@ -440,27 +440,98 @@ module Herb
             spelled.start_with?("A", "E", "I", "O", "U") ? "an #{spelled}" : "a #{spelled}"
           end
 
-          #: (String, String) -> String
-          def rewrite_reads(source, name)
-            rewritten = source
+          #: (String, String, ?untyped) -> String
+          def rewrite_reads(source, name, resolved = nil)
+            splices = read_splices(source, name, resolved&.source == source ? resolved : nil)
 
-            PREDICATES.each do |spelled, predicate|
-              rewrite = predicate[:rewrite]
+            return source if splices.empty?
 
-              next unless rewrite
+            rewritten = source.dup
 
-              rewritten = rewritten.gsub(/(?<![\w?!])#{Regexp.escape(name)}\.#{Regexp.escape(spelled)}(?![\w?!])/) { "(#{name} #{rewrite})" }
-            end
+            splices.reverse_each { |start, finish, replacement| rewritten.bytesplice(start, finish - start, replacement) }
 
-            rewritten.gsub(/(?<![\w?!])#{Regexp.escape(name)}\?(?![\w?!])/) { name }
+            rewritten
           end
 
           #: (String, Hash[String, Declaration]) -> bool
           def mentions_any?(source, states)
-            states.each_key.any? { |name| /(?<![\w?])#{Regexp.escape(name)}\??(?![\w?!])/.match?(source) }
+            return false if states.empty?
+
+            reads_any?(expression_nodes(source), states)
+          end
+
+          #: (untyped, Hash[String, Declaration]) -> bool
+          def mentions?(node, states)
+            return false if states.empty? || node.nil?
+
+            reads_any?(descendants(node), states)
           end
 
           private
+
+          #: (untyped, String) -> untyped
+          def resolved_expression(resolved, source)
+            nodes = resolved&.nodes
+
+            return nil unless nodes&.one?
+
+            node = nodes.fetch(0)
+
+            node.slice == source ? node : nil
+          end
+
+          #: (Array[untyped], Hash[String, Declaration]) -> bool
+          def reads_any?(nodes, states)
+            nodes.any? { |node| states.key?(bare_name(node).to_s.delete_suffix("?")) }
+          end
+
+          #: (String, String, untyped) -> Array[[Integer, Integer, String]]
+          def read_splices(source, name, resolved = nil)
+            splices = [] #: Array[[Integer, Integer, String]]
+            nodes = resolved ? resolved.nodes.flat_map { |node| descendants(node) } : expression_nodes(source)
+            base = resolved ? resolved.offset : 0
+
+            nodes.each do |node|
+              next unless node.is_a?(Prism::CallNode) && node.arguments.nil? && node.block.nil?
+
+              rewrite = PREDICATES.dig(node.name.to_s, :rewrite)
+
+              if rewrite && bare_name(node.receiver) == name
+                splices << [node.location.start_offset - base, node.location.end_offset - base, "(#{name} #{rewrite})"]
+              elsif node.receiver.nil? && node.name.to_s == "#{name}?"
+                splices << [node.location.start_offset - base, node.location.end_offset - base, name]
+              end
+            end
+
+            splices.sort_by { |splice| splice[0] }
+          end
+
+          #: (String) -> Array[untyped]
+          def expression_nodes(source)
+            Prism.parse(source).value.statements.body.compact.flat_map { |node| descendants(node) }
+          end
+
+          #: (untyped) -> Array[untyped]
+          def descendants(node)
+            found = [] #: Array[untyped]
+            queue = [node] #: Array[untyped]
+
+            until queue.empty?
+              current = queue.shift
+              found << current
+              queue.concat(current.compact_child_nodes)
+            end
+
+            found
+          end
+
+          #: (untyped) -> String?
+          def bare_name(node)
+            return node.name.to_s if node.is_a?(Prism::LocalVariableReadNode)
+            return nil unless node.is_a?(Prism::CallNode) && node.receiver.nil? && node.arguments.nil? && node.block.nil?
+
+            node.name.to_s
+          end
 
           #: (untyped, Parsing) -> Declaration
           def declaration_for(state, parsing)

--- a/lib/herb/engine/slots/visitor.rb
+++ b/lib/herb/engine/slots/visitor.rb
@@ -3,6 +3,7 @@
 
 require "digest"
 
+require_relative "../../ruby_program"
 require_relative "../../visitor"
 require_relative "../../visitor/context_aware"
 require_relative "../../visitor/diagnostics"
@@ -42,7 +43,7 @@ module Herb
         include Herb::Visitor::ContextAware
         include Herb::Visitor::Diagnostics
 
-        recommended_parser_option iteration_nodes: true, render_nodes: true, strict_locals: true
+        recommended_parser_option iteration_nodes: true, render_nodes: true, strict_locals: true, prism_program: true
         required_parser_option action_view_helpers: true, track_locations: true, herb_directives: true
         experimental "Slots are experimental. Their markers, payload and client API may change."
 
@@ -414,6 +415,18 @@ module Herb
         #: () -> String
         def occurrence_expression
           "((#{OCCURRENCES} ||= ::Hash.new(0))[#{identifier.inspect}] += 1) - 1"
+        end
+
+        #: (Herb::Location?) -> Herb::RubyProgram::Resolved?
+        def ruby_at(location)
+          return nil unless location
+
+          unless @ruby_program_built
+            @ruby_program_built = true
+            @ruby_program = @document ? Herb::RubyProgram.for(@document) : nil
+          end
+
+          @ruby_program&.resolve(location)
         end
 
         def visit_document_node(node)

--- a/lib/herb/parse_result.rb
+++ b/lib/herb/parse_result.rb
@@ -3,6 +3,8 @@
 
 require "json"
 
+require_relative "locate"
+
 module Herb
   class ParseResult < Result
     attr_reader :value #: Herb::AST::DocumentNode

--- a/lib/herb/ruby_program.rb
+++ b/lib/herb/ruby_program.rb
@@ -1,0 +1,110 @@
+# frozen_string_literal: true
+# typed: true
+
+require "prism"
+
+module Herb
+  # Answers what Ruby a span of a template holds, out of the one Prism program the parser built
+  # for the whole document. `extract_ruby` blanks the HTML in place, so a Prism byte offset and a
+  # template byte offset are the same number, which is what lets a `Herb::Location` address Ruby.
+  #
+  #     program = Herb::RubyProgram.for(document)
+  #     program.resolve(node.content.location)&.nodes #=> [#<Prism::CallNode>]
+  #
+  # The document has to have been parsed with the `prism_program` parser option, and `for` answers
+  # `nil` when it was not. `Herb::Locate` is the same question asked of the HTML tree, and
+  # `Herb::Analysis::RubyLocalsIndex::OffsetTable` walks the other way, from a Prism offset back
+  # to a `Herb::Location`.
+  #
+  class RubyProgram
+    Resolved = Data.define(
+      :nodes,  #: Array[untyped]
+      :offset, #: Integer
+      :source  #: String
+    )
+
+    #: (untyped) -> RubyProgram?
+    def self.for(document)
+      return nil unless document.respond_to?(:source) && document.respond_to?(:deserialized_prism_node)
+
+      source = document.source
+      program = document.deserialized_prism_node
+
+      return nil unless source.is_a?(String) && program
+
+      new(source, program)
+    end
+
+    #: (String, untyped) -> void
+    def initialize(source, program)
+      @source = source
+      @lines = source.lines
+      @starts = [0] #: Array[Integer]
+
+      @lines.each { |line| @starts << (@starts.fetch(-1) + line.bytesize) }
+
+      @nodes = flatten(program)
+    end
+
+    #: (Herb::Location?) -> Resolved?
+    def resolve(location)
+      return nil unless location
+
+      from = offset_of(location.start)
+      to = offset_of(location.end)
+
+      return nil unless from && to && from < to
+
+      Resolved.new(nodes: enclosed(from, to), offset: from, source: @source.byteslice(from, to - from).to_s)
+    end
+
+    private
+
+    #: (untyped) -> Array[untyped]
+    def flatten(program)
+      found = [] #: Array[untyped]
+      queue = [program] #: Array[untyped]
+
+      until queue.empty?
+        node = queue.shift
+
+        found << node unless node.is_a?(Prism::StatementsNode) || node.is_a?(Prism::ProgramNode)
+        queue.concat(node.compact_child_nodes)
+      end
+
+      found.sort_by { |node| [node.location.start_offset, -node.location.end_offset] }
+    end
+
+    #: (Integer, Integer) -> Array[untyped]
+    def enclosed(from, to)
+      found = [] #: Array[untyped]
+      index = @nodes.bsearch_index { |node| node.location.start_offset >= from } || @nodes.length
+      reach = from
+
+      while (node = @nodes[index])
+        location = node.location
+
+        break if location.start_offset >= to
+
+        if location.start_offset >= reach && location.end_offset <= to
+          found << node
+          reach = location.end_offset
+        end
+
+        index += 1
+      end
+
+      found
+    end
+
+    #: (untyped) -> Integer?
+    def offset_of(position)
+      start = @starts[position.line - 1]
+      line = @lines[position.line - 1]
+
+      return nil unless start && line
+
+      start + line[0, position.column].to_s.bytesize
+    end
+  end
+end

--- a/sig/herb/analysis/ruby_locals_index/offset_table.rbs
+++ b/sig/herb/analysis/ruby_locals_index/offset_table.rbs
@@ -4,9 +4,13 @@ module Herb
   module Analysis
     class RubyLocalsIndex
       # Prism reports byte offsets into the whole template while the Herb AST
-      # reports lines and columns, so one of them has to be translated.
+      # reports lines and 0-based character columns, so one of them has to be
+      # translated. The line table stays in bytes to index into the source, and
+      # only the column is counted in characters.
       class OffsetTable
-        @line_starts: Array[Integer]
+        attr_reader source: String
+
+        attr_reader line_starts: Array[Integer]
 
         # : (String) -> void
         def initialize: (String) -> void

--- a/sig/herb/engine/slots/state_anchor.rbs
+++ b/sig/herb/engine/slots/state_anchor.rbs
@@ -10,11 +10,17 @@ module Herb
       # the string came from and turns those offsets back into a location in the template. When it
       # has nothing to work with it answers the whole node's location, which is what every
       # diagnostic used before.
+      #
+      # A node resolved out of the template's whole Prism program counts from the start of the
+      # template instead, so `rebased` takes the offset those nodes count from.
       class StateAnchor
         attr_reader location: Herb::Location?
 
-        # : (Herb::Location?, ?token: Herb::Token?, ?expression: String?, ?context: Symbol) -> void
-        def initialize: (Herb::Location?, ?token: Herb::Token?, ?expression: String?, ?context: Symbol) -> void
+        # : (Herb::Location?, ?token: Herb::Token?, ?expression: String?, ?context: Symbol, ?base: Integer) -> void
+        def initialize: (Herb::Location?, ?token: Herb::Token?, ?expression: String?, ?context: Symbol, ?base: Integer) -> void
+
+        # : (Integer) -> StateAnchor
+        def rebased: (Integer) -> StateAnchor
 
         # : () -> bool
         def condition?: () -> bool

--- a/sig/herb/engine/slots/state_compiler.rbs
+++ b/sig/herb/engine/slots/state_compiler.rbs
@@ -112,6 +112,9 @@ module Herb
         def condition_expression: (untyped) -> String
 
         # : (untyped) -> untyped
+        def resolved_ruby: (untyped) -> untyped
+
+        # : (untyped) -> untyped
         def register_count_fold: (untyped) -> untyped
 
         # : (untyped) -> void

--- a/sig/herb/engine/slots/state_directives.rbs
+++ b/sig/herb/engine/slots/state_directives.rbs
@@ -132,8 +132,8 @@ module Herb
         # : (untyped, Hash[String, Symbol], visitor: untyped, ?enclosing: Hash[String, Declaration]) -> Array[Declaration]
         def self.parse: (untyped, Hash[String, Symbol], visitor: untyped, ?enclosing: Hash[String, Declaration]) -> Array[Declaration]
 
-        # : (String, Hash[String, Declaration], untyped, (StateAnchor | Herb::Location)?) -> (Read | Combo | Symbol)?
-        def self.condition_read: (String, Hash[String, Declaration], untyped, (StateAnchor | Herb::Location)?) -> (Read | Combo | Symbol)?
+        # : (String, Hash[String, Declaration], untyped, (StateAnchor | Herb::Location)?, ?untyped) -> (Read | Combo | Symbol)?
+        def self.condition_read: (String, Hash[String, Declaration], untyped, (StateAnchor | Herb::Location)?, ?untyped) -> (Read | Combo | Symbol)?
 
         # : (untyped, Hash[String, Declaration], untyped, (StateAnchor | Herb::Location)?) -> (Read | Combo | Symbol)?
         def self.tree_read: (untyped, Hash[String, Declaration], untyped, (StateAnchor | Herb::Location)?) -> (Read | Combo | Symbol)?
@@ -198,11 +198,32 @@ module Herb
         # : ((Symbol | String)?) -> String
         def self.kind_article: ((Symbol | String)?) -> String
 
-        # : (String, String) -> String
-        def self.rewrite_reads: (String, String) -> String
+        # : (String, String, ?untyped) -> String
+        def self.rewrite_reads: (String, String, ?untyped) -> String
 
         # : (String, Hash[String, Declaration]) -> bool
         def self.mentions_any?: (String, Hash[String, Declaration]) -> bool
+
+        # : (untyped, Hash[String, Declaration]) -> bool
+        def self.mentions?: (untyped, Hash[String, Declaration]) -> bool
+
+        # : (untyped, String) -> untyped
+        private def self.resolved_expression: (untyped, String) -> untyped
+
+        # : (Array[untyped], Hash[String, Declaration]) -> bool
+        private def self.reads_any?: (Array[untyped], Hash[String, Declaration]) -> bool
+
+        # : (String, String, untyped) -> Array[[Integer, Integer, String]]
+        private def self.read_splices: (String, String, untyped) -> Array[[ Integer, Integer, String ]]
+
+        # : (String) -> Array[untyped]
+        private def self.expression_nodes: (String) -> Array[untyped]
+
+        # : (untyped) -> Array[untyped]
+        private def self.descendants: (untyped) -> Array[untyped]
+
+        # : (untyped) -> String?
+        private def self.bare_name: (untyped) -> String?
 
         # : (untyped, Parsing) -> Declaration
         private def self.declaration_for: (untyped, Parsing) -> Declaration

--- a/sig/herb/engine/slots/visitor.rbs
+++ b/sig/herb/engine/slots/visitor.rbs
@@ -226,6 +226,9 @@ module Herb
         # : () -> String
         def occurrence_expression: () -> String
 
+        # : (Herb::Location?) -> Herb::RubyProgram::Resolved?
+        def ruby_at: (Herb::Location?) -> Herb::RubyProgram::Resolved?
+
         def visit_document_node: (untyped node) -> untyped
 
         # : (untyped) -> void

--- a/sig/herb/ruby_program.rbs
+++ b/sig/herb/ruby_program.rbs
@@ -1,0 +1,51 @@
+# Generated from lib/herb/ruby_program.rb with RBS::Inline
+
+module Herb
+  # Answers what Ruby a span of a template holds, out of the one Prism program the parser built
+  # for the whole document. `extract_ruby` blanks the HTML in place, so a Prism byte offset and a
+  # template byte offset are the same number, which is what lets a `Herb::Location` address Ruby.
+  #
+  #     program = Herb::RubyProgram.for(document)
+  #     program.resolve(node.content.location)&.nodes #=> [#<Prism::CallNode>]
+  #
+  # The document has to have been parsed with the `prism_program` parser option, and `for` answers
+  # `nil` when it was not. `Herb::Locate` is the same question asked of the HTML tree, and
+  # `Herb::Analysis::RubyLocalsIndex::OffsetTable` walks the other way, from a Prism offset back
+  # to a `Herb::Location`.
+  class RubyProgram
+    class Resolved < Data
+      attr_reader nodes(): Array[untyped]
+
+      attr_reader offset(): Integer
+
+      attr_reader source(): String
+
+      def self.new: (Array[untyped] nodes, Integer offset, String source) -> instance
+                  | (nodes: Array[untyped], offset: Integer, source: String) -> instance
+
+      def self.members: () -> [ :nodes, :offset, :source ]
+
+      def members: () -> [ :nodes, :offset, :source ]
+    end
+
+    # : (untyped) -> RubyProgram?
+    def self.for: (untyped) -> RubyProgram?
+
+    # : (String, untyped) -> void
+    def initialize: (String, untyped) -> void
+
+    # : (Herb::Location?) -> Resolved?
+    def resolve: (Herb::Location?) -> Resolved?
+
+    private
+
+    # : (untyped) -> Array[untyped]
+    def flatten: (untyped) -> Array[untyped]
+
+    # : (Integer, Integer) -> Array[untyped]
+    def enclosed: (Integer, Integer) -> Array[untyped]
+
+    # : (untyped) -> Integer?
+    def offset_of: (untyped) -> Integer?
+  end
+end

--- a/test/analysis/ruby_locals_index_test.rb
+++ b/test/analysis/ruby_locals_index_test.rb
@@ -108,12 +108,23 @@ class RubyLocalsIndexTest < Minitest::Spec
     assert_includes index.names, "post"
   end
 
-  test "counts columns in bytes so multibyte content does not shift a location" do
+  test "multibyte content on an earlier line does not shift a location" do
     source = "<%# locals: (title:) %>\n<p>über</p>\n<p><%= title %></p>\n"
     local = index_for(source).find("title")
 
     assert_equal 3, local.usages.first.start.line
     assert_equal "title", text_at(source, local.declaration)
+    assert_equal "title", text_at(source, local.usages.first)
+  end
+
+  test "counts columns in characters, so multibyte content on the same line does not shift a location" do
+    source = "<%# locals: (title:) %>\n<p>üü <%= title %></p>\n"
+    local = index_for(source).find("title")
+    usage = local.usages.first
+
+    assert_equal 2, usage.start.line
+    assert_equal 10, usage.start.column
+    assert_equal "title", text_at(source, usage)
   end
   test "declares herb:state names, so a state read is not an unknown name" do
     source = "<%# herb:state (pending: false, attempts: 0) %>\n<p><%= attempts %></p>\n<% if pending? %><b>x</b><% end %>\n"

--- a/test/engine/slots/states_test.rb
+++ b/test/engine/slots/states_test.rb
@@ -609,6 +609,61 @@ module Engine
         end
       end
 
+      test "a read is rewritten where it is code and left alone everywhere else" do
+        {
+          [" draft? ", "draft"] => " draft ",
+          [" !open? ", "open"] => " !open ",
+          [" count.one? ", "count"] => " (count == 1) ",
+          [' draft == "draft?" ', "draft"] => ' draft == "draft?" ',
+          [' draft == "count.one?" ', "count"] => ' draft == "count.one?" ',
+          [" \"\#{draft?} draft?\" ", "draft"] => " \"\#{draft} draft?\" ",
+          [" :draft? ", "draft"] => " :draft? ",
+          [" foo.draft? ", "draft"] => " foo.draft? ",
+          [" item.draft? && draft? ", "draft"] => " item.draft? && draft ",
+          [" foo.count.one? ", "count"] => " foo.count.one? ",
+        }.each do |(source, name), rewritten|
+          assert_equal rewritten, Herb::Engine::Slots::StateDirectives.rewrite_reads(source, name)
+        end
+      end
+
+      test "two predicates in one tag both rewrite, after the first shifts the source" do
+        template = %(<%# herb:state (pending: false, failed: false) %><div><% if pending? && failed? %>x<% end %></div>)
+        _, src = compile(template)
+
+        assert_equal "if pending && failed;", src[/if pending[^;]*;/]
+      end
+
+      test "a call on a receiver that spells a state name is not a read" do
+        template = <<~ERB
+          <%# herb:state (draft: "") %>
+          <ul><% @items.each do |item| %><%# herb:key item %><li id="i<%= item %>"><%= item.draft %></li><% end %></ul>
+        ERB
+
+        visitor, = compile(template)
+
+        assert_empty visitor.state_values
+        assert_empty visitor.state_presence
+      end
+
+      test "a string literal that spells a predicate keeps its `?` in the server's comparison" do
+        template = %(<%# herb:state (draft: "draft?") %><p><%= draft == "draft?" %></p>)
+        visitor, = compile(template)
+
+        assert_equal ["draft", { "value" => "draft?" }], encoded(visitor.state_values.fetch(0))
+
+        assert_equal(
+          %(<!--herb-region:app/views/test.html.erb:a560d282:0--><p data-herb-slot="0:child">true</p><!--/herb-region:app/views/test.html.erb-->),
+          render(template)
+        )
+      end
+
+      test "a negated predicate read evaluates on the server" do
+        assert_equal(
+          %(<!--herb-region:app/views/test.html.erb:50a4b7a7:0--><div><!--herb-slot:0:conditional--><!--herb-branch:0:0-->x<!--/herb-slot:0--></div><!--/herb-region:app/views/test.html.erb--><template data-herb-region="app/views/test.html.erb:50a4b7a7"><!--herb-branch:0:0-->x</template>),
+          render(%(<%# herb:state (open: false) %><div><% if !open? %>x<% end %></div>))
+        )
+      end
+
       test "a negated read renders for the server" do
         rendered = render(%(<%# herb:state (open: false) %><button disabled="<%= !open %>">Send</button>))
 
@@ -701,6 +756,22 @@ module Engine
           ["`draft.upcase` computes with the state `draft`. The client cannot run Ruby to keep the result current."],
           compiler_findings(error)
         )
+      end
+
+      test "a string literal that spells a state name is not a read" do
+        visitor, = compile(%(<%# herb:state (draft: "") %><p><%= "draft" %></p>))
+
+        assert_empty visitor.state_values
+        assert_empty visitor.state_presence
+      end
+
+      test "a string literal that spells a counted state is not a read inside its loop" do
+        visitor, = compile(<<~ERB)
+          <%# herb:state (total: 0) %>
+          <ul><% @items.each do |item| %><%# herb:key item %><% total += 1 %><li id="i<%= item %>"><%= "total" %></li><% end %></ul>
+        ERB
+
+        assert_equal [{ name: "total", collection: 0, by: 1, when: nil }], visitor.state_count_entries
       end
 
       test "a second directive in the same scope is refused, since one declaration owns the scope" do

--- a/test/ruby_program_test.rb
+++ b/test/ruby_program_test.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+require_relative "test_helper"
+require_relative "../lib/herb/ruby_program"
+
+class RubyProgramTest < Minitest::Spec
+  def program_for(template)
+    result = Herb.parse(template, prism_program: true)
+
+    Herb::RubyProgram.for(result.value)
+  end
+
+  def erb_tokens(template)
+    nodes(Herb.parse(template, prism_program: true).value).filter_map { |node|
+      node.content if node.class.name.to_s.include?("ERB") && node.respond_to?(:content) && node.content.is_a?(Herb::Token)
+    }
+  end
+
+  def nodes(root)
+    found = []
+    queue = [root]
+
+    until queue.empty?
+      node = queue.shift
+      found << node
+      queue.unshift(*node.child_nodes.compact) if node.respond_to?(:child_nodes)
+    end
+
+    found
+  end
+
+  def resolved_sources(template)
+    program = program_for(template)
+
+    erb_tokens(template).map { |token|
+      resolved = program&.resolve(token.location)
+
+      [token.value, resolved&.nodes&.map(&:slice)]
+    }
+  end
+
+  test "resolves the Ruby each ERB tag holds, including an elsif arm" do
+    template = %(<%# herb:state (pending: false, draft: "") %><div><% if pending? %>a<% elsif draft.blank? %>b<% end %></div>)
+
+    assert_equal(
+      [
+        [" herb:state (pending: false, draft: \"\") ", []],
+        [" if pending? ", ["pending?"]],
+        [" elsif draft.blank? ", ["draft.blank?"]],
+        [" end ", []]
+      ],
+      resolved_sources(template)
+    )
+  end
+
+  test "resolves a case subject and an output expression" do
+    template = %(<%# herb:state (draft: "") %><div><% case draft %><% when "x" %>a<% end %></div><p><%= draft == "draft?" %></p>)
+
+    assert_equal(
+      [
+        [" herb:state (draft: \"\") ", []],
+        [" case draft ", ["draft"]],
+        [" when \"x\" ", ["when \"x\""]],
+        [" end ", []],
+        [" draft == \"draft?\" ", ["draft == \"draft?\""]]
+      ],
+      resolved_sources(template)
+    )
+  end
+
+  test "reports the byte offset and source a range covers, so a splice can rebase" do
+    template = %(<%# herb:state (draft: "") %><p><%= draft == "café?" %></p>)
+    program = program_for(template)
+    resolved = program&.resolve(erb_tokens(template).fetch(1).location)
+
+    assert_equal " draft == \"café?\" ", resolved&.source
+    assert_equal template.byteindex(" draft"), resolved&.offset
+  end
+
+  test "answers nothing when the document carries no program" do
+    document = Herb.parse(%(<p><%= @a %></p>)).value
+
+    assert_nil Herb::RubyProgram.for(document)
+  end
+end

--- a/test/source_path_test.rb
+++ b/test/source_path_test.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative "test_helper"
+require_relative "../lib/herb/source_path"
 
 class SourcePathTest < Minitest::Spec
   PATH = "app/views/posts/_card.html.erb"


### PR DESCRIPTION
This pull request updates the `herb:state` compiler to decide what reads a state by looking at Prism nodes instead of running regular expressions over the raw expression source.

#### A string literal that spells a state name raised `slots-read`

`mentions_any?` gates the state read checks. Because it matched inside the literal, a template that never touches a state was refused.

```erb
<%# herb:slots client %>
<%# herb:state (abc: 1) %>

<%= "abc" %>
```

```
app/views/chat/show.html.erb:4:1: `"abc"` computes with a state.
The client cannot evaluate Ruby, so read the state bare, read it with a
predicate, or compare it to a literal.
```

#### A call on a receiver that spells a state name raised `slots-read`

The same false positive fired without any string being involved, because the old pattern allowed a dot in front of the name.

```erb
<%# herb:state (draft: "") %>
<ul><% @items.each do |item| %><%# herb:key item %>
  <li><%= item.draft %></li>
<% end %></ul>
```

```
`item.draft` computes with a state.
```

#### `rewrite_reads` rewrote inside string literals and unrelated calls

`rewrite_reads` turns a predicate read into something the server can evaluate, so `pending?` becomes `pending` and `count.one?` becomes `(count == 1)`. Rewriting the raw source also rewrote matching text inside literals, which left the server evaluating a different comparison than the one recorded for the client.

```erb
<%# herb:state (draft: "draft?") %>
<p><%= draft == "draft?" %></p>
```

```ruby
# compiled server source
_buf << (draft == "draft").to_s

# recorded manifest
"computed" => { "0" => ["draft", { "value" => "draft?" }] }
```

#### A negated predicate reached the server unrewritten

The lookbehind in the old pattern excluded `!`, so a bang in front of a predicate stopped the rewrite and left an undefined method call behind.

```erb
<%# herb:state (open: false) %>
<div><% if !open? %>x<% end %></div>
```

```
NoMethodError: undefined method 'open?' for main
```