### PR TITLE
Language Server: Show what the application recorded from its journal

### DIFF
--- a/javascript/packages/config/src/config.ts
+++ b/javascript/packages/config/src/config.ts
@@ -50,6 +50,9 @@ export interface PersonalHerbSettings {
     minimumLines?: number
     maximumClasses?: number
   }
+  runtimeReports?: {
+    inlayHints?: boolean
+  }
 }
 
 export const defaultPersonalSettings: PersonalHerbSettings = {
@@ -67,6 +70,9 @@ export const defaultPersonalSettings: PersonalHerbSettings = {
     enabled: true,
     minimumLines: 10,
     maximumClasses: 2
+  },
+  runtimeReports: {
+    inlayHints: true
   }
 }
 

--- a/javascript/packages/language-server/src/capabilities.ts
+++ b/javascript/packages/language-server/src/capabilities.ts
@@ -5,6 +5,7 @@ import type { PersonalHerbSettings } from "./user_settings"
 export interface HerbInitializationOptions extends PersonalHerbSettings {
   experimental?: {
     extractToPartialCommand?: boolean
+    runtimeOverlays?: boolean
   }
 }
 
@@ -46,6 +47,12 @@ export class Capabilities {
 
   get supportsResourceCreation(): boolean {
     return this.client.workspace?.workspaceEdit?.resourceOperations?.includes(ResourceOperationKind.Create) ?? false
+  }
+
+  get supportsRuntimeOverlays(): boolean {
+    const options = this.params.initializationOptions as HerbInitializationOptions | undefined | null
+
+    return options?.experimental?.runtimeOverlays === true
   }
 
   get supportsExtractToPartialCommand(): boolean {

--- a/javascript/packages/language-server/src/project.ts
+++ b/javascript/packages/language-server/src/project.ts
@@ -9,6 +9,7 @@ import { AutofixService } from "./autofix_service"
 
 import { CodeActionProvider } from "./code_action_provider"
 import { FormattingProvider } from "./formatting_provider"
+import { RuntimeReports } from "./runtime_reports"
 import { CompletionProvider, ReferencesProvider } from "@herb-tools/language-service"
 
 import { version } from "../package.json"
@@ -44,6 +45,7 @@ export class Project {
   readonly formattingProvider: FormattingProvider
   readonly referencesProvider: ReferencesProvider
   readonly completionProvider: CompletionProvider
+  readonly runtimeReports: RuntimeReports
 
   private readonly connection: Connection
   private readonly userSettings: UserSettings
@@ -64,6 +66,7 @@ export class Project {
     this.autofixService = new AutofixService(connection, this, undefined, this.index)
     this.codeActionProvider = new CodeActionProvider(this, undefined, this.index)
     this.formattingProvider = new FormattingProvider(connection, shared.documents, this, userSettings, capabilities)
+    this.runtimeReports = new RuntimeReports(root)
 
     this.completionProvider = new CompletionProvider(
       shared.parserService,

--- a/javascript/packages/language-server/src/runtime_reports.ts
+++ b/javascript/packages/language-server/src/runtime_reports.ts
@@ -1,0 +1,588 @@
+import { join } from "node:path"
+import { createHash } from "node:crypto"
+import { readFileSync, statSync, watch, type FSWatcher } from "node:fs"
+
+import { InlayHint, InlayHintKind, MarkupKind, Position, Range } from "vscode-languageserver/node"
+
+const SHORT_LENGTH = 8
+const RECORD_VERSION = 1
+
+const DEFAULT_ROOT = join("tmp", "herb")
+const JOURNAL_DIRECTORY = "journal"
+const EXTENSION = ".jsonl"
+
+const MAX_TOOLTIP_OBSERVATIONS = 12
+const WRAPPING_OBSERVATION = 80
+const MAX_RECENT = 5
+const REFRESH_DEBOUNCE = 200
+const ATTACH_RETRY = 5_000
+
+export function templateDigest(source: string): string {
+  const text = source.startsWith("﻿") ? source.slice(1) : source
+
+  return createHash("sha256").update(Buffer.from(text, "utf8")).digest("hex")
+}
+
+export function shortDigest(digest: string): string {
+  return digest.slice(0, SHORT_LENGTH)
+}
+
+interface FindingRecord {
+  v: number
+  t: string
+  at?: string
+  run?: string
+  request_path?: string
+  node?: string
+  line?: number
+  column?: number
+  end_line?: number
+  end_column?: number
+  code?: string
+  origin?: string
+  kind?: string
+  severity?: string
+  message?: string
+  description?: string
+  value?: string
+  data?: Record<string, unknown>
+  data_trimmed?: boolean
+  dropped?: number
+  digest?: string
+  path?: string
+  first_seen?: string
+}
+
+export interface RuntimeFinding {
+  line: number
+  column: number
+  endLine: number
+  endColumn: number
+  code: string | null
+  origin: string | null
+  kind: string | null
+  value: string
+  message: string
+  peakMessage: string
+  description: string | null
+  count: number
+  values: Record<string, number>
+  range: { min: number; max: number } | null
+  observations: Record<string, unknown>
+  observationsTrimmed: boolean
+  recent: { value: string; at: string | null }[]
+  firstSeen: string | null
+  lastSeen: string | null
+  runs: string[]
+}
+
+export interface RuntimeOverlay {
+  range: Range
+  text: string
+  code: string | null
+  origin: string | null
+  recent: { value: string; at: string | null }[]
+}
+
+interface CallRecord {
+  v: number
+  t: string
+  at?: string
+  run?: string
+  request_path?: string
+  line?: number
+  column?: number
+  via?: string
+  targets?: Record<string, number>
+  parents?: number
+  renders?: number
+  per_parent?: Record<string, number>
+}
+
+export interface RuntimeCall {
+  line: number
+  column: number
+  via: string | null
+  targets: Record<string, number>
+  perParent: Record<number, number>
+  peak: number
+  onlyTarget: string | null
+  parents: number
+  renders: number
+  observed: number
+  paths: Record<string, number>
+}
+
+export interface RuntimeShard {
+  template: string
+  digest: string
+  findings: RuntimeFinding[]
+  calls: RuntimeCall[]
+  dropped: number
+  firstSeen: string | null
+}
+
+interface CacheEntry {
+  key: string
+  shard: RuntimeShard | null
+}
+
+/**
+ * What the renderer saw, for the file the editor has open.
+ *
+ * The editor hashes its buffer, which produces the name of a file the renderer
+ * may or may not have written. That it exists is the whole staleness check. A
+ * buffer edited since the render hashes to a name that is not there, so a
+ * position recorded against text that no longer exists is never shown, and
+ * nothing has to work out how far an edit moved things.
+ *
+ * What comes back is folded across every request that touched the template,
+ * which is the part a single request cannot say. One page load reports three
+ * queries at a tag. The shard reports three to forty seven across two hundred
+ * renders, and that is the difference between a number and an N+1.
+ */
+export class RuntimeReports {
+  private readonly root: string
+  private readonly cache: Map<string, CacheEntry> = new Map()
+
+  private watcher: FSWatcher | null = null
+  private retry: NodeJS.Timeout | null = null
+  private debounce: NodeJS.Timeout | null = null
+
+  constructor(projectRoot: string, storeRoot: string = DEFAULT_ROOT) {
+    this.root = join(projectRoot, storeRoot)
+  }
+
+  inlayHintsFor(relativePath: string | null, source: string, includeValues = false): InlayHint[] {
+    const shard = this.shardFor(relativePath, source)
+
+    if (!shard) return []
+
+    const lines = source.split("\n")
+
+    return shard.findings.filter(finding => includeValues || !this.overlays(finding)).map(finding => this.hint(finding, lines))
+  }
+
+  overlaysFor(relativePath: string | null, source: string): RuntimeOverlay[] {
+    const shard = this.shardFor(relativePath, source)
+
+    if (!shard) return []
+
+    return shard.findings.filter(finding => this.overlays(finding)).map(finding => ({
+      range: Range.create(
+        Position.create(Math.max(finding.line - 1, 0), Math.max(finding.column - 1, 0)),
+        Position.create(Math.max(finding.endLine - 1, 0), Math.max(finding.endColumn - 1, 0)),
+      ),
+      text: finding.value,
+      code: finding.code,
+      origin: finding.origin,
+      recent: finding.recent,
+    }))
+  }
+
+  private overlays(finding: RuntimeFinding): boolean {
+    return finding.kind === "value"
+  }
+
+  shardFor(relativePath: string | null, source: string): RuntimeShard | null {
+    if (!relativePath) return null
+
+    const digest = templateDigest(source)
+
+    return this.read(this.shardPath(relativePath, digest), relativePath, digest)
+  }
+
+  shardPath(relativePath: string, digest: string): string {
+    return join(this.root, JOURNAL_DIRECTORY, `${relativePath}.${shortDigest(digest)}${EXTENSION}`)
+  }
+
+  watch(onChange: () => void): void {
+    if (this.watcher) return
+
+    try {
+      this.watcher = watch(join(this.root, JOURNAL_DIRECTORY), { recursive: true }, () => {
+        this.cache.clear()
+
+        if (this.debounce) clearTimeout(this.debounce)
+
+        this.debounce = setTimeout(onChange, REFRESH_DEBOUNCE)
+      })
+
+      this.watcher.on("error", () => this.reattach(onChange))
+
+      if (this.retry) {
+        clearTimeout(this.retry)
+        this.retry = null
+      }
+    } catch {
+      this.reattach(onChange)
+    }
+  }
+
+  dispose(): void {
+    this.watcher?.close()
+    this.watcher = null
+
+    if (this.retry) clearTimeout(this.retry)
+    if (this.debounce) clearTimeout(this.debounce)
+
+    this.retry = null
+    this.debounce = null
+  }
+
+  private reattach(onChange: () => void): void {
+    this.watcher?.close()
+    this.watcher = null
+
+    if (this.retry) return
+
+    this.retry = setTimeout(() => {
+      this.retry = null
+
+      this.watch(onChange)
+    }, ATTACH_RETRY)
+
+    this.retry.unref?.()
+  }
+
+  private read(path: string, template: string, digest: string): RuntimeShard | null {
+    let key: string
+
+    try {
+      const stats = statSync(path)
+
+      key = `${stats.mtimeMs}:${stats.size}`
+    } catch {
+      this.cache.delete(path)
+
+      return null
+    }
+
+    const cached = this.cache.get(path)
+
+    if (cached && cached.key === key) {
+      return cached.shard
+    }
+
+    const shard = this.parse(path, template, digest)
+
+    this.cache.set(path, { key, shard })
+
+    return shard
+  }
+
+  private parse(path: string, template: string, digest: string): RuntimeShard | null {
+    let contents: string
+
+    try {
+      contents = readFileSync(path, "utf8")
+    } catch {
+      return null
+    }
+
+    const records = this.records(contents)
+    const header = records.find(record => record.t === "template")
+    const findings = records.filter(record => record.t === "finding")
+    const dropped = records.filter(record => record.t === "truncated").reduce((total, record) => total + (record.dropped ?? 0), 0)
+
+    return {
+      template,
+      digest: header?.digest ?? digest,
+      findings: this.fold(findings),
+      calls: this.foldCalls(records.filter(record => record.t === "call") as unknown as CallRecord[]),
+      dropped,
+      firstSeen: header?.first_seen ?? null,
+    }
+  }
+
+  private records(contents: string): FindingRecord[] {
+    const records: FindingRecord[] = []
+
+    for (const line of contents.split("\n")) {
+      if (line.trim() === "") continue
+
+      try {
+        const record = JSON.parse(line)
+
+        if (record && typeof record === "object" && record.v === RECORD_VERSION) {
+          records.push(record as FindingRecord)
+        }
+      } catch {
+        continue
+      }
+    }
+
+    return records
+  }
+
+  callsFor(relativePath: string | null, source: string): RuntimeCall[] {
+    return this.shardFor(relativePath, source)?.calls ?? []
+  }
+
+  private foldCalls(records: CallRecord[]): RuntimeCall[] {
+    const groups = new Map<string, CallRecord[]>()
+
+    for (const record of records) {
+      const key = `${record.line}:${record.column}`
+      const group = groups.get(key)
+
+      if (group) {
+        group.push(record)
+      } else {
+        groups.set(key, [record])
+      }
+    }
+
+    return [...groups.values()].map(group => this.call(group)).sort((a, b) => a.line - b.line || a.column - b.column)
+  }
+
+  private call(group: CallRecord[]): RuntimeCall {
+    const latest = group.reduce((newest, record) => ((record.at ?? "") >= (newest.at ?? "") ? record : newest), group[0])
+    const targets = this.mergeCounts(group.map(record => record.targets))
+    const perParent: Record<number, number> = {}
+
+    for (const [count, parents] of Object.entries(this.mergeCounts(group.map(record => record.per_parent)))) {
+      perParent[Number(count)] = parents
+    }
+
+    const names = Object.keys(targets)
+
+    return {
+      line: latest.line ?? 1,
+      column: latest.column ?? 1,
+      via: latest.via ?? null,
+      targets,
+      perParent,
+      peak: Math.max(0, ...Object.keys(perParent).map(Number)),
+      onlyTarget: names.length === 1 ? names[0] : null,
+      parents: group.reduce((total, record) => total + (record.parents ?? 0), 0),
+      renders: group.reduce((total, record) => total + (record.renders ?? 0), 0),
+      observed: group.length,
+      paths: this.tally(group.map(record => record.request_path)),
+    }
+  }
+
+  private mergeCounts(counts: (Record<string, number> | undefined)[]): Record<string, number> {
+    const merged: Record<string, number> = {}
+
+    for (const tally of counts) {
+      if (!tally) continue
+
+      for (const [key, count] of Object.entries(tally)) {
+        merged[key] = (merged[key] ?? 0) + count
+      }
+    }
+
+    return merged
+  }
+
+  private tally(values: (string | undefined)[]): Record<string, number> {
+    const counted: Record<string, number> = {}
+
+    for (const value of values) {
+      if (value === undefined) {
+        continue
+      }
+
+      counted[value] = (counted[value] ?? 0) + 1
+    }
+
+    return counted
+  }
+
+  private fold(records: FindingRecord[]): RuntimeFinding[] {
+    const groups = new Map<string, FindingRecord[]>()
+
+    for (const record of records) {
+      const key = `${record.line}:${record.column}:${record.code ?? record.message}`
+      const group = groups.get(key)
+
+      if (group) {
+        group.push(record)
+      } else {
+        groups.set(key, [record])
+      }
+    }
+
+    const findings = [...groups.values()].map(group => this.finding(group))
+
+    return findings.sort((a, b) => a.line - b.line || a.column - b.column || (a.code ?? "").localeCompare(b.code ?? ""))
+  }
+
+  private recent(group: FindingRecord[]): { value: string; at: string | null }[] {
+    const ordered = [...group].sort((a, b) => (a.at ?? "").localeCompare(b.at ?? "")).reverse()
+    const history: { value: string; at: string | null }[] = []
+
+    for (const record of ordered) {
+      const observed = record.data?.output
+
+      const values = Array.isArray(observed) && observed.length > 0
+        ? [...observed].reverse().map(entry => String(entry))
+        : [record.value ?? record.message].filter((entry): entry is string => entry !== undefined)
+
+      for (const value of values) {
+        if (history.length >= MAX_RECENT) {
+          return history
+        }
+
+        history.push({ value, at: record.at ?? null })
+      }
+    }
+
+    return history
+  }
+
+  private finding(group: FindingRecord[]): RuntimeFinding {
+    const latest = group.reduce((newest, record) => ((record.at ?? "") >= (newest.at ?? "") ? record : newest), group[0])
+    const peak = group.reduce((worst, record) => (this.leading(record.value) > this.leading(worst.value) ? record : worst), group[0])
+    const values = group.map(record => record.value).filter((value): value is string => value !== undefined)
+    const seen = group.map(record => record.at).filter((at): at is string => at !== undefined).sort()
+
+    const tally: Record<string, number> = {}
+
+    for (const value of values) {
+      tally[value] = (tally[value] ?? 0) + 1
+    }
+
+    return {
+      line: latest.line ?? 1,
+      column: latest.column ?? 1,
+      endLine: latest.end_line ?? latest.line ?? 1,
+      endColumn: latest.end_column ?? latest.column ?? 1,
+      code: latest.code ?? null,
+      origin: latest.origin ?? null,
+      kind: latest.kind ?? null,
+      value: latest.value ?? latest.message ?? "",
+      message: latest.message ?? "",
+      peakMessage: peak.message ?? latest.message ?? "",
+      description: peak.description ?? latest.description ?? null,
+      count: group.length,
+      values: tally,
+      range: this.range(values),
+      observations: peak.data ?? {},
+      observationsTrimmed: peak.data_trimmed === true,
+      recent: this.recent(group),
+      firstSeen: seen[0] ?? null,
+      lastSeen: seen[seen.length - 1] ?? null,
+      runs: [...new Set(group.map(record => record.run).filter((run): run is string => run !== undefined))].slice(-5),
+    }
+  }
+
+  private range(values: string[]): { min: number; max: number } | null {
+    if (values.length === 0) return null
+
+    const numbers: number[] = []
+
+    for (const value of values) {
+      const match = /^\s*(-?\d+(?:\.\d+)?)/.exec(value)
+
+      if (!match) return null
+
+      numbers.push(Number(match[1]))
+    }
+
+    return { min: Math.min(...numbers), max: Math.max(...numbers) }
+  }
+
+  private leading(value: string | undefined): number {
+    const match = /^\s*(-?\d+(?:\.\d+)?)/.exec(value ?? "")
+
+    return match ? Number(match[1]) : Number.NEGATIVE_INFINITY
+  }
+
+  private hint(finding: RuntimeFinding, lines: string[]): InlayHint {
+    const single = finding.endLine === finding.line
+    const line = single ? finding.endLine : finding.line
+    const column = single ? finding.endColumn - 1 : (lines[finding.line - 1]?.length ?? finding.endColumn - 1)
+
+    return {
+      position: Position.create(Math.max(line - 1, 0), Math.max(column, 0)),
+      label: this.label(finding),
+      kind: InlayHintKind.Parameter,
+      paddingLeft: true,
+      tooltip: {
+        kind: MarkupKind.Markdown,
+        value: this.tooltip(finding),
+      },
+    }
+  }
+
+  private label(finding: RuntimeFinding): string {
+    const phrase = finding.range && finding.range.min !== finding.range.max
+      ? finding.peakMessage.replace(/^\s*-?\d+(?:\.\d+)?/, `${finding.range.min} to ${finding.range.max}`)
+      : finding.peakMessage
+
+    return `(${phrase})`
+  }
+
+  private tooltip(finding: RuntimeFinding): string {
+    const lines: string[] = [`**${finding.peakMessage}**`, ""]
+
+    if (finding.description) {
+      lines.push(finding.description, "")
+    }
+
+    const spread = finding.range && finding.range.min !== finding.range.max
+      ? `${finding.range.min} to ${finding.range.max} across ${finding.count} ${finding.count === 1 ? "render" : "renders"}`
+      : `across ${finding.count} ${finding.count === 1 ? "render" : "renders"}`
+
+    lines.push(spread, "")
+
+    for (const [key, observed] of Object.entries(finding.observations)) {
+      if (!Array.isArray(observed) || observed.length === 0) {
+        continue
+      }
+
+      const shown = observed.slice(0, MAX_TOOLTIP_OBSERVATIONS)
+
+      lines.push(`**${key}**`, "")
+      lines.push(key === "queries" ? "```sql" : "```")
+      lines.push(...this.spaced(shown.map(entry => this.observation(entry))))
+      lines.push("```")
+
+      if (finding.observationsTrimmed || observed.length > shown.length) {
+        lines.push("", `showing ${shown.length} of them`)
+      }
+
+      lines.push("")
+    }
+
+    if (new Set(finding.recent.map(entry => entry.value)).size > 1) {
+      lines.push(`**Last ${finding.recent.length} renders**`, "")
+      lines.push(...finding.recent.map(entry => `- ${this.oneLine(entry.value)}`))
+      lines.push("")
+    }
+
+    if (finding.origin) {
+      lines.push(`recorded by ${finding.origin}`)
+    }
+
+    return lines.join("\n")
+  }
+
+  private spaced(entries: string[]): string[] {
+    if (!entries.some(entry => entry.length > WRAPPING_OBSERVATION)) {
+      return entries
+    }
+
+    return entries.flatMap((entry, index) => index === 0 ? [entry] : ["", entry])
+  }
+
+  private observation(entry: unknown): string {
+    if (entry === null || typeof entry !== "object") {
+      return String(entry)
+    }
+
+    return Object.entries(entry as Record<string, unknown>).map(([key, value]) => `${key}: ${value}`).join("  ")
+  }
+
+  private oneLine(value: string): string {
+    const flattened = value.replace(/\s+/g, " ").trim()
+
+    if (flattened === "") {
+      return "_(empty)_"
+    }
+
+    return flattened.length > 80 ? `${flattened.slice(0, 80)}…` : flattened
+  }
+}

--- a/javascript/packages/language-server/src/server.ts
+++ b/javascript/packages/language-server/src/server.ts
@@ -16,6 +16,7 @@ import {
   FoldingRangeParams,
   DocumentHighlightParams,
   SelectionRangeParams,
+  InlayHint,
   InlayHintParams,
   DocumentSymbolParams,
   HoverParams,
@@ -371,12 +372,24 @@ export class Server {
 
       const settings = await this.session.userSettings.getDocumentSettings(params.textDocument.uri)
 
-      if (!settings.inlayHints?.enabled) return []
+      const hints: InlayHint[] = []
 
-      return this.session.inlayHintProvider.getInlayHints(document, {
-        minimumLines: settings.inlayHints.minimumLines,
-        maximumClasses: settings.inlayHints.maximumClasses
-      })
+      if (settings.inlayHints?.enabled) {
+        hints.push(...this.session.inlayHintProvider.getInlayHints(document, {
+          minimumLines: settings.inlayHints.minimumLines,
+          maximumClasses: settings.inlayHints.maximumClasses
+        }))
+      }
+
+      if (settings.runtimeReports?.inlayHints) {
+        hints.push(...this.runtimeHints(params.textDocument.uri, document))
+      }
+
+      return hints
+    })
+
+    this.connection.onRequest("herb/runtimeOverlays", (params: { textDocument: TextDocumentIdentifier }) => {
+      return this.runtimeOverlays(params.textDocument.uri)
     })
 
     this.connection.onRequest('herb/toggleLineComment', (params: { textDocument: TextDocumentIdentifier, range: Range }) => {
@@ -394,6 +407,57 @@ export class Server {
 
       return this.session.commentProvider.toggleBlockComment(document, params.range)
     })
+  }
+
+  private runtimeHints(uri: string, document: { getText: () => string }): InlayHint[] {
+    const project = this.session.projects.get(uri)
+
+    if (!project) return []
+
+    try {
+      this.watchRuntimeReports(uri)
+
+      return project.runtimeReports.inlayHintsFor(
+        project.index.relativePathFor(uri),
+        document.getText(),
+        !this.session.capabilities.supportsRuntimeOverlays,
+      )
+    } catch {
+      return []
+    }
+  }
+
+  private runtimeOverlays(uri: string) {
+    const document = this.session.documents.get(uri)
+    const project = this.session.projects.get(uri)
+
+    if (!document || !project) return []
+
+    try {
+      this.watchRuntimeReports(uri)
+
+      return project.runtimeReports.overlaysFor(project.index.relativePathFor(uri), document.getText())
+    } catch {
+      return []
+    }
+  }
+
+  private watchRuntimeReports(uri: string) {
+    this.session.projects.get(uri)?.runtimeReports.watch(() => {
+      this.refreshInlayHints()
+
+      this.connection.sendNotification("herb/runtimeReportsChanged", { uri })
+    })
+  }
+
+  private async refreshInlayHints(): Promise<void> {
+    if (!this.session.capabilities.supportsInlayHintRefresh) return
+
+    try {
+      await this.connection.languages.inlayHint.refresh()
+    } catch {
+      // the client went away, and there is nothing to refresh for
+    }
   }
 
   private async updatePartialIndex(event: FileEvent): Promise<boolean> {

--- a/javascript/packages/language-server/src/user_settings.ts
+++ b/javascript/packages/language-server/src/user_settings.ts
@@ -79,6 +79,9 @@ export class UserSettings {
         enabled: resolved.inlayHints?.enabled ?? this.defaults.inlayHints!.enabled!,
         minimumLines: resolved.inlayHints?.minimumLines ?? this.defaults.inlayHints!.minimumLines!,
         maximumClasses: resolved.inlayHints?.maximumClasses ?? this.defaults.inlayHints!.maximumClasses!
+      },
+      runtimeReports: {
+        inlayHints: resolved.runtimeReports?.inlayHints ?? this.defaults.runtimeReports!.inlayHints!
       }
     }
   }

--- a/javascript/packages/language-server/test/runtime_reports.test.ts
+++ b/javascript/packages/language-server/test/runtime_reports.test.ts
@@ -1,0 +1,515 @@
+import { afterEach, beforeEach, describe, expect, test } from "vitest"
+
+import { execFileSync } from "node:child_process"
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync, appendFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { dirname, join, resolve } from "node:path"
+
+import { RuntimeReports, templateDigest, shortDigest } from "../src/runtime_reports"
+
+const TEMPLATE = "app/views/posts/_card.html.erb"
+const SOURCE = "<div><%= post.title %></div>"
+const REPOSITORY = resolve(__dirname, "../../../..")
+
+function record(overrides: Record<string, unknown> = {}) {
+  return JSON.stringify({
+    v: 1,
+    t: "finding",
+    at: "2026-08-14T20:11:04.221Z",
+    run: "20260814T201104-abcdef0123",
+    line: 7,
+    column: 8,
+    end_line: 7,
+    end_column: 24,
+    code: "sql-queries",
+    origin: "Herb Engine",
+    kind: "metric",
+    message: "3 SQL queries",
+    value: "3 SQL queries",
+    ...overrides,
+  })
+}
+
+function header(digest: string) {
+  return JSON.stringify({
+    v: 1,
+    t: "template",
+    path: TEMPLATE,
+    digest,
+    first_seen: "2026-08-14T20:11:04.221Z",
+  })
+}
+
+describe("templateDigest", () => {
+  test("is stable for the same text", () => {
+    expect(templateDigest(SOURCE)).toEqual(templateDigest(SOURCE))
+  })
+
+  test("moves when the text moves", () => {
+    expect(templateDigest(SOURCE)).not.toEqual(templateDigest(`${SOURCE} `))
+  })
+
+  test("ignores a byte order mark", () => {
+    expect(templateDigest(SOURCE)).toEqual(templateDigest(`﻿${SOURCE}`))
+  })
+
+  test("keeps line endings apart", () => {
+    expect(templateDigest("<div>\n</div>")).not.toEqual(templateDigest("<div>\r\n</div>"))
+  })
+
+  test("shortens to what fits in a filename", () => {
+    expect(shortDigest(templateDigest(SOURCE))).toHaveLength(8)
+  })
+})
+
+describe("agreeing with the Ruby digest", () => {
+  const cases: Record<string, string> = {
+    plain: "<div></div>",
+    "with a byte order mark": "﻿<div></div>",
+    "with CRLF line endings": "<div>\r\n</div>",
+    "without a trailing newline": "<div>\n  <span></span>\n</div>",
+    "with a trailing newline": "<div>\n  <span></span>\n</div>\n",
+    "with multibyte text": "<div>café ☕ 日本語</div>",
+    empty: "",
+  }
+
+  test.each(Object.entries(cases))("matches Ruby for a template %s", (_name, source) => {
+    const ruby = execFileSync(
+      "ruby",
+      [
+        "-Ilib",
+        "-rherb/fingerprint",
+        "-e",
+        "print Herb::Fingerprint.template(STDIN.binmode.read)",
+      ],
+      { cwd: REPOSITORY, input: Buffer.from(source, "utf8") },
+    ).toString()
+
+    expect(ruby).toEqual(templateDigest(source))
+  })
+})
+
+describe("RuntimeReports", () => {
+  let root: string
+  let reports: RuntimeReports
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), "herb-runtime-"))
+    reports = new RuntimeReports(root)
+  })
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true })
+  })
+
+  function shard(lines: string[], source = SOURCE) {
+    const path = reports.shardPath(TEMPLATE, templateDigest(source))
+
+    mkdirSync(dirname(path), { recursive: true })
+    writeFileSync(path, `${lines.join("\n")}\n`)
+
+    return path
+  }
+
+  test("says nothing about a template nobody rendered", () => {
+    expect(reports.inlayHintsFor(TEMPLATE, SOURCE)).toEqual([])
+    expect(reports.shardFor(TEMPLATE, SOURCE)).toBeNull()
+  })
+
+  test("says nothing about a document it cannot place in the project", () => {
+    expect(reports.inlayHintsFor(null, SOURCE)).toEqual([])
+  })
+
+  test("says nothing once the buffer stops being the text that was rendered", () => {
+    shard([header(templateDigest(SOURCE)), record()])
+
+    expect(reports.inlayHintsFor(TEMPLATE, SOURCE)).toHaveLength(1)
+    expect(reports.inlayHintsFor(TEMPLATE, `${SOURCE}<p>typing</p>`)).toEqual([])
+  })
+
+  test("sits after the tag closes rather than splitting it", () => {
+    shard([header(templateDigest(SOURCE)), record()])
+
+    const [hint] = reports.inlayHintsFor(TEMPLATE, SOURCE)
+
+    expect(hint.position).toEqual({ line: 6, character: 23 })
+    expect(hint.label).toEqual("(3 SQL queries)")
+    expect(hint.paddingLeft).toBe(true)
+  })
+
+  test("annotates the line a multi-line tag opens on, not the `end` many lines below", () => {
+    const block = "<% posts.each do |post| %>\n  <span></span>\n<% end %>\n"
+
+    shard([header(templateDigest(block)), record({ line: 1, column: 1, end_line: 3, end_column: 10 })], block)
+
+    const [hint] = reports.inlayHintsFor(TEMPLATE, block)
+
+    expect(hint.position).toEqual({ line: 0, character: "<% posts.each do |post| %>".length })
+  })
+
+  test("knows the whole span of the tag, not just where it starts", () => {
+    shard([header(templateDigest(SOURCE)), record()])
+
+    const [finding] = reports.shardFor(TEMPLATE, SOURCE)!.findings
+
+    expect([finding.line, finding.column]).toEqual([7, 8])
+    expect([finding.endLine, finding.endColumn]).toEqual([7, 24])
+  })
+
+  test("falls back to the start for a finding recorded without an end", () => {
+    shard([header(templateDigest(SOURCE)), record({ end_line: undefined, end_column: undefined })])
+
+    const [finding] = reports.shardFor(TEMPLATE, SOURCE)!.findings
+
+    expect([finding.endLine, finding.endColumn]).toEqual([7, 8])
+  })
+
+  test("shows the statements behind a count, since the number alone is not actionable", () => {
+    shard([
+      header(templateDigest(SOURCE)),
+      record({ data: { queries: ["SELECT 1 FROM posts", "SELECT 2 FROM posts"] } }),
+    ])
+
+    const [hint] = reports.inlayHintsFor(TEMPLATE, SOURCE)
+    const tooltip = typeof hint.tooltip === "string" ? hint.tooltip : hint.tooltip!.value
+
+    expect(tooltip).toContain("```sql")
+    expect(tooltip).toContain("SELECT 1 FROM posts")
+    expect(tooltip).toContain("SELECT 2 FROM posts")
+    expect(tooltip).toContain("recorded by Herb Engine")
+  })
+
+  test("puts a blank line between statements long enough to wrap into each other", () => {
+    const first = `SELECT "events".* FROM "events" WHERE "events"."id" IN (20, 320, 137, 556, 85) ORDER BY "events"."id"`
+    const second = `SELECT "talks".* FROM "talks" WHERE "talks"."event_id" IN (20, 320, 137, 556, 85) ORDER BY "talks"."id"`
+
+    shard([
+      header(templateDigest(SOURCE)),
+      record({ data: { queries: [first, second] } }),
+    ])
+
+    const [hint] = reports.inlayHintsFor(TEMPLATE, SOURCE)
+    const tooltip = typeof hint.tooltip === "string" ? hint.tooltip : hint.tooltip!.value
+
+    expect(tooltip).toContain(`${first}\n\n${second}`)
+  })
+
+  test("leaves observations that fit on a line packed together", () => {
+    shard([
+      header(templateDigest(SOURCE)),
+      record({
+        code: "render-time",
+        message: "1.6 ms",
+        value: "1.6 ms",
+        data: { render: [{ duration: 1.6, gc: 0.0 }, { duration: 2.4, gc: 0.1 }] },
+      }),
+    ])
+
+    const [hint] = reports.inlayHintsFor(TEMPLATE, SOURCE)
+    const tooltip = typeof hint.tooltip === "string" ? hint.tooltip : hint.tooltip!.value
+
+    expect(tooltip).toContain("duration: 1.6  gc: 0\nduration: 2.4  gc: 0.1")
+  })
+
+  test("spells out an observation that is an object rather than printing its type", () => {
+    shard([
+      header(templateDigest(SOURCE)),
+      record({
+        code: "render-time",
+        message: "1.6 ms",
+        value: "1.6 ms",
+        data: { render: [{ duration: 1.6, gc: 0.0, allocations: 3373 }] },
+      }),
+    ])
+
+    const [hint] = reports.inlayHintsFor(TEMPLATE, SOURCE)
+    const tooltip = typeof hint.tooltip === "string" ? hint.tooltip : hint.tooltip!.value
+
+    expect(tooltip).not.toContain("[object Object]")
+    expect(tooltip).toContain("duration: 1.6")
+    expect(tooltip).toContain("allocations: 3373")
+  })
+
+  test("shows the statements from the worst request, not the most recent one", () => {
+    shard([
+      header(templateDigest(SOURCE)),
+      record({ value: "47 SQL queries", message: "47 SQL queries", data: { queries: ["SELECT worst"] } }),
+      record({ value: "3 SQL queries", message: "3 SQL queries", at: "2026-08-14T23:00:00.000Z", data: { queries: ["SELECT latest"] } }),
+    ])
+
+    const [hint] = reports.inlayHintsFor(TEMPLATE, SOURCE)
+    const tooltip = typeof hint.tooltip === "string" ? hint.tooltip : hint.tooltip!.value
+
+    expect(hint.label).toEqual("(3 to 47 SQL queries)")
+    expect(tooltip).toContain("SELECT worst")
+    expect(tooltip).not.toContain("SELECT latest")
+  })
+
+  test("puts the producer's own sentence in the tooltip, not in the label", () => {
+    shard([
+      header(templateDigest(SOURCE)),
+      record({ description: "This ERB tag ran 3 SQL queries while the page rendered." }),
+    ])
+
+    const [hint] = reports.inlayHintsFor(TEMPLATE, SOURCE)
+    const tooltip = typeof hint.tooltip === "string" ? hint.tooltip : hint.tooltip!.value
+
+    expect(hint.label).toEqual("(3 SQL queries)")
+    expect(tooltip).toContain("This ERB tag ran 3 SQL queries while the page rendered.")
+  })
+
+  test("says nothing extra when the producer wrote no sentence", () => {
+    shard([header(templateDigest(SOURCE)), record()])
+
+    const [hint] = reports.inlayHintsFor(TEMPLATE, SOURCE)
+    const tooltip = typeof hint.tooltip === "string" ? hint.tooltip : hint.tooltip!.value
+
+    expect(tooltip).toContain("**3 SQL queries**")
+    expect(tooltip).not.toContain("undefined")
+  })
+
+  test("says when it kept only the head of what was observed", () => {
+    shard([
+      header(templateDigest(SOURCE)),
+      record({ data: { queries: ["SELECT 1"] }, data_trimmed: true }),
+    ])
+
+    const [hint] = reports.inlayHintsFor(TEMPLATE, SOURCE)
+    const tooltip = typeof hint.tooltip === "string" ? hint.tooltip : hint.tooltip!.value
+
+    expect(tooltip).toContain("showing 1 of them")
+  })
+
+  test("shows a value-bearing finding in place of the tag rather than beside it", () => {
+    shard([
+      header(templateDigest(SOURCE)),
+      record({ kind: "value", code: "rendered-output", message: "Upcoming events", value: "Upcoming events" }),
+    ])
+
+    const [overlay] = reports.overlaysFor(TEMPLATE, SOURCE)
+
+    expect(overlay.text).toEqual("Upcoming events")
+    expect(overlay.range.start).toEqual({ line: 6, character: 7 })
+    expect(overlay.range.end).toEqual({ line: 6, character: 23 })
+    expect(reports.inlayHintsFor(TEMPLATE, SOURCE)).toEqual([])
+  })
+
+  test("falls back to a hint for a client that cannot draw over the tag", () => {
+    shard([
+      header(templateDigest(SOURCE)),
+      record({ kind: "value", code: "rendered-output", message: "Upcoming events", value: "Upcoming events" }),
+    ])
+
+    expect(reports.inlayHintsFor(TEMPLATE, SOURCE)).toEqual([])
+
+    const [hint] = reports.inlayHintsFor(TEMPLATE, SOURCE, true)
+
+    expect(hint.label).toEqual("(Upcoming events)")
+  })
+
+  test("keeps the last few things the tag produced, newest first", () => {
+    shard([
+      header(templateDigest(SOURCE)),
+      record({ kind: "value", value: "gamma", data: { output: ["alpha", "beta", "gamma"] } }),
+      record({ kind: "value", value: "epsilon", at: "2026-08-15T09:00:00.000Z", data: { output: ["delta", "epsilon"] } }),
+    ])
+
+    const [overlay] = reports.overlaysFor(TEMPLATE, SOURCE)
+
+    expect(overlay.recent.map(entry => entry.value)).toEqual(["epsilon", "delta", "gamma", "beta", "alpha"])
+    expect(overlay.text).toEqual("epsilon")
+  })
+
+  test("falls back to the recorded value when the tag observed nothing itself", () => {
+    shard([
+      header(templateDigest(SOURCE)),
+      record({ kind: "value", value: "first" }),
+      record({ kind: "value", value: "second", at: "2026-08-15T09:00:00.000Z" }),
+    ])
+
+    expect(reports.overlaysFor(TEMPLATE, SOURCE)[0].recent.map(entry => entry.value)).toEqual(["second", "first"])
+  })
+
+  test("takes the later record when two share a timestamp, since a shard is appended to", () => {
+    shard([
+      header(templateDigest(SOURCE)),
+      record({ kind: "value", value: "older" }),
+      record({ kind: "value", value: "newer" }),
+    ])
+
+    expect(reports.overlaysFor(TEMPLATE, SOURCE)[0].text).toEqual("newer")
+  })
+
+  test("shows the history in the hint tooltip for a client that cannot draw over the tag", () => {
+    shard([
+      header(templateDigest(SOURCE)),
+      record({ kind: "value", value: "gamma", data: { output: ["alpha", "beta", "gamma"] } }),
+    ])
+
+    const [hint] = reports.inlayHintsFor(TEMPLATE, SOURCE, true)
+    const tooltip = typeof hint.tooltip === "string" ? hint.tooltip : hint.tooltip!.value
+
+    expect(tooltip).toContain("Last 3 renders")
+    expect(tooltip).toContain("- gamma")
+    expect(tooltip).toContain("- alpha")
+  })
+
+  test("says nothing about a history of a tag that rendered the same thing every time", () => {
+    shard([header(templateDigest(SOURCE)), record(), record({ at: "2026-08-15T09:00:00.000Z" })])
+
+    const [hint] = reports.inlayHintsFor(TEMPLATE, SOURCE)
+    const tooltip = typeof hint.tooltip === "string" ? hint.tooltip : hint.tooltip!.value
+
+    expect(tooltip).not.toContain("Last")
+  })
+
+  test("counts a render tag against the parent render it happened in", () => {
+    shard([
+      header(templateDigest(SOURCE)),
+      JSON.stringify({
+        v: 1, t: "call", at: "2026-08-14T20:11:04.221Z", run: "r1", request_path: "/posts",
+        line: 3, column: 5, via: "partial",
+        targets: { "app/views/posts/_card.html.erb": 3 },
+        parents: 1, renders: 3, per_parent: { "3": 1 },
+      }),
+    ])
+
+    const [call] = reports.callsFor(TEMPLATE, SOURCE)
+
+    expect(call.perParent).toEqual({ 3: 1 })
+    expect(call.peak).toEqual(3)
+    expect(call.onlyTarget).toEqual("app/views/posts/_card.html.erb")
+    expect(call.observed).toEqual(1)
+    expect(call.paths).toEqual({ "/posts": 1 })
+  })
+
+  test("merges the histogram across requests instead of summing it away", () => {
+    const record = (per: Record<string, number>, renders: number) => JSON.stringify({
+      v: 1, t: "call", at: "2026-08-14T20:11:04.221Z", line: 3, column: 5,
+      targets: { "app/views/posts/_card.html.erb": renders },
+      parents: 1, renders, per_parent: per,
+    })
+
+    shard([header(templateDigest(SOURCE)), record({ "3": 1 }, 3), record({ "1": 1 }, 1)])
+
+    const [call] = reports.callsFor(TEMPLATE, SOURCE)
+
+    expect(call.perParent).toEqual({ 3: 1, 1: 1 })
+    expect(call.peak).toEqual(3)
+    expect(call.renders).toEqual(4)
+    expect(call.observed).toEqual(2)
+  })
+
+  test("names no single target once a tag resolved to more than one thing", () => {
+    shard([
+      header(templateDigest(SOURCE)),
+      JSON.stringify({
+        v: 1, t: "call", at: "2026-08-14T20:11:04.221Z", line: 3, column: 5,
+        targets: { "a.html.erb": 2, "b.html.erb": 1 }, parents: 1, renders: 3, per_parent: { "3": 1 },
+      }),
+    ])
+
+    expect(reports.callsFor(TEMPLATE, SOURCE)[0].onlyTarget).toBeNull()
+  })
+
+  test("says nothing about calls once the buffer stops being the text that was rendered", () => {
+    shard([
+      header(templateDigest(SOURCE)),
+      JSON.stringify({ v: 1, t: "call", at: "2026-08-14T20:11:04.221Z", line: 3, column: 5, per_parent: { "1": 1 } }),
+    ])
+
+    expect(reports.callsFor(TEMPLATE, `${SOURCE}<p>typing</p>`)).toEqual([])
+  })
+
+  test("leaves a measurement as a hint beside the tag", () => {
+    shard([header(templateDigest(SOURCE)), record()])
+
+    expect(reports.overlaysFor(TEMPLATE, SOURCE)).toEqual([])
+    expect(reports.inlayHintsFor(TEMPLATE, SOURCE)).toHaveLength(1)
+  })
+
+  test("stops overlaying once the buffer stops being the text that was rendered", () => {
+    shard([header(templateDigest(SOURCE)), record({ kind: "value", value: "Upcoming events" })])
+
+    expect(reports.overlaysFor(TEMPLATE, `${SOURCE}<p>typing</p>`)).toEqual([])
+  })
+
+  test("overlays the most recent value, since that is what the tag renders now", () => {
+    shard([
+      header(templateDigest(SOURCE)),
+      record({ kind: "value", value: "Old title", message: "Old title" }),
+      record({ kind: "value", value: "New title", message: "New title", at: "2026-08-15T09:00:00.000Z" }),
+    ])
+
+    expect(reports.overlaysFor(TEMPLATE, SOURCE)[0].text).toEqual("New title")
+  })
+
+  test("folds every occurrence of one finding into one", () => {
+    shard([header(templateDigest(SOURCE)), record(), record(), record()])
+
+    const found = reports.shardFor(TEMPLATE, SOURCE)!.findings
+
+    expect(found).toHaveLength(1)
+    expect(found[0].count).toEqual(3)
+  })
+
+  test("reports the spread across requests, which no single request could", () => {
+    shard([
+      header(templateDigest(SOURCE)),
+      record({ value: "3 SQL queries", message: "3 SQL queries" }),
+      record({ value: "47 SQL queries", message: "47 SQL queries", at: "2026-08-14T20:12:04.221Z" }),
+      record({ value: "3 SQL queries", message: "3 SQL queries" }),
+    ])
+
+    const [finding] = reports.shardFor(TEMPLATE, SOURCE)!.findings
+
+    expect(finding.range).toEqual({ min: 3, max: 47 })
+    expect(reports.inlayHintsFor(TEMPLATE, SOURCE)[0].label).toEqual("(3 to 47 SQL queries)")
+  })
+
+  test("leaves the spread alone when what was measured is not a number", () => {
+    shard([header(templateDigest(SOURCE)), record({ value: "slow" }), record({ value: "slower" })])
+
+    expect(reports.shardFor(TEMPLATE, SOURCE)!.findings[0].range).toBeNull()
+  })
+
+  test("keeps findings at different places apart, in the order they are read in", () => {
+    shard([
+      header(templateDigest(SOURCE)),
+      record({ line: 9 }),
+      record({ line: 7 }),
+    ])
+
+    expect(reports.shardFor(TEMPLATE, SOURCE)!.findings.map(finding => finding.line)).toEqual([7, 9])
+  })
+
+  test("carries what was dropped, so a spread is not read as the truth when it is a floor", () => {
+    shard([header(templateDigest(SOURCE)), JSON.stringify({ v: 1, t: "truncated", dropped: 40 }), record()])
+
+    expect(reports.shardFor(TEMPLATE, SOURCE)!.dropped).toEqual(40)
+  })
+
+  test("skips a record written by a version it does not know", () => {
+    shard([header(templateDigest(SOURCE)), record(), JSON.stringify({ v: 99, t: "finding", line: 1, column: 1 })])
+
+    expect(reports.shardFor(TEMPLATE, SOURCE)!.findings).toHaveLength(1)
+  })
+
+  test("loses a torn write and nothing behind it", () => {
+    const path = shard([header(templateDigest(SOURCE)), record()])
+
+    appendFileSync(path, '{"v":1,"t":"finding","li')
+
+    expect(reports.shardFor(TEMPLATE, SOURCE)!.findings).toHaveLength(1)
+  })
+
+  test("re-reads a shard once the renderer appends to it", () => {
+    const path = shard([header(templateDigest(SOURCE)), record()])
+
+    expect(reports.shardFor(TEMPLATE, SOURCE)!.findings[0].count).toEqual(1)
+
+    appendFileSync(path, `${record({ at: "2026-08-14T20:13:04.221Z" })}\n`)
+
+    expect(reports.shardFor(TEMPLATE, SOURCE)!.findings[0].count).toEqual(2)
+  })
+})

