### PR TITLE
Engine: Collapse static subtrees into single appends when the buffer stays

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -161,6 +161,7 @@ Metrics/ParameterLists:
     - lib/herb.rb
     - lib/herb/ast/node.rb
     - lib/herb/ast/nodes.rb
+    - lib/herb/engine/visitors/optimize_visitor.rb
     - lib/herb/dev/runner.rb
     - lib/herb/diagnostic.rb
     - lib/herb/diff_operation.rb

--- a/docs/docs/projects/engine.md
+++ b/docs/docs/projects/engine.md
@@ -845,9 +845,17 @@ end
 
 The conditions compile onto the lines they were written on, so backtraces stay right, and a chain without an `else` gets one that returns what the template renders without it. A pattern matching chain is the exception, since it keeps raising `NoMatchingPatternError` for a value no pattern accepts. The path literals repeat the markup the paths share, so the collapse steps back once they would hold more than four times the template's static bytes, and the buffer stays. A branch that carries an expression keeps the buffer, and so does a chain that sits beside another in the same scope.
 
+A template that keeps its buffer can still get its static subtrees, with `subtrees: true`. A chain whose branches are static collapses into a single append of the chain picking between path literals, with the static text around it merged in, so a conditional attribute next to a dynamic one renders in one append where it took three:
+
+```ruby
+_buf << '<option class="'.freeze; _buf << ::Herb::Engine.attr((kind)); _buf << (if (option == current); "\" selected>One</option>".freeze; else "\">One</option>".freeze;end;).to_s;
+```
+
+A chain the buffer already renders in one append is left as it was. The pass trades compiled template bytes for fewer appends at render time, which is why it is the one pass that is off by default.
+
 The `herb compile --optimize` and `herb render --optimize` commands wire the visitor up from the command line. The engine keeps the buffer when the caller drives it through `preamble`, `postamble`, `bufval`, or `ensure`, and when a visitor recorded a diagnostic the compiled template still has to report.
 
