### PR TITLE
Dev Tools: Show `bundle exec herb dev` when server is unreachable

### DIFF
--- a/javascript/packages/dev-tools/src/dev-server/client.ts
+++ b/javascript/packages/dev-tools/src/dev-server/client.ts
@@ -2,6 +2,7 @@ import { Connection } from "./connection"
 import { Toast } from "./toast"
 import { ConnectionDot } from "./connection-dot"
 import { MismatchAlert } from "./mismatch-alert"
+import { UnavailableAlert } from "./unavailable-alert"
 
 import { applyPatch } from "./patch"
 import { diagnosticsFromError } from "./diagnostics"
@@ -19,6 +20,7 @@ import type {
 } from "./types"
 
 const DEFAULT_PORT = 8592
+const UNAVAILABLE_HINT_AFTER_ATTEMPTS = 3
 
 type ClientState = "connected" | "disconnected" | "given-up"
 
@@ -55,10 +57,14 @@ export class HerbClient {
   }
 
   disconnect(): void {
+    UnavailableAlert.hide()
+
     this.connection.disconnect()
   }
 
   retry(): void {
+    UnavailableAlert.hide()
+
     this.updateState("disconnected")
     this.connection.retry()
   }
@@ -86,6 +92,8 @@ export class HerbClient {
       Toast.show("Herb Dev Server reconnected", "connected")
     }
 
+    UnavailableAlert.reset()
+
     this.hasConnectedBefore = true
     this.updateState("connected")
     this.options.onConnect?.()
