### PR TITLE
Dev Server: Refresh stylesheets and reload on rebuilt JavaScript

### DIFF
--- a/javascript/packages/dev-tools/src/dev-server/client.ts
+++ b/javascript/packages/dev-tools/src/dev-server/client.ts
@@ -7,7 +7,7 @@ import { UnavailableAlert } from "./unavailable-alert"
 import { diagnosticsFromError } from "./diagnostics"
 import { heldRuntime } from "./runtime-handle"
 
-import type { DiagnosticSink, HerbClientOptions, HerbMessage, WelcomeMessage, SchemaMessage, InvalidateMessage, ErrorMessage } from "./types"
+import type { AssetMessage, DiagnosticSink, HerbClientOptions, HerbMessage, WelcomeMessage, SchemaMessage, InvalidateMessage, ErrorMessage } from "./types"
 
 const DEFAULT_PORT = 8592
 const UNAVAILABLE_HINT_AFTER_ATTEMPTS = 3
@@ -146,6 +146,9 @@ export class HerbClient {
       case "error":
         this.handleError(message)
         break
+      case "asset":
+        this.handleAsset(message)
+        break
     }
   }
 
@@ -174,6 +177,12 @@ export class HerbClient {
   private handleInvalidate(message: InvalidateMessage): void {
     this.options.onInvalidate?.(message)
     this.options.hotReload?.onInvalidate(message)
+  }
+
+  private handleAsset(message: AssetMessage): void {
+    this.options.onAsset?.(message)
+
+    this.options.hotReload?.onAsset(message)
   }
 
   private handleError(message: ErrorMessage): void {

--- a/javascript/packages/dev-tools/src/dev-server/hot-reload.ts
+++ b/javascript/packages/dev-tools/src/dev-server/hot-reload.ts
@@ -6,11 +6,12 @@ import { diffStateManifests } from "./manifest-diff"
 import { rebuildRegion, stateOwnedIndices } from "./rebuild"
 import { heldRuntime } from "./runtime-handle"
 import { diagnosticFromRefreshFailure } from "./diagnostics"
+import { refreshStylesheets } from "./stylesheets"
 
 import { SlotsRequestError, parseStaticsKey } from "@herb-tools/client"
 
 import type { Region, Runtime } from "@herb-tools/client"
-import type { DiagnosticSink, ErrorMessage, HotReloadHandler, InvalidateMessage, SchemaMessage } from "./types"
+import type { AssetMessage, DiagnosticSink, ErrorMessage, HotReloadHandler, InvalidateMessage, SchemaMessage } from "./types"
 
 export interface HotReloadOptions {
   runtime?: () => Runtime | null
@@ -168,6 +169,24 @@ export class HotReload implements HotReloadHandler {
     }
 
     entry.timer = setTimeout(() => this.settle(message.file), this.options.graceMs ?? DEFAULT_GRACE_MS)
+  }
+
+  onAsset(message: AssetMessage): void {
+    if (!this.enabled) {
+      return
+    }
+
+    if (message.kind === "script") {
+      this.reload(message.file, "a JavaScript build output changed")
+
+      return
+    }
+
+    void refreshStylesheets().then((swapped) => {
+      if (swapped > 0) {
+        console.debug(`[Herb Dev Tools] refreshed ${swapped} stylesheet${swapped === 1 ? "" : "s"} for ${message.file}`)
+      }
+    })
   }
 
   onError(message: ErrorMessage): void {

--- a/javascript/packages/dev-tools/src/dev-server/stylesheets.ts
+++ b/javascript/packages/dev-tools/src/dev-server/stylesheets.ts
@@ -1,0 +1,70 @@
+const DIGEST_PATTERN = /-[0-9a-f]{8,64}(\.\w+)$/
+
+export async function refreshStylesheets(): Promise<number> {
+  const response = await fetch(window.location.href, { headers: { Accept: "text/html" } })
+
+  if (!response.ok) {
+    return 0
+  }
+
+  const fresh = new DOMParser().parseFromString(await response.text(), "text/html")
+  const links = [...fresh.querySelectorAll('link[rel="stylesheet"]')]
+
+  let swapped = 0
+
+  for (const link of links) {
+    const href = link.getAttribute("href")
+
+    if (!href) {
+      continue
+    }
+
+    const live = currentLink(href)
+
+    if (!live || live.getAttribute("href") === href) {
+      continue
+    }
+
+    await swap(live, href)
+
+    swapped += 1
+  }
+
+  return swapped
+}
+
+function currentLink(href: string): HTMLLinkElement | null {
+  const logical = logicalName(href)
+
+  for (const link of document.querySelectorAll<HTMLLinkElement>('link[rel="stylesheet"]')) {
+    if (logicalName(link.getAttribute("href") ?? "") === logical) {
+      return link
+    }
+  }
+
+  return null
+}
+
+function logicalName(href: string): string {
+  return href.split("?")[0].replace(DIGEST_PATTERN, "$1")
+}
+
+function swap(live: HTMLLinkElement, href: string): Promise<void> {
+  return new Promise((resolve) => {
+    const next = live.cloneNode() as HTMLLinkElement
+
+    next.setAttribute("href", href)
+
+    next.onload = () => {
+      live.remove()
+      resolve()
+    }
+
+    next.onerror = () => {
+      next.remove()
+      resolve()
+    }
+
+    live.after(next)
+  })
+}

--- a/javascript/packages/dev-tools/src/dev-server/types.ts
+++ b/javascript/packages/dev-tools/src/dev-server/types.ts
@@ -62,7 +62,13 @@ export interface WelcomeMessage {
 
 export const DEV_SERVER_COMMAND = "bundle exec herb dev"
 
-export type HerbMessage = WelcomeMessage | SchemaMessage | InvalidateMessage | ErrorMessage
+export interface AssetMessage {
+  type: "asset"
+  kind: "stylesheet" | "script"
+  file: string
+}
+
+export type HerbMessage = WelcomeMessage | SchemaMessage | InvalidateMessage | ErrorMessage | AssetMessage
 export type ConnectionState = "connected" | "disconnected" | "given-up"
 export type MessageHandler = (message: HerbMessage) => void
 
@@ -87,6 +93,7 @@ export interface HotReloadHandler {
   onSchema(message: SchemaMessage): void
   onInvalidate(message: InvalidateMessage): void
   onError(message: ErrorMessage): void
+  onAsset(message: AssetMessage): void
 }
 
 export interface HerbClientOptions {
@@ -97,6 +104,7 @@ export interface HerbClientOptions {
   onSchema?: (message: SchemaMessage) => void
   onInvalidate?: (message: InvalidateMessage) => void
   onError?: (message: ErrorMessage) => void
+  onAsset?: (message: AssetMessage) => void
   onConnect?: () => void
   onDisconnect?: () => void
 }

--- a/javascript/packages/dev-tools/test/hot-reload.test.ts
+++ b/javascript/packages/dev-tools/test/hot-reload.test.ts
@@ -347,3 +347,24 @@ describe("the per-file diagnostics sink", () => {
     }
   })
 })
+
+describe("a rebuilt asset", () => {
+  test("a script build output reloads the page", () => {
+    const reload = vi.fn()
+    const hotReload = new HotReload({ runtime: () => null, reload })
+
+    hotReload.onAsset({ type: "asset", kind: "script", file: "app/assets/builds/application.js" })
+
+    expect(reload).toHaveBeenCalledTimes(1)
+  })
+
+  test("hot reloading off leaves the page alone", () => {
+    const reload = vi.fn()
+    const hotReload = new HotReload({ runtime: () => null, reload })
+
+    hotReload.setEnabled(false)
+    hotReload.onAsset({ type: "asset", kind: "script", file: "app/assets/builds/application.js" })
+
+    expect(reload).not.toHaveBeenCalled()
+  })
+})

--- a/javascript/packages/dev-tools/test/stylesheets.test.ts
+++ b/javascript/packages/dev-tools/test/stylesheets.test.ts
@@ -1,0 +1,62 @@
+import { describe, test, expect, afterEach, vi } from "vitest"
+
+import { refreshStylesheets } from "../src/dev-server/stylesheets"
+
+function liveLink(href: string): HTMLLinkElement {
+  const link = document.createElement("link")
+
+  link.rel = "stylesheet"
+  link.setAttribute("href", href)
+  document.head.appendChild(link)
+
+  return link
+}
+
+function pageWith(href: string): Response {
+  return new Response(`<html><head><link rel="stylesheet" href="${href}"></head><body></body></html>`, {
+    status: 200,
+    headers: { "Content-Type": "text/html" },
+  })
+}
+
+afterEach(() => {
+  document.querySelectorAll('link[rel="stylesheet"]').forEach((link) => link.remove())
+  vi.unstubAllGlobals()
+})
+
+describe("refreshStylesheets", () => {
+  test("swaps a stylesheet whose digest moved and drops the stale link", async () => {
+    const old = liveLink("/src/base.css?v=old")
+
+    vi.stubGlobal("fetch", vi.fn(async () => pageWith("/src/base.css?v=new")))
+
+    expect(await refreshStylesheets()).toBe(1)
+    expect(old.isConnected).toBe(false)
+    expect(document.querySelector('link[href="/src/base.css?v=new"]')).not.toBeNull()
+  })
+
+  test("leaves an unchanged stylesheet alone", async () => {
+    const link = liveLink("/src/base.css?v=old")
+
+    vi.stubGlobal("fetch", vi.fn(async () => pageWith("/src/base.css?v=old")))
+
+    expect(await refreshStylesheets()).toBe(0)
+    expect(link.isConnected).toBe(true)
+  })
+
+  test("matches links by logical name across digests, and a failed load keeps the old rules", async () => {
+    const old = liveLink("/assets/application-aaaaaaaa.css")
+
+    vi.stubGlobal("fetch", vi.fn(async () => pageWith("/assets/application-bbbbbbbb.css")))
+
+    expect(await refreshStylesheets()).toBe(1)
+    expect(old.isConnected).toBe(true)
+    expect(document.querySelector('link[href="/assets/application-bbbbbbbb.css"]')).toBeNull()
+  })
+
+  test("ignores a stylesheet the page does not hold", async () => {
+    vi.stubGlobal("fetch", vi.fn(async () => pageWith("/assets/other-bbbbbbbb.css")))
+
+    expect(await refreshStylesheets()).toBe(0)
+  })
+})

--- a/lib/herb/dev/assets.rb
+++ b/lib/herb/dev/assets.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+# typed: true
+
+require "digest"
+
+module Herb
+  module Dev
+    # Tracks the build outputs a project's asset watchers write.
+    #
+    # A build tool rewrites its output on every run, and most runs change nothing,
+    # so only a moved digest counts as a change.
+    #
+    class Assets
+      ROOT = "app/assets/builds" #: String
+      PATTERNS = ["#{ROOT}/**/*.css", "#{ROOT}/**/*.js"].freeze #: Array[String]
+
+      #: () -> void
+      def initialize
+        @digests = {} #: Hash[String, String]
+      end
+
+      #: (String) -> Symbol
+      def self.kind_for(path)
+        path.end_with?(".css") ? :stylesheet : :script
+      end
+
+      #: (String) -> void
+      def index(root)
+        PATTERNS.each do |pattern|
+          Dir.glob(File.join(root, pattern)).each do |asset|
+            @digests[asset] = Digest::SHA256.file(asset).hexdigest
+          rescue StandardError
+            nil
+          end
+        end
+      end
+
+      #: (String) -> bool
+      def changed?(path)
+        return false unless File.exist?(path)
+
+        digest = Digest::SHA256.file(path).hexdigest
+
+        return false if @digests[path] == digest
+
+        @digests[path] = digest
+
+        true
+      rescue StandardError
+        false
+      end
+    end
+  end
+end

--- a/lib/herb/dev/pipeline.rb
+++ b/lib/herb/dev/pipeline.rb
@@ -54,6 +54,8 @@ module Herb
           handle_added(event)
         when :changed
           handle_changed(event)
+        when :stylesheet, :script
+          broadcast(Protocol.asset(kind: event.kind, file: event.relative_path))
         end
       end
 

--- a/lib/herb/dev/protocol.rb
+++ b/lib/herb/dev/protocol.rb
@@ -50,6 +50,15 @@ module Herb
         }
       end
 
+      #: (kind: Symbol, file: String) -> Hash[Symbol, untyped]
+      def self.asset(kind:, file:)
+        {
+          type: "asset",
+          kind: kind.to_s,
+          file: file,
+        }
+      end
+
       #: (file: String, source: String, errors: Array[untyped]) -> Hash[Symbol, untyped]
       def self.error(file:, source:, errors:)
         entries = errors.map { |parse_error|

--- a/lib/herb/dev/watcher.rb
+++ b/lib/herb/dev/watcher.rb
@@ -2,6 +2,7 @@
 # typed: true
 
 require_relative "../configuration"
+require_relative "assets"
 
 module Herb
   module Dev
@@ -41,6 +42,7 @@ module Herb
         @on_event = on_event
         @watch_paths = resolve_watch_paths(watch_paths) #: Array[String]
         @file_states = {} #: Hash[String, String]
+        @assets = Assets.new
         @include_patterns = config.file_include_patterns
         @exclude_patterns = config.file_exclude_patterns
         @thread = nil #: Thread?
@@ -54,6 +56,8 @@ module Herb
         rescue StandardError
           nil
         end
+
+        @assets.index(path)
 
         @file_states.size
       end
@@ -102,9 +106,21 @@ module Herb
         return [@root] if candidates.empty?
         return [@root] if candidates.include?(@root)
 
-        candidates.reject do |path|
+        narrowed = candidates.reject do |path|
           candidates.any? { |other| other != path && path.start_with?("#{other}/") }
         end
+
+        (narrowed + asset_watch_paths(narrowed)).sort
+      end
+
+      #: (Array[String]) -> Array[String]
+      def asset_watch_paths(narrowed)
+        builds = File.join(@root, Assets::ROOT)
+
+        return [] unless File.directory?(builds)
+        return [] if narrowed.any? { |path| builds == path || builds.start_with?("#{path}/") }
+
+        [builds]
       end
 
       #: (Cruise::Event) -> void
@@ -112,12 +128,20 @@ module Herb
         path = raw.path
         relative_path = path.delete_prefix("#{@root}/")
 
+        return handle_asset(path, relative_path) if @config.path_included?(relative_path, Assets::PATTERNS)
         return if @config.path_excluded?(relative_path, @exclude_patterns)
         return unless @config.path_included?(relative_path, @include_patterns)
 
         event = normalize(raw.kind, path, relative_path)
 
         @on_event.call(event) if event
+      end
+
+      #: (String, String) -> void
+      def handle_asset(path, relative_path)
+        return unless @assets.changed?(path)
+
+        @on_event.call(Event.new(kind: Assets.kind_for(path), path: path, relative_path: relative_path, previous: nil, current: nil))
       end
 
       #: (String, String, String) -> Event?

--- a/sig/herb/dev/assets.rbs
+++ b/sig/herb/dev/assets.rbs
@@ -1,0 +1,27 @@
+# Generated from lib/herb/dev/assets.rb with RBS::Inline
+
+module Herb
+  module Dev
+    # Tracks the build outputs a project's asset watchers write.
+    #
+    # A build tool rewrites its output on every run, and most runs change nothing,
+    # so only a moved digest counts as a change.
+    class Assets
+      ROOT: String
+
+      PATTERNS: Array[String]
+
+      # : () -> void
+      def initialize: () -> void
+
+      # : (String) -> Symbol
+      def self.kind_for: (String) -> Symbol
+
+      # : (String) -> void
+      def index: (String) -> void
+
+      # : (String) -> bool
+      def changed?: (String) -> bool
+    end
+  end
+end

--- a/sig/herb/dev/protocol.rbs
+++ b/sig/herb/dev/protocol.rbs
@@ -23,6 +23,9 @@ module Herb
       # : (file: String, version: String?, node_path: Array[Integer], scope: Symbol) -> Hash[Symbol, untyped]
       def self.invalidate: (file: String, version: String?, node_path: Array[Integer], scope: Symbol) -> Hash[Symbol, untyped]
 
+      # : (kind: Symbol, file: String) -> Hash[Symbol, untyped]
+      def self.asset: (kind: Symbol, file: String) -> Hash[Symbol, untyped]
+
       # : (file: String, source: String, errors: Array[untyped]) -> Hash[Symbol, untyped]
       def self.error: (file: String, source: String, errors: Array[untyped]) -> Hash[Symbol, untyped]
 

--- a/sig/herb/dev/watcher.rbs
+++ b/sig/herb/dev/watcher.rbs
@@ -62,8 +62,14 @@ module Herb
       # : (Array[String]?) -> Array[String]
       def resolve_watch_paths: (Array[String]?) -> Array[String]
 
+      # : (Array[String]) -> Array[String]
+      def asset_watch_paths: (Array[String]) -> Array[String]
+
       # : (Cruise::Event) -> void
       def handle: (Cruise::Event) -> void
+
+      # : (String, String) -> void
+      def handle_asset: (String, String) -> void
 
       # : (String, String, String) -> Event?
       def normalize: (String, String, String) -> Event?

--- a/test/dev/pipeline_test.rb
+++ b/test/dev/pipeline_test.rb
@@ -254,5 +254,26 @@ module Dev
       assert_includes types, "schema"
       assert_equal [], server.messages.find { |message, _| message[:type] == "schema" }.first[:diagnostics]
     end
+
+    test "a rebuilt stylesheet broadcasts an asset message to browsers" do
+      server = FakeServer.new
+      subject = pipeline(server)
+
+      subject.handle_event(event(:stylesheet, "app/assets/builds/tailwind.css", nil, nil))
+
+      message, to = server.messages.first
+
+      assert_equal({ type: "asset", kind: "stylesheet", file: "app/assets/builds/tailwind.css" }, message)
+      assert_equal :browsers, to
+    end
+
+    test "a rebuilt script broadcasts its own asset kind" do
+      server = FakeServer.new
+      subject = pipeline(server)
+
+      subject.handle_event(event(:script, "app/assets/builds/application.js", nil, nil))
+
+      assert_equal({ type: "asset", kind: "script", file: "app/assets/builds/application.js" }, server.messages.first.first)
+    end
   end
 end

--- a/test/dev/watcher_test.rb
+++ b/test/dev/watcher_test.rb
@@ -193,5 +193,78 @@ module Dev
         assert_equal [root], watcher_for(root, [root, views]).watch_paths
       end
     end
+
+    test "a rebuilt stylesheet is one :stylesheet event per changed digest" do
+      with_watcher do |root, watcher, events|
+        path = write(root, "app/assets/builds/tailwind.css", ".a{}")
+
+        watcher.send(:handle, RawEvent.new("created", path))
+        watcher.send(:handle, RawEvent.new("modified", path))
+
+        write(root, "app/assets/builds/tailwind.css", ".a{} .b{}")
+        watcher.send(:handle, RawEvent.new("modified", path))
+
+        assert_equal [:stylesheet, :stylesheet], events.map(&:kind)
+        assert_equal "app/assets/builds/tailwind.css", events.first.relative_path
+        assert_nil events.first.current
+      end
+    end
+
+    test "an indexed stylesheet stays quiet until its content moves" do
+      with_watcher do |root, watcher, events|
+        path = write(root, "app/assets/builds/tailwind.css", ".a{}")
+
+        watcher.index
+
+        watcher.send(:handle, RawEvent.new("modified", path))
+
+        assert_empty events
+
+        write(root, "app/assets/builds/tailwind.css", ".b{}")
+        watcher.send(:handle, RawEvent.new("modified", path))
+
+        assert_equal [:stylesheet], events.map(&:kind)
+      end
+    end
+
+    test "a narrowed watcher keeps the CSS build outputs in its watch paths" do
+      Dir.mktmpdir do |root|
+        root = File.realpath(root)
+        views = File.join(root, "app/views")
+        builds = File.join(root, "app/assets/builds")
+
+        FileUtils.mkdir_p(views)
+        FileUtils.mkdir_p(builds)
+
+        assert_equal [builds, views], watcher_for(root, [views]).watch_paths
+      end
+    end
+
+    test "a rebuilt script is a :script event" do
+      with_watcher do |root, watcher, events|
+        path = write(root, "app/assets/builds/application.js", "console.log(1)")
+
+        watcher.send(:handle, RawEvent.new("modified", path))
+
+        assert_equal [:script], events.map(&:kind)
+      end
+    end
+
+    test "a removed asset stays silent, and an identical rebuild after it stays quiet" do
+      with_watcher do |root, watcher, events|
+        path = write(root, "app/assets/builds/tailwind.css", ".a{}")
+
+        watcher.send(:handle, RawEvent.new("modified", path))
+        events.clear
+
+        File.delete(path)
+        watcher.send(:handle, RawEvent.new("removed", path))
+
+        write(root, "app/assets/builds/tailwind.css", ".a{}")
+        watcher.send(:handle, RawEvent.new("created", path))
+
+        assert_empty events
+      end
+    end
   end
 end


### PR DESCRIPTION
This pull request makes hot reload pick up rebuilt assets, so adding a Tailwind class to a template stops needing a manual page reload to get its styles, and an edited JavaScript entrypoint stops running stale in the page.

The gap sat between two watchers. Editing a template resolves in place through the slot tiers, and the CSS watcher, `tailwindcss-rails` or a `yarn build:css --watch`, rebuilds its output moments later, but the page keeps its old `<link>` and its old digested URL. Propshaft refuses a stale digest, so the classic cache-busting trick cannot work either, the browser has to learn the new URL.

The dev server's watcher now also covers the CSS and JavaScript outputs under `app/assets/builds`. Those files never enter the compile pipeline, a change broadcasts one new message, deduplicated by content digest since build tools rewrite their output on runs that change nothing:

```jsonc
{ "type": "asset", "kind": "stylesheet", "file": "app/assets/builds/tailwind.css" }
```

On that message the dev tools fetch the current page once, read which URL each stylesheet lives at now, and swap any changed `<link>` in behind an `onload`, so the old rules stay applied until the new ones are ready and nothing flashes unstyled. Asking the freshly rendered page for its own asset URLs keeps the dev server out of the asset pipeline entirely, the same mechanism serves Propshaft and Sprockets, digested and plain. A failed load keeps the old stylesheet. The whole path respects the Hot Reloading toggle.

A rebuilt script reloads the page instead. Re-executing a bundle in place would double up listeners, redefine custom elements and duplicate Stimulus controllers, so without module-level HMR hooks a full reload is the only correct answer, and it goes through the same reload path the tiers use, counted, logged and behind the Hot Reloading toggle.

The sequencing needs no coordination. The template edit updates the class attribute onto the element first, the CSS rebuild lands a few hundred milliseconds later, and the swap gives the class its rules. 