### PR TITLE
Engine: Compile a template's slot schema without rendering it

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -165,13 +165,14 @@ Metrics/ParameterLists:
     - lib/herb/dev/runner.rb
     - lib/herb/diagnostic.rb
     - lib/herb/diff_operation.rb
-    - lib/herb/visitor/diagnostics.rb
     - lib/herb/engine/errors.rb
+    - lib/herb/engine/slots/schema_compiler.rb
     - lib/herb/engine/slots/visitor.rb
     - lib/herb/errors.rb
     - lib/herb/parse_result.rb
     - lib/herb/parser_options.rb
     - lib/herb/prism_inspect.rb
+    - lib/herb/visitor/diagnostics.rb
 
 Metrics/PerceivedComplexity:
   Exclude:

--- a/javascript/packages/client/test/fixtures/contract/a-boolean-attribute-inside-a-block.json
+++ b/javascript/packages/client/test/fixtures/contract/a-boolean-attribute-inside-a-block.json
@@ -68,7 +68,8 @@
           null
         ]
       },
-      "computed": {}
+      "computed": {},
+      "server": {}
     }
   },
   "dependencies": {

--- a/javascript/packages/client/test/fixtures/contract/a-keyed-collection-with-declared-item-state.json
+++ b/javascript/packages/client/test/fixtures/contract/a-keyed-collection-with-declared-item-state.json
@@ -132,7 +132,8 @@
           ]
         }
       },
-      "computed": {}
+      "computed": {},
+      "server": {}
     }
   },
   "dependencies": {

--- a/lib/herb/engine/slots/schema_compiler.rb
+++ b/lib/herb/engine/slots/schema_compiler.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+# typed: true
+
+require_relative "../../../herb"
+require_relative "../../engine"
+require_relative "visitor"
+
+module Herb
+  class Engine
+    module Slots
+      # Compiles a template into what a browser needs to know about its slots, without
+      # rendering anything.
+      #
+      # Slot identity depends on every visitor that runs before the slot visitor, and only
+      # the host knows its stack, so the host hands one over and this runs it. The stack
+      # arrives as a builder returning fresh visitors, because a visitor is stateful and the
+      # statics need a second compile:
+      #
+      #     result = Herb::Engine::Slots::SchemaCompiler.call(
+      #       source,
+      #       filename: "app/views/posts/index.html.erb",
+      #       mode: :client,
+      #       visitors: -> { [Herb::Engine::Validators::SecurityValidator.new(fatal: false)] }
+      #     )
+      #
+      #     result.version        #=> "5d1e0c77"
+      #     result.manifest       #=> what the page's manifest says
+      #     result.static_markup  #=> the markup with every slot as an empty marker pair
+      #
+      # A nil `mode` means slots are off for this template. The stack still runs so its
+      # diagnostics still flow, and everything slot-shaped comes back nil.
+      #
+      class SchemaCompiler
+        Result = Data.define(
+          :mode,          #: Symbol?
+          :manifest,      #: Hash[String, untyped]?
+          :version,       #: String?
+          :slot_entries,  #: Array[Hash[Symbol, untyped]]?
+          :statics,       #: Hash[String, String]?
+          :static_markup, #: String?
+          :diagnostics    #: Array[Herb::Diagnostic]
+        )
+
+        #: (String, filename: String, mode: Symbol?, ?visitors: ^() -> Array[::Herb::Visitor], ?engine: singleton(::Herb::Engine), ?options: Hash[Symbol, untyped]) -> Result
+        def self.call(source, filename:, mode:, visitors: -> { [] }, engine: Herb::Engine, options: {})
+          unless mode
+            stack = visitors.call
+
+            compile(engine, source, filename, stack, options)
+
+            return Result.new(
+              mode: nil,
+              manifest: nil,
+              version: nil,
+              slot_entries: nil,
+              statics: nil,
+              static_markup: nil,
+              diagnostics: collect(stack)
+            )
+          end
+
+          slot_visitor = Visitor.new(mode: mode, mark: false, deliver: :none, fatal: false)
+          stack = visitors.call + [slot_visitor]
+
+          compile(engine, source, filename, stack, options)
+
+          marking = Visitor.new(mode: mode, mark: true, deliver: :none, fatal: false, static_markup: true)
+
+          compile(engine, source, filename, visitors.call + [marking], options)
+
+          Result.new(
+            mode: mode,
+            manifest: slot_visitor.manifest,
+            version: slot_visitor.version,
+            slot_entries: slot_visitor.slot_entries,
+            statics: marking.statics,
+            static_markup: marking.static_markup,
+            diagnostics: collect(stack)
+          )
+        end
+
+        #: (singleton(::Herb::Engine), String, String, Array[::Herb::Visitor], Hash[Symbol, untyped]) -> void
+        def self.compile(engine, source, filename, stack, options)
+          engine.new(source, options.merge(filename: filename, visitors: stack))
+        end
+
+        #: (Array[::Herb::Visitor]) -> Array[Herb::Diagnostic]
+        def self.collect(stack)
+          stack.flat_map { |visitor| visitor.is_a?(Herb::Visitor::Diagnostics) ? visitor.diagnostics : [] }
+        end
+      end
+    end
+  end
+end

--- a/lib/herb/engine/slots/state_compiler.rb
+++ b/lib/herb/engine/slots/state_compiler.rb
@@ -130,6 +130,7 @@ module Herb
             "conditionals" => conditionals,
             "presence" => presence,
             "computed" => computed,
+            "server" => {},
           }
         end
 

