### PR TITLE
Engine: Add Erubi line parity test for multi-line code blocks

### DIFF
--- a/test/engine/whitespace_trimming_test.rb
+++ b/test/engine/whitespace_trimming_test.rb
@@ -478,5 +478,12 @@ module Engine
 
       assert_compiled_snapshot(template)
     end
+
+    test "multi-line code block preserves line count parity with erubi" do
+      template = "<%\n  x = 1\n  y = 2\n%>\n<%= x %>"
+
+      assert_compiled_snapshot(template)
+      assert_erubi_line_parity(template)
+    end
   end
 end

--- a/test/snapshots/engine/whitespace_trimming_test/test_0060_multi-line_code_block_preserves_line_count_parity_with_erubi_056ad410b82f521050ab536ab6d01f5f.txt
+++ b/test/snapshots/engine/whitespace_trimming_test/test_0060_multi-line_code_block_preserves_line_count_parity_with_erubi_056ad410b82f521050ab536ab6d01f5f.txt
@@ -1,0 +1,10 @@
+---
+source: "Engine::WhitespaceTrimmingTest#test_0060_multi-line code block preserves line count parity with erubi"
+input: "{source: \"<%\\n  x = 1\\n  y = 2\\n%>\\n<%= x %>\", options: {}}"
+---
+_buf = ::String.new;
+ x = 1
+  y = 2 
+
+ _buf << (x).to_s;
+_buf.to_s


### PR DESCRIPTION
Follow up on #1546 and #1555.

This pull request picks up the test case from #1556 by @joelhawksley and drops the engine change that came with it. Multi-line `<% ... %>` blocks with the delimiters on their own lines already compile to the same number of lines as Erubi, so what is left worth landing is the regression test.

The test compiles the template through both engines and asserts they agree on the line count, using the `assert_erubi_line_parity` helper from #1555 alongside the existing snapshot assertion.

Opened here because #1556 was closed by an accidental force push to its branch.
