### PR TITLE
Ruby: Introduce `Herb::Fingerprint` and record a template's digest

### DIFF
--- a/lib/herb.rb
+++ b/lib/herb.rb
@@ -2,6 +2,7 @@
 # typed: false
 
 require_relative "herb/colors"
+require_relative "herb/fingerprint"
 require_relative "herb/range"
 require_relative "herb/position"
 require_relative "herb/location"

--- a/lib/herb/dev/assets.rb
+++ b/lib/herb/dev/assets.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 # typed: true
 
-require "digest"
+require_relative "../fingerprint"
 
 module Herb
   module Dev
@@ -28,7 +28,9 @@ module Herb
       def index(root)
         PATTERNS.each do |pattern|
           Dir.glob(File.join(root, pattern)).each do |asset|
-            @digests[asset] = Digest::SHA256.file(asset).hexdigest
+            digest = Herb::Fingerprint.file(asset)
+
+            @digests[asset] = digest if digest
           rescue StandardError
             nil
           end
@@ -39,8 +41,9 @@ module Herb
       def changed?(path)
         return false unless File.exist?(path)
 
-        digest = Digest::SHA256.file(path).hexdigest
+        digest = Herb::Fingerprint.file(path)
 
+        return false unless digest
         return false if @digests[path] == digest
 
         @digests[path] = digest

--- a/lib/herb/engine/runtime/report.rb
+++ b/lib/herb/engine/runtime/report.rb
@@ -15,6 +15,7 @@ module Herb
 
         attr_reader :meta #: Hash[Symbol, untyped]
         attr_reader :sources #: Hash[String, String]
+        attr_reader :digests #: Hash[String, String]
         attr_reader :nodes #: Hash[String, Hash[String, Hash[Symbol, untyped]]]
         attr_reader :render_tree #: Array[Hash[Symbol, untyped]]
 
@@ -24,6 +25,7 @@ module Herb
           @diagnostics = {} #: Hash[Array[untyped], Herb::Diagnostic]
           @meta = {} #: Hash[Symbol, untyped]
           @sources = {} #: Hash[String, String]
+          @digests = {} #: Hash[String, String]
           @nodes = {} #: Hash[String, Hash[String, Hash[Symbol, untyped]]]
           @render_tree = [] #: Array[Hash[Symbol, untyped]]
           @channels = {} #: Hash[Symbol, untyped]
@@ -67,8 +69,15 @@ module Herb
           @sources[template] = source if source
         end
 
-        #: (String, String?, String?, ?called_from: Array[untyped]?) -> void
-        def render(id, template, parent, called_from: nil)
+        #: (String?) -> String?
+        def digest_for(template)
+          @digests[template]
+        end
+
+        #: (String, String?, String?, ?called_from: Array[untyped]?, ?digest: String?) -> void
+        def render(id, template, parent, called_from: nil, digest: nil)
+          @digests[template] ||= digest if template && digest
+
           node = { id: id, template: template, parent: parent } #: Hash[Symbol, untyped]
 
           if called_from

--- a/lib/herb/engine/runtime/session.rb
+++ b/lib/herb/engine/runtime/session.rb
@@ -129,18 +129,18 @@ module Herb
           current.leave
         end
 
-        #: [T] (String?) { () -> T } -> T
-        def self.render(template)
-          enter_render(template)
+        #: [T] (String?, ?String?) { () -> T } -> T
+        def self.render(template, digest = nil)
+          enter_render(template, digest)
 
           yield
         ensure
           leave_render
         end
 
-        #: (String?) -> String
-        def self.enter_render(template)
-          current.enter_render(template)
+        #: (String?, ?String?) -> String
+        def self.enter_render(template, digest = nil)
+          current.enter_render(template, digest)
         end
 
         #: () -> void
@@ -303,11 +303,11 @@ module Herb
         # The tag that is open when a render starts is the tag that started it, so the call site
         # comes for free. Without it the tree would say a partial rendered twice under one parent but
         # not from where, which `stack` can say and a payload built from the tree alone could not.
-        #: (String?) -> String
-        def enter_render(template)
+        #: (String?, ?String?) -> String
+        def enter_render(template, digest = nil)
           id = (@minted += 1).to_s
 