--- a/lib/herb/engine/slots/statics.rb
+++ b/lib/herb/engine/slots/statics.rb
@@ -73,7 +73,7 @@ module Herb
 
           return write_placeholder(standing) if standing
 
-          return if SKIPPED_PREFIXES.any? { |prefix| node.type.to_s.start_with?(prefix) }
+          return if !node.is_a?(Herb::AST::ERBOpenTagNode) && SKIPPED_PREFIXES.any? { |prefix| node.type.to_s.start_with?(prefix) }
 
           case node
           when Herb::AST::HTMLTextNode, Herb::AST::LiteralNode
@@ -84,6 +84,16 @@ module Herb
             write(node.open_tag)
             write_all(node.body)
             write(node.close_tag) if node.close_tag
+          when Herb::AST::ERBOpenTagNode
+            raise Unprintable unless node.tag_name
+
+            emit("<")
+            emit(node.tag_name.value)
+
+            @anchored[node]&.each { |annotation| write_placeholder(annotation) }
+
+            write_all(node.children)
+            emit(">")
           when Herb::AST::HTMLOpenTagNode
             emit(node.tag_opening&.value || "<")
             emit(node.tag_name&.value)

--- a/lib/herb/engine/slots/visitor.rb
+++ b/lib/herb/engine/slots/visitor.rb
@@ -53,6 +53,8 @@ module Herb
         attr_reader :states #: StateCompiler
         attr_reader :document #: untyped
         attr_reader :warnings #: Array[Herb::Warnings::Warning]
+        attr_reader :static_markup #: String?
+        attr_reader :slot_nodes #: Array[untyped]
 
         SLOTS_DIRECTIVE = /<%#-?\s*herb:slots\b(?<mode>[^%]*?)-?%>/ #: Regexp
         MODE_OPTION = /\b(server|client)\b/ #: Regexp
@@ -127,8 +129,8 @@ module Herb
           true
         end
 
-        #: (?markers: Markers, ?mode: Symbol, ?identifier: (Symbol | ^(String) -> String), ?mark: bool, ?deliver: Symbol, ?fatal: bool) -> void
-        def initialize(markers: Markers.new, mode: :server, identifier: :path, mark: true, deliver: :hoist, fatal: true)
+        #: (?markers: Markers, ?mode: Symbol, ?identifier: (Symbol | ^(String) -> String), ?mark: bool, ?deliver: Symbol, ?fatal: bool, ?static_markup: bool) -> void
+        def initialize(markers: Markers.new, mode: :server, identifier: :path, mark: true, deliver: :hoist, fatal: true, static_markup: false)
           super(fatal: fatal)
 
           raise ArgumentError, "`mode: #{mode.inspect}` is not a slot mode. Pass one of #{MODES.map(&:inspect).join(", ")}." unless MODES.include?(mode)
