### PR TITLE
VS Code: Draw what an ERB tag rendered over the tag

### DIFF
--- a/javascript/packages/vscode/README.md
+++ b/javascript/packages/vscode/README.md
@@ -153,9 +153,11 @@ If a `.herb.yml` exists in the project root, its configuration always takes prec
 | `languageServerHerb.inlayHints.enabled`        | `true`    | Annotate closing tags with what they close                        |
 | `languageServerHerb.inlayHints.minimumLines`   | `10`      | How far below its opening tag a closing tag must be to get a hint |
 | `languageServerHerb.inlayHints.maximumClasses` | `2`       | How many of an element's classes to include in its hint           |
+| `languageServerHerb.runtimeReports.inlayHints` | `true`    | Annotate tags with what the application recorded at runtime       |
+| `languageServerHerb.runtimeOverlays.display`   | `replace` | How to show what an ERB tag rendered                              |
 | `languageServerHerb.trace.server`              | `verbose` | Trace the communication with the language server (for debugging)  |
 
-`languageServerHerb.trace.server` is the exception: it is editor-only and is never read from `.herb.yml`.
+`languageServerHerb.trace.server` and the `inlayHints`, `runtimeReports` and `runtimeOverlays` settings are the exceptions. They are editor-only and are never read from `.herb.yml`.
 
 
 ## Commands

--- a/javascript/packages/vscode/package.json
+++ b/javascript/packages/vscode/package.json
@@ -145,6 +145,28 @@
           "default": true,
           "description": "Suggest adding a file's project folder to the workspace when an HTML+ERB file outside the current workspace folders is opened. Herb only analyzes files inside workspace folders.",
           "markdownDescription": "Suggest adding a file's project folder to the workspace when an HTML+ERB file outside the current workspace folders is opened. Herb only analyzes files inside workspace folders."
+        },
+        "languageServerHerb.runtimeReports.inlayHints": {
+          "scope": "resource",
+          "type": "boolean",
+          "default": true,
+          "description": "Annotate ERB tags with what the application recorded against them while it rendered, like how many queries a render call ran. Nothing appears until the application writes a journal, and a tag stops being annotated once you edit the template.",
+          "markdownDescription": "Annotate ERB tags with what the application recorded against them while it rendered, like `(2 SQL queries)` beside a `render` call. Nothing appears until the application writes a journal, and a tag stops being annotated once you edit the template, since what was recorded no longer describes what is written there."
+        },
+        "languageServerHerb.runtimeOverlays.display": {
+          "type": "string",
+          "enum": [
+            "replace",
+            "report",
+            "off"
+          ],
+          "enumDescriptions": [
+            "Show what the tag rendered in place of the tag. The tag is revealed on whichever line the cursor is on, so it stays editable.",
+            "Leave the tag as written and underline it, with what it rendered in the hover.",
+            "Show nothing."
+          ],
+          "default": "replace",
+          "description": "How to show what an ERB tag rendered, for tags the application asked Herb to capture."
         }
       }
     },
@@ -229,6 +251,11 @@
         "command": "herb.setMaxLineLength",
         "title": "Herb: Set Max Line Length",
         "icon": "$(symbol-numeric)"