-          report.render(id, template, @renders.last, called_from: @frames.last)
+          report.render(id, template, @renders.last, called_from: @frames.last, digest: digest)
           @renders.push(id)
 
           id

--- a/lib/herb/engine/visitors/instrumentation_visitor.rb
+++ b/lib/herb/engine/visitors/instrumentation_visitor.rb
@@ -81,7 +81,7 @@ module Herb
       private
 
       def frame_render(node)
-        template = context.relative_file_path.dump
+        template = render_arguments(context.relative_file_path)
 
         node.children.unshift(erb_node(node, "<%", "#{SESSION}.enter_render(#{template}); begin"))
         node.children.push(erb_node(node, "<%", "ensure; #{SESSION}.leave_render; end"))
@@ -210,7 +210,19 @@ module Herb
       end
 
       def enter_render_node(node, file)
-        erb_node(node, "<%", "#{SESSION}.enter_render(#{file.dump}); begin")
+        erb_node(node, "<%", "#{SESSION}.enter_render(#{render_arguments(file)}); begin")
+      end
+
+      def render_arguments(file)
+        digest = digest_for(file)
+
+        digest ? "#{file.dump}, #{digest.dump}" : file.dump
+      end
+
+      def digest_for(file)
+        Herb::Fingerprint.template_file(context.project_path + file)
+      rescue StandardError
+        nil
       end
 
       def leave_render_node(node)

--- a/lib/herb/fingerprint.rb
+++ b/lib/herb/fingerprint.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+# typed: true
+
+require "digest"
+
+module Herb
+  # Identifies content by what it is instead of by where it lives or when it was touched.
+  #
+  #     Herb::Fingerprint.file(asset)      #=> "9f2a1c4e…"
+  #     Herb::Fingerprint.template(source) #=> "d242d277…"
+  #
+  module Fingerprint
+    BOM = "\xEF\xBB\xBF".b #: String
+    SHORT_LENGTH = 8 #: Integer
+
+    #: (String?) -> String?
+    def self.of(content)
+      return nil unless content
+
+      ::Digest::SHA256.hexdigest(content.to_s.b)
+    end
+
+    #: ((String | Pathname)?) -> String?
+    def self.file(path)
+      return nil unless path
+
+      ::Digest::SHA256.file(path.to_s).hexdigest
+    rescue SystemCallError, IOError
+      nil
+    end
+
+    #: (String?) -> String?
+    def self.template(source)
+      return nil unless source
+
+      of(strip_bom(source.to_s.b))
+    end
+
+    #: ((String | Pathname)?) -> String?
+    def self.template_file(path)
+      return nil unless path
+
+      stat = File.stat(path.to_s)
+      key = [path.to_s, stat.mtime.to_i, stat.size]
+      cached = cache[key]
+
+      return cached if cached
+
+      digest = template(File.binread(path.to_s))
+
+      return nil unless digest
+
+      cache[key] = digest
+    rescue SystemCallError, IOError
+      nil
+    end
+
+    #: (String?) -> String?
+    def self.short(digest)
+      digest&.slice(0, SHORT_LENGTH)
+    end
+
+    #: () -> void
+    def self.clear_cache
+      cache.clear
+
+      nil
+    end
+
+    #: () -> Hash[Array[untyped], String]
+    def self.cache
+      @cache ||= {} #: Hash[Array[untyped], String]
+    end
+
+    #: (String) -> String
+    def self.strip_bom(bytes)
+      return bytes unless bytes.start_with?(BOM)
+
+      bytes.byteslice(BOM.bytesize, bytes.bytesize - BOM.bytesize) || ""
+    end
+  end
+end

--- a/sig/herb/engine/runtime/report.rbs
+++ b/sig/herb/engine/runtime/report.rbs
@@ -14,6 +14,8 @@ module Herb
 
         attr_reader sources: Hash[String, String]
 
+        attr_reader digests: Hash[String, String]
+
         attr_reader nodes: Hash[String, Hash[String, Hash[Symbol, untyped]]]
 
         attr_reader render_tree: Array[Hash[Symbol, untyped]]
