### PR TITLE
Engine: Write a request's session to a journal

### DIFF
--- a/lib/herb/engine/runtime/middleware.rb
+++ b/lib/herb/engine/runtime/middleware.rb
@@ -13,11 +13,32 @@ module Herb
       # One request is the right scope because a page is what the dev tools show: findings from every
       # template that took part in it, in one payload, whoever found them.
       #
+      # Given a journal, the same session is also written to disk, where it outlives the page and an
+      # editor can read it. Whoever mounts this middleware is often not the application, so the
+      # journal can be set on the class instead of passed:
+      #
+      #     Herb::Engine::Runtime::Middleware.journal = "tmp/herb"
+      #
       # Nothing here is allowed to be the reason a page fails. A response it cannot safely touch is
-      # returned untouched, and any error while injecting is swallowed in favour of the original
-      # response.
+      # returned untouched, and any error while injecting, measuring or writing is swallowed in
+      # favour of the original response.
       #
       class Middleware
+        # Where a session goes when whoever mounted this middleware did not say. Left unset, nothing
+        # is written.
+        #
+        # Written out instead of as an `attr_accessor` in a `class << self` block, because rbs-inline
+        # emits that as an instance accessor and the signature would be wrong.
+        #: () -> untyped
+        def self.journal # rubocop:disable Style/TrivialAccessors
+          @journal
+        end
+
+        #: (untyped) -> void
+        def self.journal=(journal) # rubocop:disable Style/TrivialAccessors
+          @journal = journal
+        end
+
         HTML_CONTENT_TYPE = %r{\Atext/html}i #: Regexp
         BODY_END_TAG = %r{</body>}i #: Regexp
         HEAD_END_TAG = %r{</head>}i #: Regexp
@@ -32,10 +53,11 @@ module Herb
         #
         ENV_KEY = "herb.report_session" #: String
 
-        #: (untyped, ?inject: bool) -> void
-        def initialize(app, inject: true)
+        #: (untyped, ?inject: bool, ?journal: untyped) -> void
+        def initialize(app, inject: true, journal: nil)
           @app = app
           @inject = inject
+          @journal = journal
         end
 
         #: (untyped) -> untyped
@@ -47,6 +69,11 @@ module Herb
 
           response = @app.call(env)
 
+          unless borrowed
+            measure(session)
+            persist(session, env, response)
+          end
+
           return response unless @inject
           return response if session.empty?
 
@@ -56,6 +83,50 @@ module Herb
         end
 
         private
+
+        #: (Herb::Engine::Runtime::Session) -> void
+        def measure(session)
+          session.apply_measurements
+
+          nil
+        rescue StandardError
+          nil
+        end
+
+        #: (Herb::Engine::Runtime::Session, untyped, untyped) -> void
+        def persist(session, env, response)
+          journal = coerce(@journal || self.class.journal)
+
+          return unless journal
+          return if session.empty?
+
+          journal.write(session.report, request: request_of(env, response))
+
+          nil
+        rescue StandardError
+          nil
+        end
+
+        #: (untyped, untyped) -> Hash[Symbol, untyped]
+        def request_of(env, response)
+          {
+            method: env["REQUEST_METHOD"],
+            path: env["PATH_INFO"],
+            status: response.is_a?(Array) ? response[0] : nil,
+          }.compact
+        end
+
+        #: (untyped) -> untyped
+        def coerce(journal)
+          return nil unless journal
+
+          require_relative "journal"
+
+          return journal if journal.is_a?(Journal)
+          return Journal.new if journal == true
+
+          Journal.new(root: journal)
+        end
 
         #: (untyped, Herb::Engine::Runtime::Report) -> untyped
         def inject(response, report)

--- a/sig/herb/engine/runtime/middleware.rbs
+++ b/sig/herb/engine/runtime/middleware.rbs
@@ -10,10 +10,27 @@ module Herb
       # One request is the right scope because a page is what the dev tools show: findings from every
       # template that took part in it, in one payload, whoever found them.
       #
