### PR TITLE
Dev Tools: Choose which metrics the runtime panel shows

### DIFF
--- a/javascript/packages/dev-tools/demo/demo.ts
+++ b/javascript/packages/dev-tools/demo/demo.ts
@@ -69,6 +69,32 @@ on("report-spaced", () => {
   })
 })
 
+on("report-metrics", () => {
+  const templates = ["app/views/posts/index.html.erb", "app/views/posts/_post.html.erb", "app/components/post_actions_component.html.erb"]
+
+  const renders = templates.flatMap((template, index) => [3, 7, 11, 18].map((line, position) => ({
+    template,
+    message: `This tag rendered once, taking ${(0.4 + index + position).toFixed(1)} ms and allocating ${(1200 * (position + 1)).toLocaleString("en-US")} objects.`,
+    code: "render-time",
+    kind: "metric" as const,
+    origin: "Herb Engine",
+    value: `${(0.4 + index + position).toFixed(1)} ms`,
+    location: { start: { line, column: 3 } },
+  })))
+
+  const queries = [4, 9].map(line => ({
+    template: "app/views/posts/index.html.erb",
+    message: "This ERB tag ran 5 SQL queries while the page rendered.",
+    code: "sql-queries",
+    kind: "metric" as const,
+    origin: "Herb Engine",
+    value: "5 SQL queries",
+    location: { start: { line, column: 5 } },
+  }))
+
+  lastHandle = devTools.report([...renders, ...queries])
+})
+
 on("report-blocking", () => {
   lastHandle = devTools.report({
     template: "app/views/posts/_post.html.erb",

--- a/javascript/packages/dev-tools/demo/index.html
+++ b/javascript/packages/dev-tools/demo/index.html
@@ -199,6 +199,7 @@
           <button id="report-spaced">report() with a trailing space in origin</button>
           <button id="report-blocking" title="Covers the page with no way out. Reload to leave it.">report() a blocking overlay</button>
           <button id="report-dismissible">report() a dismissible overlay</button>
+          <button id="report-metrics" title="What a page reports when every tag is measured. Enough of one kind to be worth putting away.">report() a page full of metrics</button>
           <button id="report-located" title="Every entry carries an element. Two are on the page and one is inside a hidden article.">report() pointing at DOM elements</button>
           <button id="dismiss-last">dismiss() the last handle</button>
           <button id="clear-origin">clear("Acme Scanner")</button>
@@ -451,6 +452,7 @@
           {
             "template": "app/views/posts/_post.html.erb",
             "node": "3",
+            "code": "sql-queries",
             "message": "This partial issued 3 SQL queries while rendering.",
             "kind": "metric",
             "origin": "Herb Engine Runtime",
@@ -469,6 +471,7 @@
           {
             "template": "app/components/post_actions_component.html.erb",
             "node": "4",
+            "code": "render-count",
             "message": "This component rendered twice on this page.",
             "kind": "metric",
             "origin": "Herb Engine Runtime",

--- a/javascript/packages/dev-tools/src/runtime/panel.css
+++ b/javascript/packages/dev-tools/src/runtime/panel.css
@@ -308,6 +308,30 @@
   color: var(--herb-dev-tools-ink);
 }
 
+.herb-dev-tools-action-icon {
+  gap: 4px;
+  padding: 0 7px;
+  color: var(--herb-dev-tools-ink-faint);
+  flex: none;
+  overflow: visible;
+}
+
+.herb-dev-tools-action-icon:hover {
+  color: var(--herb-dev-tools-ink);
+}
+
+.herb-dev-tools-muted-count {
+  font-size: 10px;
+  font-variant-numeric: tabular-nums;
+  line-height: 1;
+}
+
+.herb-dev-tools-metrics-toggle.herb-dev-tools-metrics-toggle-open {
+  border-color: var(--herb-dev-tools-ink-faint);
+  background: #f4f4f5;
+  color: var(--herb-dev-tools-ink);
+}
+
 .herb-dev-tools-window-controls {
   display: flex;
   align-items: center;
@@ -389,6 +413,38 @@
 .herb-dev-tools-filters-severity {
   border-top: 1px solid var(--herb-dev-tools-line);
   border-bottom: 1px solid var(--herb-dev-tools-line);
+}
+
+.herb-dev-tools-mutes {
+  border-bottom: 1px solid var(--herb-dev-tools-line);
+}
+
+.herb-dev-tools-mute {
+  border: 1px solid var(--herb-dev-tools-ink);
+  border-radius: 999px;
+  background: var(--herb-dev-tools-ink);
+  color: #ffffff;
+  font-size: 11px;
+  font-weight: 500;
+  padding: 3px 9px;
+  cursor: pointer;
+}
+
+.herb-dev-tools-mute:hover {
+  opacity: 0.85;
+}
+
+.herb-dev-tools-mute.herb-dev-tools-mute-off {
+  border-color: var(--herb-dev-tools-border);
+  background: var(--herb-dev-tools-surface);
+  color: var(--herb-dev-tools-ink-faint);
+  text-decoration: line-through;
+}
+
+.herb-dev-tools-mute.herb-dev-tools-mute-off:hover {
+  border-color: var(--herb-dev-tools-ink-faint);
+  color: var(--herb-dev-tools-ink-soft);
+  opacity: 1;
 }
 
 .herb-dev-tools-filter {

--- a/javascript/packages/dev-tools/src/runtime/panel.ts
+++ b/javascript/packages/dev-tools/src/runtime/panel.ts
@@ -15,11 +15,13 @@ export type BadgeTone = RuntimeSeverity | 'metric'
 
 const ALL_ORIGINS = '*'
 const ALL_SEVERITIES = '*'
+const ALL_METRICS = '*'
 const MIN_PANEL_WIDTH = 440
 const MIN_PANEL_HEIGHT = 180
 const VIEWPORT_MARGIN = 24
 const RESIZE_EDGES = ['left', 'bottom', 'corner'] as const
 const STATE_KEY = 'herb-dev-tools-runtime-panel'
+const MUTED_KEY = 'herb-dev-tools-muted-metrics'
 const ROOT_CLASS = 'herb-dev-tools-runtime-root'
 const LINKABLE_SCHEMES = ['http:', 'https:', 'file:']
 const MARKDOWN_CONTEXT_LINES = 3
@@ -70,6 +72,7 @@ interface PanelState {
   expanded: boolean
   origin: string
   severity: string
+  choosing: boolean
   width: number | null
   height: number | null
 }
@@ -78,6 +81,14 @@ type ResizeEdge = typeof RESIZE_EDGES[number]
 
 function clamp(value: number, low: number, high: number): number {
   return Math.min(Math.max(value, low), Math.max(low, high))
+}
+
+function metricKey(diagnostic: NormalizedDiagnostic): string | null {
+  return diagnostic.kind === 'metric' ? diagnostic.code : null
+}
+
+function asMuted(value: unknown): string[] {
+  return Array.isArray(value) ? value.filter((entry): entry is string => typeof entry === 'string') : []
 }
 
 function asSize(value: unknown): number | null {
@@ -124,6 +135,37 @@ const COPY_ICON = [
   ` fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">`,
   `<rect x="5.5" y="5.5" width="8" height="9" rx="1.5"/>`,
   `<path d="M10.5 5.5v-2a1.5 1.5 0 0 0-1.5-1.5H4a1.5 1.5 0 0 0-1.5 1.5v7A1.5 1.5 0 0 0 4 12h1.5"/>`,
+  `</svg>`,
+].join('')
+
+const SLIDERS_ICON = [
+  `<svg class="herb-dev-tools-icon" viewBox="0 0 16 16" width="12" height="12" aria-hidden="true"`,
+  ` fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">`,
+  `<path d="M2.5 5h11"/><path d="M2.5 11h11"/>`,
+  `<circle cx="6" cy="5" r="1.8" fill="currentColor" stroke="none"/>`,
+  `<circle cx="10.5" cy="11" r="1.8" fill="currentColor" stroke="none"/>`,
+  `</svg>`,
+].join('')
+
+const TRASH_ICON = [
+  `<svg class="herb-dev-tools-icon" viewBox="0 0 16 16" width="12" height="12" aria-hidden="true"`,
+  ` fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">`,
+  `<path d="M2.8 4.3h10.4"/><path d="M6.2 4.3V2.9h3.6v1.4"/>`,
+  `<path d="M4.4 4.3 5 13.1h6l.6-8.8"/>`,
+  `</svg>`,
+].join('')
+
+const FOLD_ICON = [
+  `<svg class="herb-dev-tools-icon" viewBox="0 0 16 16" width="12" height="12" aria-hidden="true"`,
+  ` fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round">`,
+  `<path d="M4 2 8 5.2 12 2"/><path d="M2.5 8h11"/><path d="M4 14 8 10.8 12 14"/>`,
+  `</svg>`,
+].join('')
+
+const UNFOLD_ICON = [
+  `<svg class="herb-dev-tools-icon" viewBox="0 0 16 16" width="12" height="12" aria-hidden="true"`,
+  ` fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round">`,
+  `<path d="M4 5.2 8 2 12 5.2"/><path d="M2.5 8h11"/><path d="M4 10.8 8 14 12 10.8"/>`,
   `</svg>`,
 ].join('')
 
@@ -341,7 +383,8 @@ export class RuntimePanel {
   private onOpenFile: ((file: string, line: number, column: number) => void) | null = null
   private onRender: (() => void) | null = null
   private onOpen: (() => void) | null = null
-  private state: PanelState = { dismissed: false, open: false, expanded: false, origin: ALL_ORIGINS, severity: ALL_SEVERITIES, width: null, height: null }
+  private mutes: string[] = []
+  private state: PanelState = { dismissed: false, open: false, expanded: false, origin: ALL_ORIGINS, severity: ALL_SEVERITIES, choosing: false, width: null, height: null }
   private root: HTMLElement | null = null
   private highlighting: RuntimeHighlighting | null = null
   private hydrating = false
@@ -452,15 +495,37 @@ export class RuntimePanel {
   }
 
   public get diagnosticCount(): number {
-    return this.entries
+    return this.shown
       .filter(entry => entry.diagnostic.kind === 'diagnostic')
       .reduce((total, entry) => total + entry.count, 0)
   }
 
   public get metricCount(): number {
-    return this.entries
+    return this.shown
       .filter(entry => entry.diagnostic.kind === 'metric')
       .reduce((total, entry) => total + entry.count, 0)
+  }
+
+  private get shown(): PanelEntry[] {
+    if (this.mutes.length === 0) {
+      return this.entries
+    }
+
+    return this.entries.filter(entry => !this.muted(entry.diagnostic))
+  }
+
+  private muted(diagnostic: NormalizedDiagnostic): boolean {
+    if (diagnostic.kind !== 'metric') {
+      return false
+    }
+
+    if (this.mutes.includes(ALL_METRICS)) {
+      return true
+    }
+
+    const key = metricKey(diagnostic)
+
+    return key !== null && this.mutes.includes(key)
   }
 
   public get badgeCount(): number {
@@ -468,11 +533,11 @@ export class RuntimePanel {
   }
 
   public get badgeSeverity(): RuntimeSeverity | null {
-    return severityOf(this.entries)
+    return severityOf(this.shown)
   }
 
   private get headerTone(): BadgeTone {
-    const scope = this.overlayFocused ? this.visibleEntries() : this.entries
+    const scope = this.overlayFocused ? this.visibleEntries() : this.shown
 
     return severityOf(scope) ?? 'metric'
   }
@@ -727,8 +792,8 @@ export class RuntimePanel {
     const description = collapsed ? 'Show the diagnostics for every file' : 'Hide the diagnostics for every file'
 
     return [
-      `<button type="button" class="herb-dev-tools-collapse-all" data-herb-dev-tools-action="collapse-all"`,
-      `${tip(description, label)}>${label}</button>`,
+      `<button type="button" class="herb-dev-tools-collapse-all herb-dev-tools-action-icon" data-herb-dev-tools-action="collapse-all"`,
+      `${tip(description, label)}>${collapsed ? UNFOLD_ICON : FOLD_ICON}</button>`,
     ].join('')
   }
 
@@ -780,6 +845,7 @@ export class RuntimePanel {
 
   private init() {
     this.loadState()
+    this.loadMutes()
     this.loadPayload()
 
     this.render()
@@ -861,17 +927,34 @@ export class RuntimePanel {
         expanded: parsed?.expanded === true,
         origin: typeof parsed?.origin === 'string' ? parsed.origin : ALL_ORIGINS,
         severity: typeof parsed?.severity === 'string' ? parsed.severity : ALL_SEVERITIES,
+        choosing: parsed?.choosing === true,
         width: asSize(parsed?.width),
         height: asSize(parsed?.height),
       }
     } catch (_error) {
-      this.state = { dismissed: false, open: false, expanded: false, origin: ALL_ORIGINS, severity: ALL_SEVERITIES, width: null, height: null }
+      this.state = { dismissed: false, open: false, expanded: false, origin: ALL_ORIGINS, severity: ALL_SEVERITIES, choosing: false, width: null, height: null }
     }
   }
 
   private saveState() {
     try {
       sessionStorage.setItem(STATE_KEY, JSON.stringify(this.state))
+    } catch (_error) {
+      return
+    }
+  }
+
+  private loadMutes() {
+    try {
+      this.mutes = asMuted(JSON.parse(localStorage.getItem(MUTED_KEY) ?? '[]'))
+    } catch (_error) {
+      this.mutes = []
+    }
+  }
+
+  private saveMutes() {
+    try {
+      localStorage.setItem(MUTED_KEY, JSON.stringify(this.mutes))
     } catch (_error) {
       return
     }
@@ -976,7 +1059,7 @@ export class RuntimePanel {
   }
 
   private matching(origin: string, severity: string): PanelEntry[] {
-    return this.entries.filter(entry => {
+    return this.shown.filter(entry => {
       const sameOrigin = origin === ALL_ORIGINS || entry.diagnostic.origin === origin
 
       return sameOrigin && matchesSeverity(entry.diagnostic, severity)
@@ -1509,9 +1592,9 @@ export class RuntimePanel {
     const description = `Clear all ${entries} and empty the panel`
 
     return [
-      `<button type="button" class="herb-dev-tools-clear" data-herb-dev-tools-action="clear"`,
+      `<button type="button" class="herb-dev-tools-clear herb-dev-tools-action-icon" data-herb-dev-tools-action="clear"`,
       tip(`${description}. Reload the page to read its report again`, description),
-      `>Clear</button>`,
+      `>${TRASH_ICON}</button>`,
     ].join('')
   }
 
@@ -1524,7 +1607,7 @@ export class RuntimePanel {
       return ''
     }
 
-    return `${this.originFiltersHTML()}${this.severityFiltersHTML()}`
+    return `${this.originFiltersHTML()}${this.severityFiltersHTML()}${this.metricMutesHTML()}`
   }
 
   private countOf(entries: PanelEntry[]): number {
@@ -1562,7 +1645,7 @@ export class RuntimePanel {
       buttons.push(this.filterButtonHTML('origin', origin, origin, count, this.state.origin === origin))
     }
 
-    const actions = `${this.collapseAllButtonHTML()}${this.clearButtonHTML()}`
+    const actions = `${this.metricsToggleHTML()}${this.collapseAllButtonHTML()}${this.clearButtonHTML()}`
     const trailing = actions === '' ? '' : `<div class="herb-dev-tools-filters-actions">${actions}</div>`
 
     return `<div class="herb-dev-tools-filters">${buttons.join('')}${trailing}</div>`
@@ -1590,6 +1673,103 @@ export class RuntimePanel {
     }
 
     return `<div class="herb-dev-tools-filters herb-dev-tools-filters-severity">${buttons.join('')}</div>`
+  }
+
+  private metricMutesHTML(): string {
+    const reported = this.entries.filter(entry => entry.diagnostic.kind === 'metric')
+
+    if (reported.length === 0 || !this.state.choosing) {
+      return ''
+    }
+
+    const metrics = new Map<string, number>()
+
+    for (const entry of reported) {
+      const key = metricKey(entry.diagnostic)
+
+      if (key === null) {
+        continue
+      }
+
+      metrics.set(key, (metrics.get(key) ?? 0) + entry.count)
+    }
+
+    const off = this.mutes.includes(ALL_METRICS)
+    const total = this.countOf(reported)
+    const buttons = [this.muteButtonHTML(ALL_METRICS, 'All metrics', total, off)]
+
+    if (!off) {
+      for (const [key, count] of metrics) {
+        buttons.push(this.muteButtonHTML(key, key, count, this.mutes.includes(key)))
+      }
+    }
+
+    return `<div class="herb-dev-tools-filters herb-dev-tools-mutes">${buttons.join('')}</div>`
+  }
+
+  private metricsToggleHTML(): string {
+    if (!this.entries.some(entry => entry.diagnostic.kind === 'metric')) {
+      return ''
+    }
+
+    const off = this.mutedCount
+    const label = off === 0 ? 'Choose which metrics are shown' : `Choose which metrics are shown, ${off} off`
+    const description = this.state.choosing ? 'Stop choosing which metrics are shown' : label
+    const counted = off === 0 ? '' : `<span class="herb-dev-tools-muted-count">${off}</span>`
+
+    return [
+      `<button type="button" class="herb-dev-tools-collapse-all herb-dev-tools-action-icon herb-dev-tools-metrics-toggle${this.state.choosing ? ' herb-dev-tools-metrics-toggle-open' : ''}"`,
+      ` data-herb-dev-tools-action="choose-metrics"`,
+      `${tip(description, label)} aria-expanded="${this.state.choosing}">${SLIDERS_ICON}${counted}</button>`,
+    ].join('')
+  }
+
+  private get mutedCount(): number {
+    if (this.mutes.includes(ALL_METRICS)) {
+      const keys = new Set<string>()
+
+      for (const entry of this.entries) {
+        const key = metricKey(entry.diagnostic)
+
+        if (key !== null) {
+          keys.add(key)
+        }
+      }
+
+      return Math.max(keys.size, 1)
+    }
+
+    return this.mutes.length
+  }
+
+  private toggleChoosing() {
+    this.state.choosing = !this.state.choosing
+
+    this.saveState()
+    this.render()
+  }
+
+  private muteButtonHTML(key: string, label: string, count: number, muted: boolean): string {
+    const description = muted ? `Show ${label.toLowerCase()} again` : `Stop showing ${label.toLowerCase()} here`
+
+    return [
+      `<button type="button" class="herb-dev-tools-mute${muted ? ' herb-dev-tools-mute-off' : ''}"`,
+      ` data-herb-dev-tools-action="mute" data-herb-dev-tools-metric="${escapeHTML(key)}"`,
+      `${tip(description)} aria-pressed="${!muted}">${escapeHTML(label)} (${count})</button>`,
+    ].join('')
+  }
+
+  private toggleMute(key: string | null) {
+    if (key === null) {
+      return
+    }
+
+    this.mutes = this.mutes.includes(key)
+      ? this.mutes.filter(muted => muted !== key)
+      : [...this.mutes, key]
+
+    this.saveMutes()
+    this.render()
   }
 
   private get heroEntry(): PanelEntry | null {
@@ -2282,6 +2462,10 @@ export class RuntimePanel {
 
           this.saveState()
           this.render()
+        } else if (action === 'choose-metrics') {
+          this.toggleChoosing()
+        } else if (action === 'mute') {
+          this.toggleMute(element.getAttribute('data-herb-dev-tools-metric'))
         } else if (action === 'open') {
           this.openFrom(element)
         } else if (action === 'locate') {

--- a/javascript/packages/dev-tools/test/runtime-panel.test.ts
+++ b/javascript/packages/dev-tools/test/runtime-panel.test.ts
@@ -158,6 +158,7 @@ function diagnostic(overrides: Partial<RuntimeDiagnostic> = {}): RuntimeDiagnost
 beforeEach(() => {
   resetRuntimeReportWarnings()
   sessionStorage.clear()
+  localStorage.clear()
 
   document.body.innerHTML = ""
   panels = []
@@ -170,6 +171,7 @@ afterEach(() => {
 
   document.body.innerHTML = ""
   sessionStorage.clear()
+  localStorage.clear()
 })
 
 describe("clear control", () => {
@@ -212,18 +214,28 @@ describe("clear control", () => {
     const groups = () => document.querySelectorAll(".herb-dev-tools-group").length
 
     expect(groups()).toBeGreaterThan(1)
-    expect(toggle().textContent).toBe("Collapse all")
+    expect(toggle().getAttribute("aria-label")).toBe("Collapse all")
     expect(collapsed()).toBe(0)
 
     toggle().click()
 
     expect(collapsed()).toBe(groups())
-    expect(toggle().textContent).toBe("Expand all")
+    expect(toggle().getAttribute("aria-label")).toBe("Expand all")
 
     toggle().click()
 
     expect(collapsed()).toBe(0)
-    expect(toggle().textContent).toBe("Collapse all")
+    expect(toggle().getAttribute("aria-label")).toBe("Collapse all")
+  })
+
+  test("can show the tooltip that says what it does", () => {
+    embed(PAYLOAD)
+    createPanel().open()
+
+    const button = clearButton()!
+
+    expect(button.getAttribute("data-herb-dev-tools-tip")).toContain("Clear all")
+    expect(getComputedStyle(button).overflow).not.toBe("hidden")
   })
 
   test("empties everything while the All filter is active", () => {
@@ -234,7 +246,7 @@ describe("clear control", () => {
     panel.open()
 
     expect(cards()).toHaveLength(3)
-    expect(clearButton()!.textContent).toBe("Clear")
+    expect(clearButton()!.getAttribute("aria-label")).toBe("Clear all 3 entries and empty the panel")
 
     clearButton()!.click()
 
@@ -250,7 +262,7 @@ describe("clear control", () => {
     panel.open()
     chip("Herb Linter").click()
 
-    expect(clearButton()!.textContent).toBe("Clear")
+    expect(clearButton()!.getAttribute("aria-label")).toBe("Clear all 3 entries and empty the panel")
 
     clearButton()!.click()
 
@@ -3937,5 +3949,255 @@ describe("what a blocking screen calls itself", () => {
     ])
 
     expect(title()).toBe("Herb Parser")
+  })
+})
+
+describe("muting metrics", () => {
+  const METRICS = {
+    version: 1,
+    diagnostics: [
+      {
+        template: "app/views/posts/index.html.erb",
+        message: "This tag rendered once, taking 1.4 ms.",
+        code: "render-time",
+        kind: "metric",
+        origin: "Herb Engine",
+        value: "1.4 ms",
+        location: { start: { line: 2, column: 1 } },
+      },
+      {
+        template: "app/views/posts/index.html.erb",
+        message: "This ERB tag ran 3 SQL queries while the page rendered.",
+        code: "sql-queries",
+        kind: "metric",
+        origin: "Herb Engine",
+        value: "3 SQL queries",
+        location: { start: { line: 5, column: 1 } },
+      },
+      {
+        template: "app/views/posts/_actions.html.erb",
+        message: "Image is missing an alt attribute.",
+        code: "html-img-require-alt",
+        severity: "warning",
+        origin: "Herb Linter",
+        location: { start: { line: 3, column: 3 } },
+      },
+    ],
+  }
+
+  function mute(key: string) {
+    return document.querySelector(`.herb-dev-tools-mute[data-herb-dev-tools-metric="${key}"]`) as HTMLButtonElement | null
+  }
+
+  function chooser() {
+    return document.querySelector(".herb-dev-tools-metrics-toggle") as HTMLButtonElement | null
+  }
+
+  function choosing() {
+    chooser()!.click()
+  }
+
+  function messages() {
+    return cards().map(card => card.textContent ?? "")
+  }
+
+  test("keeps the chips out of the way until they are asked for", () => {
+    embed(METRICS)
+    createPanel().open()
+
+    expect(document.querySelector(".herb-dev-tools-mutes")).toBeNull()
+    expect(chooser()!.textContent).toBe("")
+    expect(chooser()!.getAttribute("aria-expanded")).toBe("false")
+
+    choosing()
+
+    expect(document.querySelector(".herb-dev-tools-mutes")).not.toBeNull()
+    expect(chooser()!.getAttribute("aria-expanded")).toBe("true")
+
+    choosing()
+
+    expect(document.querySelector(".herb-dev-tools-mutes")).toBeNull()
+  })
+
+  test("says how many are off once the chips are closed again", () => {
+    embed(METRICS)
+    createPanel().open()
+
+    choosing()
+    mute("render-time")!.click()
+    choosing()
+
+    expect(document.querySelector(".herb-dev-tools-mutes")).toBeNull()
+    expect(chooser()!.textContent).toBe("1")
+  })
+
+  test("counts every metric as off while the switch for all of them is on", () => {
+    embed(METRICS)
+    createPanel().open()
+
+    choosing()
+    mute("*")!.click()
+
+    expect(chooser()!.textContent).toBe("2")
+  })
+
+  test("names every metric it was told about, and the switch for all of them", () => {
+    embed(METRICS)
+    createPanel().open()
+
+    choosing()
+
+    const chips = Array.from(document.querySelectorAll(".herb-dev-tools-mutes .herb-dev-tools-mute"))
+
+    expect(chips.map(chip => chip.textContent)).toEqual(["All metrics (2)", "render-time (1)", "sql-queries (1)"])
+  })
+
+  test("takes a muted metric out of the panel and leaves the rest", () => {
+    embed(METRICS)
+    createPanel().open()
+
+    choosing()
+    mute("render-time")!.click()
+
+    expect(messages().some(message => message.includes("1.4 ms"))).toBe(false)
+    expect(messages().some(message => message.includes("3 SQL queries"))).toBe(true)
+    expect(messages().some(message => message.includes("alt attribute"))).toBe(true)
+  })
+
+  test("stops counting what it stopped showing", () => {
+    embed(METRICS)
+
+    const panel = createPanel()
+
+    panel.open()
+
+    expect(panel.metricCount).toBe(2)
+
+    choosing()
+    mute("sql-queries")!.click()
+
+    expect(panel.metricCount).toBe(1)
+    expect(panel.diagnosticCount).toBe(1)
+  })
+
+  test("brings a metric back when its chip is pressed again", () => {
+    embed(METRICS)
+    createPanel().open()
+
+    choosing()
+    mute("render-time")!.click()
+
+    expect(mute("render-time")!.getAttribute("aria-pressed")).toBe("false")
+
+    mute("render-time")!.click()
+
+    expect(mute("render-time")!.getAttribute("aria-pressed")).toBe("true")
+    expect(messages().some(message => message.includes("1.4 ms"))).toBe(true)
+  })
+
+  test("leaves only the way back once every metric is off", () => {
+    embed(METRICS)
+
+    const panel = createPanel()
+
+    panel.open()
+
+    choosing()
+    mute("*")!.click()
+
+    expect(panel.metricCount).toBe(0)
+    expect(messages().some(message => message.includes("alt attribute"))).toBe(true)
+    expect(document.querySelectorAll(".herb-dev-tools-mutes .herb-dev-tools-mute")).toHaveLength(1)
+
+    mute("*")!.click()
+
+    expect(panel.metricCount).toBe(2)
+  })
+
+  test("keeps what was muted somewhere the session does not reach", () => {
+    embed(METRICS)
+    createPanel().open()
+
+    choosing()
+    mute("render-time")!.click()
+
+    expect(JSON.parse(localStorage.getItem("herb-dev-tools-muted-metrics")!)).toEqual(["render-time"])
+    expect(JSON.parse(sessionStorage.getItem("herb-dev-tools-runtime-panel")!).muted).toBeUndefined()
+  })
+
+  test("is still muted for a panel that never saw the click", () => {
+    embed(METRICS)
+    createPanel().open()
+
+    choosing()
+    mute("render-time")!.click()
+
+    panels.forEach(panel => panel.destroy())
+    document.body.innerHTML = ""
+    sessionStorage.clear()
+
+    embed(METRICS)
+
+    const reopened = createPanel()
+
+    reopened.open()
+
+    expect(reopened.metricCount).toBe(1)
+    expect(chooser()!.textContent).toBe("1")
+  })
+
+  test("says nothing is muted when the browser refuses to remember", () => {
+    const getItem = vi.spyOn(Storage.prototype, "getItem").mockImplementation(() => {
+      throw new Error("denied")
+    })
+
+    embed(METRICS)
+
+    const panel = createPanel()
+
+    panel.open()
+
+    expect(panel.metricCount).toBe(2)
+
+    getItem.mockRestore()
+  })
+
+  test("counts a metric its producer left uncoded without offering a chip for it", () => {
+    embed({
+      version: 1,
+      diagnostics: [
+        ...METRICS.diagnostics,
+        {
+          template: "app/views/posts/index.html.erb",
+          message: "This component rendered twice on this page.",
+          kind: "metric",
+          origin: "Herb Engine",
+          value: "2 renders",
+          location: { start: { line: 9, column: 1 } },
+        },
+      ],
+    })
+
+    const panel = createPanel()
+
+    panel.open()
+
+    choosing()
+
+    const chips = Array.from(document.querySelectorAll(".herb-dev-tools-mutes .herb-dev-tools-mute"))
+
+    expect(chips.map(chip => chip.textContent)).toEqual(["All metrics (3)", "render-time (1)", "sql-queries (1)"])
+
+    mute("*")!.click()
+
+    expect(panel.metricCount).toBe(0)
+  })
+
+  test("says nothing about muting when nothing reported a metric", () => {
+    embed(fixPayload(null, null))
+    createPanel().open()
+
+    expect(chooser()).toBeNull()
+    expect(document.querySelector(".herb-dev-tools-mutes")).toBeNull()
   })
 })


### PR DESCRIPTION
This pull request adds muting to the runtime panel, so a metric that reports on every render can be put away by the code its producer registered it under, with one switch for all of them.

<img width="575" height="284" alt="CleanShot 2026-09-05 at 13 55 27@2x" src="https://github.com/user-attachments/assets/f8feac89-1d89-4468-ada4-891ab9bdf24c" />
