### PR TITLE
Dev Server: Detect already broken templates and show them on connect

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -138,6 +138,7 @@ Metrics/ClassLength:
     - lib/herb/dev/runner.rb
     - lib/herb/dev/server_entry.rb
     - lib/herb/dev/server.rb
+    - lib/herb/dev/watcher.rb
     - lib/herb/diagnostic.rb
     - lib/herb/engine.rb
     - lib/herb/engine/**/*.rb

--- a/javascript/packages/dev-tools/src/dev-server/client.ts
+++ b/javascript/packages/dev-tools/src/dev-server/client.ts
@@ -4,7 +4,7 @@ import { ConnectionDot } from "./connection-dot"
 import { MismatchAlert } from "./mismatch-alert"
 import { UnavailableAlert } from "./unavailable-alert"
 
-import { diagnosticsFromError } from "./diagnostics"
+import { diagnosticsFromError, diagnosticFromBrokenTemplate } from "./diagnostics"
 import { heldRuntime } from "./runtime-handle"
 
 import type { AssetMessage, DiagnosticSink, HerbClientOptions, HerbMessage, WelcomeMessage, SchemaMessage, InvalidateMessage, ErrorMessage } from "./types"
@@ -163,6 +163,18 @@ export class HerbClient {
       MismatchAlert.show(message.project, clientProject)
     } else {
       this.projectMatch = true
+
+      this.reportBroken(message.broken_files ?? [])
+    }
+  }
+
+  private reportBroken(files: string[]): void {
+    const diagnostics = this.getDiagnostics()
+
+    if (!diagnostics) return
+
+    for (const file of files) {
+      diagnostics.report(file, [diagnosticFromBrokenTemplate(file)])
     }
   }
 

--- a/javascript/packages/dev-tools/src/dev-server/diagnostics.ts
+++ b/javascript/packages/dev-tools/src/dev-server/diagnostics.ts
@@ -20,6 +20,17 @@ export function diagnosticsFromError(message: ErrorMessage): RuntimeDiagnostic[]
   }))
 }
 
