### PR TITLE
Engine: Compile mixed rcdata to parts and diagnose slots

### DIFF
--- a/javascript/packages/client/src/markup/fragments.ts
+++ b/javascript/packages/client/src/markup/fragments.ts
@@ -73,6 +73,16 @@ export function fillSlots(fragment: DocumentFragment, dynamics: SlotValues, text
       continue
     }
 
+    if (entry.type === "raw_text_interpolation") {
+      const whole = interpolateParts(parts?.(entry.index) ?? null, value)
+
+      if (whole !== null) {
+        element.textContent = whole
+      }
+
+      continue
+    }
+
     if (entry.type === DEFAULT_SLOT_TYPE && !Array.isArray(value)) {
       element.innerHTML = markup(value, text)
     }

--- a/javascript/packages/client/src/markup/markers.ts
+++ b/javascript/packages/client/src/markup/markers.ts
@@ -16,7 +16,8 @@ export const ITEM_STATICS = "item"
 export const PARTS_STATICS = "parts"
 export const PART_MARKER = "herb-part"
 export const DEFAULT_SLOT_TYPE: SlotType = "child"
-export const CONTENT_SLOT_TYPES: SlotType[] = ["child", "raw_text"]
+export const CONTENT_SLOT_TYPES: SlotType[] = ["child", "raw_text", "raw_text_interpolation"]
+export const INTERPOLATED_SLOT_TYPES: SlotType[] = ["attribute_interpolation", "raw_text_interpolation"]
 
 export interface RegionOpenMarker {
   kind: "region-open"

--- a/javascript/packages/client/src/slots/apply.ts
+++ b/javascript/packages/client/src/slots/apply.ts
@@ -135,6 +135,12 @@ function applyLeaf(slots: Slots, payload: Payload, slot: Slot, index: number, va
 
         return
       }
+    } else if (slot.type === "raw_text_interpolation") {
+      if (!slots.setText(slot, written)) {
+        defer(report, payload, index, "partial-content")
+
+        return
+      }
     } else {
       if (Array.isArray(written)) {
         defer(report, payload, index, "partial-attribute")

--- a/javascript/packages/client/src/slots/slots.ts
+++ b/javascript/packages/client/src/slots/slots.ts
@@ -289,12 +289,28 @@ export class Slots implements ElementObserverDelegate, JournalDelegate, Collecti
     return this.attributeValue(slot) ?? currentText(slot.anchor)
   }
 
-  setText(slot: Slot, text: string): boolean {
+  setText(slot: Slot, text: SlotValue): boolean {
     if (slot.anchor.kind === "element") {
       return false
     }
 
-    if (this.currentText(slot) === text) {
+    let written = text
+
+    if (slot.type === "raw_text_interpolation") {
+      const whole = this.interpolate(slot, text)
+
+      if (whole === null) {
+        return false
+      }
+
+      written = whole
+    }
+
+    if (Array.isArray(written)) {
+      return false
+    }
+
+    if (this.currentText(slot) === written) {
       return false
     }
 
@@ -309,11 +325,11 @@ export class Slots implements ElementObserverDelegate, JournalDelegate, Collecti
     this.index.forgetChildren(slot)
 
     if (slot.anchor.kind === "content") {
-      slot.anchor.element.textContent = text
+      slot.anchor.element.textContent = written
     } else {
       const fragment = document.createDocumentFragment()
 
-      fragment.append(document.createTextNode(text))
+      fragment.append(document.createTextNode(written))
 
       this.rewrite(this.rangeOf(slot), fragment, { region: slot.region, slot, item: slot.item })
     }
@@ -354,6 +370,16 @@ export class Slots implements ElementObserverDelegate, JournalDelegate, Collecti
       }
 
       return this.attributeValue(slot) === whole
+    }
+
+    if (slot.type === "raw_text_interpolation") {
+      const whole = this.interpolate(slot, value)
+
+      if (whole === null) {
+        return false
+      }
+
+      return this.currentText(slot) === whole
     }
 
     if (Array.isArray(value)) {

--- a/javascript/packages/client/src/state/bindings.ts
+++ b/javascript/packages/client/src/state/bindings.ts
@@ -8,7 +8,7 @@ const BINDABLE_ELEMENTS = ["input", "textarea", "select", "option"]
 const BINDABLE_ATTRIBUTES = ["value", "checked", "selected"]
 
 export function bindable(slot: Slot): boolean {
-  if (slot.type === "attribute_interpolation") {
+  if (slot.type === "attribute_interpolation" || slot.type === "raw_text_interpolation") {
     return false
   }
 

--- a/javascript/packages/client/src/state/bound-inputs.ts
+++ b/javascript/packages/client/src/state/bound-inputs.ts
@@ -1,6 +1,7 @@
 import { VALUE_ELEMENTS } from "./bindings"
 
 import { bindable } from "./bindings"
+import { bareRead } from "./conditions"
 import { elementOf } from "../markup/anchors"
 import { boundValue } from "./values"
 
@@ -107,6 +108,10 @@ export class BoundInputs {
           }
 
           if (!shipped && !bindable(slot)) {
+            continue
+          }
+
+          if (!shipped && slot.type === "boolean_attribute" && bareRead(manifest.presence?.[String(index)]) !== name) {
             continue
           }
 

--- a/javascript/packages/client/src/state/conditions.ts
+++ b/javascript/packages/client/src/state/conditions.ts
@@ -1,5 +1,19 @@
 import type { Arm, ComboCondition, ConditionValue, ConditionalArm, StateComparand, StateCondition, ValueOf } from "./types"
 
+export function bareRead(condition: StateCondition | null | undefined): string | null {
+  if (!condition || !Array.isArray(condition)) {
+    return null
+  }
+
+  const [name, comparand, operator, transform] = condition
+
+  if (comparand !== null || operator || transform) {
+    return null
+  }
+
+  return typeof name === "string" ? name : null
+}
+
 export function armOf(arm: ConditionalArm): Arm {
   if (Array.isArray(arm)) {
     const [name, comparand, branch, operator] = arm

--- a/javascript/packages/client/src/state/seeds.ts
+++ b/javascript/packages/client/src/state/seeds.ts
@@ -1,3 +1,5 @@
+import { INTERPOLATED_SLOT_TYPES } from "../markup/markers"
+
 import { armOf } from "./conditions"
 import { report } from "../shared/report"
 import { scoped } from "./scopes"
@@ -164,6 +166,10 @@ export class Seeds {
 
     for (const index of manifest.reads[name] ?? []) {
       for (const slot of this.delegate.scopedSlots(scope, index)) {
+        if (INTERPOLATED_SLOT_TYPES.includes(slot.type)) {
+          continue
+        }
+
         const element = elementOf(slot.anchor)
 
         if (slot.type === "boolean_attribute") {

--- a/javascript/packages/client/src/types.ts
+++ b/javascript/packages/client/src/types.ts
@@ -9,6 +9,7 @@ export type SlotType =
   | "boolean_attribute"
   | "element"
   | "raw_text"
+  | "raw_text_interpolation"
 
 export type SlotOperation =
   | "value"
@@ -46,7 +47,7 @@ export type PayloadItems = Record<string, PayloadSlots>
 export type SeededSlots = PayloadSlots & { seeds?: Seeds }
 export type PayloadValue = string | string[] | boolean | Payload | Branched | Collected
 export type AppliedValue = Exclude<PayloadValue, Payload>
-export type DeferredReason = "no-region" | "stale-version" | "no-slot" | "branch" | "block" | "items" | "partial-attribute"
+export type DeferredReason = "no-region" | "stale-version" | "no-slot" | "branch" | "block" | "items" | "partial-attribute" | "partial-content"
 
 export type SlotAnchor = RangeAnchor | ElementAnchor | ContentAnchor
 

--- a/javascript/packages/client/test/binding.test.ts
+++ b/javascript/packages/client/test/binding.test.ts
@@ -210,6 +210,59 @@ const AREA_PAGE =
     },
   })}</template>`
 
+describe("a boolean attribute that computes", () => {
+  const COMPUTED_FILE = "app/views/page/computed.html.erb"
+
+  const COMPUTED_PAGE =
+    `<!--herb-region:${COMPUTED_FILE}:beefcafe:0-->` +
+    `<input id="plain" type="checkbox" data-herb-slot="0:boolean_attribute:checked">` +
+    `<input id="derived" type="checkbox" checked data-herb-slot="1:boolean_attribute:checked">` +
+    `<!--/herb-region:${COMPUTED_FILE}-->` +
+    `<template data-herb-dependencies>${JSON.stringify({
+      state: {},
+      states: {
+        [COMPUTED_FILE]: {
+          version: "beefcafe",
+          declarations: [
+            { name: "agreed", kind: "boolean", default: "false", scope: "region" },
+            { name: "unread", kind: "number", default: "5", scope: "region" },
+          ],
+          reads: { agreed: [0], unread: [1] },
+          conditionals: {},
+          presence: { 0: ["agreed", null], 1: ["unread", { value: 3 }, ">"] },
+        },
+      },
+    })}</template>`
+
+  let computedSlots: Slots
+  let computedState: State
+
+  beforeEach(() => {
+    document.body.innerHTML = COMPUTED_PAGE
+
+    computedSlots = new Slots()
+    computedSlots.scan(document.body)
+
+    computedState = new State(computedSlots, {})
+    computedState.adopt()
+    computedState.observe()
+  })
+
+  afterEach(() => computedState.disconnect())
+
+  test("a bare presence read still binds the click", () => {
+    document.querySelector<HTMLInputElement>("#plain")!.click()
+
+    expect(computedState.getState("agreed")).toBe(true)
+  })
+
+  test("a computed presence read never writes its operand back", () => {
+    document.querySelector<HTMLInputElement>("#derived")!.click()
+
+    expect(computedState.getState("unread")).toBe(5)
+  })
+})
+
 describe("a state rendered as a textarea's content", () => {
   test("a write reaches the textarea", () => {
     document.body.innerHTML = AREA_PAGE

--- a/javascript/packages/client/test/content-parts.test.ts
+++ b/javascript/packages/client/test/content-parts.test.ts
@@ -1,0 +1,82 @@
+import { describe, test, expect, beforeEach } from "vitest"
+import { Slots } from "../src/slots/slots"
+
+const FILE = "app/views/chat/show.html.erb"
+
+const MANIFEST = {
+  file: FILE,
+  identifier: FILE,
+  version: "aaaaaaaa",
+  names: {},
+  parts: { 0: ["", "11"] },
+  states: null,
+}
+
+const MANIFEST_TAG = `<template data-herb-manifests>${JSON.stringify({ [`${FILE}:aaaaaaaa`]: MANIFEST })}</template>`
+
+const PAGE =
+  `<!--herb-region:${FILE}:aaaaaaaa:0-->` +
+  `<div><textarea rows="2" data-herb-slot="0:raw_text_interpolation">draft11</textarea></div>` +
+  `<!--/herb-region:${FILE}-->` + MANIFEST_TAG
+
+let slots: Slots
+
+function editor(): HTMLTextAreaElement {
+  return document.querySelector("textarea")!
+}
+
+beforeEach(() => {
+  document.body.innerHTML = PAGE
+
+  slots = new Slots()
+  slots.scan(document.body)
+})
+
+describe("interpolated content slots", () => {
+  test("a payload's dynamic parts reconstruct the whole content", () => {
+    const report = slots.apply({
+      template: FILE,
+      version: "aaaaaaaa",
+      occurrence: 0,
+      slots: { 0: ["typed"] },
+    })
+
+    expect(report.deferred).toEqual([])
+    expect(editor().textContent).toBe("typed11")
+  })
+
+  test("a payload that already matches the content writes nothing", () => {
+    const payload = {
+      template: FILE,
+      version: "aaaaaaaa",
+      occurrence: 0,
+      slots: { 0: ["typed"] },
+    }
+
+    expect(slots.apply(payload).applied).toBe(1)
+    expect(slots.apply(payload).applied).toBe(0)
+    expect(editor().textContent).toBe("typed11")
+  })
+
+  test("a plain text write interpolates around the literal parts", () => {
+    const slot = slots.slot(FILE, 0)!
+
+    expect(slots.setText(slot, "hey")).toBe(true)
+    expect(editor().textContent).toBe("hey11")
+  })
+
+  test("the revert restores the previous whole content", () => {
+    const { token } = slots.transaction(() => slots.apply({
+      template: FILE,
+      version: "aaaaaaaa",
+      occurrence: 0,
+      slots: { 0: ["typed"] },
+    }))
+
+    expect(editor().textContent).toBe("typed11")
+
+    slots.revert(token!)
+
+    expect(editor().textContent).toBe("draft11")
+  })
+})

--- a/javascript/packages/client/test/contract.test.ts
+++ b/javascript/packages/client/test/contract.test.ts
@@ -20,6 +20,7 @@ import aValueCarryingMarkupAndQuotes from "./fixtures/contract/a-value-carrying-
 import anAttributeAndAChild from "./fixtures/contract/an-attribute-and-a-child.json"
 import anEmptyCollection from "./fixtures/contract/an-empty-collection.json"
 import anInterpolatedAttributeInsideABlock from "./fixtures/contract/an-interpolated-attribute-inside-a-block.json"
+import anInterpolatedTextarea from "./fixtures/contract/an-interpolated-textarea.json"
 import expressionsInOrder from "./fixtures/contract/expressions-in-order.json"
 import nothingDynamicAtAll from "./fixtures/contract/nothing-dynamic-at-all.json"
 import twoAttributesOnOneElement from "./fixtures/contract/two-attributes-on-one-element.json"
@@ -59,6 +60,7 @@ const FIXTURES: Record<string, Fixture> = {
   "an attribute and a child": anAttributeAndAChild as Fixture,
   "an empty collection": anEmptyCollection as Fixture,
   "an interpolated attribute inside a block": anInterpolatedAttributeInsideABlock as Fixture,
+  "an interpolated textarea": anInterpolatedTextarea as Fixture,
   "expressions in order": expressionsInOrder as Fixture,
   "nothing dynamic at all": nothingDynamicAtAll as Fixture,
   "a value carrying markup and quotes": aValueCarryingMarkupAndQuotes as Fixture,

--- a/javascript/packages/client/test/fixtures/contract/an-interpolated-textarea.json
+++ b/javascript/packages/client/test/fixtures/contract/an-interpolated-textarea.json
@@ -1,0 +1,48 @@
+{
+  "file": "app/views/contract/an-interpolated-textarea.html.erb",
+  "template": "<textarea><%= @d %>11</textarea>",
+  "rendered": "<!--herb-region:app/views/contract/an-interpolated-textarea.html.erb:c380979f:0--><textarea data-herb-slot=\"0:raw_text_interpolation\">draft11</textarea><!--/herb-region:app/views/contract/an-interpolated-textarea.html.erb-->",
+  "client": "<!--herb-region:app/views/contract/an-interpolated-textarea.html.erb:c380979f:0--><textarea data-herb-slot=\"0:raw_text_interpolation\">draft11</textarea><!--/herb-region:app/views/contract/an-interpolated-textarea.html.erb-->",
+  "values": {
+    "template": "app/views/contract/an-interpolated-textarea.html.erb",
+    "version": "c380979f",
+    "occurrence": 0,
+    "slots": {
+      "0": [
+        "typed"
+      ]
+    }
+  },
+  "expected": "<!--herb-region:app/views/contract/an-interpolated-textarea.html.erb:c380979f:0--><textarea data-herb-slot=\"0:raw_text_interpolation\">typed11</textarea><!--/herb-region:app/views/contract/an-interpolated-textarea.html.erb-->",
+  "schema": {
+    "file": "app/views/contract/an-interpolated-textarea.html.erb",
+    "identifier": "app/views/contract/an-interpolated-textarea.html.erb",
+    "version": "c380979f",
+    "slots": [
+      {
+        "index": 0,
+        "type": "raw_text_interpolation",
+        "node_path": [
+          0
+        ]
+      }
+    ]
+  },
+  "manifest": {
+    "file": "app/views/contract/an-interpolated-textarea.html.erb",
+    "identifier": "app/views/contract/an-interpolated-textarea.html.erb",
+    "version": "c380979f",
+    "names": {},
+    "parts": {
+      "0": [
+        "",
+        "11"
+      ]
+    },
+    "states": null
+  },
+  "dependencies": {
+    "state": {},
+    "params": {}
+  }
+}

--- a/lib/herb/engine/slots/dynamics_compiler.rb
+++ b/lib/herb/engine/slots/dynamics_compiler.rb
@@ -133,6 +133,7 @@ module Herb
             @slot_visitor = engine.slot_visitor
             @current_node = nil
             @current_attribute = nil
+            @current_rcdata = nil
             @rendering = false
             @block_depth = 0
 
@@ -151,6 +152,18 @@ module Herb
             super
           ensure
             @current_attribute = previous
+          end
+
+          #: (untyped) -> void
+          def visit_html_element_node(node)
+            index = @slot_visitor.index_for(node)
+            previous = @current_rcdata
+
+            @current_rcdata = node if index && @slot_visitor.slots[index]&.type == :raw_text_interpolation
+
+            super
+          ensure
+            @current_rcdata = previous
           end
 
           #: (untyped) -> void
@@ -310,7 +323,7 @@ module Herb
 
           #: (untyped) -> Integer?
           def claim(node)
-            @slot_visitor.index_for(@current_attribute || node)
+            @slot_visitor.index_for(@current_attribute || @current_rcdata || node)
           end
 
           #: (String) -> void
@@ -643,7 +656,7 @@ module Herb
 
         #: (Integer) -> bool
         def interpolated?(index)
-          @slot_visitor.slots[index]&.type == :attribute_interpolation
+          @slot_visitor.slots[index]&.interpolated? || false
         end
 
         #: (String) -> void

--- a/lib/herb/engine/slots/state_compiler.rb
+++ b/lib/herb/engine/slots/state_compiler.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "did_you_mean"
+
 require_relative "state_directives"
 
 module Herb
@@ -14,19 +16,26 @@ module Herb
       #
       class StateCompiler
         STATE_KEYWORDS = {
-          "if" => :if, "elsif" => :elsif, "unless" => :unless, "case" => :case, "when" => :when,
+          "if" => :if,
+          "elsif" => :elsif,
+          "unless" => :unless,
+          "case" => :case,
+          "when" => :when,
         }.freeze #: Hash[String, Symbol]
 
         SEEDS_LOCAL = "_herb_seeds" #: String
+        BARE_IDENTIFIER = /\A[a-z_][a-zA-Z0-9_]*\z/ #: Regexp
+        BINDABLE_ATTRIBUTES = ["value", "checked", "selected"].freeze #: Array[String]
+        BINDABLE_ELEMENTS = ["input", "textarea", "select", "option"].freeze #: Array[String]
 
         attr_reader :state_presence #: Hash[Integer, untyped]
-
         attr_reader :state_values #: Hash[Integer, untyped]
 
         #: (untyped) -> void
         def initialize(visitor)
           @visitor = visitor
           @strict_locals = {} #: Hash[String, Symbol]
+          @near_missed = Set.new #: Set[Integer]
           @region_states = {} #: Hash[String, StateDirectives::Declaration]
           item_states = {} #: Hash[untyped, Hash[String, StateDirectives::Declaration]]
           @item_states = item_states.compare_by_identity
@@ -71,9 +80,15 @@ module Herb
 
             name = slot.expression.to_s.strip.delete_suffix("?")
 
-            next unless names.include?(name)
+            unless names.include?(name)
+              warn_near_miss(slot, name, names)
+
+              next
+            end
 
             (reads[name] ||= []) << slot.index
+
+            warn_unbindable(slot, name) if slot.interpolated?
           end
 
           presence = {} #: Hash[String, untyped]
@@ -81,6 +96,8 @@ module Herb
           state_presence.each do |index, read|
             presence[index.to_s] = StateDirectives.condition_entry(read)
             StateDirectives.read_names(read).each { |name| (reads[name] ||= []) << index }
+
+            warn_computed_presence(index, read)
           end
 
           computed = {} #: Hash[String, untyped]
@@ -104,6 +121,8 @@ module Herb
             declaration["count"] = { "collection" => count[:collection], "when" => count[:when], "by" => count[:by] }
           end
 
+          warn_branch_orphans(reads, computed, presence)
+
           {
             "version" => @visitor.version,
             "declarations" => declarations,
@@ -112,6 +131,99 @@ module Herb
             "presence" => presence,
             "computed" => computed,
           }
+        end
+
+        #: (untyped, String) -> void
+        def warn_unbindable(slot, name)
+          return unless bindable_shape?(slot)
+          return if @visitor.listener_writes?(slot.index, [name])
+
+          place = slot.attribute ? "`#{slot.attribute}`" : "content"
+
+          @visitor.slot_warning(
+            "`#{name}` shares this `<#{slot.tag}>`'s #{place} with other text, so typing here will not write the state back. State writes still update the whole #{place}.",
+            @visitor.slot_nodes[slot.index]&.location,
+            :binding,
+            suggestion: "Make `#{name}` the only #{slot.attribute ? "value of `#{slot.attribute}`" : "content of the `<#{slot.tag}>`"} to bind it, or write the state from your own listener."
+          )
+        end
+
+        #: (untyped) -> bool
+        def bindable_shape?(slot)
+          if slot.attribute
+            BINDABLE_ATTRIBUTES.include?(slot.attribute) && BINDABLE_ELEMENTS.include?(slot.tag.to_s)
+          else
+            slot.tag == "textarea"
+          end
+        end
+
+        #: (Integer, untyped) -> void
+        def warn_computed_presence(index, read)
+          slot = @visitor.slots[index]
+
+          return unless slot && bindable_shape?(slot)
+          return if bare_presence?(read)
+          return if @visitor.listener_writes?(index, StateDirectives.read_names(read))
+
+          @visitor.slot_warning(
+            "`#{slot.attribute}` on this `<#{slot.tag}>` follows `#{StateDirectives.condition_source(read)}`, so using the control cannot write a state back. The attribute still updates when the states change.",
+            @visitor.slot_nodes[index]&.location,
+            :binding,
+            suggestion: "Drive `#{slot.attribute}` with a single state to bind it, or write the states from your own listener."
+          )
+        end
+
+        #: (untyped) -> bool
+        def bare_presence?(read)
+          read.is_a?(StateDirectives::Read) && read.operator.nil? && read.transform.nil? && read.comparand.nil? && read.against.nil?
+        end
+
+        #: (untyped, String, Array[String]) -> void
+        def warn_near_miss(slot, name, names)
+          return unless BARE_IDENTIFIER.match?(name)
+          return if @strict_locals.key?(name)
+
+          suggestions = DidYouMean::SpellChecker.new(dictionary: names).correct(name)
+
+          return if suggestions.empty?
+
+          @near_missed << slot.index
+
+          @visitor.slot_warning(
+            "`#{name}` reads like the state `#{suggestions.first}` but is not declared, so the server owns it and the client can never fill it.",
+            @visitor.slot_nodes[slot.index]&.location,
+            :unknown,
+            suggestion: "Spell the state's name, or declare `#{name}` in `herb:state`."
+          )
+        end
+
+        #: (Hash[String, Array[Integer]], Hash[String, untyped], Hash[String, untyped]) -> void
+        def warn_branch_orphans(reads, computed, presence)
+          return unless @visitor.client?
+
+          covered = (reads.values.flatten + computed.keys.map(&:to_i) + presence.keys.map(&:to_i)).to_set
+          warned = Set.new #: Set[Integer]
+
+          state_conditional_entries.each_key do |index|
+            @visitor.slots_inside(index).each do |inside|
+              next unless warned.add?(inside)
+
+              slot = @visitor.slots[inside]
+
+              next unless slot&.valued?
+              next if covered.include?(inside)
+              next if @near_missed.include?(inside)
+
+              expression = slot.expression.to_s.strip
+
+              @visitor.slot_warning(
+                "`<%= #{expression} %>` sits inside a branch the client can show on its own, but its value comes from the server. The server only computes values for the branch it renders, so showing this branch ahead of the server leaves the value empty.",
+                @visitor.slot_nodes[inside]&.location,
+                :branch,
+                suggestion: "Declare a state holding the value, or move `<%= #{expression} %>` out of the conditional."
+              )
+            end
+          end
         end
 
         #: (Hash[Symbol, untyped], (String | Integer)) -> Hash[String, untyped]
@@ -708,14 +820,24 @@ module Herb
 
         #: (untyped, Hash[String, StateDirectives::Declaration]) -> void
         def check_interpolated_state_read(node, states)
-          return unless node.respond_to?(:value)
+          children = if node.is_a?(Herb::AST::HTMLElementNode)
+                       Array(node.body)
+                     elsif node.respond_to?(:value)
+                       node.value&.children || []
+                     else
+                       [] #: Array[untyped]
+                     end
 
-          outputs = (node.value&.children || []).grep(Herb::AST::ERBContentNode)
+          outputs = children.grep(Herb::AST::ERBContentNode)
           read = outputs.map { |output| output.content&.value.to_s.strip }.find { |expression| StateDirectives.mentions_any?(expression, states) }
 
           return unless read
 
-          @visitor.slot_error("`#{read}` reads a state inside an interpolated attribute that mixes other dynamic parts. A state write cannot supply the other values.", node.location, :read, suggestion: "Give the state its own attribute, or its own output outside this one.")
+          if node.is_a?(Herb::AST::HTMLElementNode)
+            @visitor.slot_error("`#{read}` reads a state inside a `<#{node.tag_name&.value}>` that mixes other dynamic parts. A state write cannot supply the other values.", node.location, :read, suggestion: "Give the state its own element, or its own output outside this one.")
+          else
+            @visitor.slot_error("`#{read}` reads a state inside an interpolated attribute that mixes other dynamic parts. A state write cannot supply the other values.", node.location, :read, suggestion: "Give the state its own attribute, or its own output outside this one.")
+          end
         end
 
         #: () -> void
@@ -734,7 +856,7 @@ module Herb
 
             next if states.empty?
 
-            if slot.type == :attribute_interpolation && slot.expression.to_s.strip.empty?
+            if slot.interpolated? && slot.expression.to_s.strip.empty?
               check_interpolated_state_read(node, states)
               next
             end
@@ -745,6 +867,7 @@ module Herb
             next if expression.empty?
             next unless StateDirectives.mentions_any?(expression, states)
 
+            next if refuse_mixed_boolean(node, slot, expression)
             next if convert_boolean_attribute(node, index, slot, expression, states)
 
             if states.key?(expression) || states.key?(expression.delete_suffix("?"))
@@ -770,6 +893,21 @@ module Herb
           StateDirectives.read_names(read).each { |name| rewrite_predicate(node, name) }
 
           @state_values[index] = read
+        end
+
+        #: (untyped, untyped, String) -> Symbol?
+        def refuse_mixed_boolean(node, slot, expression)
+          return nil unless slot.type == :attribute_interpolation
+          return nil unless slot.attribute && Herb::HTML::Util.boolean_attribute?(slot.attribute)
+
+          @visitor.slot_error(
+            "`#{slot.attribute}` on this `<#{slot.tag}>` mixes `#{expression}` with other text. A boolean attribute follows presence and any value keeps it present, so it could never turn off.",
+            node.location,
+            :read,
+            suggestion: "Make `<%= #{expression} %>` the whole value of `#{slot.attribute}`."
+          )
+
+          :reported
         end
 
         #: (untyped, Integer, untyped, String, Hash[String, StateDirectives::Declaration]) -> untyped

--- a/lib/herb/engine/slots/types.rb
+++ b/lib/herb/engine/slots/types.rb
@@ -11,9 +11,10 @@ module Herb
       module Types
         STRUCTURAL = [:conditional, :collection, :block].freeze #: Array[Symbol]
         ATTRIBUTE_VALUES = [:attribute, :attribute_interpolation].freeze #: Array[Symbol]
-        ELEMENT_ANCHORED = [*ATTRIBUTE_VALUES, :boolean_attribute, :element, :raw_text].freeze #: Array[Symbol]
+        ELEMENT_ANCHORED = [*ATTRIBUTE_VALUES, :boolean_attribute, :element, :raw_text, :raw_text_interpolation].freeze #: Array[Symbol]
         NAMEABLE = [:child, :collection, :conditional, :block].freeze #: Array[Symbol]
-        VALUED = [:child, :attribute, :attribute_interpolation, :element, :raw_text].freeze #: Array[Symbol]
+        VALUED = [:child, :attribute, :attribute_interpolation, :element, :raw_text, :raw_text_interpolation].freeze #: Array[Symbol]
+        INTERPOLATED = [:attribute_interpolation, :raw_text_interpolation].freeze #: Array[Symbol]
 
         #: (Symbol) -> bool
         def self.structural?(type) = STRUCTURAL.include?(type)
@@ -32,6 +33,9 @@ module Herb
 
         #: (Symbol) -> bool
         def self.valued?(type) = VALUED.include?(type)
+
+        #: (Symbol) -> bool
+        def self.interpolated?(type) = INTERPOLATED.include?(type)
       end
     end
   end

--- a/lib/herb/engine/slots/visitor.rb
+++ b/lib/herb/engine/slots/visitor.rb
@@ -37,7 +37,7 @@ module Herb
       #     visitors = mode ? [Herb::Engine::Slots::Visitor.new(mode: mode)] : []
       #
       class Visitor < Herb::Visitor
-        STATE_FAMILIES = [:read, :compare, :declaration, :conditional, :count, :assignment].freeze #: Array[Symbol]
+        STATE_FAMILIES = [:read, :compare, :declaration, :conditional, :count, :assignment, :unknown, :binding].freeze #: Array[Symbol]
 
         extend Herb::Visitor::Experimental
         include Herb::Visitor::ContextAware
@@ -64,6 +64,7 @@ module Herb
         NAME_ATTRIBUTE = "data-herb-name" #: String
 
         CAPTURING = /\b(?:content_for|provide|capture)\b/ #: Regexp
+        LISTENER_ATTRIBUTES = ["data-herb-set", "data-herb-toggle", "data-herb-increment", "data-herb-decrement", "data-herb-reset"].freeze #: Array[String]
         OPEN_TAG_TYPES = [Herb::AST::HTMLOpenTagNode, Herb::AST::ERBOpenTagNode].freeze #: Array[Herb::AST::HTMLOpenTagNode|Herb::AST::ERBOpenTagNode]
         BRANCH_BODY_PROPERTIES = [:statements, :body, :children, :conditions].freeze #: Array[Symbol]
         BRANCH_CONTINUATION_PROPERTIES = [:subsequent, :else_clause, :rescue_clause, :ensure_clause].freeze #: Array[Symbol]
@@ -101,7 +102,7 @@ module Herb
           def presence? = type == :boolean_attribute
 
           #: () -> bool
-          def interpolated? = type == :attribute_interpolation
+          def interpolated? = Types.interpolated?(type)
         end
 
         #: (String) -> bool
@@ -178,12 +179,39 @@ module Herb
           @in_html_doctype = false
           @raw_text_depth = 0
           @rcdata_depth = 0
+          @rcdata_mixed_depth = 0
+          @rcdata_interpolated_depth = 0
+          @interpolated_rcdata = [] #: Array[untyped]
+          @listener_stack = [] #: Array[Array[String]]
+          listener_written = {} #: Hash[untyped, Array[String]]
+          @listener_written = listener_written.compare_by_identity
           @current_open_tag = nil
         end
 
         #: () -> bool
         def degraded?
           @degraded
+        end
+
+        #: () -> bool
+        def client?
+          @mode == :client
+        end
+
+        #: (Integer, Array[String]) -> bool
+        def listener_writes?(index, names)
+          written = @listener_written[@slot_nodes[index]]
+
+          !written.nil? && written.intersect?(names)
+        end
+
+        #: (Integer) -> Array[Integer]
+        def slots_inside(index)
+          node = @slot_nodes[index]
+
+          return [] unless node
+
+          branch_bodies(node).flat_map { |body| slot_indices_within(body) }.uniq
         end
 
         #: (String, Herb::Location?, Symbol, ?suggestion: String?) -> nil
@@ -195,9 +223,14 @@ module Herb
           nil
         end
 
+        #: (String, untyped, Symbol, ?suggestion: String?) -> void
+        def slot_warning(message, location, family, suggestion: nil)
+          warning(message, location, code: diagnostic_code_for(family), suggestion: suggestion)
+        end
+
         #: (Symbol) -> String
         def diagnostic_code_for(family)
-          STATE_FAMILIES.include?(family) ? "herb-state-#{family}" : "slots-#{family}"
+          STATE_FAMILIES.include?(family) ? "herb-state-#{family}" : "herb-slots-#{family}"
         end
 
         #: () -> String
@@ -377,6 +410,18 @@ module Herb
             parts[index.to_s] = segments
           end
 
+          @interpolated_rcdata.each do |node|
+            index = @indices[node]
+
+            next unless index
+
+            segments = rcdata_segments(node.body)
+
+            next unless segments
+
+            parts[index.to_s] = segments
+          end
+
           parts
         end
 
@@ -489,13 +534,23 @@ module Herb
           tag_name = node.tag_name&.value&.downcase.to_s
           raw_text = Herb::HTML::Util.raw_text_element?(tag_name)
           rcdata = Herb::HTML::Util.rcdata_element?(tag_name)
+          segments = rcdata && mixed_rcdata_body?(node.body) ? rcdata_segments(node.body) : nil
+          mixed = rcdata && segments.nil? && mixed_rcdata_body?(node.body)
 
           @raw_text_depth += 1 if raw_text
           @rcdata_depth += 1 if rcdata
+          @rcdata_mixed_depth += 1 if mixed
+          @rcdata_interpolated_depth += 1 if segments
 
           previous_open_tag = @current_open_tag
           @current_open_tag = node.open_tag
           @tag_stack.push(tag_name)
+          @listener_stack.push(listener_names_for(node))
+
+          if segments
+            record_slot(node, :raw_text_interpolation)
+            @interpolated_rcdata << node
+          end
 
           name_attribute = attributes_for(node).find { |attribute| attribute_name_for(attribute)&.downcase == NAME_ATTRIBUTE }
           base = @annotations.size
@@ -508,9 +563,12 @@ module Herb
 
           record_named_element(node, name_attribute, base, base_scope, base_depth) if name_attribute
 
+          @listener_stack.pop
           @tag_stack.pop
           @current_open_tag = previous_open_tag
 
+          @rcdata_interpolated_depth -= 1 if segments
+          @rcdata_mixed_depth -= 1 if mixed
           @rcdata_depth -= 1 if rcdata
           @raw_text_depth -= 1 if raw_text
         end
@@ -803,6 +861,20 @@ module Herb
           @standing.delete_if { |_node, annotation| annotation.dropped }
         end
 
+        #: (untyped) -> Array[Integer]
+        def slot_indices_within(nodes)
+          children = Array(nodes) #: Array[untyped]
+
+          children.compact.flat_map { |child|
+            next [] unless child.is_a?(Herb::AST::Node)
+
+            inside = slot_indices_within(child.compact_child_nodes)
+            index = @indices[child]
+
+            index ? [index, *inside] : inside
+          }
+        end
+
         #: (String) -> bool
         def branching_shape?(shape)
           Types::STRUCTURAL.any? { |type| shape.include?("\u0000#{type}\u0000") }
@@ -832,6 +904,8 @@ module Herb
 
           return unless type
           return if @in_html_comment || @in_html_doctype
+          return if type == :raw_text && @rcdata_interpolated_depth.positive?
+          return refuse_mixed_rcdata(node) if type == :raw_text && @rcdata_mixed_depth.positive?
 
           key_source, key_expression = type == :collection ? key_for(node) : [nil, nil]
 
@@ -850,6 +924,9 @@ module Herb
 
           @annotations << annotation
           @annotation_of[node] = annotation
+
+          written = @listener_stack.flatten
+          @listener_written[node] = written unless written.empty?
 
           if type == :collection && key_source == :index
             @warnings << Herb::Warnings::UnkeyedCollectionWarning.new(
@@ -871,6 +948,7 @@ module Herb
 
         #: (Symbol) -> Symbol?
         def anchored_type_for(type)
+          return type if type == :raw_text_interpolation
           return type if Types.attribute_value?(type)
 
           return nil if @in_attribute
@@ -879,6 +957,88 @@ module Herb
           return :raw_text if @rcdata_depth.positive?
 
           type
+        end
+
+        #: (Array[untyped]) -> Array[String]?
+        def rcdata_segments(children)
+          segments = [+""]
+
+          Array(children).each do |child|
+            case child
+            when Herb::AST::HTMLTextNode, Herb::AST::LiteralNode
+              segments.last << child.content.to_s
+            when Herb::AST::WhitespaceNode
+              segments.last << child.value&.value.to_s
+            when Herb::AST::ERBContentNode
+              return nil unless erb_outputs?(child)
+
+              segments << +""
+            else
+              return nil
+            end
+          end
+
+          segments.size > 1 ? segments : nil
+        end
+
+        #: (untyped) -> Array[String]
+        def listener_names_for(node)
+          attributes_for(node).flat_map { |attribute|
+            name = attribute_name_for(attribute)&.downcase
+
+            next [] unless name && LISTENER_ATTRIBUTES.include?(name)
+
+            value = static_attribute_value(attribute)
+
+            next [] unless value
+
+            value.split.flat_map { |clause|
+              rest = clause.split("->", 2).last.to_s
+
+              rest.split(",").filter_map { |piece|
+                target = name == "data-herb-set" ? piece.split("=", 2).first : piece
+                cleaned = target.to_s.strip
+
+                cleaned unless cleaned.empty?
+              }
+            }
+          }
+        end
+
+        #: (untyped) -> String?
+        def rcdata_expression_for(node)
+          outputs = Array(node.body).grep(Herb::AST::ERBContentNode) #: Array[untyped]
+
+          return nil unless outputs.one?
+
+          outputs.fetch(0).content&.value&.strip
+        end
+
+        #: (Array[untyped]) -> bool
+        def mixed_rcdata_body?(children)
+          outputs = children.count { |child| child.is_a?(Herb::AST::ERBContentNode) && erb_outputs?(child) }
+
+          return false if outputs.zero?
+          return true if outputs > 1
+
+          children.any? { |child|
+            (child.is_a?(Herb::AST::HTMLTextNode) || child.is_a?(Herb::AST::LiteralNode)) && !child.content.to_s.strip.empty?
+          }
+        end
+
+        #: (untyped) -> nil
+        def refuse_mixed_rcdata(node)
+          expression = expression_for(node)
+          tag = @tag_stack.last
+
+          slot_warning(
+            "`<%= #{expression} %>` shares the `<#{tag}>` content with other text. The client writes this content as one piece and would discard the rest, so the expression stays server-rendered and never updates.",
+            node.location,
+            :content,
+            suggestion: "Make `<%= #{expression} %>` the only content of the `<#{tag}>`, or move the other text outside it."
+          )
+
+          nil
         end
 
         #: (untyped) -> Symbol
@@ -1150,6 +1310,7 @@ module Herb
 
         def expression_for(node)
           return attribute_expression_for(node) if node.is_a?(Herb::AST::HTMLAttributeNode)
+          return rcdata_expression_for(node) if node.is_a?(Herb::AST::HTMLElementNode)
           return nil unless node.respond_to?(:content)
 
           content = node.content

--- a/sig/herb/engine/slots/dynamics_compiler.rbs
+++ b/sig/herb/engine/slots/dynamics_compiler.rbs
@@ -127,6 +127,9 @@ module Herb
           def visit_html_attribute_node: (untyped) -> void
 
           # : (untyped) -> void
+          def visit_html_element_node: (untyped) -> void
+
+          # : (untyped) -> void
           def visit_erb_content_node: (untyped) -> void
 
           # : (untyped) -> void

--- a/sig/herb/engine/slots/state_compiler.rbs
+++ b/sig/herb/engine/slots/state_compiler.rbs
@@ -14,6 +14,12 @@ module Herb
 
         SEEDS_LOCAL: String
 
+        BARE_IDENTIFIER: Regexp
+
+        BINDABLE_ATTRIBUTES: Array[String]
+
+        BINDABLE_ELEMENTS: Array[String]
+
         attr_reader state_presence: Hash[Integer, untyped]
 
         attr_reader state_values: Hash[Integer, untyped]
@@ -29,6 +35,24 @@ module Herb
 
         # : () -> Hash[String, untyped]?
         def manifest: () -> Hash[String, untyped]?
+
+        # : (untyped, String) -> void
+        def warn_unbindable: (untyped, String) -> void
+
+        # : (untyped) -> bool
+        def bindable_shape?: (untyped) -> bool
+
+        # : (Integer, untyped) -> void
+        def warn_computed_presence: (Integer, untyped) -> void
+
+        # : (untyped) -> bool
+        def bare_presence?: (untyped) -> bool
+
+        # : (untyped, String, Array[String]) -> void
+        def warn_near_miss: (untyped, String, Array[String]) -> void
+
+        # : (Hash[String, Array[Integer]], Hash[String, untyped], Hash[String, untyped]) -> void
+        def warn_branch_orphans: (Hash[String, Array[Integer]], Hash[String, untyped], Hash[String, untyped]) -> void
 
         # : (Hash[Symbol, untyped], (String | Integer)) -> Hash[String, untyped]
         def declared_entry: (Hash[Symbol, untyped], String | Integer) -> Hash[String, untyped]
@@ -143,6 +167,9 @@ module Herb
 
         # : (untyped, Integer, untyped, String, Hash[String, StateDirectives::Declaration]) -> void
         def register_state_value: (untyped, Integer, untyped, String, Hash[String, StateDirectives::Declaration]) -> void
+
+        # : (untyped, untyped, String) -> Symbol?
+        def refuse_mixed_boolean: (untyped, untyped, String) -> Symbol?
 
         # : (untyped, Integer, untyped, String, Hash[String, StateDirectives::Declaration]) -> untyped
         def convert_boolean_attribute: (untyped, Integer, untyped, String, Hash[String, StateDirectives::Declaration]) -> untyped

--- a/sig/herb/engine/slots/types.rbs
+++ b/sig/herb/engine/slots/types.rbs
@@ -18,6 +18,8 @@ module Herb
 
         VALUED: Array[Symbol]
 
+        INTERPOLATED: Array[Symbol]
+
         # : (Symbol) -> bool
         def self.structural?: (Symbol) -> bool
 
@@ -35,6 +37,9 @@ module Herb
 
         # : (Symbol) -> bool
         def self.valued?: (Symbol) -> bool
+
+        # : (Symbol) -> bool
+        def self.interpolated?: (Symbol) -> bool
       end
     end
   end

--- a/sig/herb/engine/slots/visitor.rbs
+++ b/sig/herb/engine/slots/visitor.rbs
@@ -57,6 +57,8 @@ module Herb
 
         CAPTURING: Regexp
 
+        LISTENER_ATTRIBUTES: Array[String]
+
         OPEN_TAG_TYPES: Array[Herb::AST::HTMLOpenTagNode | Herb::AST::ERBOpenTagNode]
 
         BRANCH_BODY_PROPERTIES: Array[Symbol]
@@ -130,8 +132,20 @@ module Herb
         # : () -> bool
         def degraded?: () -> bool
 
+        # : () -> bool
+        def client?: () -> bool
+
+        # : (Integer, Array[String]) -> bool
+        def listener_writes?: (Integer, Array[String]) -> bool
+
+        # : (Integer) -> Array[Integer]
+        def slots_inside: (Integer) -> Array[Integer]
+
         # : (String, Herb::Location?, Symbol, ?suggestion: String?) -> nil
         def slot_error: (String, Herb::Location?, Symbol, ?suggestion: String?) -> nil
+
+        # : (String, untyped, Symbol, ?suggestion: String?) -> void
+        def slot_warning: (String, untyped, Symbol, ?suggestion: String?) -> void
 
         # : (Symbol) -> String
         def diagnostic_code_for: (Symbol) -> String
@@ -312,6 +326,9 @@ module Herb
         # : () -> void
         def collapse_invariant_conditionals: () -> void
 
+        # : (untyped) -> Array[Integer]
+        def slot_indices_within: (untyped) -> Array[Integer]
+
         # : (String) -> bool
         def branching_shape?: (String) -> bool
 
@@ -323,6 +340,21 @@ module Herb
 
         # : (Symbol) -> Symbol?
         def anchored_type_for: (Symbol) -> Symbol?
+
+        # : (Array[untyped]) -> Array[String]?
+        def rcdata_segments: (Array[untyped]) -> Array[String]?
+
+        # : (untyped) -> Array[String]
+        def listener_names_for: (untyped) -> Array[String]
+
+        # : (untyped) -> String?
+        def rcdata_expression_for: (untyped) -> String?
+
+        # : (Array[untyped]) -> bool
+        def mixed_rcdata_body?: (Array[untyped]) -> bool
+
+        # : (untyped) -> nil
+        def refuse_mixed_rcdata: (untyped) -> nil
 
         # : (untyped) -> Symbol
         def attribute_type_for: (untyped) -> Symbol

--- a/test/engine/slots/contract_test.rb
+++ b/test/engine/slots/contract_test.rb
@@ -85,6 +85,11 @@ module Engine
           { c: "c", i: "i" },
           { c: "d", i: "j" }
         ],
+        "an interpolated textarea" => [
+          %(<textarea><%= @d %>11</textarea>),
+          { d: "draft" },
+          { d: "typed" }
+        ],
         "a block and what follows it" => [
           %(<%= form_with(model: 1) do |f| %><%= f.label %><% end %><%= @after %>),
           { after: "A" },

--- a/test/engine/slots/diagnostics_test.rb
+++ b/test/engine/slots/diagnostics_test.rb
@@ -93,7 +93,7 @@ module Engine
       test "one template reports problems from unrelated parts of itself" do
         diagnostics, = report(THREE_FAMILIES)
 
-        assert_equal ["herb-state-declaration", "slots-name", "herb-state-compare"], diagnostics.map(&:code)
+        assert_equal ["herb-state-declaration", "herb-slots-name", "herb-state-compare"], diagnostics.map(&:code)
 
         assert_equal(
           [
@@ -149,7 +149,7 @@ module Engine
       test "findings from different families both reach the page" do
         _, src = report(THREE_FAMILIES)
 
-        assert_equal ["herb-state-declaration", "slots-name", "herb-state-compare"], recorded(src).map(&:code)
+        assert_equal ["herb-state-declaration", "herb-slots-name", "herb-state-compare"], recorded(src).map(&:code)
       end
 
       test "findings of one family on one line reach the page as one" do
@@ -215,6 +215,229 @@ module Engine
 
         assert_equal([[2, 35]], diagnostics.map { |diagnostic| at(diagnostic) })
         assert_equal(["1.0"], diagnostics.map { |diagnostic| spelled(SECOND_LINE_DIRECTIVE, diagnostic) })
+      end
+
+      NEAR_MISS = <<~ERB
+        <%# herb:state (editing: false, body_draft: "") %>
+        <div>
+          <% if editing %>
+            <textarea rows="2"><%= body_draft11 %></textarea>
+          <% else %>
+            <p>view</p>
+          <% end %>
+        </div>
+      ERB
+
+      test "a bare identifier one typo away from a state warns without degrading" do
+        diagnostics, = report(NEAR_MISS)
+
+        assert_equal 1, diagnostics.length
+
+        warning = diagnostics.first
+
+        assert_equal :warning, warning.severity
+        assert_equal "herb-state-unknown", warning.code
+        assert_equal "`body_draft11` reads like the state `body_draft` but is not declared, so the server owns it and the client can never fill it.", warning.message
+        assert_equal 4, warning.location.start.line
+      end
+
+      test "helper calls, chains and unrelated identifiers stay silent" do
+        ["body_draft", "sanitize(body)", "current_user_name", "message.body_draft1"].each do |expression|
+          diagnostics, = report(<<~ERB)
+            <%# herb:state (editing: false, body_draft: "") %>
+            <div><span><%= #{expression} %></span></div>
+          ERB
+
+          assert_empty diagnostics
+        end
+      end
+
+      MIXED_TEXTAREA = <<~ERB
+        <%# herb:state (editing: false, body_draft: "") %>
+        <div>
+          <textarea data-chat-target="editor" rows="2"><%= body_draft %>11</textarea>
+        </div>
+      ERB
+
+      test "an expression sharing a textarea with other text compiles to an interpolation" do
+        visitor = Herb::Engine::Slots::Visitor.new(mode: :client, fatal: false)
+
+        Herb::Engine.new(MIXED_TEXTAREA, visitors: [visitor], filename: "app/views/test.html.erb")
+
+        assert_equal ["herb-state-binding"], visitor.diagnostics.map(&:code)
+        assert_equal [:raw_text_interpolation], visitor.slots.map(&:type)
+        assert_equal({ "0" => ["", "11"] }, visitor.manifest["parts"])
+        assert_equal({ "body_draft" => [0] }, visitor.manifest["states"]["reads"])
+      end
+
+      test "a state mixed into a form control's value warns that it cannot bind" do
+        diagnostics, = report(<<~ERB)
+          <%# herb:state (body_draft: "") %>
+          <input value="<%= body_draft %>blahblah">
+        ERB
+
+        assert_equal 1, diagnostics.length
+        assert_equal :warning, diagnostics.first.severity
+        assert_equal "herb-state-binding", diagnostics.first.code
+        assert_equal "`body_draft` shares this `<input>`'s `value` with other text, so typing here will not write the state back. State writes still update the whole `value`.", diagnostics.first.message
+      end
+
+      test "mixes that never bound stay silent" do
+        [
+          %(<input value="<%= body_draft %>">),
+          %(<div class="<%= body_draft %>x"></div>),
+          %(<input value="<%= message.author %>x">)
+        ].each do |element|
+          diagnostics, = report(<<~ERB)
+            <%# herb:state (body_draft: "") %>
+            #{element}
+          ERB
+
+          assert_empty diagnostics
+        end
+      end
+
+      test "a lone or whitespace-framed textarea expression stays a plain content slot" do
+        [
+          "<textarea><%= body_draft %></textarea>",
+          "<textarea>\n    <%= body_draft %>\n  </textarea>"
+        ].each do |element|
+          visitor = Herb::Engine::Slots::Visitor.new(mode: :client, fatal: false)
+
+          Herb::Engine.new(MIXED_TEXTAREA.sub(%(<textarea data-chat-target="editor" rows="2"><%= body_draft %>11</textarea>), element), visitors: [visitor], filename: "app/views/test.html.erb")
+
+          assert_empty visitor.diagnostics
+          assert_equal [:raw_text], visitor.slots.map(&:type)
+        end
+      end
+
+      test "two state reads in one textarea cannot share the content" do
+        diagnostics, = report(MIXED_TEXTAREA.sub("<%= body_draft %>11", "<%= body_draft %><%= editing %>"))
+
+        assert_equal 1, diagnostics.length
+        assert_equal :error, diagnostics.first.severity
+        assert_equal "herb-state-read", diagnostics.first.code
+        assert_equal "`body_draft` reads a state inside a `<textarea>` that mixes other dynamic parts. A state write cannot supply the other values.", diagnostics.first.message
+      end
+
+      test "content that parts cannot express warns and keeps the slot off" do
+        diagnostics, = report(MIXED_TEXTAREA.sub("<%= body_draft %>11", "<%= body_draft %><% x = 1 %>11"))
+
+        assert_equal 1, diagnostics.length
+        assert_equal :warning, diagnostics.first.severity
+        assert_equal "herb-slots-content", diagnostics.first.code
+        assert_equal "`<%= body_draft %>` shares the `<textarea>` content with other text. The client writes this content as one piece and would discard the rest, so the expression stays server-rendered and never updates.", diagnostics.first.message
+      end
+
+      CLIENT_BRANCH = <<~ERB
+        <%# herb:state (editing: false, body_draft: "") %>
+        <div>
+          <% if editing %>
+            <span><%= message.sent_label %></span>
+            <p><%= body_draft %></p>
+          <% end %>
+          <em><%= message.author %></em>
+        </div>
+      ERB
+
+      test "a server value inside a client branch warns while state reads and top-level values stay silent" do
+        diagnostics, = report(CLIENT_BRANCH)
+
+        assert_equal 1, diagnostics.length
+
+        warning = diagnostics.first
+
+        assert_equal :warning, warning.severity
+        assert_equal "herb-slots-branch", warning.code
+        assert_equal "`<%= message.sent_label %>` sits inside a branch the client can show on its own, but its value comes from the server. The server only computes values for the branch it renders, so showing this branch ahead of the server leaves the value empty.", warning.message
+        assert_equal 4, warning.location.start.line
+      end
+
+      test "a server-driven conditional keeps its branches silent" do
+        diagnostics, = report(CLIENT_BRANCH.sub("<% if editing %>", "<% if message.editable? %>"))
+
+        assert_empty diagnostics
+      end
+
+      test "a computed boolean attribute on a form control warns that it cannot bind" do
+        diagnostics, = report(<<~ERB)
+          <%# herb:state (agreed: true, unread: 0) %>
+          <%= tag.input type: "checkbox", checked: unread > 3 %>
+        ERB
+
+        assert_equal 1, diagnostics.length
+        assert_equal :warning, diagnostics.first.severity
+        assert_equal "herb-state-binding", diagnostics.first.code
+        assert_equal "`checked` on this `<input>` follows `unread > 3`, so using the control cannot write a state back. The attribute still updates when the states change.", diagnostics.first.message
+      end
+
+      test "bare and off-control boolean attributes stay silent" do
+        [
+          %(<%= tag.input type: "checkbox", checked: agreed %>),
+          %(<%= tag.input type: "checkbox", checked: agreed? %>),
+          %(<%= tag.button "Send", disabled: unread > 3 %>)
+        ].each do |element|
+          diagnostics, = report(<<~ERB)
+            <%# herb:state (agreed: true, unread: 0) %>
+            #{element}
+          ERB
+
+          assert_empty diagnostics
+        end
+      end
+
+      test "a control whose listener already writes the state stays silent" do
+        [
+          <<~HTML,
+            <select data-herb-set="change->filter=$value">
+              <option value="all" selected="<%= filter == "all" %>">All</option>
+            </select>
+          HTML
+          %(<input type="checkbox" data-herb-set="unread=0" checked="<%= unread > 3 %>">),
+          %(<textarea data-herb-set="input->body_draft=$value"><%= body_draft %>11</textarea>)
+        ].each do |element|
+          diagnostics, = report(<<~ERB)
+            <%# herb:state (filter: "all", unread: 0, body_draft: "") %>
+            #{element}
+          ERB
+
+          assert_empty diagnostics
+        end
+      end
+
+      test "a listener writing a different state does not excuse the control" do
+        diagnostics, = report(<<~ERB)
+          <%# herb:state (filter: "all", unread: 0) %>
+          <input type="checkbox" data-herb-set="filter=all" checked="<%= unread > 3 %>">
+        ERB
+
+        assert_equal ["herb-state-binding"], diagnostics.map(&:code)
+      end
+
+      test "a state condition mixed into a boolean attribute is refused" do
+        diagnostics, = report(<<~ERB)
+          <%# herb:state (draft: "") %>
+          <button data-herb-reset="draft" hidden="<%= draft == "" %>111">x</button>
+        ERB
+
+        assert_equal 1, diagnostics.length
+        assert_equal :error, diagnostics.first.severity
+        assert_equal "herb-state-read", diagnostics.first.code
+        assert_equal "`hidden` on this `<button>` mixes `draft == \"\"` with other text. A boolean attribute follows presence and any value keeps it present, so it could never turn off.", diagnostics.first.message
+      end
+
+      test "whole-value and non-state boolean attributes stay silent" do
+        [
+          %(<button hidden="<%= draft == "" %>">x</button>),
+          %(<button hidden="<%= @x %>111">x</button>)
+        ].each do |element|
+          diagnostics, = report(<<~ERB)
+            <%# herb:state (draft: "") %>
+            #{element}
+          ERB
+
+          assert_empty diagnostics
+        end
       end
     end
   end


### PR DESCRIPTION
This pull request takes a family of slot shapes that compiled cleanly and failed silently at runtime, and makes each one either work or speak up.

#### Mixed rcdata content becomes a real slot

A textarea cannot hold comment markers, so its content slot owns the whole interior. Mixing an expression with literal text compiled to a slot whose first client write discarded everything around the expression:

```erb
<textarea><%= body_draft %> characters</textarea>
```

This now compiles to a `raw_text_interpolation` slot, the same shape an interpolated attribute has. The literal segments travel in the manifest's `parts`, the values program collects the outputs into a list, and the client joins the parts with the values and writes the content whole, through payload applies, state writes and parked-branch materialization alike. 

#### Slots that silently do nothing now say so

- `herb-state-unknown` catches a bare identifier one typo away from a declared state, via `DidYouMean`. A misspelled state read never raises anywhere, since it renders in a branch the server did not take, so the server never evaluates it and the client never owns it.
- `herb-slots-branch` warns when a server-computed value sits inside a branch the client can materialize on its own, where showing the branch ahead of the server leaves the value empty.
- `herb-state-binding` warns when a form control cannot two-way bind: a state read sharing the control's `value` or a textarea's content with other text, or a boolean attribute following a computed condition, where a click cannot say which state to write. Outgoing writes keep flowing either way. The warning stays quiet when the control or an ancestor carries a `data-herb-*` action writing one of the states involved, so the canonical select pattern, options comparing a state per `value` under a `data-herb-set="change->filter=$value"`, stays silent.
- A state condition mixed into a boolean attribute's value, like `hidden="<%= draft == "" %>1"`, is refused with an error. Presence has no room for extra text, and any value keeps the attribute on the element, so it could never turn off.