+      },
+      {
+        "command": "herb.changeRuntimeOverlayDisplay",
+        "title": "Change Runtime Value Display",
+        "category": "Herb"
       }
     ],
     "keybindings": [

--- a/javascript/packages/vscode/src/client.ts
+++ b/javascript/packages/vscode/src/client.ts
@@ -5,6 +5,7 @@ import { LanguageClient, LanguageClientOptions, ServerOptions, TransportKind, Wo
 import { Config, defaultPersonalSettings } from "@herb-tools/config"
 
 const inlayHintDefaults = defaultPersonalSettings.inlayHints!
+const runtimeReportDefaults = defaultPersonalSettings.runtimeReports!
 
 export class Client {
   private client!: LanguageClient
@@ -67,6 +68,10 @@ export class Client {
     return await this.client.sendNotification(method, params)
   }
 
+  onNotification(method: string, handler: (params: any) => void) {
+    return this.client.onNotification(method, handler)
+  }
+
   async sendRequest<T>(method: string, params: any): Promise<T> {
     return await this.client.sendRequest(method, params)
   }
@@ -103,6 +108,9 @@ export class Client {
             minimumLines: vscodeConfig.get('inlayHints.minimumLines', inlayHintDefaults.minimumLines),
             maximumClasses: vscodeConfig.get('inlayHints.maximumClasses', inlayHintDefaults.maximumClasses),
           },
+          runtimeReports: {
+            inlayHints: vscodeConfig.get('runtimeReports.inlayHints', runtimeReportDefaults.inlayHints),
+          },
           trace: {
             server: vscodeConfig.get('trace.server', 'verbose'),
           },
@@ -125,6 +133,9 @@ export class Client {
             minimumLines: vscodeConfig.get('inlayHints.minimumLines', inlayHintDefaults.minimumLines),
             maximumClasses: vscodeConfig.get('inlayHints.maximumClasses', inlayHintDefaults.maximumClasses),
           },
+          runtimeReports: {
+            inlayHints: vscodeConfig.get('runtimeReports.inlayHints', runtimeReportDefaults.inlayHints),
+          },
           trace: {
             server: vscodeConfig.get('trace.server', 'verbose'),
           },
@@ -135,6 +146,7 @@ export class Client {
         linter: { enabled: true },
         formatter: { enabled: false, indentWidth: 2, indentStyle: 'space', maxLineLength: 80 },
         inlayHints: { ...inlayHintDefaults },
+        runtimeReports: { ...runtimeReportDefaults },
         trace: { server: 'verbose' },
       }
     }
@@ -190,6 +202,7 @@ export class Client {
   private get experimentalCapabilities() {
     return {
       extractToPartialCommand: true,
+      runtimeOverlays: true,
     }
   }
 
@@ -218,6 +231,9 @@ export class Client {
             minimumLines: vscodeConfig.get('inlayHints.minimumLines', inlayHintDefaults.minimumLines),
             maximumClasses: vscodeConfig.get('inlayHints.maximumClasses', inlayHintDefaults.maximumClasses),
           },
+          runtimeReports: {
+            inlayHints: vscodeConfig.get('runtimeReports.inlayHints', runtimeReportDefaults.inlayHints),
+          },
           trace: {
             server: vscodeConfig.get('trace.server', 'verbose'), // Trace is always from VS Code
           },
@@ -241,6 +257,9 @@ export class Client {
             minimumLines: vscodeConfig.get('inlayHints.minimumLines', inlayHintDefaults.minimumLines),
             maximumClasses: vscodeConfig.get('inlayHints.maximumClasses', inlayHintDefaults.maximumClasses),
           },
+          runtimeReports: {
+            inlayHints: vscodeConfig.get('runtimeReports.inlayHints', runtimeReportDefaults.inlayHints),
+          },
           trace: {
             server: vscodeConfig.get('trace.server', 'verbose'),
           },
@@ -252,6 +271,7 @@ export class Client {
         linter: { enabled: true },
         formatter: { enabled: false, indentWidth: 2, indentStyle: 'space', maxLineLength: 80 },
         inlayHints: { ...inlayHintDefaults },
+        runtimeReports: { ...runtimeReportDefaults },
         trace: { server: 'verbose' },
         experimental: this.experimentalCapabilities,
       }

--- a/javascript/packages/vscode/src/extension.ts
+++ b/javascript/packages/vscode/src/extension.ts
@@ -7,6 +7,7 @@ import { Config } from "@herb-tools/config"
 import { registerWorkspaceSuggestion } from "./workspace-suggestion"
 
 import { Client } from "./client"
+import { RuntimeOverlayProvider } from "./runtime-overlay-provider"
 import { HerbAnalysisProvider } from "./herb-analysis-provider"
 import { HerbCodeActionProvider } from "./code-action-provider"
 import { HerbConfigProvider } from "./config-provider"
@@ -130,6 +131,34 @@ export async function activate(context: vscode.ExtensionContext) {
   )
 
   await client.start()
+
+  const runtimeOverlayProvider = new RuntimeOverlayProvider(client)
+
+  context.subscriptions.push(
+    ...runtimeOverlayProvider.register(),
+    vscode.commands.registerCommand('herb.changeRuntimeOverlayDisplay', async () => {
+      const current = runtimeOverlayProvider.display()
+
+      const picked = await vscode.window.showQuickPick(
+        [
+          { label: 'Replace the tag', description: 'Show what it rendered in place of the tag', value: 'replace' as const },
+          { label: 'Report the tag', description: 'Underline it and show what it rendered on hover', value: 'report' as const },
+          { label: 'Off', description: 'Show nothing', value: 'off' as const },
+        ].map(item => (item.value === current ? { ...item, label: `$(check) ${item.label}` } : item)),
+        { placeHolder: 'How should Herb show what an ERB tag rendered?' }
+      )
+
+      if (!picked) return
+
+      await vscode.workspace
+        .getConfiguration('languageServerHerb')
+        .update('runtimeOverlays.display', picked.value, vscode.ConfigurationTarget.Workspace)
+
+      runtimeOverlayProvider.refreshAll()
+    })
+  )
+
+  runtimeOverlayProvider.refreshAll()
 
   informationProvider = new HerbInformationProvider(context)
   supportProvider = new HerbSupportProvider()

--- a/javascript/packages/vscode/src/runtime-overlay-provider.ts
+++ b/javascript/packages/vscode/src/runtime-overlay-provider.ts
@@ -1,0 +1,205 @@
+import { window,  workspace } from "vscode"
+import { DecorationOptions, DecorationRangeBehavior, Disposable, MarkdownString, Range, TextEditor, TextEditorDecorationType, ThemeColor } from "vscode"
+import type { Client } from "./client"
+
+interface RuntimeOverlay {
+  range: { start: { line: number; character: number }; end: { line: number; character: number } }
+  text: string
+  code: string | null
+  origin: string | null
+  recent: { value: string; at: string | null }[]
+}
+
+export type RuntimeOverlayDisplay = "replace" | "report" | "off"
+
+const SETTING = "languageServerHerb.runtimeOverlays.display"
+const DEBOUNCE = 150
+const MAX_LENGTH = 120
+
+export const DISPLAY_MODES: RuntimeOverlayDisplay[] = ["replace", "report", "off"]
+
+/**
+ * Shows a tag as the thing it rendered instead of the expression that rendered it,
+ * so a template reads "Upcoming events" where it says `<%= t(".title") %>`.
+ *
+ * This cannot be done from the language server. LSP can add text beside a range
+ * (an inlay hint) but has nothing that replaces or hides one, so the server says
+ * what to draw and the editor's decoration API is what draws it. Hiding the
+ * source is a CSS trick on a decoration, which is an editor concept and not a
+ * protocol one.
+ *
+ * Which of those two things is wanted depends on what the file is being opened
+ * for, so it is a setting rather than a decision made here. Reading a template
+ * is easier when it shows what it produced; editing one is impossible when the
+ * code is hidden. `replace` swaps the tag for its value, `report` leaves the tag
+ * alone and marks it as having one.
+ *
+ * Under `replace` the overlay is dropped on whichever lines the selection
+ * touches, because text you cannot see is text you cannot edit. Moving the caret
+ * onto a tag reveals it and moving away hides it again.
+ */
+export class RuntimeOverlayProvider {
+  private readonly client: Client
+
+  private readonly replaced = window.createTextEditorDecorationType({
+    textDecoration: "none; display: none;",
+    rangeBehavior: DecorationRangeBehavior.ClosedClosed,
+  })
+
+  private readonly reported = window.createTextEditorDecorationType({
+    textDecoration: "underline dashed 1px",
+    rangeBehavior: DecorationRangeBehavior.ClosedClosed,
+  })
+
+  private timer: NodeJS.Timeout | undefined
+
+  constructor(client: Client) {
+    this.client = client
+  }
+
+  register(): Disposable[] {
+    return [
+      this.replaced,
+      this.reported,
+      window.onDidChangeVisibleTextEditors(() => this.refreshAll()),
+      window.onDidChangeTextEditorSelection(event => this.refresh(event.textEditor)),
+      workspace.onDidChangeTextDocument(event => {
+        for (const editor of window.visibleTextEditors) {
+          if (editor.document === event.document) this.schedule(editor)
+        }
+      }),
+      workspace.onDidChangeConfiguration(event => {
+        if (event.affectsConfiguration(SETTING)) this.refreshAll()
+      }),
+      this.client.onNotification("herb/runtimeReportsChanged", () => this.refreshAll()),
+    ]
+  }
+
+  refreshAll() {
+    for (const editor of window.visibleTextEditors) {
+      this.refresh(editor)
+    }
+  }
+
+  display(): RuntimeOverlayDisplay {
+    return workspace.getConfiguration().get<RuntimeOverlayDisplay>(SETTING, "replace")
+  }
+
+  private schedule(editor: TextEditor) {
+    if (this.timer) clearTimeout(this.timer)
+
+    this.timer = setTimeout(() => this.refresh(editor), DEBOUNCE)
+  }
+
+  private async refresh(editor: TextEditor) {
+    const display = this.display()
+
+    if (display === "off" || !this.erb(editor)) {
+      this.clear(editor)
+
+      return
+    }
+
+    let overlays: RuntimeOverlay[]
+
+    try {
+      overlays = await this.client.sendRequest<RuntimeOverlay[]>("herb/runtimeOverlays", {
+        textDocument: { uri: editor.document.uri.toString() },
+      })
+    } catch {
+      return
+    }
+
+    if (!window.visibleTextEditors.includes(editor)) return
+
+    const decorations = overlays.flatMap(overlay => this.decoration(editor, overlay, display))
+
+    editor.setDecorations(this.of(display), decorations)
+    editor.setDecorations(this.of(display === "replace" ? "report" : "replace"), [])
+  }
+
+  private clear(editor: TextEditor) {
+    editor.setDecorations(this.replaced, [])
+    editor.setDecorations(this.reported, [])
+  }
+
+  private of(display: RuntimeOverlayDisplay): TextEditorDecorationType {
+    return display === "replace" ? this.replaced : this.reported
+  }
+
+  private erb(editor: TextEditor): boolean {
+    return editor.document.languageId === "erb" || editor.document.fileName.endsWith(".erb")
+  }
+
+  private decoration(editor: TextEditor, overlay: RuntimeOverlay, display: RuntimeOverlayDisplay): DecorationOptions[] {
+    const range = new Range(
+      overlay.range.start.line,
+      overlay.range.start.character,
+      overlay.range.end.line,
+      overlay.range.end.character,
+    )
+
+    if (display === "replace" && editor.selections.some(selection => this.sharesLine(selection, range))) {
+      return []
+    }
+
+    const option: DecorationOptions = {
+      range,
+      hoverMessage: this.hover(editor, overlay, range, display),
+    }
+
+    if (display === "replace") {
+      option.renderOptions = {
+        after: {
+          contentText: this.text(overlay.text),
+          color: new ThemeColor("editorCodeLens.foreground"),
+          backgroundColor: new ThemeColor("editor.inlayHint.background"),
+          margin: "0 0.15em",
+          fontStyle: "normal",
+        },
+      }
+    }
+
+    return [option]
+  }
+
+  private hover(editor: TextEditor, overlay: RuntimeOverlay, range: Range, display: RuntimeOverlayDisplay): MarkdownString {
+    const hover = new MarkdownString()
+
+    hover.appendMarkdown("**Source**\n")
+    hover.appendCodeblock(editor.document.getText(range), "erb")
+
+    if (new Set(overlay.recent.map(entry => entry.value)).size > 1) {
+      hover.appendMarkdown(`\n**Last ${overlay.recent.length} renders**\n`)
+      hover.appendMarkdown(overlay.recent.map(entry => `- ${this.text(entry.value)}`).join("\n"))
+      hover.appendMarkdown("\n")
+    } else {
+      hover.appendMarkdown("\n**Rendered**\n")
+      hover.appendCodeblock(overlay.text, "text")
+    }
+
+    hover.appendMarkdown(`\nFrom the last time this page was built${overlay.origin ? `, recorded by ${overlay.origin}` : ""}.`)
+
+    hover.appendMarkdown(
+      display === "replace"
+        ? "\n\nClick the line to edit the tag, or run *Herb: Change Runtime Value Display* to stop replacing it."
+        : "\n\nRun *Herb: Change Runtime Value Display* to show this value in place of the tag.",
+    )
+
+    return hover
+  }
+
+  private sharesLine(selection: { start: { line: number }; end: { line: number } }, range: Range): boolean {
+    return selection.start.line <= range.end.line && selection.end.line >= range.start.line
+  }
+
+  private text(value: string): string {
+    const flattened = value.replace(/\s+/g, " ").trim()
+
+    if (flattened === "") {
+      return "″"
+    }
+
+    return flattened.length > MAX_LENGTH ? `${flattened.slice(0, MAX_LENGTH)}…` : flattened
+  }
+}


### PR DESCRIPTION
This pull request draws what an ERB tag produced in place of the tag, so a template reads "Upcoming events" where it says `<%= t(".title") %>`.

The language server can say what a tag rendered, but it cannot show it in place of the tag. LSP can add text beside a range and has nothing that replaces or hides one, so this reads `herb/runtimeOverlays` and draws the result with editor decorations, which are an editor concept and not a protocol one.

Which of those is wanted depends on what the file is open for, so it is a setting instead of a decision made here. Reading a template is easier when it shows what it produced. Editing one is impossible when the code is hidden. `languageServerHerb.runtimeOverlays.display` has three options:

* `replace` Show what the tag rendered in place of the tag
* `report` Leave the tag as written, underline it, and show the value on hover
* `off` Show nothing 

Under `replace` the overlay is dropped on whichever lines the selection touches, because text you cannot see is text you cannot edit. Moving the caret onto a tag reveals it and moving away hides it again. The hover shows the source and the value either way, and a tag that rendered several different things lists the last few instead of pretending the newest one is what it does.

The client declares `runtimeOverlays` so the server knows to leave those findings out of the inlay hints. Without that they would be reported twice here, and not at all in editors that cannot draw them.


### Demo

Original Source File:

<img width="2142" height="540" alt="CleanShot 2026-09-05 at 11 11 18@2x" src="https://github.com/user-attachments/assets/c531b652-0e77-48c1-8499-ef48b207b499" />


After first render (without having the key defined in en.yml):

<img width="2142" height="540" alt="CleanShot 2026-09-05 at 11 11 27@2x" src="https://github.com/user-attachments/assets/1ae3c65d-397d-42e4-b316-c04ebfa91ac6" />

After defining the key in `en.yml`:

<img width="2142" height="540" alt="CleanShot 2026-09-05 at 11 12 19@2x" src="https://github.com/user-attachments/assets/83001cb2-0162-4fc1-8963-c7b2fad9b170" />

When you put the cursor on the line it toggles:

https://github.com/user-attachments/assets/594d8232-93e1-447a-9164-336c0491504d


Using the `report` option:

<img width="1354" height="582" alt="CleanShot 2026-09-05 at 11 15 29@2x" src="https://github.com/user-attachments/assets/c07d1579-c48d-4ddf-89a8-962a2f3d3a8c" />