+export function diagnosticFromBrokenTemplate(file: string): RuntimeDiagnostic {
+  return {
+    template: file,
+    message: "This template did not parse when the dev server started. Edit it to see the errors.",
+    severity: "error" as const,
+    origin: DEV_SERVER_ORIGIN,
+    phase: "compile" as const,
+    overlay: "dismissible" as const,
+  }
+}
+
 export function diagnosticFromRefreshFailure(file: string, status: number, failure: SlotsRequestFailure | null): RuntimeDiagnostic {
   return {
     template: failure?.template ?? file,

--- a/javascript/packages/dev-tools/src/dev-server/types.ts
+++ b/javascript/packages/dev-tools/src/dev-server/types.ts
@@ -58,6 +58,7 @@ export interface WelcomeMessage {
   type: "welcome"
   project: string
   compiler?: boolean
+  broken_files?: string[]
 }
 
 export const DEV_SERVER_COMMAND = "bundle exec herb dev"

--- a/javascript/packages/dev-tools/test/dev-server-diagnostics.test.ts
+++ b/javascript/packages/dev-tools/test/dev-server-diagnostics.test.ts
@@ -2,12 +2,12 @@ import { DEV_SERVER_ORIGIN } from "../src/dev-server/diagnostics"
 
 import { afterEach, beforeEach, describe, expect, test } from "vitest"
 import { stripAnsiColors } from "@herb-tools/highlighter"
-import { diagnosticsFromError } from "../src/dev-server/diagnostics"
+import { diagnosticsFromError, diagnosticFromBrokenTemplate } from "../src/dev-server/diagnostics"
 
 import { HerbClient } from "../src/dev-server/client"
 import { RuntimePanel } from "../src/runtime/panel"
 
-import type { ErrorMessage } from "../src/dev-server/types"
+import type { ErrorMessage, WelcomeMessage } from "../src/dev-server/types"
 
 let panels: RuntimePanel[] = []
 
@@ -141,6 +141,74 @@ describe("diagnostics from a dev server error", () => {
     message.errors.push({ name: "second", message: "another", line: 9, column: 4 })
 
     expect(diagnosticsFromError(message)).toHaveLength(2)
+  })
+})
+
+describe("templates the server says were already broken", () => {
+  function collectingSink() {
+    const reported: Array<[string, number]> = []
+
+    return {
+      reported,
+      sink: {
+        report: (file: string, diagnostics: unknown[]) => {
+          reported.push([file, diagnostics.length])
+        },
+        clear: () => {},
+        clearAll: () => {},
+      },
+    }
+  }
+
+  function welcome(broken?: string[]): WelcomeMessage {
+    return { type: "welcome", project: "/app", ...(broken === undefined ? {} : { broken_files: broken }) } as WelcomeMessage
+  }
+
+  test("reports one diagnostic for every template the welcome names", () => {
+    const { reported, sink } = collectingSink()
+    const client = new HerbClient({ diagnostics: () => sink })
+
+    client["handleWelcome"](welcome(["a.html.erb", "b.html.erb"]))
+
+    expect(reported).toEqual([["a.html.erb", 1], ["b.html.erb", 1]])
+  })
+
+  test("reports nothing when the project has nothing broken", () => {
+    const { reported, sink } = collectingSink()
+    const client = new HerbClient({ diagnostics: () => sink })
+
+    client["handleWelcome"](welcome([]))
+
+    expect(reported).toEqual([])
+  })
+
+  test("reports nothing when the server is old enough not to say", () => {
+    const { reported, sink } = collectingSink()
+    const client = new HerbClient({ diagnostics: () => sink })
+
+    client["handleWelcome"](welcome())
+
+    expect(reported).toEqual([])
+  })
+
+  test("names the dev server as the origin, so a clearing schema takes it away", () => {
+    const diagnostic = diagnosticFromBrokenTemplate("a.html.erb")
+
+    expect(diagnostic.origin).toBe(DEV_SERVER_ORIGIN)
+    expect(diagnostic.overlay).toBe("dismissible")
+    expect(diagnostic.template).toBe("a.html.erb")
+  })
+
+  test("opens a card naming the template that did not parse", () => {
+    const panel = createPanel()
+
+    panel.report([diagnosticFromBrokenTemplate("app/views/posts/index.html.erb")])
+
+    expect(document.querySelector(".herb-dev-tools-card")?.textContent).toContain("app/views/posts/index.html.erb")
+
+    panel.clear(DEV_SERVER_ORIGIN)
+
+    expect(document.querySelector(".herb-dev-tools-card")).toBeNull()
   })
 })
 

--- a/lib/herb/dev.rb
+++ b/lib/herb/dev.rb
@@ -95,6 +95,8 @@ module Herb
       server = Server.new(port: port, project_path: expanded, kind: "embedded")
       pipeline = Pipeline.new(server: server, configuration: configuration)
 
+      server.on_welcome { pipeline.broken_files }
+
       server.on_client do |event, count|
         logger.call("Herb dev server client #{event} (#{count} #{count == 1 ? "connection" : "connections"} open)")
       end
@@ -110,6 +112,7 @@ module Herb
       end
 
       watcher.index
+      pipeline.remember_broken(watcher.broken_files)
       server.start
       watcher.spawn
 

--- a/lib/herb/dev/pipeline.rb
+++ b/lib/herb/dev/pipeline.rb
@@ -40,6 +40,16 @@ module Herb
         @on_classified = block
       end
 
+      #: (Enumerable[String]) -> void
+      def remember_broken(files)
+        files.each { |file| @file_state[file] = :parse_error }
+      end
+
+      #: () -> Array[String]
+      def broken_files
+        @file_state.select { |_, state| state == :parse_error }.keys
+      end
+
       #: () -> bool
       def compiles?
         !@compiler.call.nil?
@@ -64,7 +74,7 @@ module Herb
       #: (Watcher::Event) -> void
       def handle_removed(event)
         file = event.relative_path
