### PR TITLE
Dev Tools: Show what a tag rendered as a value, not an error

### DIFF
--- a/javascript/packages/dev-tools/demo/demo.ts
+++ b/javascript/packages/dev-tools/demo/demo.ts
@@ -92,7 +92,17 @@ on("report-metrics", () => {
     location: { start: { line, column: 5 } },
   }))
 
-  lastHandle = devTools.report([...renders, ...queries])
+  const rendered = ["Latest posts", "Neueste Beiträge"].map((value, index) => ({
+    template: "app/views/posts/index.html.erb",
+    message: value,
+    code: "rendered-output",
+    kind: "value" as const,
+    origin: "Herb Engine",
+    value,
+    location: { start: { line: 2 + index, column: 5 } },
+  }))
+
+  lastHandle = devTools.report([...renders, ...queries, ...rendered])
 })
 
 on("report-blocking", () => {

--- a/javascript/packages/dev-tools/src/runtime/panel.css
+++ b/javascript/packages/dev-tools/src/runtime/panel.css
@@ -654,6 +654,7 @@
 }
 
 .herb-dev-tools-metric {
+  flex: none;
   padding: 2px 7px;
   border-radius: 999px;
   background: #eef2ff;
@@ -661,6 +662,7 @@
   color: #3730a3;
   font-size: 10px;
   font-weight: 600;
+  line-height: 1.3;
 }
 
 .herb-dev-tools-code {

--- a/javascript/packages/dev-tools/src/runtime/panel.ts
+++ b/javascript/packages/dev-tools/src/runtime/panel.ts
@@ -40,7 +40,7 @@ const SEVERITY_FILTERS: Array<{ value: string, label: string, matches: (diagnost
   { value: 'error', label: 'Errors', matches: diagnostic => diagnostic.kind === 'diagnostic' && diagnostic.severity === 'error' },
   { value: 'warning', label: 'Warnings', matches: diagnostic => diagnostic.kind === 'diagnostic' && diagnostic.severity === 'warning' },
   { value: 'notice', label: 'Notices', matches: diagnostic => diagnostic.kind === 'diagnostic' && (diagnostic.severity === 'info' || diagnostic.severity === 'hint') },
-  { value: 'metric', label: 'Metrics', matches: diagnostic => diagnostic.kind === 'metric' },
+  { value: 'metric', label: 'Metrics', matches: diagnostic => isReading(diagnostic) },
 ]
 
 export interface RuntimeReportHandle {
@@ -84,8 +84,12 @@ function clamp(value: number, low: number, high: number): number {
   return Math.min(Math.max(value, low), Math.max(low, high))
 }
 
+function isReading(diagnostic: NormalizedDiagnostic): boolean {
+  return diagnostic.kind !== 'diagnostic'
+}
+
 function metricKey(diagnostic: NormalizedDiagnostic): string | null {
-  return diagnostic.kind === 'metric' ? diagnostic.code : null
+  return isReading(diagnostic) ? diagnostic.code : null
 }
 
 function asMuted(value: unknown): string[] {
@@ -510,7 +514,7 @@ export class RuntimePanel {
 
   public get metricCount(): number {
     return this.shown
-      .filter(entry => entry.diagnostic.kind === 'metric')
+      .filter(entry => isReading(entry.diagnostic))
       .reduce((total, entry) => total + entry.count, 0)
   }
 
@@ -523,7 +527,7 @@ export class RuntimePanel {
   }
 
   private muted(diagnostic: NormalizedDiagnostic): boolean {
-    if (diagnostic.kind !== 'metric') {
+    if (!isReading(diagnostic)) {
       return false
     }
 
@@ -1378,7 +1382,7 @@ export class RuntimePanel {
     const errors = this.countBy(scope, entry => entry.diagnostic.severity === 'error')
     const warnings = this.countBy(scope, entry => entry.diagnostic.severity === 'warning')
     const notices = this.countBy(scope, entry => entry.diagnostic.severity === 'info' || entry.diagnostic.severity === 'hint')
-    const metrics = this.countBy(scope, entry => entry.diagnostic.kind === 'metric')
+    const metrics = this.countBy(scope, entry => isReading(entry.diagnostic))
     const parts: string[] = []
 
     if (errors > 0) parts.push(`${errors} error${errors === 1 ? '' : 's'}`)
@@ -1685,7 +1689,7 @@ export class RuntimePanel {
   }
 
   private metricMutesHTML(): string {
-    const reported = this.entries.filter(entry => entry.diagnostic.kind === 'metric')
+    const reported = this.entries.filter(entry => isReading(entry.diagnostic))
 
     if (reported.length === 0 || !this.state.choosing) {
       return ''
@@ -1717,7 +1721,7 @@ export class RuntimePanel {
   }
 
   private metricsToggleHTML(): string {
-    if (!this.entries.some(entry => entry.diagnostic.kind === 'metric')) {
+    if (!this.entries.some(entry => isReading(entry.diagnostic))) {
       return ''
     }
 
@@ -1809,8 +1813,8 @@ export class RuntimePanel {
       ? ''
       : `<span class="herb-dev-tools-hero-chip herb-dev-tools-hero-chip-soft">${escapeHTML(sentenceCase(diagnostic.overlay))}</span>`
 
-    const marker = diagnostic.kind === 'metric'
-      ? `<span class="herb-dev-tools-hero-chip herb-dev-tools-hero-chip-solid">${escapeHTML(diagnostic.value ?? 'metric')}</span>`
+    const marker = isReading(diagnostic)
+      ? `<span class="herb-dev-tools-hero-chip herb-dev-tools-hero-chip-solid">${escapeHTML(diagnostic.value ?? diagnostic.kind)}</span>`
       : `<span class="herb-dev-tools-hero-chip herb-dev-tools-hero-chip-solid">${escapeHTML(sentenceCase(diagnostic.severity ?? 'error'))}</span>`
 
     const chips = `${marker}${mode}${group}`
@@ -2135,7 +2139,7 @@ export class RuntimePanel {
 
   private cardHTML(entry: PanelEntry): string {
     const diagnostic = entry.diagnostic
-    const isMetric = diagnostic.kind === 'metric'
+    const isMetric = isReading(diagnostic)
     const url = safeUrl(diagnostic.docsUrl)
     const codeTone = isMetric ? 'metric' : (diagnostic.severity ?? 'error')
     const codeLabel = diagnostic.code ?? (isMetric ? null : sentenceCase(diagnostic.severity ?? 'error'))

--- a/javascript/packages/dev-tools/src/runtime/report.ts
+++ b/javascript/packages/dev-tools/src/runtime/report.ts
@@ -6,7 +6,7 @@ export const UNKNOWN_TEMPLATE = '(unknown template)';
 export const DEFAULT_SEVERITY: RuntimeSeverity = 'error';
 export const RENDER_VIA_VALUES = ['layout', 'template', 'partial', 'component'] as const;
 export const RUNTIME_SEVERITIES = ['error', 'warning', 'info', 'hint'] as const;
-export const RUNTIME_KINDS = ['diagnostic', 'metric'] as const;
+export const RUNTIME_KINDS = ['diagnostic', 'metric', 'value'] as const;
 export const OVERLAY_MODES = ['blocking', 'dismissible'] as const;
 export const PHASES = ['compile', 'runtime'] as const;
 export const FIX_KINDS = ['safe', 'unsafe'] as const;
@@ -284,7 +284,7 @@ export function normalizeDiagnostic(value: unknown, sources: Record<string, stri
     message,
     node: asString(value.node),
     code: asString(value.code),
-    severity: kind === 'metric' ? null : severity ?? DEFAULT_SEVERITY,
+    severity: kind === 'diagnostic' ? severity ?? DEFAULT_SEVERITY : null,
     kind,
     origin: trimOrigin(value.origin),
     location: normalizeRange(value.location),

--- a/javascript/packages/dev-tools/test/runtime-panel.test.ts
+++ b/javascript/packages/dev-tools/test/runtime-panel.test.ts
@@ -4464,3 +4464,105 @@ describe("hovering a frame in the render stack", () => {
     expect(outlines()).toBe(0)
   })
 })
+
+describe("what a tag rendered", () => {
+  const RENDERED = {
+    version: 1,
+    diagnostics: [
+      {
+        template: "app/views/posts/index.html.erb",
+        message: "Latest posts",
+        code: "rendered-output",
+        kind: "value",
+        origin: "Herb Engine",
+        value: "Latest posts",
+        location: { start: { line: 4, column: 5 } },
+      },
+      {
+        template: "app/views/posts/index.html.erb",
+        message: "Image is missing an alt attribute.",
+        code: "html-img-require-alt",
+        severity: "warning",
+        origin: "Herb Linter",
+        location: { start: { line: 9, column: 3 } },
+      },
+    ],
+  }
+
+  test("is not an error just because nobody gave it a severity", () => {
+    embed(RENDERED)
+
+    const panel = createPanel()
+
+    panel.open()
+
+    expect(panel.badgeSeverity).toBe("warning")
+    expect(document.querySelectorAll(".herb-dev-tools-badge-error")).toHaveLength(0)
+    expect(cards().some(card => (card.textContent ?? "").includes("Latest posts"))).toBe(true)
+  })
+
+  test("is counted beside the metrics instead of against the page", () => {
+    embed(RENDERED)
+
+    const panel = createPanel()
+
+    panel.open()
+
+    expect(panel.metricCount).toBe(1)
+    expect(panel.diagnosticCount).toBe(1)
+  })
+
+  test("wears a chip the same height as the ones beside it", () => {
+    embed({
+      version: 1,
+      renderTree: [
+        { id: "0", template: "app/views/posts/index.html.erb", parent: null, via: "template" },
+      ],
+      diagnostics: [
+        {
+          template: "app/views/posts/index.html.erb",
+          node: "0",
+          message: "This ERB tag ran 3 SQL queries while the page rendered.",
+          code: "sql-queries",
+          kind: "metric",
+          origin: "Herb Engine",
+          value: "3 SQL queries",
+          location: { start: { line: 4, column: 5 } },
+        },
+      ],
+    })
+
+    createPanel().open()
+
+    const height = (selector: string) => {
+      const element = document.querySelector(selector) as HTMLElement
+
+      return Math.round(element.getBoundingClientRect().height)
+    }
+
+    expect(height(".herb-dev-tools-metric")).toBe(height(".herb-dev-tools-code"))
+    expect(height(".herb-dev-tools-metric")).toBe(height(".herb-dev-tools-frame-via"))
+  })
+
+  test("can be put away like a metric", () => {
+    embed(RENDERED)
+
+    const panel = createPanel()
+
+    panel.open()
+
+    const chooser = document.querySelector(".herb-dev-tools-metrics-toggle") as HTMLButtonElement
+
+    chooser.click()
+
+    const chip = document.querySelector('.herb-dev-tools-mute[data-herb-dev-tools-metric="rendered-output"]') as HTMLButtonElement
+
+    expect(chip).not.toBeNull()
+
+    chip.click()
+
+    expect(panel.metricCount).toBe(0)
+    expect(cards().some(card => (card.textContent ?? "").includes("Latest posts"))).toBe(false)
+    expect(cards().some(card => (card.textContent ?? "").includes("alt attribute"))).toBe(true)
+  })
+})


### PR DESCRIPTION
This pull request teaches the runtime panel the third kind of finding, so an output tag that reports what it rendered stops being drawn in red as an error.

An application asks Herb to capture what a tag rendered, and the panel showed the result as a failure. Nothing was wrong with the tag. The default is `error`. The engine had already said what it meant, sending no severity at all for anything a measurement produced.