-Every pass is on by default, and each can be left off on its own. `helpers: false` stops asking the parser to resolve helpers, `conditionals: false` stops asking it to unroll the postfix conditionals and ternaries it would have, `literals: false` keeps literal outputs dynamic, and `collapse: false` keeps the buffer for a template either collapse would have compiled without one:
+Every pass except `subtrees` is on by default, and each can be toggled on its own. `helpers: false` stops asking the parser to resolve helpers, `conditionals: false` stops asking it to unroll the postfix conditionals and ternaries it would have, `literals: false` keeps literal outputs dynamic, and `collapse: false` keeps the buffer for a template either collapse would have compiled without one:
 
 ```ruby
 Herb::Engine::OptimizeVisitor.new(literals: false, collapse: false)

--- a/lib/herb/engine/compiler.rb
+++ b/lib/herb/engine/compiler.rb
@@ -61,6 +61,8 @@ module Herb
             @engine.send(:add_expression_block, indicator_for(type), value)
           when :expr_block_end
             @engine.send(:add_expression_block_end, value, escaped: escaped)
+          when :chain
+            @engine.send(:add_expression_result, value)
           end
         end
       end

--- a/lib/herb/engine/visitors/optimize_visitor.rb
+++ b/lib/herb/engine/visitors/optimize_visitor.rb
@@ -56,7 +56,16 @@ module Herb
     # would hold more than `DUPLICATION_LIMIT` times the template's static bytes, and the buffer
     # stays. A chain that sits beside another in the same scope keeps the buffer too.
     #
-    # Every pass is on by default, and each can be left off on its own. `helpers: false` stops
+    # A template the collapse walks away from can still get its static subtrees. With
+    # `subtrees: true`, when the buffer stays, a chain whose branches are static collapses into a
+    # single append of the chain picking between path literals, the static text around it merged
+    # in, so a conditional attribute next to a dynamic one costs one append where it cost three.
+    # A chain the buffer already renders in one append is left as it was, and the duplication
+    # limit governs each subtree the way it governs the template. The pass trades compiled
+    # template bytes for fewer appends at render time, which is why it is the one pass that is
+    # off by default.
+    #
+    # Every other pass is on by default, and each can be left off on its own. `helpers: false` stops
     # asking the parser to resolve helpers, `conditionals: false` stops asking it to unroll the
     # postfix conditionals and ternaries it would have, `literals: false` keeps literal outputs
     # dynamic, and `collapse: false` keeps the buffer for a template either collapse above would
@@ -108,14 +117,15 @@ module Herb
         true
       end
 
-      #: (?helpers: bool, ?conditionals: bool, ?literals: bool, ?collapse: bool, ?verify: bool) -> void
-      def initialize(helpers: true, conditionals: true, literals: true, collapse: true, verify: false)
+      #: (?helpers: bool, ?conditionals: bool, ?literals: bool, ?collapse: bool, ?subtrees: bool, ?verify: bool) -> void
+      def initialize(helpers: true, conditionals: true, literals: true, collapse: true, subtrees: false, verify: false)
         super()
 
         @helpers = helpers
         @conditionals = conditionals
         @literals = literals
         @collapse = collapse
+        @subtrees = subtrees
         @verify = verify
         @sources = {} #: Hash[String, Herb::Location?]
         @output_contexts = [] #: Array[Symbol]
@@ -181,13 +191,13 @@ module Herb
 
       #: (Herb::Engine, untyped) -> String?
       def compile_static_body(engine, compiler)
-        return unless @collapse
+        body = static_body(engine, compiler)
 
-        text = compiler.static_template_text
+        return body if body
 
-        return engine.string_literal(text) if text
+        collapse_subtrees(engine, compiler.optimized_tokens) if @subtrees
 
-        compile_static_branches(engine, compiler.optimized_tokens)
+        nil
       end
 
       #: () -> String
@@ -209,9 +219,40 @@ module Herb
         toggles << "conditionals=false" unless @conditionals
         toggles << "literals=false" unless @literals
         toggles << "collapse=false" unless @collapse
+        toggles << "subtrees=true" if @subtrees
         toggles << "verify=true" if @verify
 
         toggles
+      end
+
+      #: (Herb::Engine, untyped) -> String?
+      def static_body(engine, compiler)
+        return unless @collapse
+
+        text = compiler.static_template_text
+
+        return engine.string_literal(text) if text
+
+        compile_static_branches(engine, compiler.optimized_tokens)
+      end
+
+      #: (Herb::Engine, Array[untyped]) -> void
+      def collapse_subtrees(engine, tokens)
+        cursor = { index: 0 } #: Hash[Symbol, Integer]
+
+        while cursor[:index] < tokens.length
+          replacement = chain_run_replacement(engine, tokens, cursor[:index])
+
+          if replacement
+            range, token = replacement
+            tokens[range] = [token]
+            cursor[:index] = range.begin + 1
+          else
+            cursor[:index] += 1
+          end
+        end
+
+        nil
       end
 
       #: ((Herb::AST::HTMLElementNode | Herb::AST::HTMLConditionalElementNode)) -> Symbol?
@@ -517,6 +558,66 @@ module Herb
         implicit = !chain[:else_seen] && chain[:kind] != :in
 
         queues[:ends] << (implicit ? engine.escaped_string_literal("#{full_prefix}#{full_suffix}") : nil)
+      end
+
+      #: (Herb::Engine, Array[untyped], Integer) -> [::Range[Integer], Array[untyped]]?
+      def chain_run_replacement(engine, tokens, index)
+        opening = tokens[index]
+
+        return unless opening[0] == :code
+        return unless [:opening, :case_opening].include?(chain_keyword(opening[1].strip.to_s))
+
+        closing = chain_end_index(tokens, index)
+
+        return unless closing
+
+        start = index
+        start -= 1 while start.positive? && tokens[start - 1][0] == :text
+
+        stop = closing
+        stop += 1 while stop + 1 < tokens.length && tokens[stop + 1][0] == :text
+
+        slice = tokens[start..stop] #: Array[untyped]
+        root = branch_tree(slice)
+
+        return unless root
+        return unless start < index || stop > closing || nested_chain?(root)
+        return unless within_duplication_limit?(container_paths(root), slice)
+
+        source = render_static_branches(engine, slice, root)
+
+        return if Helpers.comment?(source) || Helpers.heredoc?(source)
+
+        [(start..stop), [:chain, source, nil]]
+      end
+
+      #: (Array[untyped], Integer) -> Integer?
+      def chain_end_index(tokens, index)
+        depth = 0
+
+        (index...tokens.length).each do |position|
+          token = tokens[position]
+
+          next unless token[0] == :code
+
+          keyword = chain_keyword(token[1].strip.to_s)
+
+          depth += 1 if [:opening, :case_opening].include?(keyword)
+          depth -= 1 if keyword == :end
+
+          return position if depth.zero? && keyword == :end
+        end
+
+        nil
+      end
+
+      #: (Hash[Symbol, untyped]) -> bool
+      def nested_chain?(container)
+        chain = container_chain(container)
+
+        return false unless chain
+
+        chain[:branches].any? { |branch| container_chain(branch) }
       end
 
       #: (String) -> Symbol?

--- a/sig/herb/engine/visitors/optimize_visitor.rbs
+++ b/sig/herb/engine/visitors/optimize_visitor.rbs
@@ -49,7 +49,16 @@ module Herb
     # would hold more than `DUPLICATION_LIMIT` times the template's static bytes, and the buffer
     # stays. A chain that sits beside another in the same scope keeps the buffer too.
     #
-    # Every pass is on by default, and each can be left off on its own. `helpers: false` stops
+    # A template the collapse walks away from can still get its static subtrees. With
+    # `subtrees: true`, when the buffer stays, a chain whose branches are static collapses into a
+    # single append of the chain picking between path literals, the static text around it merged
+    # in, so a conditional attribute next to a dynamic one costs one append where it cost three.
+    # A chain the buffer already renders in one append is left as it was, and the duplication
+    # limit governs each subtree the way it governs the template. The pass trades compiled
+    # template bytes for fewer appends at render time, which is why it is the one pass that is
+    # off by default.
+    #
+    # Every other pass is on by default, and each can be left off on its own. `helpers: false` stops
     # asking the parser to resolve helpers, `conditionals: false` stops asking it to unroll the
     # postfix conditionals and ternaries it would have, `literals: false` keeps literal outputs
     # dynamic, and `collapse: false` keeps the buffer for a template either collapse above would
@@ -98,8 +107,8 @@ module Herb
       # : () -> bool
       def self.rewrites_erb_source?: () -> bool
 
-      # : (?helpers: bool, ?conditionals: bool, ?literals: bool, ?collapse: bool, ?verify: bool) -> void
-      def initialize: (?helpers: bool, ?conditionals: bool, ?literals: bool, ?collapse: bool, ?verify: bool) -> void
+      # : (?helpers: bool, ?conditionals: bool, ?literals: bool, ?collapse: bool, ?subtrees: bool, ?verify: bool) -> void
+      def initialize: (?helpers: bool, ?conditionals: bool, ?literals: bool, ?collapse: bool, ?subtrees: bool, ?verify: bool) -> void
 
       # : () -> Hash[Symbol, untyped]
       def required_parser_options: () -> Hash[Symbol, untyped]
@@ -129,6 +138,12 @@ module Herb
 
       # : () -> Array[String]
       def non_default_toggles: () -> Array[String]
+
+      # : (Herb::Engine, untyped) -> String?
+      def static_body: (Herb::Engine, untyped) -> String?
+
+      # : (Herb::Engine, Array[untyped]) -> void
+      def collapse_subtrees: (Herb::Engine, Array[untyped]) -> void
 
       # : ((Herb::AST::HTMLElementNode | Herb::AST::HTMLConditionalElementNode)) -> Symbol?
       def element_output_context: (Herb::AST::HTMLElementNode | Herb::AST::HTMLConditionalElementNode) -> Symbol?
@@ -195,6 +210,15 @@ module Herb
 
       # : (Herb::Engine, Hash[Symbol, untyped], String, String, Hash[Symbol, Array[String?]]) -> void
       def collect_leaf_literals: (Herb::Engine, Hash[Symbol, untyped], String, String, Hash[Symbol, Array[String?]]) -> void
+
+      # : (Herb::Engine, Array[untyped], Integer) -> [::Range[Integer], Array[untyped]]?
+      def chain_run_replacement: (Herb::Engine, Array[untyped], Integer) -> [ ::Range[Integer], Array[untyped] ]?
+
+      # : (Array[untyped], Integer) -> Integer?
+      def chain_end_index: (Array[untyped], Integer) -> Integer?
+
+      # : (Hash[Symbol, untyped]) -> bool
+      def nested_chain?: (Hash[Symbol, untyped]) -> bool
 
       # : (String) -> Symbol?
       def chain_keyword: (String) -> Symbol?

--- a/test/engine/optimize_toggles_test.rb
+++ b/test/engine/optimize_toggles_test.rb
@@ -70,6 +70,22 @@ module Engine
       end
     end
 
+    describe "the subtrees pass" do
+      test "off by default, a static chain inside a kept buffer stays buffered" do
+        assert_compiled_snapshot(
+          "<div>\n  <%= name %>\n  <% if flag %>Admin<% else %>Member<% end %>\n</div>",
+          optimize_options
+        )
+      end
+
+      test "turned on, the chain and the text around it become one append" do
+        assert_compiled_snapshot(
+          "<div>\n  <%= name %>\n  <% if flag %>Admin<% else %>Member<% end %>\n</div>",
+          optimize_options({ subtrees: true })
+        )
+      end
+    end
+
     describe "what inspect names" do
       test "default construction names no toggles" do
         assert_equal "#<Herb::Engine::OptimizeVisitor>", Herb::Engine::OptimizeVisitor.new.inspect
@@ -84,9 +100,9 @@ module Engine
       end
 
       test "every non-default toggle is named" do
-        visitor = Herb::Engine::OptimizeVisitor.new(helpers: false, conditionals: false, literals: false, collapse: false, verify: true)
+        visitor = Herb::Engine::OptimizeVisitor.new(helpers: false, conditionals: false, literals: false, collapse: false, subtrees: true, verify: true)
 
-        assert_equal "#<Herb::Engine::OptimizeVisitor helpers=false conditionals=false literals=false collapse=false verify=true>", visitor.inspect
+        assert_equal "#<Herb::Engine::OptimizeVisitor helpers=false conditionals=false literals=false collapse=false subtrees=true verify=true>", visitor.inspect
       end
     end
 

--- a/test/engine/optimized_branches_test.rb
+++ b/test/engine/optimized_branches_test.rb
@@ -22,6 +22,10 @@ module Engine
       { visitors: [Herb::Engine::OptimizeVisitor.new], **options }
     end
 
+    def subtree_options
+      { visitors: [Herb::Engine::OptimizeVisitor.new(subtrees: true)] }
+    end
+
     describe "what collapses into branch literals" do
       test "a conditional between static markup" do
         assert_compiled_snapshot(CONDITIONAL, optimize_options)
@@ -125,6 +129,38 @@ module Engine
         template = "#{"x" * 120}<% if flag %>1<% elsif other %>2<% elsif third %>3<% elsif fourth %>4<% elsif fifth %>5<% end %>"
 
         assert_compiled_snapshot(template, optimize_options)
+      end
+    end
+
+    describe "what collapses inside a kept buffer" do
+      test "a static chain and its surrounding text become one append" do
+        template = "<div>\n  <%= name %>\n  <% if flag %>Admin<% else %>Member<% end %>\n</div>"
+
+        assert_compiled_snapshot(template, subtree_options)
+      end
+
+      test "a conditional attribute beside a dynamic one" do
+        template = <<~ERB
+          <select>
+          <% if flag %>
+          <option <%= tag.attributes(class: kind, selected: option == current) %>>One</option>
+          <% else %>
+          <option>None</option>
+          <% end %>
+          </select>
+        ERB
+
+        assert_compiled_snapshot(template, subtree_options)
+      end
+
+      test "each chain collapses on its own when text sits between them" do
+        template = "a <% if flag %>x<% end %> b <% if other %>y<% end %> c <%= name %>"
+
+        assert_compiled_snapshot(template, subtree_options)
+      end
+
+      test "a chain the buffer already renders in one append stays as it was" do
+        assert_compiled_snapshot("<% if flag %>a<% end %><%= name %>", subtree_options)
       end
     end
 

--- a/test/snapshots/engine/optimize_toggles_test/the_subtrees_pass/test_0001_off_by_default,_a_static_chain_inside_a_kept_buffer_stays_buffered_8867d123674dce62209fc1c6515e198d.txt
+++ b/test/snapshots/engine/optimize_toggles_test/the_subtrees_pass/test_0001_off_by_default,_a_static_chain_inside_a_kept_buffer_stays_buffered_8867d123674dce62209fc1c6515e198d.txt
@@ -1,0 +1,9 @@
+---
+source: "Engine::OptimizeTogglesTest::the subtrees pass#test_0001_off by default, a static chain inside a kept buffer stays buffered"
+input: "{source: \"<div>\\n  <%= name %>\\n  <% if flag %>Admin<% else %>Member<% end %>\\n</div>\", options: {visitors: [#<Herb::Engine::OptimizeVisitor>]}}"
+---
+_buf = ::String.new; _buf << '<div>
+  '.freeze; _buf << (name).to_s; _buf << '
+  '.freeze;   if flag ; _buf << 'Admin'.freeze; else; _buf << 'Member'.freeze; end; _buf << '
+</div>'.freeze;
+_buf.to_s

--- a/test/snapshots/engine/optimize_toggles_test/the_subtrees_pass/test_0002_turned_on,_the_chain_and_the_text_around_it_become_one_append_54b2cdfc341bc1ddfc99befc22d158c5.txt
+++ b/test/snapshots/engine/optimize_toggles_test/the_subtrees_pass/test_0002_turned_on,_the_chain_and_the_text_around_it_become_one_append_54b2cdfc341bc1ddfc99befc22d158c5.txt
@@ -1,0 +1,9 @@
+---
+source: "Engine::OptimizeTogglesTest::the subtrees pass#test_0002_turned on, the chain and the text around it become one append"
+input: "{source: \"<div>\\n  <%= name %>\\n  <% if flag %>Admin<% else %>Member<% end %>\\n</div>\", options: {visitors: [#<Herb::Engine::OptimizeVisitor subtrees=true>]}}"
+---
+_buf = ::String.new; _buf << '<div>
+  '.freeze; _buf << (name).to_s; _buf << (
+  if flag ; "\n  Admin\n</div>".freeze;else; "\n  Member\n</div>".freeze;end;
+).to_s;
+_buf.to_s

--- a/test/snapshots/engine/optimized_branches_test/what_collapses_inside_a_kept_buffer/test_0001_a_static_chain_and_its_surrounding_text_become_one_append_54b2cdfc341bc1ddfc99befc22d158c5.txt
+++ b/test/snapshots/engine/optimized_branches_test/what_collapses_inside_a_kept_buffer/test_0001_a_static_chain_and_its_surrounding_text_become_one_append_54b2cdfc341bc1ddfc99befc22d158c5.txt
@@ -1,0 +1,9 @@
+---
+source: "Engine::OptimizedBranchesTest::what collapses inside a kept buffer#test_0001_a static chain and its surrounding text become one append"
+input: "{source: \"<div>\\n  <%= name %>\\n  <% if flag %>Admin<% else %>Member<% end %>\\n</div>\", options: {visitors: [#<Herb::Engine::OptimizeVisitor subtrees=true>]}}"
+---
+_buf = ::String.new; _buf << '<div>
+  '.freeze; _buf << (name).to_s; _buf << (
+  if flag ; "\n  Admin\n</div>".freeze;else; "\n  Member\n</div>".freeze;end;
+).to_s;
+_buf.to_s

--- a/test/snapshots/engine/optimized_branches_test/what_collapses_inside_a_kept_buffer/test_0002_a_conditional_attribute_beside_a_dynamic_one_80bc921456752f1429c96db030cc4c8f.txt
+++ b/test/snapshots/engine/optimized_branches_test/what_collapses_inside_a_kept_buffer/test_0002_a_conditional_attribute_beside_a_dynamic_one_80bc921456752f1429c96db030cc4c8f.txt
@@ -1,0 +1,13 @@
+---
+source: "Engine::OptimizedBranchesTest::what collapses inside a kept buffer#test_0002_a conditional attribute beside a dynamic one"
+input: "{source: \"<select>\\n<% if flag %>\\n<option <%= tag.attributes(class: kind, selected: option == current) %>>One</option>\\n<% else %>\\n<option>None</option>\\n<% end %>\\n</select>\\n\", options: {visitors: [#<Herb::Engine::OptimizeVisitor subtrees=true>]}}"
+---
+_buf = ::String.new; _buf << '<select>
+'.freeze; if flag 
+ _buf << '<option class="'.freeze; _buf << ::Herb::Engine.attr((kind)); _buf << (if (option == current); "\" selected>One</option>\n".freeze; else "\">One</option>\n".freeze;end;
+).to_s; else 
+ _buf << '<option>None</option>
+'.freeze; end 
+ _buf << '</select>
+'.freeze;
+_buf.to_s

--- a/test/snapshots/engine/optimized_branches_test/what_collapses_inside_a_kept_buffer/test_0003_each_chain_collapses_on_its_own_when_text_sits_between_them_dbdd0999f5c86bd304716702d0711a68.txt
+++ b/test/snapshots/engine/optimized_branches_test/what_collapses_inside_a_kept_buffer/test_0003_each_chain_collapses_on_its_own_when_text_sits_between_them_dbdd0999f5c86bd304716702d0711a68.txt
@@ -1,0 +1,6 @@
+---
+source: "Engine::OptimizedBranchesTest::what collapses inside a kept buffer#test_0003_each chain collapses on its own when text sits between them"
+input: "{source: \"a <% if flag %>x<% end %> b <% if other %>y<% end %> c <%= name %>\", options: {visitors: [#<Herb::Engine::OptimizeVisitor subtrees=true>]}}"
+---
+_buf = ::String.new; _buf << (if flag; "a x b ".freeze; else "a  b ".freeze;end;).to_s; _buf << (if other; "y c ".freeze; else " c ".freeze;end;).to_s; _buf << (name).to_s;
+_buf.to_s

--- a/test/snapshots/engine/optimized_branches_test/what_collapses_inside_a_kept_buffer/test_0004_a_chain_the_buffer_already_renders_in_one_append_stays_as_it_was_acb851b0482211f2e936edb951c6c20c.txt
+++ b/test/snapshots/engine/optimized_branches_test/what_collapses_inside_a_kept_buffer/test_0004_a_chain_the_buffer_already_renders_in_one_append_stays_as_it_was_acb851b0482211f2e936edb951c6c20c.txt
@@ -1,0 +1,6 @@
+---
+source: "Engine::OptimizedBranchesTest::what collapses inside a kept buffer#test_0004_a chain the buffer already renders in one append stays as it was"
+input: "{source: \"<% if flag %>a<% end %><%= name %>\", options: {visitors: [#<Herb::Engine::OptimizeVisitor subtrees=true>]}}"
+---
+_buf = ::String.new; if flag ; _buf << 'a'.freeze; end; _buf << (name).to_s;
+_buf.to_s


### PR DESCRIPTION
This pull request extends the static branch collapse from #2497 to templates it walks away from. 

When an expression anywhere keeps the buffer, each static conditional chain inside it still collapses, together with the static text right around it, into a single append of the chain picking between path literals.

```erb
<select>
<% if signed_in? %>
<option <%= tag.attributes(class: kind, selected: option == current) %>>One</option>
<% else %>
<option>None</option>
<% end %>
</select>
```

The `class` value is dynamic, so the template keeps its buffer and #2497 leaves it fully buffered. The `selected` chain and the markup around it are static, so they now render in one append where they took three:

```ruby
_buf << '<option class="'.freeze; _buf << ::Herb::Engine.attr((kind)); _buf << (if (option == current); "\" selected>One</option>\n".freeze; else "\">One</option>\n".freeze;end;
);
```

A new `compile_buffered_tokens` hook on the engine lets a visitor rewrite the compiler's token stream before output is generated. The visitor splices each static chain run into a `:chain` token that compiles to a raw `_buf << (...)` append, with no context escaping, since the text tokens it merges are already the final output bytes. Merging the adjacent text is always sound because text next to a chain in the token stream sits in the same basic block as the chain.

The collapse machinery from #2497 carries over whole. The chain keywords are emitted verbatim with the token stream's own newline layout, so every condition stays on the line it was written on, nesting and `case` chains work the same way, and `DUPLICATION_LIMIT` governs each subtree the way it governs a template. A chain the buffer already renders in one append, like a bare `<% if flag %>a<% end %>`, is left exactly as it was, so no template compiles to a worse shape than before.

The pass joins the toggles from #2499 as `subtrees:`, and it is the one pass that is off by default, since it trades compiled template bytes for fewer appends at render time:

```ruby
Herb::Engine::OptimizeVisitor.new(subtrees: true)
```

Follow up on #2497 and #2499.