-        was_errored = @file_state[file] && @file_state[file] != :ok
+        was_broken = @file_state[file] && @file_state[file] != :ok
         from = @versions[file]
 
         @versions.delete(file)
@@ -73,7 +83,7 @@ module Herb
         @statics.delete(file)
         @file_state.delete(file)
 
-        broadcast(Protocol.schema(file: file, mode: nil, from: from, to: nil)) if was_errored
+        broadcast(Protocol.schema(file: file, mode: nil, from: from, to: nil)) if was_broken
 
         notify(event, nil)
       end

--- a/lib/herb/dev/protocol.rb
+++ b/lib/herb/dev/protocol.rb
@@ -39,6 +39,15 @@ module Herb
         }
       end
 
+      #: (project: String?, ?broken_files: Array[String]) -> Hash[Symbol, untyped]
+      def self.welcome(project:, broken_files: [])
+        {
+          type: "welcome",
+          project: project,
+          broken_files: broken_files,
+        }
+      end
+
       #: (file: String, version: String?, node_path: Array[Integer], scope: Symbol) -> Hash[Symbol, untyped]
       def self.invalidate(file:, version:, node_path:, scope:)
         {

--- a/lib/herb/dev/runner.rb
+++ b/lib/herb/dev/runner.rb
@@ -56,7 +56,9 @@ module Herb
         pipeline.on_classified { |event, classification| paint(event, classification) }
 
         @first_change = true
-        @errored_files = Set.new
+        @broken_files = Set.new
+
+        websocket.on_welcome { pipeline.broken_files }
 
         websocket.on_client do |event, count|
           announce_first_change
@@ -69,6 +71,9 @@ module Herb
         end
 
         index_files(watcher)
+
+        @broken_files = watcher.broken_files.dup
+        pipeline.remember_broken(watcher.broken_files)
 
         websocket.start
 
@@ -243,9 +248,17 @@ module Herb
         puts "  #{fg("Indexing files...", 241)}" if interactive?
 
         count = watcher.index(@path)
+        broken = watcher.broken_files.size
 
         terminal("\e[1A\e[2K")
-        puts "  #{fg("Files:".ljust(11), 245)}#{fg("#{count} templates indexed", 250)}"
+        puts "  #{fg("Files:".ljust(11), 245)}#{fg("#{pluralize(count, "template")} indexed", 250)}#{broken_summary(broken)}"
+      end
+
+      #: (Integer) -> String
+      def broken_summary(broken)
+        return "" unless broken.positive?
+
+        fg(", #{broken} #{broken == 1 ? "doesn't" : "don't"} parse", 214)
       end
 
       #: () -> Thread
@@ -283,7 +296,7 @@ module Herb
 
         case event.kind
         when :removed
-          @errored_files.delete(event.path)
+          @broken_files.delete(event.relative_path)
           puts "    #{timestamp} #{bold(fg("- removed", 196))} #{display_path}"
         when :added
           puts "    #{timestamp} #{bold(fg("+ added  ", 42))} #{display_path}"
@@ -296,16 +309,23 @@ module Herb
       def paint_change(event, classification, timestamp, display_path)
         case classification&.kind
         when :parse_error
-          @errored_files.add(event.path)
+          @broken_files.add(event.relative_path)
 
-          print "    #{timestamp} #{bold(fg("\u{2717} error", 196))}"
-          print_diagnostics(event.current.to_s, Herb::Diagnostic.from_errors(new_errors(event, classification), template: event.relative_path), event.relative_path)
-          puts
+          errors = new_errors(event, classification)
+
+          unless errors.empty?
+            print "    #{timestamp} #{bold(fg("\u{2717} error", 196))}"
+            print_diagnostics(event.current.to_s, Herb::Diagnostic.from_errors(errors, template: event.relative_path), event.relative_path)
+            puts
+          end
         when :none, :whitespace, nil
           paint_cleared(event, timestamp, display_path)
         else
-          paint_cleared(event, timestamp, display_path)
-          print_diff_summary(classification, timestamp, display_path)
+          if @broken_files.include?(event.relative_path)
+            paint_cleared(event, timestamp, display_path)
+          else
+            print_diff_summary(classification, timestamp, display_path)
+          end
         end
       end
 
@@ -322,7 +342,7 @@ module Herb
 
       #: (Watcher::Event, String, String) -> void
       def paint_cleared(event, timestamp, display_path)
-        return unless @errored_files.delete?(event.path)
+        return unless @broken_files.delete?(event.relative_path)
 
         puts "    #{timestamp} #{bold(fg("\u{2713} clear  ", 42))} #{display_path}"
         puts

--- a/lib/herb/dev/server.rb
+++ b/lib/herb/dev/server.rb
@@ -8,6 +8,7 @@ require_relative "../../herb"
 
 Herb.ensure_installed("websocket")
 
+require_relative "protocol"
 require_relative "server_entry"
 
 module Herb
@@ -33,6 +34,7 @@ module Herb
         @accept_thread = nil
         @entry = nil
         @on_client = nil #: (^(Symbol, Integer) -> void)?
+        @on_welcome = nil #: (^() -> Array[String])?
       end
 
       #: () -> void
@@ -91,6 +93,11 @@ module Herb
       #: () { (Symbol, Integer) -> void } -> void
       def on_client(&block)
         @on_client = block
+      end
+
+      #: () { () -> Array[String] } -> void
+      def on_welcome(&block)
+        @on_welcome = block
       end
 
       #: (Client) -> void
@@ -166,6 +173,13 @@ module Herb
 
       private
 
+      #: () -> Array[String]
+      def broken_files
+        @on_welcome&.call || []
+      rescue StandardError
+        []
+      end
+
       #: (untyped) -> void
       def safely_close(resource)
         resource&.close
@@ -203,7 +217,7 @@ module Herb
 
         welcome = WebSocket::Frame::Outgoing::Server.new(
           version: handshake.version,
-          data: JSON.generate({ type: "welcome", project: @project_path }),
+          data: JSON.generate(Protocol.welcome(project: @project_path, broken_files: broken_files)),
           type: :text
         )
 

--- a/lib/herb/dev/watcher.rb
+++ b/lib/herb/dev/watcher.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 # typed: true
 
+require_relative "../../herb"
 require_relative "../configuration"
 require_relative "assets"
 
@@ -34,6 +35,7 @@ module Herb
 
       attr_reader :file_states #: Hash[String, String]
       attr_reader :watch_paths #: Array[String]
+      attr_reader :broken_files #: Set[String]
 
       #: (config: Herb::Configuration, root: String, ?watch_paths: Array[String]?) { (Event) -> void } -> void
       def initialize(config:, root:, watch_paths: nil, &on_event)
@@ -43,6 +45,7 @@ module Herb
         @watch_paths = resolve_watch_paths(watch_paths) #: Array[String]
         @file_states = {} #: Hash[String, String]
         @assets = Assets.new
+        @broken_files = Set.new #: Set[String]
         @include_patterns = config.file_include_patterns
         @exclude_patterns = config.file_exclude_patterns
         @thread = nil #: Thread?
@@ -52,7 +55,9 @@ module Herb
       #: (?String) -> Integer
       def index(path = @root)
         @config.find_files(path).each do |file_path|
-          @file_states[file_path] = File.read(file_path)
+          content = File.read(file_path)
+          @file_states[file_path] = content
+          @broken_files.add(relative_for(file_path)) if Herb.parse(content, strict: true, analyze: true).errors.any?
         rescue StandardError
           nil
         end
@@ -123,10 +128,15 @@ module Herb
         [builds]
       end
 
+      #: (String) -> String
+      def relative_for(path)
+        path.delete_prefix("#{@root}/")
+      end
+
       #: (Cruise::Event) -> void
       def handle(raw)
         path = raw.path
-        relative_path = path.delete_prefix("#{@root}/")
+        relative_path = relative_for(path)
 
         return handle_asset(path, relative_path) if @config.path_included?(relative_path, Assets::PATTERNS)
         return if @config.path_excluded?(relative_path, @exclude_patterns)

--- a/sig/herb/dev/pipeline.rbs
+++ b/sig/herb/dev/pipeline.rbs
@@ -40,6 +40,12 @@ module Herb
       # : () { (untyped, Classifier::Classification?) -> void } -> void
       def on_classified: () { (untyped, Classifier::Classification?) -> void } -> void
 
+      # : (Enumerable[String]) -> void
+      def remember_broken: (Enumerable[String]) -> void
+
+      # : () -> Array[String]
+      def broken_files: () -> Array[String]
+
       # : () -> bool
       def compiles?: () -> bool
 

--- a/sig/herb/dev/protocol.rbs
+++ b/sig/herb/dev/protocol.rbs
@@ -20,6 +20,9 @@ module Herb
       # : (file: String, mode: Symbol?, from: String?, to: String?, ?manifest: Hash[String, untyped]?, ?static_markup: String?, ?statics: Hash[String, String]?, ?changed_statics: Array[String]?, ?remap: Hash[String, untyped]?, ?diagnostics: Array[Hash[Symbol, untyped]], ?source: String?) -> Hash[Symbol, untyped]
       def self.schema: (file: String, mode: Symbol?, from: String?, to: String?, ?manifest: Hash[String, untyped]?, ?static_markup: String?, ?statics: Hash[String, String]?, ?changed_statics: Array[String]?, ?remap: Hash[String, untyped]?, ?diagnostics: Array[Hash[Symbol, untyped]], ?source: String?) -> Hash[Symbol, untyped]
 
+      # : (project: String?, ?broken_files: Array[String]) -> Hash[Symbol, untyped]
+      def self.welcome: (project: String?, ?broken_files: Array[String]) -> Hash[Symbol, untyped]
+
       # : (file: String, version: String?, node_path: Array[Integer], scope: Symbol) -> Hash[Symbol, untyped]
       def self.invalidate: (file: String, version: String?, node_path: Array[Integer], scope: Symbol) -> Hash[Symbol, untyped]
 

--- a/sig/herb/dev/runner.rbs
+++ b/sig/herb/dev/runner.rbs
@@ -60,6 +60,9 @@ module Herb
       # : (Watcher) -> void
       def index_files: (Watcher) -> void
 
+      # : (Integer) -> String
+      def broken_summary: (Integer) -> String
+
       # : () -> Thread
       def watch_stdin: () -> Thread
 

--- a/sig/herb/dev/server.rbs
+++ b/sig/herb/dev/server.rbs
@@ -41,6 +41,9 @@ module Herb
       # : () { (Symbol, Integer) -> void } -> void
       def on_client: () { (Symbol, Integer) -> void } -> void
 
+      # : () { () -> Array[String] } -> void
+      def on_welcome: () { () -> Array[String] } -> void
+
       # : (Client) -> void
       def register: (Client) -> void
 
@@ -60,6 +63,9 @@ module Herb
       def handle_text_frame: (Client, String) -> void
 
       private
+
+      # : () -> Array[String]
+      def broken_files: () -> Array[String]
 
       # : (untyped) -> void
       def safely_close: (untyped) -> void

--- a/sig/herb/dev/watcher.rbs
+++ b/sig/herb/dev/watcher.rbs
@@ -42,6 +42,8 @@ module Herb
 
       attr_reader watch_paths: Array[String]
 
+      attr_reader broken_files: Set[String]
+
       # : (config: Herb::Configuration, root: String, ?watch_paths: Array[String]?) { (Event) -> void } -> void
       def initialize: (config: Herb::Configuration, root: String, ?watch_paths: Array[String]?) { (Event) -> void } -> void
 
@@ -64,6 +66,9 @@ module Herb
 
       # : (Array[String]) -> Array[String]
       def asset_watch_paths: (Array[String]) -> Array[String]
+
+      # : (String) -> String
+      def relative_for: (String) -> String
 
       # : (Cruise::Event) -> void
       def handle: (Cruise::Event) -> void

--- a/test/dev/protocol_test.rb
+++ b/test/dev/protocol_test.rb
@@ -31,6 +31,18 @@ module Dev
       Herb::Engine::Slots::SchemaCompiler.call(source, filename: "a.html.erb", mode: :client).slot_entries
     end
 
+    test "the welcome message carries the templates that don't parse" do
+      message = Herb::Dev::Protocol.welcome(project: "/app", broken_files: ["a.html.erb", "b.html.erb"])
+
+      assert_equal({ type: "welcome", project: "/app", broken_files: ["a.html.erb", "b.html.erb"] }, message)
+    end
+
+    test "a project with nothing broken welcomes with an empty list" do
+      message = Herb::Dev::Protocol.welcome(project: "/app")
+
+      assert_equal({ type: "welcome", project: "/app", broken_files: [] }, message)
+    end
+
     test "removing one span inside an item nulls only that span's slot" do
       before_source = ITEM_TEMPLATE
       after_source = ITEM_TEMPLATE.sub("<span><%= item.author %></span>", "")

--- a/test/dev/runner_test.rb
+++ b/test/dev/runner_test.rb
@@ -180,15 +180,15 @@ module Dev
         Herb::Dev::Runner.new(path: directory).send(:index_files, watcher)
       end
 
-      assert_equal "  Files:     1 templates indexed\n", output
+      assert_equal "  Files:     1 template indexed\n", output
     ensure
       FileUtils.rm_rf(directory)
       Herb.reset_configuration!
     end
 
-    def paint_error(previous, current)
+    def paint_error(previous, current, broken: [])
       runner = Herb::Dev::Runner.new
-      runner.instance_variable_set(:@errored_files, Set.new)
+      runner.instance_variable_set(:@broken_files, Set.new(broken))
 
       classification = Herb::Dev::Classifier.new.call(previous, current)
 
@@ -223,6 +223,62 @@ module Dev
       ].join("\n")
 
       assert_equal expected, output
