### PR TITLE
Engine: Give back the line an omitted tag claimed but did not swallow

### DIFF
--- a/lib/herb/engine/compiler.rb
+++ b/lib/herb/engine/compiler.rb
@@ -27,6 +27,7 @@ module Herb
         @last_trim_consumed_newline = false
         @pending_trim_newline_index = nil #: Integer?
         @pending_trim_owns_next_whitespace = false
+        @pending_span_extra_index = nil #: Integer?
         @pending_leading_whitespace = nil
         @pending_leading_whitespace_insert_index = 0
         @current_element_source = nil
@@ -452,6 +453,7 @@ module Herb
           end
 
           keep_span_line_count(node, extra: swallows_newline ? 1 : 0)
+          @pending_span_extra_index = @tokens.length if swallows_newline
 
           return
         end
@@ -501,11 +503,13 @@ module Herb
           @trim_next_whitespace = false
 
           settle_pending_trim_newline!(@last_trim_consumed_newline)
+          settle_pending_span_extra!(@last_trim_consumed_newline)
           restore_pending_leading_whitespace! unless @last_trim_consumed_newline
         else
           @last_trim_consumed_newline = false
 
           settle_pending_trim_newline!(false)
+          settle_pending_span_extra!(false)
         end
 
         @pending_leading_whitespace = nil
@@ -822,6 +826,19 @@ module Herb
         position = node.tag_closing&.location&.end || node.location&.end
 
         !position.nil? && !position.line.positive?
+      end
+
+      #: (bool) -> void
+      def settle_pending_span_extra!(keep)
+        index = @pending_span_extra_index
+
+        return unless index
+
+        @pending_span_extra_index = nil
+
+        return if keep
+
+        @padding_before[index] -= 1 if @padding_before&.key?(index)
       end
 
       #: (bool) -> void

--- a/sig/herb/engine/compiler.rbs
+++ b/sig/herb/engine/compiler.rbs
@@ -192,6 +192,9 @@ module Herb
       def without_source?: (untyped) -> bool
 
       # : (bool) -> void
+      def settle_pending_span_extra!: (bool) -> void
+
+      # : (bool) -> void
       def settle_pending_trim_newline!: (bool) -> void
 
       def save_pending_leading_whitespace!: (untyped whitespace) -> untyped

--- a/test/engine/erb_comments_test.rb
+++ b/test/engine/erb_comments_test.rb
@@ -139,5 +139,11 @@ module Engine
 
       assert_compiled_snapshot(template)
     end
+
+    test "a multi-line comment closed with content after it keeps the following line" do
+      template = "<%#-- a\nb\nc\n--#%><div>hi</div>\n<%= z %>\n"
+
+      assert_compiled_snapshot(template)
+    end
   end
 end

--- a/test/snapshots/engine/erb_comments_test/test_0023_a_multi-line_comment_closed_with_content_after_it_keeps_the_following_line_e7ee94d4c441d85b6429f792fa0687f0.txt
+++ b/test/snapshots/engine/erb_comments_test/test_0023_a_multi-line_comment_closed_with_content_after_it_keeps_the_following_line_e7ee94d4c441d85b6429f792fa0687f0.txt
@@ -1,0 +1,11 @@
+---
+source: "Engine::ERBCommentsTest#test_0023_a multi-line comment closed with content after it keeps the following line"
+input: "{source: \"<%#-- a\\nb\\nc\\n--#%><div>hi</div>\\n<%= z %>\\n\", options: {}}"
+---
+_buf = ::String.new; _buf << '<div>hi</div>
+'.freeze; 
+
+
+ _buf << (z).to_s; _buf << '
+'.freeze;
+_buf.to_s


### PR DESCRIPTION
A tag that compiles to nothing, an ERB comment or a configured opener, keeps its lines by padding the compiled output with the newlines it spanned. When such a tag begins a line it also swallows the newline that follows it, so it claims one more line than it spans.

It claimed that line whether or not there was a newline there to swallow. A comment closed with content after it on the same line took a line that does not exist, and every tag below it compiled one line low.

```erb
<%#-- a
b
c
--#%><div>hi</div>
<%= z %>
```

`z` is written on line 5 and compiled to line 6. It now compiles to line 5.

The claim is now given back when the text that follows shows nothing was swallowed, the same way #2500 gives back the newline a trimmed statement tag emits.

```ruby
def settle_pending_span_extra!(keep)
  index = @pending_span_extra_index

  return unless index

  @pending_span_extra_index = nil

  return if keep

  @padding_before[index] -= 1 if @padding_before&.key?(index)
end
```

A comment closed on its own line does swallow the newline below it, keeps the line it claimed, and compiles exactly as before.