--- a/javascript/packages/language-server/test/user_settings.test.ts
+++ b/javascript/packages/language-server/test/user_settings.test.ts
@@ -87,7 +87,8 @@ describe("UserSettings", () => {
           indentStyle: "space",
           maxLineLength: 80
         },
-        inlayHints: { enabled: true, minimumLines: 10, maximumClasses: 2 }
+        inlayHints: { enabled: true, minimumLines: 10, maximumClasses: 2 },
+        runtimeReports: { inlayHints: true }
       })
 
       expect(mockConnection.workspace.getConfiguration).toHaveBeenCalledWith({
@@ -110,7 +111,8 @@ describe("UserSettings", () => {
           indentStyle: "space",
           maxLineLength: 80
         },
-        inlayHints: { enabled: true, minimumLines: 10, maximumClasses: 2 }
+        inlayHints: { enabled: true, minimumLines: 10, maximumClasses: 2 },
+        runtimeReports: { inlayHints: true }
       })
     })
 
@@ -145,6 +147,27 @@ describe("UserSettings", () => {
       const result = await settingsFor(withConfiguration).getDocumentSettings("file:///test.erb")
 
       expect(result.inlayHints).toEqual({ enabled: true, minimumLines: 5, maximumClasses: 2 })
+    })
+
+    test("stops offering the runtime hints once the user turns them off", async () => {
+      mockConnection.workspace.getConfiguration = vi.fn().mockResolvedValue({
+        runtimeReports: { inlayHints: false }
+      })
+
+      const result = await settingsFor(withConfiguration).getDocumentSettings("file:///test.erb")
+
+      expect(result.runtimeReports?.inlayHints).toBe(false)
+      expect(result.inlayHints?.enabled).toBe(true)
+    })
+
+    test("leaves the runtime hints on for a user who only turned the closing tag hints off", async () => {
+      mockConnection.workspace.getConfiguration = vi.fn().mockResolvedValue({
+        inlayHints: { enabled: false }
+      })
+
+      const result = await settingsFor(withConfiguration).getDocumentSettings("file:///test.erb")
+
+      expect(result.runtimeReports?.inlayHints).toBe(true)
     })
 
     test("keeps fixOnSave when the user turns it off", async () => {


### PR DESCRIPTION
This pull request reads what an application recorded while it rendered, and shows it against the tag it happened at.

An editor has a file open and wants to know what happened in it. A journal is keyed by a path and the text at that path, so the server hashes the buffer, builds that path and opens it. A file edited since hashes to a name that is not there, so a position recorded against text that no longer exists is never shown, and nothing has to work out how far an edit moved things.

Measurements arrive as inlay hints instead of diagnostics, because a count is not a fault. Whether three queries at a tag is a problem depends on what the tag is for, and publishing it as a diagnostic both makes that call on the reader's behalf and fills the problems panel with things nobody asked to fix. They are not behind the `inlayHints` setting either, which is about closing-tag hints. Turning those off should not silence what the application reported.

A tag that recorded what it rendered is different, and wants drawing over the tag instead of beside it. LSP can add text next to a range but has nothing that replaces or hides one, so `herb/runtimeOverlays` says what to draw and where, and a client with an editor API does the drawing.

```ts
const overlays = await client.sendRequest("herb/runtimeOverlays", {
  textDocument: { uri: document.uri.toString() },
})
```

A client that cannot say it does this gets those findings as inlay hints instead, so the feature degrades to something every LSP client can show instead of to nothing. Clients declare it through `initializationOptions.experimental.runtimeOverlays`, the same channel `extractToPartialCommand` already uses.

Render tags are read back as well, folded per call site. Which partials a tag resolved to, and how many children it rendered inside each single parent render. That last one is a histogram and not a total, because a total cannot tell one parent rendering fifteen children from fifteen parents rendering one each, and only the first is a loop. Everything carries how many times it was seen, so anything built on this can say what it observed instead of claiming a tag always does something.

The journal is watched, so loading a page updates the editor instead of waiting for the file to be closed and opened again.

<img width="1394" height="338" alt="CleanShot 2026-09-05 at 11 09 26@2x" src="https://github.com/user-attachments/assets/3f782984-3036-4c3e-81de-202957ee4e88" />

<img width="2052" height="542" alt="CleanShot 2026-09-05 at 11 09 42@2x" src="https://github.com/user-attachments/assets/cbb9ccf3-ccf4-43f1-b0ca-999da2c1b32d" />

<img width="2008" height="642" alt="CleanShot 2026-09-05 at 11 09 51@2x" src="https://github.com/user-attachments/assets/a294336c-5400-4b1c-bd39-1d03b26b1f74" />