@@ -138,6 +140,8 @@ module Herb
           @mark = mark
           @degraded = false
           @deliver = deliver
+          @capture_static_markup = static_markup
+          @static_markup = nil #: String?
           @bufvar = "_buf"
           @mode = mode
           @statics = mode == :client ? {} : nil #: Hash[String, String]?
@@ -302,9 +306,6 @@ module Herb
         def open_tag_for(node)
           @attribute_open_tags[node]
         end
-
-        #: () -> Array[untyped]
-        attr_reader :slot_nodes
 
         #: (untyped) -> untyped
         def scope_of(node)
@@ -486,6 +487,11 @@ module Herb
           @states.apply_states
         end
 
+        #: () -> Hash[String, String]?
+        def statics
+          @statics&.dup
+        end
+
         #: (untyped) -> void
         def finish(node)
           return unless @mark
@@ -494,6 +500,9 @@ module Herb
 
           insert_markers(node)
           wrap_displaced
+
+          @static_markup = Statics.new(@standing, @element_anchored).markup(node.children) if @capture_static_markup
+
           wrap_region(node)
           append_statics(node)
           deliver_manifest(node)

--- a/sig/herb/engine/slots/schema_compiler.rbs
+++ b/sig/herb/engine/slots/schema_compiler.rbs
@@ -1,0 +1,62 @@
+# Generated from lib/herb/engine/slots/schema_compiler.rb with RBS::Inline
+
+module Herb
+  class Engine
+    module Slots
+      # Compiles a template into what a browser needs to know about its slots, without
+      # rendering anything.
+      #
+      # Slot identity depends on every visitor that runs before the slot visitor, and only
+      # the host knows its stack, so the host hands one over and this runs it. The stack
+      # arrives as a builder returning fresh visitors, because a visitor is stateful and the
+      # statics need a second compile:
+      #
+      #     result = Herb::Engine::Slots::SchemaCompiler.call(
+      #       source,
+      #       filename: "app/views/posts/index.html.erb",
+      #       mode: :client,
+      #       visitors: -> { [Herb::Engine::Validators::SecurityValidator.new(fatal: false)] }
+      #     )
+      #
+      #     result.version        #=> "5d1e0c77"
+      #     result.manifest       #=> what the page's manifest says
+      #     result.static_markup  #=> the markup with every slot as an empty marker pair
+      #
+      # A nil `mode` means slots are off for this template. The stack still runs so its
+      # diagnostics still flow, and everything slot-shaped comes back nil.
+      class SchemaCompiler
+        class Result < Data
+          attr_reader mode(): Symbol?
+
+          attr_reader manifest(): Hash[String, untyped]?
+
+          attr_reader version(): String?
+
+          attr_reader slot_entries(): Array[Hash[Symbol, untyped]]?
+
+          attr_reader statics(): Hash[String, String]?
+
+          attr_reader static_markup(): String?
+
+          attr_reader diagnostics(): Array[Herb::Diagnostic]
+
+          def self.new: (Symbol? mode, Hash[String, untyped]? manifest, String? version, Array[Hash[Symbol, untyped]]? slot_entries, Hash[String, String]? statics, String? static_markup, Array[Herb::Diagnostic] diagnostics) -> instance
+                      | (mode: Symbol?, manifest: Hash[String, untyped]?, version: String?, slot_entries: Array[Hash[Symbol, untyped]]?, statics: Hash[String, String]?, static_markup: String?, diagnostics: Array[Herb::Diagnostic]) -> instance
+
+          def self.members: () -> [ :mode, :manifest, :version, :slot_entries, :statics, :static_markup, :diagnostics ]
+
+          def members: () -> [ :mode, :manifest, :version, :slot_entries, :statics, :static_markup, :diagnostics ]
+        end
+
+        # : (String, filename: String, mode: Symbol?, ?visitors: ^() -> Array[::Herb::Visitor], ?engine: singleton(::Herb::Engine), ?options: Hash[Symbol, untyped]) -> Result
+        def self.call: (String, filename: String, mode: Symbol?, ?visitors: ^() -> Array[::Herb::Visitor], ?engine: singleton(::Herb::Engine), ?options: Hash[Symbol, untyped]) -> Result
+
+        # : (singleton(::Herb::Engine), String, String, Array[::Herb::Visitor], Hash[Symbol, untyped]) -> void
+        def self.compile: (singleton(::Herb::Engine), String, String, Array[::Herb::Visitor], Hash[Symbol, untyped]) -> void
+
+        # : (Array[::Herb::Visitor]) -> Array[Herb::Diagnostic]
+        def self.collect: (Array[::Herb::Visitor]) -> Array[Herb::Diagnostic]
+      end
+    end
+  end
+end