@@ -39,8 +41,11 @@ module Herb
         # : (String, String?) -> void
         def source: (String, String?) -> void
 
-        # : (String, String?, String?, ?called_from: Array[untyped]?) -> void
-        def render: (String, String?, String?, ?called_from: Array[untyped]?) -> void
+        # : (String?) -> String?
+        def digest_for: (String?) -> String?
+
+        # : (String, String?, String?, ?called_from: Array[untyped]?, ?digest: String?) -> void
+        def render: (String, String?, String?, ?called_from: Array[untyped]?, ?digest: String?) -> void
 
         # : (String, Symbol, untyped, origin: String) -> void
         def annotate: (String, Symbol, untyped, origin: String) -> void

--- a/sig/herb/engine/runtime/session.rbs
+++ b/sig/herb/engine/runtime/session.rbs
@@ -85,11 +85,11 @@ module Herb
         # : () -> void
         def self.leave: () -> void
 
-        # : [T] (String?) { () -> T } -> T
-        def self.render: [T] (String?) { () -> T } -> T
+        # : [T] (String?, ?String?) { () -> T } -> T
+        def self.render: [T] (String?, ?String?) { () -> T } -> T
 
-        # : (String?) -> String
-        def self.enter_render: (String?) -> String
+        # : (String?, ?String?) -> String
+        def self.enter_render: (String?, ?String?) -> String
 
         # : () -> void
         def self.leave_render: () -> void
@@ -183,8 +183,8 @@ module Herb
         # The tag that is open when a render starts is the tag that started it, so the call site
         # comes for free. Without it the tree would say a partial rendered twice under one parent but
         # not from where, which `stack` can say and a payload built from the tree alone could not.
-        # : (String?) -> String
-        def enter_render: (String?) -> String
+        # : (String?, ?String?) -> String
+        def enter_render: (String?, ?String?) -> String
 
         # : () -> void
         def leave_render: () -> void

--- a/sig/herb/engine/visitors/instrumentation_visitor.rbs
+++ b/sig/herb/engine/visitors/instrumentation_visitor.rbs
@@ -87,6 +87,10 @@ module Herb
 
       def enter_render_node: (untyped node, untyped file) -> untyped
 
+      def render_arguments: (untyped file) -> untyped
+
+      def digest_for: (untyped file) -> untyped
+
       def leave_render_node: (untyped node) -> untyped
 
       def position: (untyped node) -> untyped

--- a/sig/herb/fingerprint.rbs
+++ b/sig/herb/fingerprint.rbs
@@ -1,0 +1,37 @@
+# Generated from lib/herb/fingerprint.rb with RBS::Inline
+
+module Herb
+  # Identifies content by what it is instead of by where it lives or when it was touched.
+  #
+  #     Herb::Fingerprint.file(asset)      #=> "9f2a1c4e…"
+  #     Herb::Fingerprint.template(source) #=> "d242d277…"
+  module Fingerprint
+    BOM: String
+
+    SHORT_LENGTH: Integer
+
+    # : (String?) -> String?
+    def self.of: (String?) -> String?
+
+    # : ((String | Pathname)?) -> String?
+    def self.file: ((String | Pathname)?) -> String?
+
+    # : (String?) -> String?
+    def self.template: (String?) -> String?
+
+    # : ((String | Pathname)?) -> String?
+    def self.template_file: ((String | Pathname)?) -> String?
+
+    # : (String?) -> String?
+    def self.short: (String?) -> String?
+
+    # : () -> void
+    def self.clear_cache: () -> void
+
+    # : () -> Hash[Array[untyped], String]
+    def self.cache: () -> Hash[Array[untyped], String]
+
+    # : (String) -> String
+    def self.strip_bom: (String) -> String
+  end
+end

