### PR TITLE
Dev Tools: Show the application backtrace when a re-render raises

### DIFF
--- a/javascript/packages/client/src/shared/slots-request.ts
+++ b/javascript/packages/client/src/shared/slots-request.ts
@@ -11,6 +11,7 @@ export interface SlotsRequestFailure {
   message?: string
   template?: string | null
   line?: number | null
+  backtrace?: string[] | null
 }
 
 export class SlotsRequestError extends Error {

--- a/javascript/packages/dev-tools/src/dev-server/diagnostics.ts
+++ b/javascript/packages/dev-tools/src/dev-server/diagnostics.ts
@@ -30,5 +30,6 @@ export function diagnosticFromRefreshFailure(file: string, status: number, failu
     phase: "runtime" as const,
     overlay: "dismissible" as const,
     ...(failure?.line ? { location: { start: { line: failure.line, column: 1 } } } : {}),
+    ...(failure?.backtrace?.length ? { backtrace: failure.backtrace } : {}),
   }
 }

--- a/javascript/packages/dev-tools/src/runtime/panel.ts
+++ b/javascript/packages/dev-tools/src/runtime/panel.ts
@@ -1695,6 +1695,7 @@ export class RuntimePanel {
     })
 
     const stack = frames.length === 0 ? [] : ['', '### Render stack', '', ...frames]
+    const backtrace = diagnostic.backtrace.length === 0 ? [] : ['', '### Backtrace', '', ...diagnostic.backtrace.map((frame) => `- \`${frame}\``)]
 
     return [
       `## ${diagnostic.code ?? diagnostic.origin}`,
@@ -1707,6 +1708,7 @@ export class RuntimePanel {
       ...facts,
       ...this.markdownExcerpt(diagnostic),
       ...stack,
+      ...backtrace,
       ...this.markdownFix(diagnostic),
     ]
   }
@@ -1990,6 +1992,7 @@ export class RuntimePanel {
       suggestion,
       this.excerptHTML(diagnostic),
       this.stackHTML(diagnostic),
+      this.backtraceHTML(diagnostic),
       this.fixHTML(diagnostic),
       `</article>`,
     ].join('')
