### PR TITLE
Linter: Allow attribute writes in `erb-no-unused-expressions`

### DIFF
--- a/javascript/packages/linter/src/rules/erb-no-unused-expressions.ts
+++ b/javascript/packages/linter/src/rules/erb-no-unused-expressions.ts
@@ -3,7 +3,7 @@ import { PrismVisitor, substringFromByteOffset , locationFromByteOffset } from "
 import { BaseRuleVisitor } from "../utils/rule-utils.js"
 
 import { isERBOutputNode, isRubyParameterNode, isPrismNodeType } from "@herb-tools/core"
-import { isAssignmentNode, isDebugOutputCall, isSleepCall, isCallOnLocal, SIDE_EFFECT_METHODS } from "../utils/prism-rule-utils.js"
+import { isAssignmentNode, isAttributeWriteCall, isDebugOutputCall, isSleepCall, isCallOnLocal, SIDE_EFFECT_METHODS } from "../utils/prism-rule-utils.js"
 import { StateScopeMap } from "../utils/state-directives-utils.js"
 
 import type { UnboundLintOffense, LintContext, FullRuleConfig } from "../types.js"
@@ -47,6 +47,7 @@ class UnusedExpressionCollector extends PrismVisitor {
     }
 
     if (isAssignmentNode(node)) return
+    if (isAttributeWriteCall(node)) return
 
     if (this.isUnusedExpression(node)) {
       this.expressions.push(node)

--- a/javascript/packages/linter/src/utils/prism-rule-utils.ts
+++ b/javascript/packages/linter/src/utils/prism-rule-utils.ts
@@ -1,8 +1,12 @@
 import { isPrismNodeType } from "@herb-tools/core"
 import type { PrismNode } from "@herb-tools/core"
 
-export const DEBUG_OUTPUT_METHODS = new Set(["p", "pp", "puts", "print", "warn", "debug", "byebug"])
 export const BINDING_DEBUGGER_METHODS = new Set(["pry", "irb"])
+export const CONTROL_FLOW_METHODS = new Set(["raise", "throw", "fail"])
+export const DEBUG_OUTPUT_METHODS = new Set(["p", "pp", "puts", "print", "warn", "debug", "byebug"])
+
+const CONTROL_FLOW_NODE_TYPES = ["BreakNode", "NextNode", "RedoNode", "RetryNode", "ReturnNode"]
+const COMPARISON_METHODS = new Set(["==", "===", "!=", "<=", ">=", "<=>", "=~"])
 
 export const SIDE_EFFECT_METHODS = new Set([
   "content_for",
@@ -13,10 +17,6 @@ export const SIDE_EFFECT_METHODS = new Set([
   "turbo_exempts_page_from_preview",
   "turbo_page_requires_reload",
 ])
-
-export const CONTROL_FLOW_METHODS = new Set(["raise", "throw", "fail"])
-
-const CONTROL_FLOW_NODE_TYPES = ["BreakNode", "NextNode", "RedoNode", "RetryNode", "ReturnNode"]
 
 export function isSideEffectCall(node: PrismNode): boolean {
   if (!isPrismNodeType(node, "CallNode")) return false
@@ -59,6 +59,14 @@ export function isAssignmentNode(prismNode: PrismNode): boolean {
   if (!type) return false
 
   return type.endsWith("WriteNode")
+}
+
+export function isAttributeWriteCall(node: PrismNode): boolean {
+  if (!isPrismNodeType(node, "CallNode")) return false
+  if (!node.receiver) return false
+  if (!node.name.endsWith("=")) return false
+
+  return !COMPARISON_METHODS.has(node.name)
 }
 
 export function isDebugOutputCall(node: PrismNode): boolean {

--- a/javascript/packages/linter/test/rules/erb-no-unused-expressions.test.ts
+++ b/javascript/packages/linter/test/rules/erb-no-unused-expressions.test.ts
@@ -39,6 +39,24 @@ describe("ERBNoUnusedExpressionsRule", () => {
       `)
     })
 
+    test("passes for attribute writers", () => {
+      expectNoOffenses(dedent`
+        <% row_data.index = 1 %>
+        <% row_data[:index] = 2 %>
+        <% row_data = 3 %>
+        <% self.title = "Hello" %>
+        <% form.object.name = @user.name %>
+      `)
+    })
+
+    test("passes for attribute operator assignments", () => {
+      expectNoOffenses(dedent`
+        <% row_data.index += 1 %>
+        <% row_data.index ||= 0 %>
+        <% row_data[:index] &&= 1 %>
+      `)
+    })
+
     test("passes for control flow", () => {
       expectNoOffenses(dedent`
         <% if logged_in? %>
@@ -308,6 +326,18 @@ describe("ERBNoUnusedExpressionsRule", () => {
 
       assertOffenses(dedent`
         <% @user.name %>
+      `)
+    })
+
+    test("fails for comparison operators that end in an equals sign", () => {
+      expectError("Avoid unused expressions in silent ERB tags. `<% @user.role == \"admin\" %>` is evaluated but its return value is discarded. Use `<%= @user.role == \"admin\" %>` to output the value or remove the expression.")
+      expectError("Avoid unused expressions in silent ERB tags. `<% @count <= 10 %>` is evaluated but its return value is discarded. Use `<%= @count <= 10 %>` to output the value or remove the expression.")
+      expectError("Avoid unused expressions in silent ERB tags. `<% @name =~ /admin/ %>` is evaluated but its return value is discarded. Use `<%= @name =~ /admin/ %>` to output the value or remove the expression.")
+
+      assertOffenses(dedent`
+        <% @user.role == "admin" %>
+        <% @count <= 10 %>
+        <% @name =~ /admin/ %>
       `)
     })
 


### PR DESCRIPTION
This pull request updates `erb-no-unused-expressions` to treat attribute writes as assignments, so all three ways of writing to something are handled the same way.

```erb
<% row_data.index = 1 %>
<% row_data[:index] = 2 %>
<% row_data = 3 %>
```

Resolves #2510 