### PR TITLE
Dev Tools: Point the render stack at what it rendered

### DIFF
--- a/javascript/packages/dev-tools/demo/index.html
+++ b/javascript/packages/dev-tools/demo/index.html
@@ -214,6 +214,7 @@
 
       <article
         class="post"
+        data-herb-source="app/views/posts/_post.html.erb:1:1"
         data-herb-debug-outline-type="partial"
         data-herb-debug-file-name="_post.html.erb"
         data-herb-debug-file-relative-path="app/views/posts/_post.html.erb"
@@ -267,6 +268,7 @@
 
       <article
         class="post"
+        data-herb-source="app/views/posts/_post.html.erb:1:1"
         data-herb-debug-outline-type="partial"
         data-herb-debug-file-name="_post.html.erb"
         data-herb-debug-file-relative-path="app/views/posts/_post.html.erb"
@@ -318,7 +320,7 @@
         <p>Rendered by app/views/posts/_post.html.erb, occurrence two.</p>
       </article>
 
-      <article class="post">
+      <article class="post" data-herb-source="app/views/posts/index.html.erb:12:3">
         <h2>Reading a render stack</h2>
         <div class="cover three" id="cover-three"></div>
         <p>Rendered inline by app/views/posts/index.html.erb.</p>

--- a/javascript/packages/dev-tools/src/runtime/panel.css
+++ b/javascript/packages/dev-tools/src/runtime/panel.css
@@ -308,6 +308,30 @@
   color: var(--herb-dev-tools-ink);
 }
 