@@ -2168,6 +2171,29 @@ export class RuntimePanel {
     return [
       `<div class="herb-dev-tools-stack">`,
       `<p class="herb-dev-tools-stack-title">Render stack<span class="herb-dev-tools-stack-order">innermost first</span></p>`,
+      `<ol class="herb-dev-tools-frames">${items.join('')}</ol>`,
+      `</div>`,
+    ].join('')
+  }
+
+  private backtraceHTML(diagnostic: NormalizedDiagnostic): string {
+    if (diagnostic.backtrace.length === 0) {
+      return ''
+    }
+
+    const items = diagnostic.backtrace.map((frame) => {
+      const parsed = /^(.+?):(\d+)(?::in .*)?$/.exec(frame)
+
+      if (!parsed) {
+        return `<li class="herb-dev-tools-frame">${escapeHTML(frame)}</li>`
+      }
+
+      return `<li class="herb-dev-tools-frame">${this.pathHTML(frame, parsed[1], Number(parsed[2]), 1, 'herb-dev-tools-frame-target')}</li>`
+    })
+
+    return [
+      `<div class="herb-dev-tools-stack">`,
+      `<p class="herb-dev-tools-stack-title">Backtrace<span class="herb-dev-tools-stack-order">innermost first</span></p>`,
       `<ol class="herb-dev-tools-frames">${items.join('')}</ol>`,
       `</div>`,
     ].join('')

--- a/javascript/packages/dev-tools/src/runtime/report.ts
+++ b/javascript/packages/dev-tools/src/runtime/report.ts
@@ -11,6 +11,7 @@ export const OVERLAY_MODES = ['blocking', 'dismissible'] as const;
 export const PHASES = ['compile', 'runtime'] as const;
 export const FIX_KINDS = ['safe', 'unsafe'] as const;
 export const DEFAULT_FIX_KIND: FixKind = 'safe';
+export const MAX_BACKTRACE_FRAMES = 5;
 
 export type RenderVia = typeof RENDER_VIA_VALUES[number];
 export type RuntimeSeverity = typeof RUNTIME_SEVERITIES[number];
@@ -73,6 +74,7 @@ export interface RuntimeDiagnostic {
   overlay?: OverlayMode | false;
   phase?: Phase;
   source?: string;
+  backtrace?: string[];
   element?: Element | null;
 }
 
@@ -106,6 +108,7 @@ export interface NormalizedDiagnostic {
   fix: NormalizedFix | null;
   overlay: OverlayMode | null;
   phase: Phase | null;
+  backtrace: string[];
   element: Element | null;
 }
 
@@ -291,8 +294,19 @@ export function normalizeDiagnostic(value: unknown, sources: Record<string, stri
     fix: normalizeFix(value.fix, template, sources),
     overlay: normalizeOverlay(value.overlay),
     phase: normalizePhase(value.phase),
+    backtrace: normalizeBacktrace(value.backtrace),
     element: asElement(value.element),
   };
+}
+
+function normalizeBacktrace(value: unknown): string[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  return value
+    .filter((frame): frame is string => typeof frame === 'string' && frame.length > 0)
+    .slice(0, MAX_BACKTRACE_FRAMES);
 }
 
 function asElement(value: unknown): Element | null {

--- a/javascript/packages/dev-tools/test/hot-reload.test.ts
+++ b/javascript/packages/dev-tools/test/hot-reload.test.ts
@@ -131,7 +131,7 @@ describe("a raising re-render", () => {
     const sink = { report, clear: vi.fn(), clearAll: vi.fn() }
 
     vi.stubGlobal("fetch", vi.fn(async () => new Response(JSON.stringify({
-      error: { class: "NoMethodError", message: "undefined method 'oops'", template: FILE },
+      error: { class: "NoMethodError", message: "undefined method 'oops'", template: FILE, backtrace: ["app/models/message.rb:12:in 'oops'", "app/views/chat/show.html.erb:5"] },
     }), { status: 500 })))
 
     try {
@@ -148,10 +148,11 @@ describe("a raising re-render", () => {
 
       expect(reload).not.toHaveBeenCalled()
 
-      const diagnostics = report.mock.calls[0][1] as Array<{ code?: string, message?: string }>
+      const diagnostics = report.mock.calls[0][1] as Array<{ code?: string, message?: string, backtrace?: string[] }>
 
       expect(diagnostics[diagnostics.length - 1]?.code).toBe("NoMethodError")
       expect(diagnostics[diagnostics.length - 1]?.message).toBe("undefined method 'oops'")
+      expect(diagnostics[diagnostics.length - 1]?.backtrace).toEqual(["app/models/message.rb:12:in 'oops'", "app/views/chat/show.html.erb:5"])
     } finally {
       vi.unstubAllGlobals()
       runtime.stop()


### PR DESCRIPTION
This pull request adds the application's backtrace to the diagnostics card a raising re-render produces, so the developer sees where the raise came from instead of only its class and message.

The dev server's fetch tier already surfaces a raise as a dismissible card through the structured error a host answers with. That envelope now carries a `backtrace`, the host sends its first five frames cleaned through `Rails.backtrace_cleaner`, and the card renders them as a frame list below the render stack. A frame shaped like `path:line` becomes a link that opens the location in the editor, the way render stack frames already do, and the panel's copied Markdown includes the frames under a `### Backtrace` heading.

```json
{ "error": { "class": "NoMethodError", "message": "undefined method 'sent_label'", "template": "chat/show", "backtrace": ["app/models/message.rb:12:in 'sent_label'"] } }
```

`RuntimeDiagnostic` gains an optional `backtrace`, normalization keeps at most five string frames, and `SlotsRequestFailure` carries the field on the client's typed failure. A report without the field behaves exactly as before.