### PR TITLE
Engine: Introduce `Runtime::Journal` to record what a template did

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -177,6 +177,7 @@ Metrics/ParameterLists:
     - lib/herb/diagnostic.rb
     - lib/herb/diff_operation.rb
     - lib/herb/engine/errors.rb
+    - lib/herb/engine/runtime/journal/summary.rb
     - lib/herb/engine/runtime/session.rb
     - lib/herb/engine/slots/schema_compiler.rb
     - lib/herb/engine/slots/visitor.rb
@@ -186,6 +187,7 @@ Metrics/ParameterLists:
     - lib/herb/prism_inspect.rb
     - lib/herb/visitor/diagnostics.rb
     - lib/herb/engine/visitors/optimize_visitor.rb
+    - test/engine/runtime/journal_test.rb
 
 Metrics/PerceivedComplexity:
   Exclude:

--- a/lib/herb/engine/runtime/journal.rb
+++ b/lib/herb/engine/runtime/journal.rb
@@ -1,0 +1,422 @@
+# frozen_string_literal: true
+# typed: true
+
+require "json"
+require "time"
+require "fileutils"
+require "securerandom"
+require "pathname"
+
+require_relative "../../fingerprint"
+require_relative "../../visitor/context"
+require_relative "journal/summary"
+
+module Herb
+  class Engine
+    module Runtime
+      # What a template did, kept after the request that did it is gone.
+      #
+      #     journal = Herb::Engine::Runtime::Journal.new(root: "tmp/herb")
+      #     journal.write(session.report, request: { method: "GET", path: "/posts" })
+      #     journal.summary("app/views/posts/_card.html.erb", digest)
+      #
+      # A report describes one request and dies with it, which is enough for the browser and no use
+      # to an editor. An editor has a file open and wants to know what happened in it, without
+      # knowing which request that was or whether the request has been made yet. So this is keyed by
+      # what the editor already has, a path and the text at that path:
+      #
+      #     tmp/herb/journal/app/views/posts/_card.html.erb.9f2a1c4e.jsonl
+      #
+      # The digest in the name is the whole staleness mechanism. An editor hashes its buffer, builds
+      # that path and opens it. A file edited since produces a different name, which does not exist,
+      # so a position recorded against text that no longer exists is never shown and nothing has to
+      # work out how far an edit moved things.
+      #
+      # Written the way `Dev::ServerEntry` writes its own registry: a known directory, one file per
+      # key, and pruning done by whoever happens to pass by rather than a separate sweep.
+      #
+      # What accumulates is the point. One request says a partial ran three queries. A journal says
+      # it ran between three and forty seven across two hundred renders, which is the shape of an
+      # N+1 and is not visible from any one request.
+      #
+      class Journal
+        RECORD_VERSION = 1 #: Integer
+        DEFAULT_ROOT = "tmp/herb" #: String
+        DIRECTORY = "journal" #: String
+        EXTENSION = ".jsonl" #: String
+        MAX_RECORDS = 2_000 #: Integer
+        MAX_RECORD_BYTES = 4_096 #: Integer
+        MIN_RECORD_BYTES = 64 #: Integer
+        MAX_SAMPLED_OBSERVATIONS = 12 #: Integer
+        MAX_OBSERVATION_LENGTH = 240 #: Integer
+        KEPT_DIGESTS = 5 #: Integer
+
+        attr_reader :root #: Pathname
+        attr_reader :max_records #: Integer
+        attr_reader :kept_digests #: Integer
+
+        #: (?root: (String | Pathname), ?max_records: Integer, ?kept_digests: Integer) -> void
+        def initialize(root: DEFAULT_ROOT, max_records: MAX_RECORDS, kept_digests: KEPT_DIGESTS)
+          @root = Pathname.new(root.to_s)
+          @max_records = max_records
+          @kept_digests = kept_digests
+          @collected = {} #: Hash[String, bool]
+        end
+
+        #: () -> Pathname
+        def directory
+          root + DIRECTORY
+        end
+
+        #: (String, String) -> Pathname?
+        def path_for(template, digest)
+          relative = safe_relative_path(template)
+          short = Fingerprint.short(digest)
+
+          return nil unless relative && short
+
+          directory + "#{relative}.#{short}#{EXTENSION}"
+        end
+
+        #: (Herb::Engine::Runtime::Report, ?request: Hash[Symbol, untyped]?) -> String?
+        def write(report, request: nil)
+          return nil if report.empty?
+
+          run = mint_run_id
+          at = timestamp
+          path = request && request[:path]
+
+          lines = Hash.new { |all, key| all[key] = [] } #: Hash[Array[untyped], Array[String]]
+
+          collect_findings(report, lines, run, at, path)
+          collect_calls(report, lines, run, at, path)
+
+          lines.each do |(template, digest), records|
+            file = path_for(template, digest)
+
+            next unless file
+
+            append(file, header: header_for(template, digest, at), lines: records)
+            collect_siblings(file)
+          end
+
+          run
+        rescue StandardError
+          nil
+        end
+
+        #: (String, String?) -> Herb::Engine::Runtime::Journal::Summary?
+        def summary(template, digest)
+          return nil unless digest
+
+          file = path_for(template, digest)
+
+          return nil unless file&.exist?
+
+          Summary.build(template, digest, records_in(file))
+        rescue SystemCallError
+          nil
+        end
+
+        #: (String) -> Array[String]
+        def digests(template)
+          file = path_for(template, "0" * Fingerprint::SHORT_LENGTH)
+
+          return [] unless file
+
+          base = base_of(file)
+
+          Dir.glob("#{base}.*#{EXTENSION}").sort_by { |found| -File.mtime(found).to_f }.filter_map { |found| found[/\.([0-9a-f]+)#{Regexp.escape(EXTENSION)}\z/, 1] }
+        rescue SystemCallError
+          []
+        end
+
+        private
+
+        #: (Herb::Engine::Runtime::Report, Hash[Array[untyped], Array[String]], String, String, String?) -> void
+        def collect_findings(report, lines, run, at, path)
+          report.diagnostics.each do |diagnostic|
+            digest = report.digest_for(diagnostic.template)
+
+            next unless digest
+
+            line = finding_line(diagnostic, run, at, path)
+
+            lines[[diagnostic.template, digest]] << line if line
+          end
+
+          nil
+        end
+
+        #: (Herb::Engine::Runtime::Report, Hash[Array[untyped], Array[String]], String, String, String?) -> void
+        def collect_calls(report, lines, run, at, path)
+          nodes = {} #: Hash[untyped, Hash[Symbol, untyped]]
+
+          report.render_tree.each { |node| nodes[node[:id]] = node }
+
+          report.render_tree.group_by { |node| call_site(nodes, node) }.each do |site, children|
+            next unless site
+
+            parent_template, line, column, via = site
+            digest = report.digest_for(parent_template)
+
+            next unless digest
+
+            per_parent = children.group_by { |child| child[:parent] }.transform_values(&:size)
+
+            lines[[parent_template, digest]] << encode(
+              {
+                t: "call",
+                at: at,
+                run: run,
+                request_path: path,
+                line: line,
+                column: column,
+                via: via,
+                targets: children.map { |child| child[:template] }.tally,
+                parents: per_parent.size,
+                renders: children.size,
+                per_parent: per_parent.values.tally.transform_keys(&:to_s),
+              }.compact
+            )
+          end
+
+          nil
+        end
+
+        #: (Hash[String, Hash[Symbol, untyped]], Hash[Symbol, untyped]) -> Array[untyped]?
+        def call_site(nodes, node)
+          parent = node[:parent] && nodes[node[:parent]]
+          location = node[:location]
+
+          return nil unless parent && location
+
+          [parent[:template], location[:line], location[:column], node[:via]]
+        end
+
+        #: (Herb::Diagnostic, String, String, String?) -> String?
+        def finding_line(diagnostic, run, at, path)
+          location = diagnostic.location
+          position = location&.start&.to_one_based
+
+          return nil unless position
+
+          finish = location&.end&.to_one_based
+
+          record = {
+            t: "finding",
+            at: at,
+            run: run,
+            request_path: path,
+            node: diagnostic.node,
+            line: position[:line],
+            column: position[:column],
+            end_line: finish && finish[:line],
+            end_column: finish && finish[:column],
+            code: diagnostic.code,
+            origin: diagnostic.origin,
+            kind: diagnostic.kind,
+            severity: diagnostic.severity,
+            message: diagnostic.message,
+            description: diagnostic.description,
+            value: diagnostic.value,
+            data: jsonable(diagnostic.data),
+          }.compact
+
+          line = encode(record)
+
+          return line if line.bytesize <= MAX_RECORD_BYTES
+
+          trimmed = encode(record.merge(data: trim(record[:data]), data_trimmed: true))
+
+          return trimmed if trimmed.bytesize <= MAX_RECORD_BYTES
+
+          encode(record.except(:data))
+        rescue StandardError
+          nil
+        end
+
+        #: (untyped) -> untyped
+        def jsonable(value)
+          case value
+          when nil, true, false, String, Integer then value
+          when Float then value.finite? ? value : value.to_s
+          when Symbol then value.to_s
+          when Array then value.map { |entry| jsonable(entry) }
+          when Hash then jsonable_hash(value)
+          else "#<#{value.class.name || "Object"}>"
+          end
+        rescue StandardError
+          nil
+        end
+
+        #: (Hash[untyped, untyped]) -> Hash[String, untyped]
+        def jsonable_hash(value)
+          sanitized = {} #: Hash[String, untyped]
+
+          value.each { |key, entry| sanitized[key.to_s] = jsonable(entry) }
+
+          sanitized
+        end
+
+        #: (Hash[Symbol, untyped]?) -> Hash[Symbol, untyped]
+        def trim(data)
+          return {} unless data.is_a?(Hash)
+
+          data.transform_values do |value|
+            next truncate(value) unless value.is_a?(Array)
+
+            value.first(MAX_SAMPLED_OBSERVATIONS).map { |observed| truncate(observed) }
+          end
+        end
+
+        #: (untyped) -> untyped
+        def truncate(observed)
+          return observed unless observed.is_a?(String)
+          return observed if observed.length <= MAX_OBSERVATION_LENGTH
+
+          "#{observed[0, MAX_OBSERVATION_LENGTH]}…"
+        end
+
+        #: (String, String, String) -> String
+        def header_for(template, digest, at)
+          encode({ t: "template", path: template, digest: digest, first_seen: at })
+        end
+
+        #: (Hash[Symbol, untyped]) -> String
+        def encode(record)
+          JSON.generate({ v: RECORD_VERSION }.merge(record))
+        end
+
+        #: (Pathname) -> Array[Hash[String, untyped]]
+        def records_in(path)
+          path.each_line.filter_map { |line|
+            next if line.strip.empty?
+
+            record = begin
+              JSON.parse(line)
+            rescue JSON::ParserError
+              next
+            end
+
+            record if record.is_a?(Hash) && record["v"] == RECORD_VERSION
+          }
+        end
+
+        #: (Pathname, header: String?, lines: Array[String]) -> void
+        def append(path, header:, lines:)
+          FileUtils.mkdir_p(path.dirname)
+
+          File.open(path, File::RDWR | File::CREAT, 0o644) do |file|
+            file.flock(File::LOCK_EX)
+
+            if header && file.stat.zero?
+              file.write("#{header}\n")
+              file.flush
+            end
+
+            compact(file, header) if over_cap?(file)
+
+            file.seek(0, IO::SEEK_END)
+
+            lines.each { |line| file.write("#{line}\n") }
+
+            file.flush
+          end
+
+          nil
+        end
+
+        #: (File) -> bool
+        def over_cap?(file)
+          return false if file.size < max_records * MIN_RECORD_BYTES
+
+          file.rewind
+
+          file.each_line.count > max_records
+        end
+
+        #: (File, String?) -> void
+        def compact(file, header)
+          file.rewind
+
+          all = file.each_line.to_a
+          first = all.first
+          keep_header = header && first&.include?(%("t":"template")) ? first : nil
+          records = keep_header ? all.drop(1) : all
+
+          dropped = records.sum { |line| truncated_count(line) }
+          kept_lines = records.reject { |line| truncated?(line) }
+          kept = kept_lines.last(max_records / 2)
+          dropped += kept_lines.size - kept.size
+
+          file.truncate(0)
+          file.rewind
+          file.write(keep_header) if keep_header
+          file.write("#{encode({ t: "truncated", dropped: dropped })}\n")
+          kept.each { |line| file.write(line) }
+
+          nil
+        end
+
+        #: (String) -> bool
+        def truncated?(line)
+          line.include?(%("t":"truncated"))
+        end
+
+        #: (String) -> Integer
+        def truncated_count(line)
+          return 0 unless truncated?(line)
+
+          JSON.parse(line)["dropped"].to_i
+        rescue JSON::ParserError
+          0
+        end
+
+        #: (Pathname) -> void
+        def collect_siblings(path)
+          return if @collected[path.to_s]
+
+          @collected[path.to_s] = true
+
+          base = base_of(path)
+          siblings = Dir.glob("#{base}.*#{EXTENSION}").sort_by { |file| -File.mtime(file).to_f }
+
+          siblings.drop(kept_digests).each { |file| File.delete(file) }
+
+          nil
+        rescue SystemCallError
+          nil
+        end
+
+        #: (Pathname) -> String
+        def base_of(path)
+          path.to_s.sub(/\.[0-9a-f]+#{Regexp.escape(EXTENSION)}\z/, "")
+        end
+
+        #: (String?) -> String?
+        def safe_relative_path(template)
+          return nil if template.nil? || template.empty?
+          return nil if template == Herb::Visitor::Context::UNKNOWN_FILE_PATH
+
+          clean = Pathname.new(template).cleanpath
+
+          return nil if clean.absolute?
+          return nil if clean.each_filename.include?("..")
+
+          clean.to_s
+        end
+
+        #: () -> String
+        def mint_run_id
+          "#{Time.now.utc.strftime("%Y%m%dT%H%M%S")}-#{SecureRandom.hex(4)}"
+        end
+
+        #: () -> String
+        def timestamp
+          Time.now.utc.iso8601(3)
+        end
+      end
+    end
+  end
+end

--- a/lib/herb/engine/runtime/journal/summary.rb
+++ b/lib/herb/engine/runtime/journal/summary.rb
@@ -1,0 +1,227 @@
+# frozen_string_literal: true
+# typed: true
+
+module Herb
+  class Engine
+    module Runtime
+      class Journal
+        # What a journal says once its records are folded together.
+        #
+        # Read raw, a journal shows the same finding two hundred times. Folding on position turns
+        # that into one finding per place, which is both what an editor can show and the only form
+        # in which the history says something the requests do not.
+        #
+        # Everything here carries the number of times it was seen, because what this holds is
+        # evidence and not proof. A rewrite proposed from it is only as good as the renders that
+        # happened to run, so a reader gets counts and phrases them itself. Nothing here says
+        # "always".
+        #
+        class Summary
+          Finding = Data.define(
+            :line, :column, :end_line, :end_column, :code, :origin, :kind, :severity,
+            :message, :value, :peak_message, :description, :observations, :values, :range,
+            :observed, :observed_trimmed, :recent, :first_seen, :last_seen, :paths, :runs
+          )
+
+          Call = Data.define(
+            :line, :column, :via, :targets, :per_parent, :parents, :renders,
+            :observations, :first_seen, :last_seen, :paths
+          )
+
+          class Call
+            #: () -> Integer
+            def peak
+              per_parent.keys.max || 0
+            end
+
+            #: () -> String?
+            def only_target
+              return nil unless targets.size == 1
+
+              targets.keys.first
+            end
+          end
+
+          MAX_RECENT = 5 #: Integer
+
+          attr_reader :template #: String
+          attr_reader :digest #: String
+          attr_reader :findings #: Array[Finding]
+          attr_reader :calls #: Array[Call]
+          attr_reader :dropped #: Integer
+          attr_reader :first_seen #: String?
+
+          #: (String, String, Array[Hash[String, untyped]]) -> Summary
+          def self.build(template, digest, records)
+            header = records.find { |record| record["t"] == "template" }
+
+            new(
+              template: template,
+              digest: (header && header["digest"]) || digest,
+              findings: fold_findings(records.select { |record| record["t"] == "finding" }),
+              calls: fold_calls(records.select { |record| record["t"] == "call" }),
+              dropped: records.select { |record| record["t"] == "truncated" }.sum { |record| record["dropped"].to_i },
+              first_seen: header && header["first_seen"]
+            )
+          end
+
+          #: (Array[Hash[String, untyped]]) -> Array[Finding]
+          def self.fold_findings(records)
+            records
+              .group_by { |record| [record["line"], record["column"], record["code"] || record["message"]] }
+              .map { |_, group| finding_for(group) }
+              .sort_by { |finding| [finding.line.to_i, finding.column.to_i, finding.code.to_s] }
+          end
+
+          #: (Array[Hash[String, untyped]]) -> Array[Call]
+          def self.fold_calls(records)
+            records
+              .group_by { |record| [record["line"], record["column"]] }
+              .map { |_, group| call_for(group) }
+              .sort_by { |call| [call.line.to_i, call.column.to_i] }
+          end
+
+          #: (Array[Hash[String, untyped]]) -> Finding
+          def self.finding_for(group)
+            latest = newest(group)
+            peak = worst(group)
+            values = group.filter_map { |record| record["value"] }
+            seen = group.filter_map { |record| record["at"] }.sort
+
+            Finding.new(
+              line: latest["line"],
+              column: latest["column"],
+              end_line: latest["end_line"],
+              end_column: latest["end_column"],
+              code: latest["code"],
+              origin: latest["origin"],
+              kind: latest["kind"],
+              severity: latest["severity"],
+              message: latest["message"],
+              value: latest["value"] || latest["message"],
+              peak_message: peak["message"] || latest["message"],
+              description: peak["description"],
+              observations: peak["data"] || {},
+              values: values.tally,
+              range: range(values),
+              observed: group.size,
+              observed_trimmed: peak["data_trimmed"] == true,
+              recent: recent(group),
+              first_seen: seen.first,
+              last_seen: seen.last,
+              paths: group.filter_map { |record| record["request_path"] }.tally,
+              runs: group.filter_map { |record| record["run"] }.uniq.last(MAX_RECENT)
+            )
+          end
+
+          #: (Array[Hash[String, untyped]]) -> Call
+          def self.call_for(group)
+            latest = newest(group)
+            seen = group.filter_map { |record| record["at"] }.sort
+
+            Call.new(
+              line: latest["line"],
+              column: latest["column"],
+              via: latest["via"],
+              targets: merge_counts(group.map { |record| record["targets"] }),
+              per_parent: merge_counts(group.map { |record| record["per_parent"] }).transform_keys(&:to_i),
+              parents: group.sum { |record| record["parents"].to_i },
+              renders: group.sum { |record| record["renders"].to_i },
+              observations: group.size,
+              first_seen: seen.first,
+              last_seen: seen.last,
+              paths: group.filter_map { |record| record["request_path"] }.tally
+            )
+          end
+
+          #: (Array[Hash[String, untyped]]) -> Hash[String, untyped]
+          def self.newest(group)
+            group.each_with_index.max_by { |record, index| [record["at"].to_s, index] }&.first || group.last || {}
+          end
+
+          #: (Array[Hash[String, untyped]]) -> Hash[String, untyped]
+          def self.worst(group)
+            group.each_with_index.max_by { |record, index|
+              [leading_number(record["value"]) || -Float::INFINITY, index]
+            }&.first || group.last || {}
+          end
+
+          #: (Array[Hash[String, untyped]]) -> Array[Hash[Symbol, untyped]]
+          def self.recent(group)
+            group
+              .each_with_index
+              .sort_by { |record, index| [record["at"].to_s, index] }
+              .reverse
+              .map { |record, _| record }
+              .flat_map { |record| values_in(record).reverse.map { |value| { value: value, at: record["at"] } } }
+              .first(MAX_RECENT)
+          end
+
+          #: (Hash[String, untyped]) -> Array[untyped]
+          def self.values_in(record)
+            observed = record.dig("data", "output")
+
+            return observed if observed.is_a?(Array) && observed.any?
+
+            [record["value"] || record["message"]].compact
+          end
+
+          #: (Array[Hash[String, untyped]?]) -> Hash[untyped, Integer]
+          def self.merge_counts(counts)
+            merged = {} #: Hash[untyped, Integer]
+
+            counts.each do |tally|
+              next unless tally.is_a?(Hash)
+
+              tally.each do |key, count|
+                seen = count.to_i #: Integer
+
+                merged[key] = (merged[key] || 0) + seen
+              end
+            end
+
+            merged
+          end
+
+          #: (Array[String]) -> Hash[Symbol, untyped]?
+          def self.range(values)
+            return nil if values.empty?
+
+            numbers = values.filter_map { |value| leading_number(value) }
+
+            return nil unless numbers.size == values.size
+
+            { min: numbers.min, max: numbers.max }
+          end
+
+          #: (untyped) -> Float?
+          def self.leading_number(value)
+            match = value.to_s[/\A\s*(-?\d+(?:\.\d+)?)/, 1]
+
+            match&.to_f
+          end
+
+          #: (template: String, digest: String, findings: Array[Finding], calls: Array[Call], dropped: Integer, first_seen: String?) -> void
+          def initialize(template:, digest:, findings:, calls:, dropped:, first_seen:)
+            @template = template
+            @digest = digest
+            @findings = findings
+            @calls = calls
+            @dropped = dropped
+            @first_seen = first_seen
+          end
+
+          #: () -> bool
+          def truncated?
+            dropped.positive?
+          end
+
+          #: () -> bool
+          def empty?
+            findings.empty? && calls.empty?
+          end
+        end
+      end
+    end
+  end
+end

--- a/sig/herb/engine/runtime/journal.rbs
+++ b/sig/herb/engine/runtime/journal.rbs
@@ -1,0 +1,142 @@
+# Generated from lib/herb/engine/runtime/journal.rb with RBS::Inline
+
+module Herb
+  class Engine
+    module Runtime
+      # What a template did, kept after the request that did it is gone.
+      #
+      #     journal = Herb::Engine::Runtime::Journal.new(root: "tmp/herb")
+      #     journal.write(session.report, request: { method: "GET", path: "/posts" })
+      #     journal.summary("app/views/posts/_card.html.erb", digest)
+      #
+      # A report describes one request and dies with it, which is enough for the browser and no use
+      # to an editor. An editor has a file open and wants to know what happened in it, without
+      # knowing which request that was or whether the request has been made yet. So this is keyed by
+      # what the editor already has, a path and the text at that path:
+      #
+      #     tmp/herb/journal/app/views/posts/_card.html.erb.9f2a1c4e.jsonl
+      #
+      # The digest in the name is the whole staleness mechanism. An editor hashes its buffer, builds
+      # that path and opens it. A file edited since produces a different name, which does not exist,
+      # so a position recorded against text that no longer exists is never shown and nothing has to
+      # work out how far an edit moved things.
+      #
+      # Written the way `Dev::ServerEntry` writes its own registry: a known directory, one file per
+      # key, and pruning done by whoever happens to pass by rather than a separate sweep.
+      #
+      # What accumulates is the point. One request says a partial ran three queries. A journal says
+      # it ran between three and forty seven across two hundred renders, which is the shape of an
+      # N+1 and is not visible from any one request.
+      class Journal
+        RECORD_VERSION: Integer
+
+        DEFAULT_ROOT: String
+
+        DIRECTORY: String
+
+        EXTENSION: String
+
+        MAX_RECORDS: Integer
+
+        MAX_RECORD_BYTES: Integer
+
+        MIN_RECORD_BYTES: Integer
+
+        MAX_SAMPLED_OBSERVATIONS: Integer
+
+        MAX_OBSERVATION_LENGTH: Integer
+
+        KEPT_DIGESTS: Integer
+
+        attr_reader root: Pathname
+
+        attr_reader max_records: Integer
+
+        attr_reader kept_digests: Integer
+
+        # : (?root: (String | Pathname), ?max_records: Integer, ?kept_digests: Integer) -> void
+        def initialize: (?root: String | Pathname, ?max_records: Integer, ?kept_digests: Integer) -> void
+
+        # : () -> Pathname
+        def directory: () -> Pathname
+
+        # : (String, String) -> Pathname?
+        def path_for: (String, String) -> Pathname?
+
+        # : (Herb::Engine::Runtime::Report, ?request: Hash[Symbol, untyped]?) -> String?
+        def write: (Herb::Engine::Runtime::Report, ?request: Hash[Symbol, untyped]?) -> String?
+
+        # : (String, String?) -> Herb::Engine::Runtime::Journal::Summary?
+        def summary: (String, String?) -> Herb::Engine::Runtime::Journal::Summary?
+
+        # : (String) -> Array[String]
+        def digests: (String) -> Array[String]
+
+        private
+
+        # : (Herb::Engine::Runtime::Report, Hash[Array[untyped], Array[String]], String, String, String?) -> void
+        def collect_findings: (Herb::Engine::Runtime::Report, Hash[Array[untyped], Array[String]], String, String, String?) -> void
+
+        # : (Herb::Engine::Runtime::Report, Hash[Array[untyped], Array[String]], String, String, String?) -> void
+        def collect_calls: (Herb::Engine::Runtime::Report, Hash[Array[untyped], Array[String]], String, String, String?) -> void
+
+        # : (Hash[String, Hash[Symbol, untyped]], Hash[Symbol, untyped]) -> Array[untyped]?
+        def call_site: (Hash[String, Hash[Symbol, untyped]], Hash[Symbol, untyped]) -> Array[untyped]?
+
+        # : (Herb::Diagnostic, String, String, String?) -> String?
+        def finding_line: (Herb::Diagnostic, String, String, String?) -> String?
+
+        # : (untyped) -> untyped
+        def jsonable: (untyped) -> untyped
+
+        # : (Hash[untyped, untyped]) -> Hash[String, untyped]
+        def jsonable_hash: (Hash[untyped, untyped]) -> Hash[String, untyped]
+
+        # : (Hash[Symbol, untyped]?) -> Hash[Symbol, untyped]
+        def trim: (Hash[Symbol, untyped]?) -> Hash[Symbol, untyped]
+
+        # : (untyped) -> untyped
+        def truncate: (untyped) -> untyped
+
+        # : (String, String, String) -> String
+        def header_for: (String, String, String) -> String
+
+        # : (Hash[Symbol, untyped]) -> String
+        def encode: (Hash[Symbol, untyped]) -> String
+
+        # : (Pathname) -> Array[Hash[String, untyped]]
+        def records_in: (Pathname) -> Array[Hash[String, untyped]]
+
+        # : (Pathname, header: String?, lines: Array[String]) -> void
+        def append: (Pathname, header: String?, lines: Array[String]) -> void
+
+        # : (File) -> bool
+        def over_cap?: (File) -> bool
+
+        # : (File, String?) -> void
+        def compact: (File, String?) -> void
+
+        # : (String) -> bool
+        def truncated?: (String) -> bool
+
+        # : (String) -> Integer
+        def truncated_count: (String) -> Integer
+
+        # : (Pathname) -> void
+        def collect_siblings: (Pathname) -> void
+
+        # : (Pathname) -> String
+        def base_of: (Pathname) -> String
+
+        # : (String?) -> String?
+        def safe_relative_path: (String?) -> String?
+
+        # : () -> String
+        def mint_run_id: () -> String
+
+        # : () -> String
+        def timestamp: () -> String
+      end
+    end
+  end
+end

--- a/sig/herb/engine/runtime/journal/summary.rbs
+++ b/sig/herb/engine/runtime/journal/summary.rbs
@@ -1,0 +1,172 @@
+# Generated from lib/herb/engine/runtime/journal/summary.rb with RBS::Inline
+
+module Herb
+  class Engine
+    module Runtime
+      class Journal
+        # What a journal says once its records are folded together.
+        #
+        # Read raw, a journal shows the same finding two hundred times. Folding on position turns
+        # that into one finding per place, which is both what an editor can show and the only form
+        # in which the history says something the requests do not.
+        #
+        # Everything here carries the number of times it was seen, because what this holds is
+        # evidence and not proof. A rewrite proposed from it is only as good as the renders that
+        # happened to run, so a reader gets counts and phrases them itself. Nothing here says
+        # "always".
+        class Summary
+          class Finding < Data
+            attr_reader line(): untyped
+
+            attr_reader column(): untyped
+
+            attr_reader end_line(): untyped
+
+            attr_reader end_column(): untyped
+
+            attr_reader code(): untyped
+
+            attr_reader origin(): untyped
+
+            attr_reader kind(): untyped
+
+            attr_reader severity(): untyped
+
+            attr_reader message(): untyped
+
+            attr_reader value(): untyped
+
+            attr_reader peak_message(): untyped
+
+            attr_reader description(): untyped
+
+            attr_reader observations(): untyped
+
+            attr_reader values(): untyped
+
+            attr_reader range(): untyped
+
+            attr_reader observed(): untyped
+
+            attr_reader observed_trimmed(): untyped
+
+            attr_reader recent(): untyped
+
+            attr_reader first_seen(): untyped
+
+            attr_reader last_seen(): untyped
+
+            attr_reader paths(): untyped
+
+            attr_reader runs(): untyped
+
+            def self.new: (untyped line, untyped column, untyped end_line, untyped end_column, untyped code, untyped origin, untyped kind, untyped severity, untyped message, untyped value, untyped peak_message, untyped description, untyped observations, untyped values, untyped range, untyped observed, untyped observed_trimmed, untyped recent, untyped first_seen, untyped last_seen, untyped paths, untyped runs) -> instance
+                        | (line: untyped, column: untyped, end_line: untyped, end_column: untyped, code: untyped, origin: untyped, kind: untyped, severity: untyped, message: untyped, value: untyped, peak_message: untyped, description: untyped, observations: untyped, values: untyped, range: untyped, observed: untyped, observed_trimmed: untyped, recent: untyped, first_seen: untyped, last_seen: untyped, paths: untyped, runs: untyped) -> instance
+
+            def self.members: () -> [ :line, :column, :end_line, :end_column, :code, :origin, :kind, :severity, :message, :value, :peak_message, :description, :observations, :values, :range, :observed, :observed_trimmed, :recent, :first_seen, :last_seen, :paths, :runs ]
+
+            def members: () -> [ :line, :column, :end_line, :end_column, :code, :origin, :kind, :severity, :message, :value, :peak_message, :description, :observations, :values, :range, :observed, :observed_trimmed, :recent, :first_seen, :last_seen, :paths, :runs ]
+          end
+
+          class Call < Data
+            attr_reader line(): untyped
+
+            attr_reader column(): untyped
+
+            attr_reader via(): untyped
+
+            attr_reader targets(): untyped
+
+            attr_reader per_parent(): untyped
+
+            attr_reader parents(): untyped
+
+            attr_reader renders(): untyped
+
+            attr_reader observations(): untyped
+
+            attr_reader first_seen(): untyped
+
+            attr_reader last_seen(): untyped
+
+            attr_reader paths(): untyped
+
+            def self.new: (untyped line, untyped column, untyped via, untyped targets, untyped per_parent, untyped parents, untyped renders, untyped observations, untyped first_seen, untyped last_seen, untyped paths) -> instance
+                        | (line: untyped, column: untyped, via: untyped, targets: untyped, per_parent: untyped, parents: untyped, renders: untyped, observations: untyped, first_seen: untyped, last_seen: untyped, paths: untyped) -> instance
+
+            def self.members: () -> [ :line, :column, :via, :targets, :per_parent, :parents, :renders, :observations, :first_seen, :last_seen, :paths ]
+
+            def members: () -> [ :line, :column, :via, :targets, :per_parent, :parents, :renders, :observations, :first_seen, :last_seen, :paths ]
+          end
+
+          class Call
+            # : () -> Integer
+            def peak: () -> Integer
+
+            # : () -> String?
+            def only_target: () -> String?
+          end
+
+          MAX_RECENT: Integer
+
+          attr_reader template: String
+
+          attr_reader digest: String
+
+          attr_reader findings: Array[Finding]
+
+          attr_reader calls: Array[Call]
+
+          attr_reader dropped: Integer
+
+          attr_reader first_seen: String?
+
+          # : (String, String, Array[Hash[String, untyped]]) -> Summary
+          def self.build: (String, String, Array[Hash[String, untyped]]) -> Summary
+
+          # : (Array[Hash[String, untyped]]) -> Array[Finding]
+          def self.fold_findings: (Array[Hash[String, untyped]]) -> Array[Finding]
+
+          # : (Array[Hash[String, untyped]]) -> Array[Call]
+          def self.fold_calls: (Array[Hash[String, untyped]]) -> Array[Call]
+
+          # : (Array[Hash[String, untyped]]) -> Finding
+          def self.finding_for: (Array[Hash[String, untyped]]) -> Finding
+
+          # : (Array[Hash[String, untyped]]) -> Call
+          def self.call_for: (Array[Hash[String, untyped]]) -> Call
+
+          # : (Array[Hash[String, untyped]]) -> Hash[String, untyped]
+          def self.newest: (Array[Hash[String, untyped]]) -> Hash[String, untyped]
+
+          # : (Array[Hash[String, untyped]]) -> Hash[String, untyped]
+          def self.worst: (Array[Hash[String, untyped]]) -> Hash[String, untyped]
+
+          # : (Array[Hash[String, untyped]]) -> Array[Hash[Symbol, untyped]]
+          def self.recent: (Array[Hash[String, untyped]]) -> Array[Hash[Symbol, untyped]]
+
+          # : (Hash[String, untyped]) -> Array[untyped]
+          def self.values_in: (Hash[String, untyped]) -> Array[untyped]
+
+          # : (Array[Hash[String, untyped]?]) -> Hash[untyped, Integer]
+          def self.merge_counts: (Array[Hash[String, untyped]?]) -> Hash[untyped, Integer]
+
+          # : (Array[String]) -> Hash[Symbol, untyped]?
+          def self.range: (Array[String]) -> Hash[Symbol, untyped]?
+
+          # : (untyped) -> Float?
+          def self.leading_number: (untyped) -> Float?
+
+          # : (template: String, digest: String, findings: Array[Finding], calls: Array[Call], dropped: Integer, first_seen: String?) -> void
+          def initialize: (template: String, digest: String, findings: Array[Finding], calls: Array[Call], dropped: Integer, first_seen: String?) -> void
+
+          # : () -> bool
+          def truncated?: () -> bool
+
+          # : () -> bool
+          def empty?: () -> bool
+        end
+      end
+    end
+  end
+end

--- a/test/engine/runtime/journal_test.rb
+++ b/test/engine/runtime/journal_test.rb
@@ -1,0 +1,364 @@
+# frozen_string_literal: true
+
+require_relative "../../test_helper"
+
+require "tmpdir"
+require "json"
+
+require "herb/engine/runtime/journal"
+
+module Engine
+  class RuntimeJournalTest < Minitest::Spec
+    TEMPLATE = "app/views/posts/_card.html.erb"
+    PARENT = "app/views/posts/index.html.erb"
+    SOURCE = "<div><%= post.title %></div>"
+
+    around do |test|
+      Dir.mktmpdir("herb-journal") do |dir|
+        @root = dir
+        @journal = Herb::Engine::Runtime::Journal.new(root: dir)
+
+        test.call
+      end
+    end
+
+    attr_reader :root, :journal
+
+    def digest(source = SOURCE)
+      Herb::Fingerprint.template(source)
+    end
+
+    def diagnostic(template: TEMPLATE, line: 7, column: 8, end_column: 24, code: "sql-queries", value: "3 SQL queries", **extra)
+      Herb::Diagnostic.new(
+        template: template, message: value, severity: nil, kind: :metric, origin: "Herb Engine",
+        code: code, location: Herb::Location.from(line, column, line, end_column), value: value, **extra
+      )
+    end
+
+    def report(source: SOURCE, diagnostics: [diagnostic])
+      built = Herb::Engine::Runtime::Report.new
+
+      built.render("1", TEMPLATE, nil, digest: digest(source))
+      diagnostics.each { |found| built.add(found) }
+
+      built
+    end
+
+    def lines_in(path)
+      File.readlines(path).map { |line| JSON.parse(line) }
+    end
+
+    def journal_file(source = SOURCE)
+      journal.path_for(TEMPLATE, digest(source))
+    end
+
+    describe "what it writes" do
+      test "writes nothing for a report with nothing in it" do
+        assert_nil journal.write(Herb::Engine::Runtime::Report.new)
+        assert_empty Dir.glob(File.join(root, "**", "*.jsonl"))
+      end
+
+      test "names the file after the template and the text it was rendered from" do
+        journal.write(report)
+
+        assert_path_exists File.join(root, "journal", "#{TEMPLATE}.#{Herb::Fingerprint.short(digest)}.jsonl")
+      end
+
+      test "opens a journal by saying which text it is about" do
+        journal.write(report)
+
+        header = lines_in(journal_file).first
+
+        assert_equal "template", header["t"]
+        assert_equal digest, header["digest"]
+      end
+
+      test "stamps every record with the run it came from and the request that caused it" do
+        run = journal.write(report, request: { method: "GET", path: "/posts" })
+
+        record = lines_in(journal_file).find { |line| line["t"] == "finding" }
+
+        assert_equal run, record["run"]
+        assert_equal "/posts", record["request_path"]
+      end
+
+      test "records where the tag ends, so a reader can mark the tag and not its first character" do
+        journal.write(report)
+
+        record = lines_in(journal_file).find { |line| line["t"] == "finding" }
+
+        assert_equal [7, 9], [record["line"], record["column"]]
+        assert_equal [7, 25], [record["end_line"], record["end_column"]]
+      end
+
+      test "writes one record per occurrence, so the spread survives" do
+        3.times { journal.write(report) }
+
+        assert_equal(3, lines_in(journal_file).count { |line| line["t"] == "finding" })
+      end
+
+      test "keeps versions of one template apart" do
+        journal.write(report)
+        journal.write(report(source: "#{SOURCE}\n<p>edited</p>"))
+
+        assert_equal 2, Dir.glob(File.join(root, "journal", "**", "*.jsonl")).length
+      end
+
+      test "writes nothing for a template it cannot place inside the journal directory" do
+        escaping = Herb::Engine::Runtime::Report.new
+        escaping.render("1", "../../etc/passwd", nil, digest: digest)
+        escaping.add(diagnostic(template: "../../etc/passwd"))
+
+        journal.write(escaping)
+
+        assert_empty Dir.glob(File.join(root, "journal", "**", "*.jsonl"))
+      end
+
+      test "writes nothing for a template whose text it never knew" do
+        unknown = Herb::Engine::Runtime::Report.new
+        unknown.add(diagnostic)
+
+        journal.write(unknown)
+
+        assert_empty Dir.glob(File.join(root, "journal", "**", "*.jsonl"))
+      end
+
+      test "keeps the head of an observation too large to write whole" do
+        large = diagnostic(data: { queries: Array.new(500) { |index| "SELECT #{index} FROM #{"x" * 60}" } })
+
+        journal.write(report(diagnostics: [large]))
+
+        record = lines_in(journal_file).find { |line| line["t"] == "finding" }
+
+        assert record["data_trimmed"]
+        assert_equal 12, record["data"]["queries"].length
+        assert_operator File.readlines(journal_file).last.bytesize, :<=, Herb::Engine::Runtime::Journal::MAX_RECORD_BYTES
+      end
+
+      test "drops the oldest records once a journal gets long, and says so" do
+        capped = Herb::Engine::Runtime::Journal.new(root: root, max_records: 10)
+
+        14.times { |index| capped.write(report(diagnostics: [diagnostic(value: "#{index} SQL queries")])) }
+
+        records = lines_in(journal_file)
+
+        assert(records.any? { |line| line["t"] == "truncated" })
+        assert_operator records.count { |line| line["t"] == "finding" }, :<=, 10
+        assert_predicate journal.summary(TEMPLATE, digest), :truncated?
+      end
+
+      test "keeps a bounded number of versions of one template" do
+        kept = Herb::Engine::Runtime::Journal.new(root: root, kept_digests: 2)
+
+        4.times do |index|
+          kept.write(report(source: "#{SOURCE}#{" " * index}"))
+
+          sleep 0.01
+        end
+
+        assert_equal 2, Dir.glob(File.join(root, "journal", "**", "*.jsonl")).length
+      end
+
+      test "writes down what an observation was without pretending to be it" do
+        connection = Class.new { def self.name = "Connection" }.new
+
+        journal.write(report(diagnostics: [diagnostic(data: { queries: [{ sql: "SELECT 1", connection: connection }] })]))
+
+        observed = lines_in(journal_file).find { |line| line["t"] == "finding" }["data"]["queries"].first
+
+        assert_equal "SELECT 1", observed["sql"]
+        refute_match(/0x[0-9a-f]+/, observed["connection"])
+      end
+
+      test "keeps a value JSON cannot hold, instead of losing the whole write to it" do
+        journal.write(report(diagnostics: [diagnostic(data: { timing: [{ duration: Float::INFINITY }] })]))
+
+        record = lines_in(journal_file).find { |line| line["t"] == "finding" }
+
+        assert_equal "Infinity", record["data"]["timing"].first["duration"]
+      end
+
+      test "loses one unwritable value instead of the finding it sat in" do
+        exploding = Object.new
+        exploding.define_singleton_method(:class) { raise "boom" }
+
+        findings = [diagnostic(line: 7, data: { queries: [exploding, "SELECT 1"] }), diagnostic(line: 9, value: "2 SQL queries")]
+
+        journal.write(report(diagnostics: findings))
+
+        recorded = lines_in(journal_file).select { |line| line["t"] == "finding" }
+
+        assert_equal([7, 9], recorded.map { |line| line["line"] })
+        assert_equal [nil, "SELECT 1"], recorded.first["data"]["queries"]
+      end
+
+      test "never raises into the request it was called from" do
+        broken = report
+
+        broken.define_singleton_method(:diagnostics) { raise "boom" }
+
+        assert_nil journal.write(broken)
+      end
+    end
+
+    describe "what it says about a render tag" do
+      def rendered(children_per_parent)
+        built = Herb::Engine::Runtime::Report.new
+        built.render("1", PARENT, nil, digest: digest)
+
+        id = 1
+
+        children_per_parent.each_with_index do |count, index|
+          parent = "p#{index}"
+
+          built.render(parent, PARENT, "1", digest: digest)
+
+          count.times do
+            built.render("c#{id += 1}", TEMPLATE, parent, called_from: [PARENT, 3, 4, :partial], digest: digest(SOURCE))
+          end
+        end
+
+        built.add(diagnostic(template: PARENT))
+
+        built
+      end
+
+      def parent_summary
+        journal.summary(PARENT, digest)
+      end
+
+      test "counts children against the parent render they happened in" do
+        journal.write(rendered([3]))
+
+        call = parent_summary.calls.first
+
+        assert_equal({ 3 => 1 }, call.per_parent)
+        assert_equal 3, call.peak
+      end
+
+      test "tells a loop apart from a partial that simply renders in many parents" do
+        journal.write(rendered([1, 1, 1]))
+
+        call = parent_summary.calls.first
+
+        assert_equal({ 1 => 3 }, call.per_parent)
+        assert_equal 1, call.peak
+      end
+
+      test "merges the histogram across requests instead of summing it away" do
+        journal.write(rendered([3]))
+        journal.write(rendered([1]))
+
+        call = parent_summary.calls.first
+
+        assert_equal({ 3 => 1, 1 => 1 }, call.per_parent)
+        assert_equal 3, call.peak
+        assert_equal 2, call.observations
+      end
+
+      test "files the call against the parent, since the parent holds the tag a rewrite would edit" do
+        journal.write(rendered([2]))
+
+        assert_equal [3], parent_summary.calls.map(&:line)
+        assert_empty(journal.summary(TEMPLATE, digest(SOURCE))&.calls || [])
+      end
+
+      test "says what the tag resolved to and how often" do
+        journal.write(rendered([2]))
+
+        call = parent_summary.calls.first
+
+        assert_equal({ TEMPLATE => 2 }, call.targets)
+        assert_equal TEMPLATE, call.only_target
+        assert_equal :partial, call.via.to_sym
+      end
+
+      test "refuses to name one target when the tag resolved to more than one" do
+        built = rendered([1])
+        built.render("other", "app/views/posts/_row.html.erb", "p0", called_from: [PARENT, 3, 4, :partial], digest: digest)
+
+        journal.write(built)
+
+        assert_nil parent_summary.calls.first.only_target
+      end
+    end
+
+    describe "reading it back" do
+      test "says nothing about a template nobody rendered" do
+        assert_nil journal.summary(TEMPLATE, digest)
+      end
+
+      test "says nothing when the text it is asked about is not the text that was rendered" do
+        journal.write(report)
+
+        assert_nil journal.summary(TEMPLATE, digest("#{SOURCE}<p>edited</p>"))
+      end
+
+      test "says nothing when it is asked without a digest at all" do
+        journal.write(report)
+
+        assert_nil journal.summary(TEMPLATE, nil)
+      end
+
+      test "folds every occurrence of one finding into one, and counts them" do
+        3.times { journal.write(report) }
+
+        findings = journal.summary(TEMPLATE, digest).findings
+
+        assert_equal 1, findings.length
+        assert_equal 3, findings.first.observed
+      end
+
+      test "reports the spread across requests, which no single request could" do
+        journal.write(report(diagnostics: [diagnostic(value: "3 SQL queries")]))
+        journal.write(report(diagnostics: [diagnostic(value: "47 SQL queries")]))
+
+        found = journal.summary(TEMPLATE, digest).findings.first
+
+        assert_equal({ min: 3.0, max: 47.0 }, found.range)
+        assert_equal "47 SQL queries", found.peak_message
+      end
+
+      test "keeps the last few things a tag produced, newest first" do
+        journal.write(report(diagnostics: [diagnostic(value: "gamma", data: { output: ["alpha", "beta", "gamma"] })]))
+        journal.write(report(diagnostics: [diagnostic(value: "epsilon", data: { output: ["delta", "epsilon"] })]))
+
+        found = journal.summary(TEMPLATE, digest).findings.first
+
+        assert_equal(["epsilon", "delta", "gamma", "beta", "alpha"], found.recent.map { |entry| entry[:value] })
+      end
+
+      test "loses a torn write and nothing behind it" do
+        journal.write(report)
+
+        File.open(journal_file, "a") { |file| file.write(%({"v":1,"t":"finding","li)) }
+
+        assert_equal 1, journal.summary(TEMPLATE, digest).findings.length
+      end
+
+      test "skips a record written by a version it does not know" do
+        journal.write(report)
+
+        File.open(journal_file, "a") { |file| file.puts(JSON.generate({ v: 99, t: "finding", line: 1, column: 1 })) }
+
+        assert_equal 1, journal.summary(TEMPLATE, digest).findings.length
+      end
+
+      test "lists the versions on disk, so a caller can tell nothing rendered from stale" do
+        assert_empty journal.digests(TEMPLATE)
+
+        journal.write(report)
+
+        assert_equal [Herb::Fingerprint.short(digest)], journal.digests(TEMPLATE)
+      end
+
+      test "says which requests a finding was seen on" do
+        journal.write(report, request: { path: "/posts" })
+        journal.write(report, request: { path: "/posts" })
+        journal.write(report, request: { path: "/" })
+
+        assert_equal({ "/posts" => 2, "/" => 1 }, journal.summary(TEMPLATE, digest).findings.first.paths)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This pull request introduces a place for a report to go once the request that produced it is gone.

A report is enough for the browser, which reads it while the page it describes is still open. An editor asks a different question. It has a file open and wants to know what happened in it, without knowing which request that was or whether the request has been made yet. So a journal is keyed by what an editor already has, a path and the text at that path.

```
tmp/herb/journal/app/views/posts/_card.html.erb.9f2a1c4e.jsonl
```

The digest in the name is the whole staleness mechanism. An editor hashes its buffer, builds that path and opens it. A file edited since produces a different name, which does not exist, so a position recorded against text that no longer exists is never shown and nothing has to work out how far an edit moved things. It is written the way `Dev::ServerEntry` writes its own registry, with a known directory, one file per key, and pruning done by whoever passes by.

What accumulates is the point. One request says a partial ran 3 queries. A journal says it ran between 3-47 across 200 renders, which is the shape of an N+1 and is not visible from any single request.

Render tags are recorded too, counted against the parent render they happened in instead of summed. A flat count cannot tell one parent rendering fifteen children from fifteen parents rendering one each, and only the first is a loop, so what is kept is a histogram.

```ruby
call.per_parent  #=> { 1 => 312, 15 => 12 }
call.peak        #=> 15
call.only_target #=> "app/views/posts/_card.html.erb"
```
