### PR TITLE
Engine: Tell a heredoc apart from the shovel operator

### DIFF
--- a/lib/herb/engine/helpers.rb
+++ b/lib/herb/engine/helpers.rb
@@ -26,16 +26,33 @@ module Herb
 
       #: (String) -> bool
       def self.ends_on_heredoc_terminator?(code)
-        return false unless heredoc?(code)
+        return false unless code.include?("<<")
 
-        terminators = code.scan(/<<[~-]?\s*['"`]?(\w+)/).flatten
+        tokens = heredoc_tokens(code)
 
-        terminators.any? && terminators.include?(code.lines.last.to_s.strip)
+        return true unless tokens
+
+        tokens.any? { |token| token.type == :HEREDOC_END && token.location.start_line == code.lines.size }
       end
 
       #: (String) -> bool
       def self.heredoc?(code)
-        code.match?(/<<[~-]?\s*['"`]?\w/)
+        return false unless code.include?("<<")
+
+        tokens = heredoc_tokens(code)
+
+        return true unless tokens
+
+        tokens.any? { |token| token.type == :HEREDOC_START }
+      end
+
+      #: (String) -> Array[untyped]?
+      def self.heredoc_tokens(code)
+        return nil unless prism_available?
+
+        Prism.lex(code).value.map(&:first)
+      rescue StandardError
+        nil
       end
 
       #: (String) -> String

--- a/sig/herb/engine/helpers.rbs
+++ b/sig/herb/engine/helpers.rbs
@@ -15,6 +15,9 @@ module Herb
       # : (String) -> bool
       def self.heredoc?: (String) -> bool
 
+      # : (String) -> Array[untyped]?
+      def self.heredoc_tokens: (String) -> Array[untyped]?
+
       # : (String) -> String
       def self.strip_trailing_comment: (String) -> String
 

--- a/test/engine/engine_test.rb
+++ b/test/engine/engine_test.rb
@@ -355,5 +355,17 @@ module Engine
 
       assert_compiled_snapshot(template)
     end
+
+    test "a shovel operator spanning two lines in an output tag keeps the following line" do
+      template = "<p><%= a <<\nb %></p>\n<%= z %>\n"
+
+      assert_compiled_snapshot(template)
+    end
+
+    test "a shovel operator in a control tag keeps the line the next tag is on" do
+      template = "<% list << item %><%= z %>\n"
+
+      assert_compiled_snapshot(template)
+    end
   end
 end

--- a/test/snapshots/engine/engine_test/test_0042_a_shovel_operator_spanning_two_lines_in_an_output_tag_keeps_the_following_line_aea747c3b6758dd8de025368eecec49d.txt
+++ b/test/snapshots/engine/engine_test/test_0042_a_shovel_operator_spanning_two_lines_in_an_output_tag_keeps_the_following_line_aea747c3b6758dd8de025368eecec49d.txt
@@ -1,0 +1,9 @@
+---
+source: "Engine::EngineTest#test_0042_a shovel operator spanning two lines in an output tag keeps the following line"
+input: "{source: \"<p><%= a <<\\nb %></p>\\n<%= z %>\\n\", options: {}}"
+---
+_buf = ::String.new; _buf << '<p>'.freeze; _buf << (a <<
+b).to_s; _buf << '</p>
+'.freeze; _buf << (z).to_s; _buf << '
+'.freeze;
+_buf.to_s

--- a/test/snapshots/engine/engine_test/test_0043_a_shovel_operator_in_a_control_tag_keeps_the_line_the_next_tag_is_on_96e4a7337c4ace948455baf187023653.txt
+++ b/test/snapshots/engine/engine_test/test_0043_a_shovel_operator_in_a_control_tag_keeps_the_line_the_next_tag_is_on_96e4a7337c4ace948455baf187023653.txt
@@ -1,0 +1,7 @@
+---
+source: "Engine::EngineTest#test_0043_a shovel operator in a control tag keeps the line the next tag is on"
+input: "{source: \"<% list << item %><%= z %>\\n\", options: {}}"
+---
+_buf = ::String.new; list << item ; _buf << (z).to_s; _buf << '
+'.freeze;
+_buf.to_s


### PR DESCRIPTION
Follow up on #2509, which stopped a heredoc that ends an output tag from counting its closing newline twice. This pull request fixes the same line drift, because the engine could not tell a heredoc from the shovel operator in the first place.

`Herb::Engine::Helpers.heredoc?` matched `/<<[~-]?\s*['"`]?\w/`. Ruby allows no whitespace between `<<` and a heredoc's name, but the pattern allowed it, so the operator followed by a word looked exactly like an opening.

```ruby
Herb::Engine::Helpers.heredoc?(" list << item ") # => true
```

`add_code` terminates a tag's code with a newline when it holds a heredoc and a semicolon when it does not, so an ordinary shovel took the wrong branch and pushed everything after it down a line.

```erb
<% list << item %><%= name %>
```

before
```ruby
_buf = ::String.new; list << item
 _buf << (name).to_s;
```
after
```ruby
_buf = ::String.new; list << item ; _buf << (name).to_s;
```

`name` sits on line 1 of the template and moved to line 2 of the compiled output, so a backtrace through it pointed at the wrong line. That happens for any ERB tag sharing a line with a `<<` that precedes it.