--- a/sig/herb/engine/slots/visitor.rbs
+++ b/sig/herb/engine/slots/visitor.rbs
@@ -39,6 +39,10 @@ module Herb
 
         attr_reader warnings: Array[Herb::Warnings::Warning]
 
+        attr_reader static_markup: String?
+
+        attr_reader slot_nodes: Array[untyped]
+
         SLOTS_DIRECTIVE: Regexp
 
         MODE_OPTION: Regexp
@@ -126,8 +130,8 @@ module Herb
         # : () -> bool
         def self.reads_erb_source?: () -> bool
 
-        # : (?markers: Markers, ?mode: Symbol, ?identifier: (Symbol | ^(String) -> String), ?mark: bool, ?deliver: Symbol, ?fatal: bool) -> void
-        def initialize: (?markers: Markers, ?mode: Symbol, ?identifier: Symbol | ^(String) -> String, ?mark: bool, ?deliver: Symbol, ?fatal: bool) -> void
+        # : (?markers: Markers, ?mode: Symbol, ?identifier: (Symbol | ^(String) -> String), ?mark: bool, ?deliver: Symbol, ?fatal: bool, ?static_markup: bool) -> void
+        def initialize: (?markers: Markers, ?mode: Symbol, ?identifier: Symbol | ^(String) -> String, ?mark: bool, ?deliver: Symbol, ?fatal: bool, ?static_markup: bool) -> void
 
         # : () -> bool
         def degraded?: () -> bool
@@ -192,9 +196,6 @@ module Herb
         # : (untyped) -> untyped
         def open_tag_for: (untyped) -> untyped
 
-        # : () -> Array[untyped]
-        attr_reader slot_nodes: untyped
-
         # : (untyped) -> untyped
         def scope_of: (untyped) -> untyped
 
@@ -244,6 +245,9 @@ module Herb
         def ruby_at: (Herb::Location?) -> Herb::RubyProgram::Resolved?
 
         def visit_document_node: (untyped node) -> untyped
+
+        # : () -> Hash[String, String]?
+        def statics: () -> Hash[String, String]?
 
         # : (untyped) -> void
         def finish: (untyped) -> void