@@ -103,11 +111,19 @@ export class HerbClient {
   private onReconnecting(attempt: number, maxAttempts: number, delay: number): void {
     console.debug(`[herb-client] reconnecting (attempt ${attempt}/${maxAttempts}, next try in ${(delay / 1000).toFixed(1)}s)...`)
     this.connectionDot.updateReconnectCountdown(attempt, maxAttempts, delay)
+
+    if (!this.hasConnectedBefore && attempt >= UNAVAILABLE_HINT_AFTER_ATTEMPTS) {
+      this.showUnavailableAlert()
+    }
   }
 
   private onGivenUp(): void {
     this.updateState("given-up")
-    Toast.show("Herb Dev Server not available — click the dot to retry", "warning")
+    this.showUnavailableAlert()
+  }
+
+  private showUnavailableAlert(): void {
+    UnavailableAlert.show({ port: this.port, onRetry: () => this.retry() })
   }
 
   private handleMessage(message: HerbMessage): void {

--- a/javascript/packages/dev-tools/src/dev-server/connection-dot.ts
+++ b/javascript/packages/dev-tools/src/dev-server/connection-dot.ts
@@ -1,4 +1,5 @@
 import { colors } from "./colors"
+import { DEV_SERVER_COMMAND } from "./types"
 
 import type { HerbClient } from "./client"
 
@@ -9,6 +10,7 @@ type UpdatePanelOptions = {
   statusText: string
   statusColor: string
   retryVisible: boolean
+  tipText?: string
   retryHandler?: (e: MouseEvent) => void
   keepStatusWhileRetrying?: boolean
 }
@@ -68,12 +70,13 @@ export class ConnectionDot {
       }
 
       case "disconnected": {
-        this.applyBadge(dot, colors.red, "Disconnected from herb dev server", false, false, "default", null)
+        this.applyBadge(dot, colors.red, `Disconnected from herb dev server. Make sure it is running with \`${DEV_SERVER_COMMAND}\``, false, false, "default", null)
 
         this.updatePanel(panelDot, panelStatus, panelRetry, {
           dotColor: colors.red,
           statusText: "Dev Server disconnected",
           statusColor: colors.gray,
+          tipText: `Dev Server disconnected. Make sure it is running with \`${DEV_SERVER_COMMAND}\``,
           retryVisible: true,
           retryHandler,
           keepStatusWhileRetrying: true,
@@ -83,12 +86,13 @@ export class ConnectionDot {
       }
 
       case "given-up": {
-        this.applyBadge(dot, colors.amber, "Connection to herb dev server failed — click to retry", false, false, "pointer", retryHandler)
+        this.applyBadge(dot, colors.amber, `Herb dev server not available. Start it with \`${DEV_SERVER_COMMAND}\`, or click to retry`, false, false, "pointer", retryHandler)
 
         this.updatePanel(panelDot, panelStatus, panelRetry, {
           dotColor: colors.amber,
           statusText: "Dev Server not available",
           statusColor: colors.amberDarker,
+          tipText: `Dev Server not available. Start it with \`${DEV_SERVER_COMMAND}\``,
           retryVisible: true,
           retryHandler,
         })
@@ -194,7 +198,7 @@ export class ConnectionDot {
     }
 
     for (const element of panelStatus) {
-      element.parentElement?.setAttribute("data-herb-dev-tools-tip", options.statusText)
+      element.parentElement?.setAttribute("data-herb-dev-tools-tip", options.tipText ?? options.statusText)
     }
 
     for (const element of panelRetry) {

--- a/javascript/packages/dev-tools/src/dev-server/types.ts
+++ b/javascript/packages/dev-tools/src/dev-server/types.ts
@@ -63,6 +63,7 @@ export interface WelcomeMessage {
 }
 
 export const DEV_SERVER_FIXED_EVENT = "herb:dev-server-fixed"
+export const DEV_SERVER_COMMAND = "bundle exec herb dev"
 
 export type HerbMessage = WelcomeMessage | PatchMessage | ReloadMessage | ErrorMessage | FixedMessage
 export type ConnectionState = "connected" | "disconnected" | "given-up"

--- a/javascript/packages/dev-tools/src/dev-server/unavailable-alert.ts
+++ b/javascript/packages/dev-tools/src/dev-server/unavailable-alert.ts
@@ -1,0 +1,76 @@
+import { colors } from "./colors"
+import { DEV_SERVER_COMMAND } from "./types"
+
+const ALERT_ID = "herbDevServerUnavailableAlert"
+
+export interface UnavailableAlertOptions {
+  port: number
+  onRetry: () => void
+}
+
+export class UnavailableAlert {
+  private static dismissed = false
+
+  static show(options: UnavailableAlertOptions): void {
+    if (this.dismissed) return
+    if (document.getElementById(ALERT_ID)) return
+
+    const alert = document.createElement("div")
+    alert.id = ALERT_ID
+    alert.style.cssText = `position:fixed;top:32px;right:10px;z-index:999998;background:${colors.amberLight};border:1px solid ${colors.amber};border-radius:8px;padding:12px 16px;max-width:320px;font-family:system-ui,sans-serif;font-size:13px;color:${colors.amberDark};box-shadow:0 4px 12px rgba(0,0,0,0.1);display:flex;gap:10px;align-items:flex-start;`
+
+    const iconElement = document.createElement("span")
+    iconElement.style.cssText = "font-size:18px;line-height:1;"
+    iconElement.textContent = "\u26A0\uFE0F"
+
+    const content = document.createElement("div")
+    content.style.flex = "1"
+
+    const title = document.createElement("div")
+    title.style.cssText = "font-weight:600;margin-bottom:4px;"
+    title.textContent = "Herb Dev Server not available"
+
+    const description = document.createElement("div")
+    description.style.cssText = `font-size:12px;color:${colors.grayLighter};`
+    description.textContent = `Nothing is listening on port ${options.port}. Make sure the Herb dev server is running:`
+
+    const command = document.createElement("code")
+    command.style.cssText = `display:block;margin-top:6px;padding:5px 8px;border-radius:6px;background:rgba(146,64,14,0.08);font-family:ui-monospace,SFMono-Regular,Menlo,monospace;font-size:12px;color:${colors.amberDark};user-select:all;`
+    command.textContent = DEV_SERVER_COMMAND
+
+    const retry = document.createElement("button")
+    retry.style.cssText = `margin-top:8px;background:none;border:1px solid ${colors.amber};border-radius:6px;cursor:pointer;font-family:inherit;font-size:12px;color:${colors.amberDark};padding:3px 10px;`
+    retry.textContent = "Retry"
+    retry.addEventListener("click", () => {
+      this.hide()
+      options.onRetry()
+    })
+
+    content.appendChild(title)
+    content.appendChild(description)
+    content.appendChild(command)
+    content.appendChild(retry)
+
+    const dismiss = document.createElement("button")
+    dismiss.style.cssText = `background:none;border:none;cursor:pointer;font-size:16px;color:${colors.amberDark};padding:0;line-height:1;`
+    dismiss.textContent = "\u2715"
+    dismiss.addEventListener("click", () => {
+      this.dismissed = true
+      this.hide()
+    })
+
+    alert.appendChild(iconElement)
+    alert.appendChild(content)
+    alert.appendChild(dismiss)
+    document.body.appendChild(alert)
+  }
+
+  static hide(): void {
+    document.getElementById(ALERT_ID)?.remove()
+  }
+
+  static reset(): void {
+    this.dismissed = false
+    this.hide()
+  }
+}

--- a/javascript/packages/dev-tools/test/dev-server-unavailable.test.ts
+++ b/javascript/packages/dev-tools/test/dev-server-unavailable.test.ts
@@ -1,0 +1,128 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest"
+
+import { HerbClient } from "../src/dev-server/client"
+import { UnavailableAlert } from "../src/dev-server/unavailable-alert"
+import { DEV_SERVER_COMMAND } from "../src/dev-server/types"
+
+const ALERT = "#herbDevServerUnavailableAlert"
+
+function alert(): HTMLElement | null {
+  return document.querySelector(ALERT)
+}
+
+beforeEach(() => {
+  document.body.innerHTML = ""
+  UnavailableAlert.reset()
+})
+
+afterEach(() => {
+  document.body.innerHTML = ""
+  UnavailableAlert.reset()
+})
+
+describe("the dev server unavailable alert", () => {
+  test("names the command that starts the dev server", () => {
+    UnavailableAlert.show({ port: 8592, onRetry: () => {} })
+
+    expect(alert()?.querySelector("code")?.textContent).toBe(DEV_SERVER_COMMAND)
+    expect(DEV_SERVER_COMMAND).toBe("bundle exec herb dev")
+  })
+
+  test("names the port nothing answered on, since a project can move it", () => {
+    UnavailableAlert.show({ port: 4000, onRetry: () => {} })
+
+    expect(alert()?.textContent).toContain("port 4000")
+  })
+
+  test("draws one alert however often the connection fails again", () => {
+    UnavailableAlert.show({ port: 8592, onRetry: () => {} })
+    UnavailableAlert.show({ port: 8592, onRetry: () => {} })
+
+    expect(document.querySelectorAll(ALERT)).toHaveLength(1)
+  })
+
+  test("retries and takes itself off the page when the button is pressed", () => {
+    const onRetry = vi.fn()
+
+    UnavailableAlert.show({ port: 8592, onRetry })
+
+    const retry = Array.from(alert()!.querySelectorAll("button")).find(button => button.textContent === "Retry")
+
+    retry!.click()
+
+    expect(onRetry).toHaveBeenCalledOnce()
+    expect(alert()).toBeNull()
+  })
+
+  test("stays away once dismissed, so a page nobody is debugging stays quiet", () => {
+    UnavailableAlert.show({ port: 8592, onRetry: () => {} })
+
+    const dismiss = Array.from(alert()!.querySelectorAll("button")).find(button => button.textContent !== "Retry")
+
+    dismiss!.click()
+
+    expect(alert()).toBeNull()
+
+    UnavailableAlert.show({ port: 8592, onRetry: () => {} })
+
+    expect(alert()).toBeNull()
+  })
+
+  test("comes back after a connection, which makes the next outage news again", () => {
+    UnavailableAlert.show({ port: 8592, onRetry: () => {} })
+
+    const dismiss = Array.from(alert()!.querySelectorAll("button")).find(button => button.textContent !== "Retry")
+
+    dismiss!.click()
+
+    UnavailableAlert.reset()
+    UnavailableAlert.show({ port: 8592, onRetry: () => {} })
+
+    expect(alert()).not.toBeNull()
+  })
+})
+
+describe("a client that cannot reach the dev server", () => {
+  test("holds the hint back on the first failed attempt, which is usually a restart", () => {
+    const client = new HerbClient({ port: 8592 })
+
+    client["onReconnecting"](1, 10, 1000)
+
+    expect(alert()).toBeNull()
+  })
+
+  test("shows the hint once the server has stayed silent, without waiting to give up", () => {
+    const client = new HerbClient({ port: 8592 })
+
+    client["onReconnecting"](3, 10, 4000)
+
+    expect(alert()?.textContent).toContain(DEV_SERVER_COMMAND)
+  })
+
+  test("keeps quiet while a server it already reached is coming back", () => {
+    const client = new HerbClient({ port: 8592 })
+
+    client["hasConnectedBefore"] = true
+    client["onReconnecting"](5, 10, 4000)
+
+    expect(alert()).toBeNull()
+  })
+
+  test("shows the hint once it gives up, even on a server it had reached", () => {
+    const client = new HerbClient({ port: 8592 })
+
+    client["hasConnectedBefore"] = true
+    client["onGivenUp"]()
+
+    expect(alert()?.textContent).toContain(DEV_SERVER_COMMAND)
+  })
+
+  test("takes the hint off the page as soon as the server answers", () => {
+    const client = new HerbClient({ port: 8592 })
+
+    client["onGivenUp"]()
+    client["onConnect"]()
+
+    expect(alert()).toBeNull()
+  })
+})


### PR DESCRIPTION
This pull request updates the dev tools so that a page which cannot reach the Herb dev server says how to start one, instead of only reporting that it is missing.

> **Herb Dev Server not available**
> Nothing is listening on port 8592. Make sure the Herb dev server is running:
> `bundle exec herb dev`
> [Retry]