+      # Given a journal, the same session is also written to disk, where it outlives the page and an
+      # editor can read it. Whoever mounts this middleware is often not the application, so the
+      # journal can be set on the class instead of passed:
+      #
+      #     Herb::Engine::Runtime::Middleware.journal = "tmp/herb"
+      #
       # Nothing here is allowed to be the reason a page fails. A response it cannot safely touch is
-      # returned untouched, and any error while injecting is swallowed in favour of the original
-      # response.
+      # returned untouched, and any error while injecting, measuring or writing is swallowed in
+      # favour of the original response.
       class Middleware
+        # Where a session goes when whoever mounted this middleware did not say. Left unset, nothing
+        # is written.
+        #
+        # Written out instead of as an `attr_accessor` in a `class << self` block, because rbs-inline
+        # emits that as an instance accessor and the signature would be wrong.
+        # : () -> untyped
+        def self.journal: () -> untyped
+
+        # : (untyped) -> void
+        def self.journal=: (untyped) -> void
+
         HTML_CONTENT_TYPE: Regexp
 
         BODY_END_TAG: Regexp
@@ -30,13 +47,25 @@ module Herb
         #     request.env[Herb::Engine::Runtime::Middleware::ENV_KEY].entries
         ENV_KEY: String
 
-        # : (untyped, ?inject: bool) -> void
-        def initialize: (untyped, ?inject: bool) -> void
+        # : (untyped, ?inject: bool, ?journal: untyped) -> void
+        def initialize: (untyped, ?inject: bool, ?journal: untyped) -> void
 
         # : (untyped) -> untyped
         def call: (untyped) -> untyped
 
         private
+
+        # : (Herb::Engine::Runtime::Session) -> void
+        def measure: (Herb::Engine::Runtime::Session) -> void
+
+        # : (Herb::Engine::Runtime::Session, untyped, untyped) -> void
+        def persist: (Herb::Engine::Runtime::Session, untyped, untyped) -> void
+
+        # : (untyped, untyped) -> Hash[Symbol, untyped]
+        def request_of: (untyped, untyped) -> Hash[Symbol, untyped]
+
+        # : (untyped) -> untyped
+        def coerce: (untyped) -> untyped
 
         # : (untyped, Herb::Engine::Runtime::Report) -> untyped
         def inject: (untyped, Herb::Engine::Runtime::Report) -> untyped

--- a/test/engine/report/middleware_test.rb
+++ b/test/engine/report/middleware_test.rb
@@ -2,6 +2,11 @@
 
 require_relative "../../test_helper"
 
+require "tmpdir"
+require "json"
+
+require "herb/engine/runtime/journal"
+
 module Engine
   class ReportMiddlewareTest < Minitest::Spec
     PAGE = "<html><body><h1>Hello</h1></body></html>"
@@ -265,6 +270,130 @@ module Engine
 
       test "returns the response untouched when nothing collected" do
         assert_equal DOCUMENT, respond_with