+    end
+
+    test "logs nothing when the template still carries only errors it already reported" do
+      assert_equal "", paint_error(BROKEN, "<div id=\"x\">\n  <form>\n</div>\n")
+    end
+
+    test "a template indexed as broken paints clear without a diff against the source that never parsed" do
+      output = paint_error(BROKEN, "<div>\n  <form></form>\n</div>\n", broken: ["app/views/posts/index.html.erb"])
+
+      assert_equal "    12:00:00 \u2713 clear   index.html.erb\n\n", output
+    end
+
+    test "indexing counts the templates that do not parse" do
+      directory = Dir.mktmpdir("herb_dev_runner_test")
+
+      File.write(File.join(directory, "good.html.erb"), "<div>Hello</div>\n")
+      File.write(File.join(directory, "broken.html.erb"), BROKEN)
+
+      config = Herb::Configuration.load(directory)
+      watcher = Herb::Dev::Watcher.new(config: config, root: directory) { |event| event }
+
+      output, = capture_io do
+        Herb::Dev::Runner.new(path: directory).send(:index_files, watcher)
+      end
+
+      assert_equal "  Files:     2 templates indexed, 1 doesn't parse\n", output
+      assert_equal ["broken.html.erb"], watcher.broken_files.to_a
+    ensure
+      FileUtils.rm_rf(directory)
+      Herb.reset_configuration!
+    end
+
+    test "a template remembered as broken broadcasts a clearing schema when it is repaired" do
+      websocket = FakeWebSocket.new
+      pipeline = Herb::Dev::Pipeline.new(server: websocket, compiler: -> {})
+      pipeline.remember_broken(["a.html.erb"])
+
+      fixed = Herb::Dev::Watcher::Event.new(kind: :changed, path: "/a", relative_path: "a.html.erb", previous: BROKEN, current: "<div>\n  <form></form>\n</div>\n")
+
+      capture_io { pipeline.handle_event(fixed) }
+
+      assert_equal(["schema", "invalidate"], websocket.messages.map { |message| message[:type] })
+    end
+
+    test "a template remembered as broken stays on the list until it is repaired" do
+      websocket = FakeWebSocket.new
+      pipeline = Herb::Dev::Pipeline.new(server: websocket, compiler: -> {})
+      pipeline.remember_broken(["a.html.erb"])
+
+      assert_equal ["a.html.erb"], pipeline.broken_files
+
+      fixed = Herb::Dev::Watcher::Event.new(kind: :changed, path: "/a", relative_path: "a.html.erb", previous: BROKEN, current: "<div>\n  <form></form>\n</div>\n")
+
+      capture_io { pipeline.handle_event(fixed) }
+
+      assert_equal [], pipeline.broken_files
     end
 
     test "a repeated event for unchanged content emits nothing from the watcher" do

