### PR TITLE
Engine: Stop counting a heredoc's closing newline twice

### DIFF
--- a/lib/herb/engine/compiler.rb
+++ b/lib/herb/engine/compiler.rb
@@ -468,7 +468,9 @@ module Herb
           apply_trim(node, code)
         end
 
-        keep_line_count(node, at: code_index)
+        absorbed = erb_output?(opening) && ::Herb::Engine::Helpers.ends_on_heredoc_terminator?(code) ? 1 : 0
+
+        keep_line_count(node, at: code_index, absorbed: absorbed)
       end
 
       #: (untyped, ?extra: Integer) -> void
@@ -481,11 +483,11 @@ module Herb
         @padding_before[@tokens.length] += lines
       end
 
-      def keep_line_count(node, extra: 0, at: nil)
+      def keep_line_count(node, extra: 0, at: nil, absorbed: 0)
         raw = node.content.value
 
         leading = raw[0, raw.length - raw.lstrip.length].to_s.count("\n")
-        trailing = raw.count("\n") - raw.strip.count("\n") - leading + extra
+        trailing = raw.count("\n") - raw.strip.count("\n") - leading + extra - absorbed
 
         block_comment = raw.include?("=begin") || raw.include?("=end")
 

--- a/sig/herb/engine/compiler.rbs
+++ b/sig/herb/engine/compiler.rbs
@@ -123,7 +123,7 @@ module Herb
       # : (untyped, ?extra: Integer) -> void
       def keep_span_line_count: (untyped, ?extra: Integer) -> void
 
-      def keep_line_count: (untyped node, ?extra: untyped, ?at: untyped) -> untyped
+      def keep_line_count: (untyped node, ?extra: untyped, ?at: untyped, ?absorbed: untyped) -> untyped
 
       def add_text: (untyped text) -> untyped
 

--- a/test/engine/engine_test.rb
+++ b/test/engine/engine_test.rb
@@ -349,5 +349,11 @@ module Engine
 
       assert_compiled_snapshot(template)
     end
+
+    test "heredoc ending an output tag keeps the following line" do
+      template = "<p><%= <<~TEXT\n  hello\nTEXT\n%></p>\n<%= z %>\n"
+
+      assert_compiled_snapshot(template)
+    end
   end
 end

--- a/test/snapshots/engine/engine_test/test_0018_heredoc_with_trailing_arguments_compiles_to_valid_Ruby_46fb4e6ec5bd55cc1041f3f88ad9508c.txt
+++ b/test/snapshots/engine/engine_test/test_0018_heredoc_with_trailing_arguments_compiles_to_valid_Ruby_46fb4e6ec5bd55cc1041f3f88ad9508c.txt
@@ -8,5 +8,5 @@ _buf = ::String.new; _buf << (method_call <<~GRAPHQL, variables
   }
 GRAPHQL
 ).to_s; _buf << '
-'.freeze; 
+'.freeze;
 _buf.to_s

--- a/test/snapshots/engine/engine_test/test_0023_heredoc_in_escaped_expression_tag_compiles_to_valid_Ruby_09b879fd48c9c55790c1b75c4a20b8a8.txt
+++ b/test/snapshots/engine/engine_test/test_0023_heredoc_in_escaped_expression_tag_compiles_to_valid_Ruby_09b879fd48c9c55790c1b75c4a20b8a8.txt
@@ -8,5 +8,5 @@ _buf = ::String.new; _buf << ::Herb::Engine.h((method_call <<~GRAPHQL, variables
   }
 GRAPHQL
 )); _buf << '
-'.freeze; 
+'.freeze;
 _buf.to_s

--- a/test/snapshots/engine/engine_test/test_0041_heredoc_ending_an_output_tag_keeps_the_following_line_7dd1158c6ef61d82996a56da6b7b907c.txt
+++ b/test/snapshots/engine/engine_test/test_0041_heredoc_ending_an_output_tag_keeps_the_following_line_7dd1158c6ef61d82996a56da6b7b907c.txt
@@ -1,0 +1,11 @@
+---
+source: "Engine::EngineTest#test_0041_heredoc ending an output tag keeps the following line"
+input: "{source: \"<p><%= <<~TEXT\\n  hello\\nTEXT\\n%></p>\\n<%= z %>\\n\", options: {}}"
+---
+_buf = ::String.new; _buf << '<p>'.freeze; _buf << (<<~TEXT
+  hello
+TEXT
+).to_s; _buf << '</p>
+'.freeze; _buf << (z).to_s; _buf << '
+'.freeze;
+_buf.to_s


### PR DESCRIPTION
An output tag whose code ends on a heredoc terminator is compiled with a newline before its closing paren, because `TEXT).to_s` is not valid Ruby. 

The newline between that terminator and the `%>` closing the tag was padded for as well, so one newline in the template became two lines in the compiled output, and every tag below it compiled one line low.

```erb
<p><%= <<~TEXT
  hello
TEXT
%></p>
<%= z %>
```

**Before**

```ruby
1 | _buf = ::String.new; _buf << '<p>'.freeze; _buf << (<<~TEXT
2 |   hello
3 | TEXT
4 | ).to_s; _buf << '</p>
5 | '.freeze; 
6 |  _buf << (z).to_s; _buf << '
```

**After**

```ruby
1 | _buf = ::String.new; _buf << '<p>'.freeze; _buf << (<<~TEXT
2 |   hello
3 | TEXT
4 | ).to_s; _buf << '</p>
5 | '.freeze;  _buf << (z).to_s; _buf << '
```

`z` is written on line 5 and compiled to line 6. It now compiles to line 5.