+      end
+    end
+
+    describe "handing the session to a journal" do
+      after do
+        Herb::Engine::Runtime::Middleware.journal = nil
+        Herb::Engine::Runtime::Session.clear_measurements
+      end
+
+      def rendered(journal, env: { "REQUEST_METHOD" => "GET", "PATH_INFO" => "/posts" })
+        Herb::Engine::Runtime::Middleware.new(
+          app {
+            Herb::Engine::Runtime::Session.current.enter_render("app/views/a.html.erb", "a" * 64)
+            Herb::Engine::Runtime::Session.record(diagnostic)
+          },
+          journal: journal
+        ).call(env)
+      end
+
+      def written(dir)
+        Dir.glob(File.join(dir, "journal", "**", "*.jsonl"))
+      end
+
+      test "writes nothing when it was not given one" do
+        Dir.mktmpdir("herb-middleware") do |dir|
+          rendered(nil)
+
+          assert_empty written(dir)
+        end
+      end
+
+      test "writes the session it opened, keyed by the text that was rendered" do
+        Dir.mktmpdir("herb-middleware") do |dir|
+          rendered(Herb::Engine::Runtime::Journal.new(root: dir))
+
+          assert_path_exists File.join(dir, "journal", "app/views/a.html.erb.#{"a" * 8}.jsonl")
+        end
+      end
+
+      test "takes a path and builds the journal itself" do
+        Dir.mktmpdir("herb-middleware") do |dir|
+          rendered(dir)
+
+          refute_empty written(dir)
+        end
+      end
+
+      test "falls back to the journal set on the class, since the host often mounts this" do
+        Dir.mktmpdir("herb-middleware") do |dir|
+          Herb::Engine::Runtime::Middleware.journal = dir
+
+          rendered(nil)
+
+          refute_empty written(dir)
+        end
+      end
+
+      test "prefers the journal it was given over the one on the class" do
+        Dir.mktmpdir("herb-class") do |ignored|
+          Dir.mktmpdir("herb-given") do |dir|
+            Herb::Engine::Runtime::Middleware.journal = ignored
+
+            rendered(dir)
+
+            refute_empty written(dir)
+            assert_empty written(ignored)
+          end
+        end
+      end
+
+      test "says what request a record came from" do
+        Dir.mktmpdir("herb-middleware") do |dir|
+          rendered(dir)
+
+          record = JSON.parse(File.readlines(written(dir).first).last)
+
+          assert_equal "/posts", record["request_path"]
+        end
+      end
+
+      test "applies what producers registered, so observations reach the journal" do
+        Herb::Engine::Runtime::Session.measurement(:queries, origin: "Herb Engine", code: "sql-queries") do |queries|
+          "#{queries.size} SQL queries"
+        end
+
+        Dir.mktmpdir("herb-middleware") do |dir|
+          Herb::Engine::Runtime::Middleware.new(
+            app {
+              Herb::Engine::Runtime::Session.current.enter_render("app/views/a.html.erb", "a" * 64)
+              Herb::Engine::Runtime::Session.at("app/views/a.html.erb", 1, 0) do
+                Herb::Engine::Runtime::Session.observe(:queries, "SELECT 1")
+              end
+            },
+            journal: dir
+          ).call({})
+
+          codes = File.readlines(written(dir).first).map { |line| JSON.parse(line)["code"] }
+
+          assert_includes codes, "sql-queries"
+        end
+      end
+
+      test "leaves a borrowed session to whoever opened it" do
+        Dir.mktmpdir("herb-middleware") do |dir|
+          Herb::Engine::Runtime::Session.capture { rendered(dir) }
+
+          assert_empty written(dir)
+        end
+      end
+
+      test "returns the page even when a measurement raises" do
+        Herb::Engine::Runtime::Session.measurement(:queries, origin: "Herb Engine") { |_| raise "boom" }
+
+        response = rendered(nil)
+
+        assert_equal 200, response[0]
+        assert_includes body_of(response), "Hello"
+      end
+
+      test "returns the page even when the journal cannot write" do
+        response = rendered("/does/not/exist/and/cannot/be/made")
+
+        assert_equal 200, response[0]
+        assert_includes body_of(response), "Hello"
       end
     end
   end


### PR DESCRIPTION
This pull request gives the middleware the two things a journal needs from it.

Observations collected onto a session's entries and stopped there, because turning them into findings means calling `measure`, and a request closing is the only moment that can happen. The entries go out of scope with it. So the session the middleware opened now has everything producers registered applied to it before anything reads it.

That runs a block somebody else wrote, after the page is already built, which is exactly the kind of thing that must not take a page down with it. It is guarded, along with the write, the same way injecting already was. A producer that raises loses its own findings and nothing else.

The journal can be set on the class as well as passed, because whoever mounts this middleware is often not the application that wants the journal. A framework integration mounts it bare, and the application says where its journal goes.

```ruby
Herb::Engine::Runtime::Middleware.journal = "tmp/herb"
```

Left unset, nothing is written, so this costs an application that never asked for one a nil check. Requiring the journal happens only once one is configured, so requiring the middleware does not drag it in either.