--- a/test/dev/server_test.rb
+++ b/test/dev/server_test.rb
@@ -36,6 +36,24 @@ module Dev
       server.instance_variable_get(:@clients) << client
     end
 
+    test "the welcome payload reports what the server was told is broken" do
+      server = build_server
+      server.on_welcome { ["a.html.erb"] }
+
+      assert_equal ["a.html.erb"], server.send(:broken_files)
+    end
+
+    test "a server nobody told about broken templates welcomes with an empty list" do
+      assert_equal [], build_server.send(:broken_files)
+    end
+
+    test "a welcome hook that raises still lets the client connect" do
+      server = build_server
+      server.on_welcome { raise "boom" }
+
+      assert_equal [], server.send(:broken_files)
+    end
+
     test "a hello frame sets the client's role" do
       server = build_server
       client = build_client


### PR DESCRIPTION
This pull request updates the dev server to notice templates that were already broken before it started, and to tell browsers about them when they connect.

Indexing read every template but never parsed one, so `broken_files` started empty and nothing downstream knew a template was broken until someone touched it. Two things followed from that, and a third fell out of fixing them.

#### Repairing a template the server indexed as broken

Because the template was never recorded as broken, repairing it missed the recovery path entirely and fell through to the diff. The diff was computed against a previous source that does not parse, so the operations were meaningless:

