### PR TITLE
 Engine: Add `capture_output` to record what an output tag rendered

### DIFF
--- a/lib/herb/engine/runtime/session.rb
+++ b/lib/herb/engine/runtime/session.rb
@@ -124,6 +124,17 @@ module Herb
           current.enter(template, line, column, via, end_line: end_line, end_column: end_column)
         end
 
+        #: [T] (String?, Integer, Integer, ?Symbol?, ?end_line: Integer?, ?end_column: Integer?) { () -> T } -> T
+        def self.output(template, line, column, via = nil, end_line: nil, end_column: nil)
+          at(template, line, column, via, end_line: end_line, end_column: end_column) do
+            value = yield
+
+            observe(:output, value)
+
+            value
+          end
+        end
+
         #: () -> void
         def self.leave
           current.leave

--- a/lib/herb/engine/visitors/instrumentation_visitor.rb
+++ b/lib/herb/engine/visitors/instrumentation_visitor.rb
@@ -64,6 +64,14 @@ module Herb
         true
       end
 
+      #: (?capture_output: (bool | ^(String) -> boolish | Regexp | Array[untyped])?) -> void
+      def initialize(capture_output: nil)
+        super()
+
+        @capture_everything = capture_output == true
+        @capture_output = (capture_output == true ? [] : Array(capture_output)) #: Array[untyped]
+      end
+
       def visit_document_node(node)
         @file = context.relative_file_path
 
@@ -180,10 +188,26 @@ module Herb
 
       def wrapped_output(node)
         body = code(node)
+        call = captured?(node) ? "output" : "at"
 
-        return erb_node(node, "<%=", "#{SESSION}.at(#{position(node)}) {\n#{body}\n}") if spans_lines?(body)
+        return erb_node(node, "<%=", "#{SESSION}.#{call}(#{position(node)}) {\n#{body}\n}") if spans_lines?(body)
 
-        erb_node(node, "<%=", "#{SESSION}.at(#{position(node)}) { #{body} }")
+        erb_node(node, "<%=", "#{SESSION}.#{call}(#{position(node)}) { #{body} }")
+      end
+
+      def captured?(node)
+        return false if !@capture_everything && @capture_output.empty?
+
+        source = code(node)
+
+        return false if source.empty?
+        return true if @capture_everything
+
+        @capture_output.any? do |matcher|
+          matcher.is_a?(Regexp) ? matcher.match?(source) : matcher.call(source)
+        end
+      rescue StandardError
+        false
       end
 
       def wrapped_statement(node)

--- a/sig/herb/engine/runtime/session.rbs
+++ b/sig/herb/engine/runtime/session.rbs
@@ -82,6 +82,9 @@ module Herb
         # : (String?, Integer, Integer, ?Symbol?, ?end_line: Integer?, ?end_column: Integer?) -> void
         def self.enter: (String?, Integer, Integer, ?Symbol?, ?end_line: Integer?, ?end_column: Integer?) -> void
 
+        # : [T] (String?, Integer, Integer, ?Symbol?, ?end_line: Integer?, ?end_column: Integer?) { () -> T } -> T
+        def self.output: [T] (String?, Integer, Integer, ?Symbol?, ?end_line: Integer?, ?end_column: Integer?) { () -> T } -> T
+
         # : () -> void
         def self.leave: () -> void
 

--- a/sig/herb/engine/visitors/instrumentation_visitor.rbs
+++ b/sig/herb/engine/visitors/instrumentation_visitor.rbs
@@ -48,6 +48,9 @@ module Herb
       # : () -> bool
       def self.rewrites_erb_source?: () -> bool
 
+      # : (?capture_output: (bool | ^(String) -> boolish | Regexp | Array[untyped])?) -> void
+      def initialize: (?capture_output: (bool | ^(String) -> boolish | Regexp | Array[untyped])?) -> void
+
       def visit_document_node: (untyped node) -> untyped
 
       def inspect: () -> untyped