--- a/test/engine/slots/schema_compiler_test.rb
+++ b/test/engine/slots/schema_compiler_test.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+require_relative "../../test_helper"
+require "herb/engine/slots/schema_compiler"
+
+module Engine
+  module Slots
+    class SchemaCompilerTest < Minitest::Spec
+      FILENAME = "app/views/posts/index.html.erb"
+
+      def compile(source, mode: :client, visitors: -> { [] })
+        Herb::Engine::Slots::SchemaCompiler.call(source, filename: FILENAME, mode: mode, visitors: visitors)
+      end
+
+      test "the version matches what a marking page compile produces" do
+        source = "<p><%= name %></p><% if open %><b>hi</b><% end %>"
+
+        page_visitor = Herb::Engine::Slots::Visitor.new(mode: :client, mark: true, deliver: :none, fatal: false)
+        Herb::Engine.new(source, visitors: [page_visitor], filename: FILENAME)
+
+        assert_equal page_visitor.version, compile(source).version
+      end
+
+      test "carries the manifest and the slot entries" do
+        result = compile("<p data-herb-name=\"title\"><%= title %></p>")
+
+        assert_equal({ "title" => 0 }, result.manifest["names"])
+        assert_equal([0], result.slot_entries.map { |entry| entry[:index] })
+      end
+
+      test "parks statics for the branches a client would build" do
+        result = compile("<% if open %><b>yes</b><% else %><i>no</i><% end %>")
+
+        refute_nil result.statics
+        assert(result.statics.keys.any? { |key| key.start_with?("0:") })
+      end
+
+      test "the static markup holds every slot as an empty marker pair and no region wrapper" do
+        result = compile("<p>Hello, <%= name %></p>")
+
+        assert_equal "<p>Hello, <!--herb-slot:0--><!--/herb-slot:0--></p>", result.static_markup
+      end
+
+      test "a server mode template still has static markup" do
+        result = compile("<p><%= name %></p>", mode: :server)
+
+        assert_equal :server, result.mode
+        assert_equal "<p data-herb-slot=\"0:child\"></p>", result.static_markup
+      end
+
+      test "a nil mode compiles for diagnostics and answers nothing slot shaped" do
+        validators = -> { [Herb::Engine::Validators::NestingValidator.new(fatal: false)] }
+        result = compile("<p><div>block in p</div></p>", mode: nil, visitors: validators)
+
+        assert_nil result.version
+        assert_nil result.manifest
+        assert_nil result.static_markup
+        refute_empty result.diagnostics
+      end
+
+      test "collects diagnostics from the whole stack, the slot visitor included" do
+        source = "<%# herb:state (count: 0) %>\n<% count = 5 %>\n<p><%= count %></p>\n"
+        result = compile(source)
+
+        assert(result.diagnostics.any? { |diagnostic| diagnostic.code == "herb-state-assignment" })
+      end
+
+      test "a helper element prints into the static markup the way the page renders it" do
+        result = compile("<div><%= image_tag \"https://example.com/a.png\" %></div>")
+
+        assert_equal "<div><img src=\"https://example.com/a.png\"></div>", result.static_markup
+      end
+
+      test "a helper element with a dynamic attribute keeps its slot anchor in the static markup" do
+        result = compile("<div><%= image_tag avatar_url %></div>")
+
+        assert_equal "<div><img src=\"\" data-herb-slot=\"0:attribute:src\"></div>", result.static_markup
+        assert_equal([[0, :attribute, "src"]], result.slot_entries.map { |entry| [entry[:index], entry[:type], entry[:attribute]] })
+      end
+
+      test "a degraded template answers nil static markup" do
+        source = "<%# herb:state (count: 0) %>\n<% count = 5 %>\n<p><%= count %></p>\n"
+        result = compile(source)
+
+        assert_nil result.static_markup
+      end
+    end
+  end
+end


### PR DESCRIPTION
This pull request introduces `Herb::Engine::Slots::SchemaCompiler`, which compiles a template into everything a browser needs to know about its slots, the manifest, the version, the slot entries, the parked statics, the whole-region static markup and the diagnostics, without rendering anything.

Slot identity depends on every visitor that runs before the slot visitor, and only the host knows its stack, so the host hands one over and the compiler runs it. The stack arrives as a builder returning fresh visitors, because a visitor is stateful and the statics need a second compile:

```ruby
result = Herb::Engine::Slots::SchemaCompiler.call(
  source,
  filename: "app/views/posts/index.html.erb",
  mode: :client,
  visitors: -> { [Herb::Engine::Validators::SecurityValidator.new(fatal: false)] }
)

result.version        #=> "5d1e0c77"
result.manifest       #=> what the page's manifest says
result.static_markup  #=> the markup with every slot as an empty marker pair
```

The first compile runs the host's stack plus an unmarked slot visitor, so the manifest, version and slot entries come out exactly as the page's own compile numbers them. The second compile marks, which is what parks the statics and lets the visitor print the whole region as static markup, a new `static_markup` capture on `Slots::Visitor` backed by the `Statics` printer. Diagnostics are collected from every visitor in the stack that includes `Herb::Visitor::Diagnostics`, so validator findings flow alongside the slot visitor's own.

A nil `mode` means slots are off for this template. The stack still runs so its diagnostics still flow, and everything slot-shaped comes back nil.

This is the bottom of the dev server stack. Those layers build on it: the host registers a compiler built on this call, and the dev server pushes what it answers to open browsers. Built on the slot diagnostics and mixed-content compilation from the PR below.