**Before**

```
    17:14:32.245 ↻ fetch   app/views/posts/index.html.erb (2 operations)
                        #1 node removed [0, 1]
                          - HTML_OPEN_TAG (2:2)
                        #2 node inserted [0, 1]
                          + <form>
```

**After**

```
    17:18:45.909 ✓ clear   app/views/posts/index.html.erb
```

`Watcher#index` now parses what it reads and records the templates that fail, the runner seeds its own set from that, and `Pipeline#remember_broken` marks them `:parse_error` so the clearing schema reaches browsers. Both entry points are wired, the CLI runner and the embedded boot in `Herb::Dev.boot`. Recovery also no longer prints a diff summary, since there is nothing meaningful to diff against.

Parsing every template at startup costs about 45ms for 1000 templates, measured against the read that was already happening.

#### Saying so at startup

Now that indexing knows, the header says it:

```
  Files:     453 templates indexed, 3 don't parse
  Files:     1 template indexed, 1 doesn't parse
```

The count goes through the existing `pluralize` helper, which also fixes `1 templates indexed`.

#### Telling browsers on connect

A browser that connects after the server started had no way to learn any of this. `Protocol.welcome` now carries the list, which is the one frame every browser receives regardless of when it shows up:

```json
{
  "type": "welcome",
  "project": "/Users/marcoroth/Development/demos/reactionview-demo",
  "broken_files": [
    "app/views/posts/index.html.erb",
    "app/views/posts/second.html.erb"
  ]
}
```

`Server#on_welcome` takes a block the server calls per connection rather than a payload baked at startup, so a browser connecting after you repair something gets the shorter list. The client reports each one into the existing diagnostic sink, so they render as ordinary overlay cards:

Follow up on #2468 and #2469.