--- a/test/fingerprint_test.rb
+++ b/test/fingerprint_test.rb
@@ -1,0 +1,111 @@
+# frozen_string_literal: true
+
+require_relative "test_helper"
+
+require "tempfile"
+require "fileutils"
+
+class FingerprintTest < Minitest::Spec
+  after do
+    Herb::Fingerprint.clear_cache
+  end
+
+  describe "hashing content" do
+    test "is stable for the same bytes" do
+      assert_equal Herb::Fingerprint.of("<div></div>"), Herb::Fingerprint.of("<div></div>")
+    end
+
+    test "moves when the bytes move" do
+      refute_equal Herb::Fingerprint.of("<div></div>"), Herb::Fingerprint.of("<div></div> ")
+    end
+
+    test "says nothing about content it was not given" do
+      assert_nil Herb::Fingerprint.of(nil)
+      assert_nil Herb::Fingerprint.short(nil)
+    end
+
+    test "reads the same bytes whatever encoding they arrive in" do
+      utf8 = "<div>café</div>"
+
+      assert_equal Herb::Fingerprint.of(utf8), Herb::Fingerprint.of(utf8.dup.force_encoding(Encoding::ASCII_8BIT))
+    end
+
+    test "shortens to something that fits in a filename" do
+      digest = Herb::Fingerprint.of("<div></div>")
+
+      assert_equal 8, Herb::Fingerprint.short(digest).length
+      assert digest.start_with?(Herb::Fingerprint.short(digest))
+    end
+  end
+
+  describe "hashing a template" do
+    test "ignores a byte order mark, since the toolchains disagree about whether it is there" do
+      assert_equal Herb::Fingerprint.template("<div></div>"), Herb::Fingerprint.template("\xEF\xBB\xBF<div></div>".b)
+    end
+
+    test "keeps line endings, since rewriting them changes the file" do
+      refute_equal Herb::Fingerprint.template("<div>\n</div>"), Herb::Fingerprint.template("<div>\r\n</div>")
+    end
+
+    test "leaves a byte order mark alone when hashing plain content" do
+      refute_equal Herb::Fingerprint.of("<div></div>"), Herb::Fingerprint.of("\xEF\xBB\xBF<div></div>".b)
+    end
+
+    test "says nothing about a template it was not given" do
+      assert_nil Herb::Fingerprint.template(nil)
+    end
+  end
+
+  describe "hashing a file" do
+    test "matches hashing the bytes in it" do
+      Tempfile.create(["asset", ".js"]) do |file|
+        file.write("console.log(1)")
+        file.flush
+
+        assert_equal Herb::Fingerprint.of("console.log(1)"), Herb::Fingerprint.file(file.path)
+      end
+    end
+
+    test "hashes a template file the way it hashes template text" do
+      Tempfile.create(["template", ".erb"]) do |file|
+        file.write("\xEF\xBB\xBF<div></div>")
+        file.flush
+
+        assert_equal Herb::Fingerprint.template("<div></div>"), Herb::Fingerprint.template_file(file.path)
+      end
+    end
+
+    test "says nothing about a file that is not there" do
+      assert_nil Herb::Fingerprint.file("does/not/exist.js")
+      assert_nil Herb::Fingerprint.template_file("does/not/exist.html.erb")
+      assert_nil Herb::Fingerprint.file(nil)
+    end
+
+    test "re-reads a template once it changes" do
+      Tempfile.create(["template", ".erb"]) do |file|
+        file.write("<div></div>")
+        file.flush
+
+        first = Herb::Fingerprint.template_file(file.path)
+
+        File.write(file.path, "<span></span>")
+        FileUtils.touch(file.path, mtime: Time.now + 2)
+
+        refute_equal first, Herb::Fingerprint.template_file(file.path)
+      end
+    end
+
+    test "re-reads a watched file every time, since a watcher is asking whether it changed" do
+      Tempfile.create(["asset", ".js"]) do |file|
+        file.write("console.log(1)")
+        file.flush
+
+        first = Herb::Fingerprint.file(file.path)
+
+        File.write(file.path, "console.log(2)")
+
+        refute_equal first, Herb::Fingerprint.file(file.path)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This pull request introduces a shared way to identify content by what it is instead of by where it lives or when it was touched.

```ruby
Herb::Fingerprint.file(asset)      #=> "9f2a1c4e…"
Herb::Fingerprint.template(source) #=> "d242d277…"
Herb::Fingerprint.short(digest)    #=> "d242d277"
```