+.herb-dev-tools-highlight {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  margin-left: 6px;
+  padding: 1px 5px;
+  border: 1px solid var(--herb-dev-tools-border);
+  border-radius: 999px;
+  background: var(--herb-dev-tools-surface);
+  color: var(--herb-dev-tools-ink-faint);
+  font-size: 10px;
+  line-height: 1;
+  cursor: pointer;
+}
+
+.herb-dev-tools-highlight:hover {
+  border-color: var(--herb-dev-tools-ink-faint);
+  color: var(--herb-dev-tools-ink);
+}
+
+.herb-dev-tools-highlight-count {
+  font-variant-numeric: tabular-nums;
+}
+
 .herb-dev-tools-action-icon {
   gap: 4px;
   padding: 0 7px;

--- a/javascript/packages/dev-tools/src/runtime/panel.ts
+++ b/javascript/packages/dev-tools/src/runtime/panel.ts
@@ -20,6 +20,7 @@ const MIN_PANEL_WIDTH = 440
 const MIN_PANEL_HEIGHT = 180
 const VIEWPORT_MARGIN = 24
 const RESIZE_EDGES = ['left', 'bottom', 'corner'] as const
+const SOURCE_ATTRIBUTE = 'data-herb-source'
 const STATE_KEY = 'herb-dev-tools-runtime-panel'
 const MUTED_KEY = 'herb-dev-tools-muted-metrics'
 const ROOT_CLASS = 'herb-dev-tools-runtime-root'
@@ -135,6 +136,13 @@ const COPY_ICON = [
   ` fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">`,
   `<rect x="5.5" y="5.5" width="8" height="9" rx="1.5"/>`,
   `<path d="M10.5 5.5v-2a1.5 1.5 0 0 0-1.5-1.5H4a1.5 1.5 0 0 0-1.5 1.5v7A1.5 1.5 0 0 0 4 12h1.5"/>`,
+  `</svg>`,
+].join('')
+
+const TARGET_ICON = [
+  `<svg class="herb-dev-tools-icon" viewBox="0 0 16 16" width="11" height="11" aria-hidden="true"`,
+  ` fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">`,
+  `<circle cx="8" cy="8" r="4.2"/><path d="M8 1.2v2"/><path d="M8 12.8v2"/><path d="M1.2 8h2"/><path d="M12.8 8h2"/>`,
   `</svg>`,
 ].join('')
 
@@ -1174,16 +1182,17 @@ export class RuntimePanel {
     return 1
   }
 
-  private pathHTML(label: string, file: string, line: number, column: number, className: string): string {
+  private pathHTML(label: string, file: string, line: number, column: number, className: string, source: string | null = null): string {
     const text = escapeHTML(label)
+    const stamped = source === null ? '' : ` data-herb-dev-tools-source="${escapeHTML(source)}"`
 
     if (this.onOpenFile === null) {
-      return `<span class="${className}">${text}</span>`
+      return `<span class="${className}"${stamped}>${text}</span>`
     }
 
     return [
       `<button type="button" class="${className} herb-dev-tools-path" data-herb-dev-tools-action="open"`,
-      ` data-herb-dev-tools-file="${escapeHTML(file)}" data-herb-dev-tools-line="${line}" data-herb-dev-tools-column="${column}"`,
+      ` data-herb-dev-tools-file="${escapeHTML(file)}" data-herb-dev-tools-line="${line}" data-herb-dev-tools-column="${column}"${stamped}`,
       ` title="Open ${text} in editor">${text}</button>`,
     ].join('')
   }
@@ -2332,7 +2341,7 @@ export class RuntimePanel {
       return ''
     }
 
-    const items = frames.map((frame) => {
+    const items = frames.map((frame, index) => {
       const via = frame.via === null
         ? ''
         : [
@@ -2341,7 +2350,10 @@ export class RuntimePanel {
           `</span>`,
         ].join('')
 
-      return `<li class="herb-dev-tools-frame">${via}${this.pathHTML(frameLabel(frame), frame.template, frame.line ?? 1, frame.column ?? 1, 'herb-dev-tools-frame-target')}</li>`
+      const path = this.pathHTML(frameLabel(frame), frame.template, frame.line ?? 1, frame.column ?? 1, 'herb-dev-tools-frame-target', frame.template)
+      const highlight = index === 0 ? this.highlightButtonHTML(frame.template, frame.line) : ''
+
+      return `<li class="herb-dev-tools-frame">${via}${path}${highlight}</li>`
     })
 
     return [
@@ -2350,6 +2362,48 @@ export class RuntimePanel {
       `<ol class="herb-dev-tools-frames">${items.join('')}</ol>`,
       `</div>`,
     ].join('')
+  }
+
+  private highlightButtonHTML(template: string, line: number | null): string {
+    const found = nearestStamped(template, line).length
+
+    if (found === 0) {
+      return ''
+    }
+
+    const description = found === 1
+      ? 'Show what this rendered on the page'
+      : `Show all ${found} of these on the page`
+
+    return [
+      `<button type="button" class="herb-dev-tools-highlight" data-herb-dev-tools-action="highlight"`,
+      ` data-herb-dev-tools-source="${escapeHTML(template)}" data-herb-dev-tools-at="${line ?? ''}"`,
+      `${tip(description)}>${TARGET_ICON}`,
+      found === 1 ? '' : `<span class="herb-dev-tools-highlight-count">${found}</span>`,
+      `</button>`,
+    ].join('')
+  }
+
+  private highlightFrom(trigger: HTMLElement) {
+    const targets = this.targetsOf(trigger)
+
+    if (targets.length === 0) return
+
+    this.stepOutOfTheWay()
+
+    targets[0].scrollIntoView({ block: 'center', behavior: 'smooth' })
+    targets.forEach(target => flashElement(target))
+  }
+
+  private targetsOf(trigger: HTMLElement): Element[] {
+    const template = trigger.getAttribute('data-herb-dev-tools-source')
+
+    if (template === null) return []
+
+    const line = Number(trigger.getAttribute('data-herb-dev-tools-at'))
+
+    return nearestStamped(template, Number.isFinite(line) && line > 0 ? line : null)
+      .filter(node => node.isConnected && hiddenBy(node) === null)
   }
 
   private backtraceHTML(diagnostic: NormalizedDiagnostic): string {
@@ -2406,7 +2460,7 @@ export class RuntimePanel {
       return
     }
 
-    root.querySelectorAll<HTMLElement>('[data-herb-dev-tools-action]').forEach((element) => {
+    root.querySelectorAll<HTMLElement>('[data-herb-dev-tools-action], [data-herb-dev-tools-source]').forEach((element) => {
       element.addEventListener('click', (event) => {
         event.preventDefault()
         event.stopPropagation()
@@ -2468,12 +2522,16 @@ export class RuntimePanel {
           this.toggleMute(element.getAttribute('data-herb-dev-tools-metric'))
         } else if (action === 'open') {
           this.openFrom(element)
+        } else if (action === 'highlight') {
+          this.highlightFrom(element)
         } else if (action === 'locate') {
           this.locateFrom(element)
         }
       })
 
-      if (element.getAttribute('data-herb-dev-tools-action') === 'locate') {
+      const action = element.getAttribute('data-herb-dev-tools-action')
+
+      if (action === 'locate' || element.hasAttribute('data-herb-dev-tools-source')) {
         element.addEventListener('mouseenter', () => this.outlineFrom(element, true))
         element.addEventListener('mouseleave', () => this.outlineFrom(element, false))
       }
@@ -2522,18 +2580,25 @@ export class RuntimePanel {
     }
   }
 
-  private outline: HTMLElement | null = null
+  private outlines: HTMLElement[] = []
 
   private outlineFrom(trigger: HTMLElement, on: boolean) {
-    this.outline?.remove()
-    this.outline = null
+    this.outlines.forEach(box => box.remove())
+    this.outlines = []
 
     if (!on) return
 
-    const target = this.entryFor(trigger)?.diagnostic.element
+    const element = this.entryFor(trigger)?.diagnostic.element
+    const targets = trigger.getAttribute('data-herb-dev-tools-source') === null
+      ? (element ? [element] : [])
+      : this.targetsOf(trigger)
 
-    if (!target || !target.isConnected || hiddenBy(target) !== null) return
+    targets
+      .filter(target => target.isConnected && hiddenBy(target) === null)
+      .forEach(target => this.outlines.push(this.outlineOver(target)))
+  }
 
+  private outlineOver(target: Element): HTMLElement {
     const rect = target.getBoundingClientRect()
     const box = document.createElement('div')
 
@@ -2541,7 +2606,8 @@ export class RuntimePanel {
     box.style.cssText = `position:absolute;z-index:2147483000;pointer-events:none;top:${rect.top + window.scrollY}px;left:${rect.left + window.scrollX}px;width:${rect.width}px;height:${rect.height}px;outline:2px solid #f59e0b;outline-offset:2px;background:rgba(245,158,11,0.12)`
 
     document.body.appendChild(box)
-    this.outline = box
+
+    return box
   }
 
   private openFrom(element: HTMLElement) {
@@ -2570,6 +2636,41 @@ function severityOf(entries: PanelEntry[]): RuntimeSeverity | null {
   }
 
   return null
+}
+
+function stampedNodes(template: string): Element[] {
+  const stamped = Array.from(document.querySelectorAll(`[${SOURCE_ATTRIBUTE}]`))
+
+  return stamped.filter(node => node.getAttribute(SOURCE_ATTRIBUTE)?.startsWith(`${template}:`) === true)
+}
+
+function stampedAt(node: Element, template: string): [number, number] | null {
+  const value = node.getAttribute(SOURCE_ATTRIBUTE)
+
+  if (value === null || !value.startsWith(`${template}:`)) return null
+
+  const [line, column] = value.slice(template.length + 1).split(':').map(Number)
+
+  return Number.isFinite(line) && Number.isFinite(column) ? [line, column] : null
+}
+
+function nearestStamped(template: string, line: number | null): Element[] {
+  const nodes = stampedNodes(template)
+
+  if (line === null || nodes.length === 0) return nodes
+
+  const positions = nodes.map(node => stampedAt(node, template)).filter((at): at is [number, number] => at !== null)
+  const above = positions.filter(([stampLine]) => stampLine <= line)
+
+  if (above.length === 0) return nodes
+
+  const best = above.reduce((carried, at) => (at[0] > carried[0] || (at[0] === carried[0] && at[1] > carried[1])) ? at : carried)
+
+  return nodes.filter(node => {
+    const at = stampedAt(node, template)
+
+    return at !== null && at[0] === best[0] && at[1] === best[1]
+  })
 }
 
 function hiddenBy(element: Element): { reason: string, culprit: Element | null } | null {

--- a/javascript/packages/dev-tools/test/runtime-panel.test.ts
+++ b/javascript/packages/dev-tools/test/runtime-panel.test.ts
@@ -4201,3 +4201,266 @@ describe("muting metrics", () => {
     expect(document.querySelector(".herb-dev-tools-mutes")).toBeNull()
   })
 })
+
+describe("pointing a frame at what it rendered", () => {
+  const STACKED = {
+    version: 1,
+    renderTree: [
+      { id: "0", template: "app/views/layouts/application.html.erb", parent: null, via: "layout" },
+      { id: "1", template: "app/views/posts/index.html.erb", parent: "0", via: "template", location: { line: 7, column: 10 } },
+      { id: "2", template: "app/views/posts/_post.html.erb", parent: "1", via: "partial", location: { line: 12, column: 4 } },
+    ],
+    diagnostics: [
+      {
+        template: "app/views/posts/_post.html.erb",
+        node: "2",
+        message: "This partial issued 3 SQL queries while rendering.",
+        code: "sql-queries",
+        kind: "metric",
+        origin: "Herb Engine",
+        value: "3 SQL queries",
+        location: { start: { line: 2, column: 1 } },
+      },
+    ],
+  }
+
+  function stamp(template: string, line: number, text: string, column = 1) {
+    const element = document.createElement("article")
+
+    element.setAttribute("data-herb-source", `${template}:${line}:${column}`)
+    element.textContent = text
+    element.getBoundingClientRect = () => ({ top: 0, left: 0, width: 100, height: 40, right: 100, bottom: 40, x: 0, y: 0, toJSON: () => ({}) }) as DOMRect
+
+    document.body.appendChild(element)
+
+    return element
+  }
+
+  function highlight() {
+    return document.querySelector(".herb-dev-tools-highlight") as HTMLButtonElement | null
+  }
+
+  test("offers nothing when the page carries no stamps", () => {
+    embed(STACKED)
+    createPanel().open()
+
+    expect(document.querySelector(".herb-dev-tools-frame")).not.toBeNull()
+    expect(highlight()).toBeNull()
+  })
+
+  test("offers the innermost frame alone, and says how many it found", () => {
+    stamp("app/views/posts/_post.html.erb", 1, "first post")
+    stamp("app/views/posts/_post.html.erb", 1, "second post")
+    stamp("app/views/posts/index.html.erb", 3, "the page")
+
+    embed(STACKED)
+    createPanel().open()
+
+    const buttons = Array.from(document.querySelectorAll(".herb-dev-tools-highlight"))
+
+    expect(buttons).toHaveLength(1)
+    expect(buttons[0].closest(".herb-dev-tools-frame")!.textContent).toContain("_post.html.erb")
+    expect(buttons[0].getAttribute("data-herb-dev-tools-source")).toBe("app/views/posts/_post.html.erb")
+    expect(buttons[0].textContent).toBe("2")
+    expect(buttons[0].getAttribute("aria-label")).toBe("Show all 2 of these on the page")
+  })
+
+  test("says it plainly when the frame rendered once", () => {
+    stamp("app/views/posts/_post.html.erb", 1, "only post")
+
+    embed(STACKED)
+    createPanel().open()
+
+    expect(highlight()!.textContent).toBe("")
+    expect(highlight()!.getAttribute("aria-label")).toBe("Show what this rendered on the page")
+  })
+
+  test("outlines every node the frame rendered while the control is under the pointer", () => {
+    stamp("app/views/posts/_post.html.erb", 1, "first post")
+    stamp("app/views/posts/_post.html.erb", 1, "second post")
+
+    embed(STACKED)
+    createPanel().open()
+
+    highlight()!.dispatchEvent(new MouseEvent("mouseenter"))
+
+    expect(document.querySelectorAll(".herb-element-outline")).toHaveLength(2)
+
+    highlight()!.dispatchEvent(new MouseEvent("mouseleave"))
+
+    expect(document.querySelectorAll(".herb-element-outline")).toHaveLength(0)
+  })
+
+  test("flashes them all when the control is pressed", () => {
+    stamp("app/views/posts/_post.html.erb", 1, "first post")
+    stamp("app/views/posts/_post.html.erb", 1, "second post")
+
+    embed(STACKED)
+    createPanel().open()
+
+    highlight()!.click()
+
+    expect(document.querySelectorAll(".herb-element-flash")).toHaveLength(2)
+  })
+
+  test("answers with what was opened above the finding, not with the whole template", () => {
+    stamp("app/views/posts/_post.html.erb", 1, "the article")
+    stamp("app/views/posts/_post.html.erb", 2, "the heading beside it")
+    stamp("app/views/posts/_post.html.erb", 9, "something written below")
+
+    embed(STACKED)
+    createPanel().open()
+
+    highlight()!.dispatchEvent(new MouseEvent("mouseenter"))
+
+    const outlined = Array.from(document.querySelectorAll(".herb-element-outline"))
+
+    expect(outlined).toHaveLength(1)
+    expect(highlight()!.getAttribute("aria-label")).toBe("Show what this rendered on the page")
+  })
+
+  test("answers with every copy when the same element was rendered again", () => {
+    stamp("app/views/posts/_post.html.erb", 2, "first copy")
+    stamp("app/views/posts/_post.html.erb", 2, "second copy")
+    stamp("app/views/posts/_post.html.erb", 2, "third copy")
+    stamp("app/views/posts/_post.html.erb", 9, "written below all of them")
+
+    embed(STACKED)
+    createPanel().open()
+
+    expect(highlight()!.textContent).toBe("3")
+
+    highlight()!.click()
+
+    expect(document.querySelectorAll(".herb-element-flash")).toHaveLength(3)
+  })
+
+  test("takes the innermost tag opened above, when two were opened on the way", () => {
+    stamp("app/views/posts/_post.html.erb", 1, "the outer one", 1)
+    stamp("app/views/posts/_post.html.erb", 1, "the inner one", 5)
+
+    embed(STACKED)
+    createPanel().open()
+
+    highlight()!.click()
+
+    const flashed = document.querySelectorAll(".herb-element-flash")
+
+    expect(flashed).toHaveLength(1)
+  })
+
+  test("falls back to everything the template rendered when nothing was opened above", () => {
+    stamp("app/views/posts/_post.html.erb", 40, "written well below the finding")
+    stamp("app/views/posts/_post.html.erb", 41, "and another")
+
+    embed(STACKED)
+    createPanel().open()
+
+    expect(highlight()!.textContent).toBe("2")
+  })
+
+  test("does not answer for a template whose name it only starts with", () => {
+    stamp("app/views/posts/_post_actions.html.erb", 1, "a different partial")
+
+    embed(STACKED)
+    createPanel().open()
+
+    expect(highlight()).toBeNull()
+  })
+})
+
+describe("hovering a frame in the render stack", () => {
+  const STACKED = {
+    version: 1,
+    renderTree: [
+      { id: "0", template: "app/views/layouts/application.html.erb", parent: null, via: "layout" },
+      { id: "1", template: "app/views/posts/index.html.erb", parent: "0", via: "template", location: { line: 7, column: 10 } },
+      { id: "2", template: "app/views/posts/_post.html.erb", parent: "1", via: "partial", location: { line: 12, column: 4 } },
+    ],
+    diagnostics: [
+      {
+        template: "app/views/posts/_post.html.erb",
+        node: "2",
+        message: "This partial issued 3 SQL queries while rendering.",
+        code: "sql-queries",
+        kind: "metric",
+        origin: "Herb Engine",
+        value: "3 SQL queries",
+        location: { start: { line: 6, column: 1 } },
+      },
+    ],
+  }
+
+  function stamp(template: string, line: number, column = 1) {
+    const element = document.createElement("article")
+
+    element.setAttribute("data-herb-source", `${template}:${line}:${column}`)
+    element.getBoundingClientRect = () => ({ top: 0, left: 0, width: 80, height: 20, right: 80, bottom: 20, x: 0, y: 0, toJSON: () => ({}) }) as DOMRect
+
+    document.body.appendChild(element)
+  }
+
+  function frames() {
+    return Array.from(document.querySelectorAll(".herb-dev-tools-frame .herb-dev-tools-frame-target")) as HTMLElement[]
+  }
+
+  function outlines() {
+    return document.querySelectorAll(".herb-element-outline").length
+  }
+
+  test("outlines everything that file put on the page, for any frame", () => {
+    stamp("app/views/posts/_post.html.erb", 2)
+    stamp("app/views/posts/_post.html.erb", 9)
+    stamp("app/views/posts/index.html.erb", 3)
+    stamp("app/views/posts/index.html.erb", 4)
+    stamp("app/views/posts/index.html.erb", 5)
+
+    embed(STACKED)
+    createPanel().open()
+
+    const [innermost, middle] = frames()
+
+    middle.dispatchEvent(new MouseEvent("mouseenter"))
+
+    expect(outlines()).toBe(3)
+
+    middle.dispatchEvent(new MouseEvent("mouseleave"))
+
+    expect(outlines()).toBe(0)
+
+    innermost.dispatchEvent(new MouseEvent("mouseenter"))
+
+    expect(outlines()).toBe(2)
+  })
+
+  test("shows the whole file, where the control beside it shows one element", () => {
+    stamp("app/views/posts/_post.html.erb", 2)
+    stamp("app/views/posts/_post.html.erb", 9)
+
+    embed(STACKED)
+    createPanel().open()
+
+    const path = frames()[0]
+    const control = document.querySelector(".herb-dev-tools-highlight") as HTMLElement
+
+    path.dispatchEvent(new MouseEvent("mouseenter"))
+
+    expect(outlines()).toBe(2)
+
+    path.dispatchEvent(new MouseEvent("mouseleave"))
+    control.dispatchEvent(new MouseEvent("mouseenter"))
+
+    expect(outlines()).toBe(1)
+  })
+
+  test("outlines nothing for a frame whose file left no mark", () => {
+    stamp("app/views/posts/_post.html.erb", 2)
+
+    embed(STACKED)
+    createPanel().open()
+
+    frames()[2].dispatchEvent(new MouseEvent("mouseenter"))
+
+    expect(outlines()).toBe(0)
+  })
+})


### PR DESCRIPTION
This pull request connects the render stack to the page it produced, so a frame can show the markup it wrote.

A render stack says which templates led to a finding, and until now that was all it said. The `SourceAttributionVisitor` stamps every element with the template and position it was written at, which is enough to find that markup in the rendered result.

Hovering any frame outlines the region that file covers. A layout outlines nearly the whole page, a partial outlines the parts it was responsible for, and a partial rendered ten times outlines all ten. One region is drawn rather than a box per element, because what a file put on a page is a region of it, and three siblings from one template are one region even when the markup between them came from a helper that left no stamp of its own.

The innermost frame carries one more control, since it is the template the finding is about while the frames above it are the path that led there. It narrows to the element the tag was written inside, outlines it on hover, and flashes it on a press.


https://github.com/user-attachments/assets/1f3ac91d-2ddd-4102-84c1-2e90e11cec21



