### PR TITLE
Dev Tools: Replace the NUL separator in `diagnosticKey` with JSON

### DIFF
--- a/javascript/packages/dev-tools/src/runtime/panel.ts
+++ b/javascript/packages/dev-tools/src/runtime/panel.ts
@@ -250,10 +250,6 @@ function sentenceCase(value: string): string {
   return value.charAt(0).toUpperCase() + value.slice(1)
 }
 
-function fixKey(diagnostic: NormalizedDiagnostic): string {
-  return diagnosticKey(diagnostic).replace(/\u0000/g, '|')
-}
-
 function tip(text: string, label: string = text): string {
   return ` aria-label="${escapeHTML(label)}" data-herb-dev-tools-tip="${escapeHTML(text)}"`
 }
@@ -672,7 +668,7 @@ export class RuntimePanel {
       return
     }
 
-    const entry = this.entries.find(candidate => fixKey(candidate.diagnostic) === key)
+    const entry = this.entries.find(candidate => diagnosticKey(candidate.diagnostic) === key)
     const source = entry?.diagnostic.fix?.source
 
     if (source === undefined) {
@@ -2085,7 +2081,7 @@ export class RuntimePanel {
       return `<div class="herb-dev-tools-fix-pending" data-herb-dev-tools-fix-pending hidden></div>`
     }
 
-    const key = fixKey(diagnostic)
+    const key = diagnosticKey(diagnostic)
     const view = this.fixViews.get(key) ?? 'diff'
     const open = this.openFixes.has(key)
 

--- a/javascript/packages/dev-tools/src/runtime/report.ts
+++ b/javascript/packages/dev-tools/src/runtime/report.ts
@@ -486,8 +486,9 @@ export function buildRenderStack(tree: RenderTreeNode[], diagnostic: NormalizedD
 }
 
 export function diagnosticKey(diagnostic: NormalizedDiagnostic): string {
-  const line = diagnostic.location?.start.line ?? '';
-  const discriminator = diagnostic.code ?? diagnostic.message;
-
-  return [diagnostic.template, line, diagnostic.code ?? '', discriminator].join(' ');
+  return JSON.stringify([
+    diagnostic.template,
+    diagnostic.location?.start.line ?? null,
+    diagnostic.code ?? diagnostic.message
+  ]);
 }


### PR DESCRIPTION
This pull request reworks `diagnosticKey` in `@herb-tools/dev-tools` so that it no longer joins its fields with a separator at all, and removes a raw NUL byte that had been sitting in the source.