@@ -75,6 +78,8 @@ module Herb
       def via: (untyped node) -> untyped
 
       def wrapped_output: (untyped node) -> untyped
+
+      def captured?: (untyped node) -> untyped
 
       def wrapped_statement: (untyped node) -> untyped
 

--- a/test/engine/visitors/instrumentation_test.rb
+++ b/test/engine/visitors/instrumentation_test.rb
@@ -204,5 +204,68 @@ module Engine
         assert_includes compile(%(<%= render layout: "box" do %>inner<% end %>)), "inner"
       end
     end
+
+    describe "capturing what a tag rendered" do
+      def captured(source, capture_output:)
+        Herb::Engine.new(
+          source,
+          filename: FILENAME,
+          visitors: [Herb::Engine::InstrumentationVisitor.new(capture_output: capture_output)]
+        ).src
+      end
+
+      def calls(compiled)
+        compiled.scan(/Session\.(output|at)\(/).flatten.tally
+      end
+
+      test "captures nothing unless it was asked to" do
+        refute_includes compile(%(<div><%= t(".title") %></div>)), "Session.output("
+      end
+
+      test "captures only the tags that match" do
+        compiled = captured(%(<div><%= t(".title") %><%= post.body %></div>), capture_output: /\A\s*t[\s(]/)
+
+        assert_equal({ "output" => 1, "at" => 1 }, calls(compiled))
+      end
+
+      test "captures every output tag when told to capture everything" do
+        compiled = captured(%(<div><%= t(".title") %><%= post.body %></div>), capture_output: true)
+
+        assert_equal({ "output" => 2 }, calls(compiled))
+      end
+
+      test "takes anything that answers to call" do
+        assert_includes captured(%(<%= post.body %>), capture_output: ->(source) { source.include?("body") }), "Session.output("
+      end
+
+      test "leaves a tag it cannot make sense of alone" do
+        refute_includes captured(%(<%= post.body %>), capture_output: ->(_source) { raise "boom" }), "Session.output("
+      end
+
+      test "records the value the tag rendered, filed against the tag" do
+        compiled = captured(%(<div><%= title %></div>), capture_output: true)
+        context = Class.new { def title = "Upcoming events" }.new
+
+        session = Herb::Engine::Runtime::Session.capture { context.instance_eval(compiled) }
+
+        assert_equal([["Upcoming events"]], session.entries.map { |entry| entry[:output] })
+      end
+
+      test "records one value per render of a tag inside a collection" do
+        compiled = captured(%(<% items.each do |item| %><%= item %><% end %>), capture_output: true)
+        context = Struct.new(:items).new(["alpha", "beta", "gamma"])
+
+        session = Herb::Engine::Runtime::Session.capture { context.instance_eval(compiled) }
+
+        assert_equal([["alpha", "beta", "gamma"]], session.entries.map { |entry| entry[:output] })
+      end
+
+      test "still renders what it would have rendered" do
+        source = %(<div><%= title %></div>)
+        context = Class.new { def title = "Upcoming events" }.new
+
+        assert_equal "<div>Upcoming events</div>", context.instance_eval(captured(source, capture_output: true))
+      end
+    end
   end
 end


### PR DESCRIPTION
This pull request lets the compiler record what an output tag produced, for the tags it is asked about.

An output tag's value already flows through the frame on its way to the buffer, so observing it costs the observation and nothing else. What it enables is showing a template the thing it produced instead of the expression that produced it, which is the difference between reading `t(".title")` and reading "Upcoming events".

```ruby
Herb::Engine::InstrumentationVisitor.new(capture_output: /\At[\s(]/)
```

Off by default, and narrow when on. A template's output is the page's content, so capturing everything means a rendered page ends up in the report, and a report can be written to disk. That is worth switching on deliberately, so `true` captures every output tag, and a Regexp or anything answering `call` captures some of them.

Deciding at compile time instead of at render time means an uncaptured tag compiles to exactly what it did before, and a matcher that raises captures nothing instead of failing the compile.

A tag inside a collection records one value per pass, because each of those is a different thing the tag produced.
