### PR TITLE
Dev Tools: Show what a finding holds, not only its headline

### DIFF
--- a/javascript/packages/dev-tools/demo/demo.ts
+++ b/javascript/packages/dev-tools/demo/demo.ts
@@ -80,6 +80,7 @@ on("report-metrics", () => {
     origin: "Herb Engine",
     value: `${(0.4 + index + position).toFixed(1)} ms`,
     location: { start: { line, column: 3 } },
+    data: { render: [{ duration: 0.4 + index + position, gc: 0.1, allocations: 1200 * (position + 1) }] },
   })))
 
   const queries = [4, 9].map(line => ({
@@ -90,6 +91,13 @@ on("report-metrics", () => {
     origin: "Herb Engine",
     value: "5 SQL queries",
     location: { start: { line, column: 5 } },
+    data: {
+      queries: [
+        `SELECT "posts".* FROM "posts" WHERE "posts"."published" = 1 ORDER BY "posts"."created_at" DESC LIMIT 10`,
+        `SELECT "users".* FROM "users" WHERE "users"."id" = 1 LIMIT 1`,
+        `SELECT COUNT(*) FROM "comments" WHERE "comments"."post_id" = 1`,
+      ],
+    },
   }))
 
   const rendered = ["Latest posts", "Neueste Beiträge"].map((value, index) => ({

--- a/javascript/packages/dev-tools/src/runtime/panel.css
+++ b/javascript/packages/dev-tools/src/runtime/panel.css
@@ -810,6 +810,39 @@
   font-size: 11px;
 }
 
+.herb-dev-tools-observed {
+  margin-top: 0;
+  border: 1px solid var(--herb-dev-tools-border);
+  border-radius: 8px;
+  background: var(--herb-dev-tools-page);
+  color: var(--herb-dev-tools-ink-soft);
+}
+
+.herb-dev-tools-observed > summary {
+  padding: 6px 8px;
+  font-size: 11px;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.herb-dev-tools-observed-key {
+  margin: 0;
+  padding: 4px 8px 0;
+  font-size: 10px;
+  font-weight: 600;
+  color: var(--herb-dev-tools-ink-faint);
+}
+
+.herb-dev-tools-observed-list {
+  margin: 2px 0 8px;
+  padding: 0 8px;
+  overflow-x: auto;
+  font-size: 11px;
+  line-height: 1.5;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
 .herb-dev-tools-fix {
   margin-top: 0;
   border: 1px solid var(--herb-dev-tools-border);

--- a/javascript/packages/dev-tools/src/runtime/panel.ts
+++ b/javascript/packages/dev-tools/src/runtime/panel.ts
@@ -13,6 +13,7 @@ import type { NormalizedDiagnostic, NormalizedRuntimeReport, OverlayMode, Runtim
 
 export type BadgeTone = RuntimeSeverity | 'metric'
 
+const WRAPPING_OBSERVATION = 80
 const ALL_ORIGINS = '*'
 const ALL_SEVERITIES = '*'
 const ALL_METRICS = '*'
@@ -82,6 +83,22 @@ type ResizeEdge = typeof RESIZE_EDGES[number]
 
 function clamp(value: number, low: number, high: number): number {
   return Math.min(Math.max(value, low), Math.max(low, high))
+}
+
+function readingLabel(diagnostic: NormalizedDiagnostic): string {
+  if (diagnostic.kind === 'value' && diagnostic.tag !== null) {
+    return diagnostic.tag
+  }
+
+  return diagnostic.value ?? diagnostic.kind
+}
+
+function spaced(entries: string[]): string[] {
+  if (!entries.some(entry => entry.length > WRAPPING_OBSERVATION)) {
+    return entries
+  }
+
+  return entries.flatMap((entry, index) => index === 0 ? [entry] : ['', entry])
 }
 
 function isReading(diagnostic: NormalizedDiagnostic): boolean {
@@ -1814,7 +1831,7 @@ export class RuntimePanel {
       : `<span class="herb-dev-tools-hero-chip herb-dev-tools-hero-chip-soft">${escapeHTML(sentenceCase(diagnostic.overlay))}</span>`
 
     const marker = isReading(diagnostic)
-      ? `<span class="herb-dev-tools-hero-chip herb-dev-tools-hero-chip-solid">${escapeHTML(diagnostic.value ?? diagnostic.kind)}</span>`
+      ? `<span class="herb-dev-tools-hero-chip herb-dev-tools-hero-chip-solid">${escapeHTML(readingLabel(diagnostic))}</span>`
       : `<span class="herb-dev-tools-hero-chip herb-dev-tools-hero-chip-solid">${escapeHTML(sentenceCase(diagnostic.severity ?? 'error'))}</span>`
 
     const chips = `${marker}${mode}${group}`
@@ -2148,7 +2165,7 @@ export class RuntimePanel {
       : `<span class="herb-dev-tools-code herb-dev-tools-code-${escapeHTML(codeTone)}">${escapeHTML(codeLabel)}</span>`
 
     const marker = isMetric
-      ? `<span class="herb-dev-tools-metric">${escapeHTML(diagnostic.value ?? 'metric')}</span>`
+      ? `<span class="herb-dev-tools-metric"${diagnostic.value === null ? '' : ` title="${escapeHTML(diagnostic.value)}"`}>${escapeHTML(readingLabel(diagnostic))}</span>`
       : ''
 
     const docs = url === null
@@ -2180,6 +2197,7 @@ export class RuntimePanel {
       element,
       suggestion,
       this.excerptHTML(diagnostic),
+      this.observationsHTML(diagnostic),
       this.stackHTML(diagnostic),
       this.backtraceHTML(diagnostic),
       this.fixHTML(diagnostic),
@@ -2336,6 +2354,43 @@ export class RuntimePanel {
       `</div>`,
       `</div>`,
     ].join('')
+  }
+
+  private observationsHTML(diagnostic: NormalizedDiagnostic): string {
+    const keys = Object.keys(diagnostic.observations)
+
+    if (keys.length === 0) {
+      return ''
+    }
+
+    const sections = keys.map((key) => {
+      const observed = diagnostic.observations[key]
+      const lines = spaced(observed.map(entry => this.observation(entry))).map(escapeHTML).join('\n')
+      const counted = observed.length === 1 ? key : `${key} (${observed.length})`
+
+      return [
+        `<p class="herb-dev-tools-observed-key">${escapeHTML(counted)}</p>`,
+        `<pre class="herb-dev-tools-observed-list"><code>${lines}</code></pre>`,
+      ].join('')
+    })
+
+    const total = keys.reduce((count, key) => count + diagnostic.observations[key].length, 0)
+    const summary = total === 1 ? 'What was observed' : `What was observed (${total})`
+
+    return [
+      `<details class="herb-dev-tools-observed">`,
+      `<summary>${escapeHTML(summary)}</summary>`,
+      sections.join(''),
+      `</details>`,
+    ].join('')
+  }
+
+  private observation(entry: unknown): string {
+    if (entry === null || typeof entry !== 'object') {
+      return String(entry)
+    }
+
+    return Object.entries(entry as Record<string, unknown>).map(([key, value]) => `${key}: ${value}`).join('  ')
   }
 
   private stackHTML(diagnostic: NormalizedDiagnostic): string {
@@ -2597,13 +2652,20 @@ export class RuntimePanel {
       ? (element ? [element] : [])
       : this.targetsOf(trigger)
 
-    targets
-      .filter(target => target.isConnected && hiddenBy(target) === null)
-      .forEach(target => this.outlines.push(this.outlineOver(target)))
+    const showing = targets.filter(target => target.isConnected && hiddenBy(target) === null)
+
+    if (showing.length === 0) return
+
+    if (trigger.hasAttribute('data-herb-dev-tools-at')) {
+      showing.forEach(target => this.outlines.push(this.outlineOver(target.getBoundingClientRect())))
+
+      return
+    }
+
+    this.outlines.push(this.outlineOver(spanning(showing)))
   }
 
-  private outlineOver(target: Element): HTMLElement {
-    const rect = target.getBoundingClientRect()
+  private outlineOver(rect: Bounds): HTMLElement {
     const box = document.createElement('div')
 
     box.className = 'herb-slot-flash herb-element-outline'
@@ -2640,6 +2702,26 @@ function severityOf(entries: PanelEntry[]): RuntimeSeverity | null {
   }
 
   return null
+}
+
+interface Bounds {
+  top: number
+  left: number
+  width: number
+  height: number
+}
+
+function spanning(elements: Element[]): Bounds {
+  const rects = elements.map(element => element.getBoundingClientRect())
+  const top = Math.min(...rects.map(rect => rect.top))
+  const left = Math.min(...rects.map(rect => rect.left))
+
+  return {
+    top,
+    left,
+    width: Math.max(...rects.map(rect => rect.right)) - left,
+    height: Math.max(...rects.map(rect => rect.bottom)) - top,
+  }
 }
 
 function stampedNodes(template: string): Element[] {

--- a/javascript/packages/dev-tools/src/runtime/report.ts
+++ b/javascript/packages/dev-tools/src/runtime/report.ts
@@ -110,6 +110,8 @@ export interface NormalizedDiagnostic {
   phase: Phase | null;
   backtrace: string[];
   element: Element | null;
+  observations: Record<string, unknown[]>;
+  tag: string | null;
 }
 
 export interface NormalizedRuntimeReport {
@@ -296,6 +298,8 @@ export function normalizeDiagnostic(value: unknown, sources: Record<string, stri
     phase: normalizePhase(value.phase),
     backtrace: normalizeBacktrace(value.backtrace),
     element: asElement(value.element),
+    observations: normalizeObservations(value.data),
+    tag: asString(value.tag),
   };
 }
 
@@ -307,6 +311,22 @@ function normalizeBacktrace(value: unknown): string[] {
   return value
     .filter((frame): frame is string => typeof frame === 'string' && frame.length > 0)
     .slice(0, MAX_BACKTRACE_FRAMES);
+}
+
+function normalizeObservations(value: unknown): Record<string, unknown[]> {
+  if (!isRecord(value)) {
+    return {};
+  }
+
+  const observations: Record<string, unknown[]> = {};
+
+  for (const [key, observed] of Object.entries(value)) {
+    if (Array.isArray(observed) && observed.length > 0) {
+      observations[key] = observed;
+    }
+  }
+
+  return observations;
 }
 
 function asElement(value: unknown): Element | null {

--- a/javascript/packages/dev-tools/test/runtime-panel.test.ts
+++ b/javascript/packages/dev-tools/test/runtime-panel.test.ts
@@ -4391,11 +4391,18 @@ describe("hovering a frame in the render stack", () => {
     ],
   }
 
-  function stamp(template: string, line: number, column = 1) {
+  function stamp(template: string, line: number, column = 1, box = { top: 0, left: 0, width: 80, height: 20 }) {
     const element = document.createElement("article")
 
     element.setAttribute("data-herb-source", `${template}:${line}:${column}`)
-    element.getBoundingClientRect = () => ({ top: 0, left: 0, width: 80, height: 20, right: 80, bottom: 20, x: 0, y: 0, toJSON: () => ({}) }) as DOMRect
+    element.getBoundingClientRect = () => ({
+      ...box,
+      right: box.left + box.width,
+      bottom: box.top + box.height,
+      x: box.left,
+      y: box.top,
+      toJSON: () => ({}),
+    }) as DOMRect
 
     document.body.appendChild(element)
   }
@@ -4408,12 +4415,11 @@ describe("hovering a frame in the render stack", () => {
     return document.querySelectorAll(".herb-element-outline").length
   }
 
-  test("outlines everything that file put on the page, for any frame", () => {
-    stamp("app/views/posts/_post.html.erb", 2)
-    stamp("app/views/posts/_post.html.erb", 9)
-    stamp("app/views/posts/index.html.erb", 3)
-    stamp("app/views/posts/index.html.erb", 4)
-    stamp("app/views/posts/index.html.erb", 5)
+  test("outlines the region a file covers, for any frame", () => {
+    stamp("app/views/posts/_post.html.erb", 2, 1, { top: 0, left: 0, width: 100, height: 40 })
+    stamp("app/views/posts/_post.html.erb", 9, 1, { top: 60, left: 0, width: 100, height: 40 })
+    stamp("app/views/posts/index.html.erb", 3, 1, { top: 200, left: 0, width: 100, height: 40 })
+    stamp("app/views/posts/index.html.erb", 5, 1, { top: 300, left: 0, width: 100, height: 40 })
 
     embed(STACKED)
     createPanel().open()
@@ -4422,7 +4428,10 @@ describe("hovering a frame in the render stack", () => {
 
     middle.dispatchEvent(new MouseEvent("mouseenter"))
 
-    expect(outlines()).toBe(3)
+    const covering = document.querySelector(".herb-element-outline") as HTMLElement
+
+    expect(outlines()).toBe(1)
+    expect([covering.style.top, covering.style.height]).toEqual(["200px", "140px"])
 
     middle.dispatchEvent(new MouseEvent("mouseleave"))
 
@@ -4430,12 +4439,14 @@ describe("hovering a frame in the render stack", () => {
 
     innermost.dispatchEvent(new MouseEvent("mouseenter"))
 
-    expect(outlines()).toBe(2)
+    const inner = document.querySelector(".herb-element-outline") as HTMLElement
+
+    expect([inner.style.top, inner.style.height]).toEqual(["0px", "100px"])
   })
 
   test("shows the whole file, where the control beside it shows one element", () => {
-    stamp("app/views/posts/_post.html.erb", 2)
-    stamp("app/views/posts/_post.html.erb", 9)
+    stamp("app/views/posts/_post.html.erb", 2, 1, { top: 0, left: 0, width: 100, height: 40 })
+    stamp("app/views/posts/_post.html.erb", 9, 1, { top: 300, left: 0, width: 100, height: 40 })
 
     embed(STACKED)
     createPanel().open()
@@ -4445,12 +4456,65 @@ describe("hovering a frame in the render stack", () => {
 
     path.dispatchEvent(new MouseEvent("mouseenter"))
 
-    expect(outlines()).toBe(2)
+    const region = document.querySelector(".herb-element-outline") as HTMLElement
+
+    expect([region.style.top, region.style.height]).toEqual(["0px", "340px"])
 
     path.dispatchEvent(new MouseEvent("mouseleave"))
     control.dispatchEvent(new MouseEvent("mouseenter"))
 
+    const narrowed = document.querySelector(".herb-element-outline") as HTMLElement
+
     expect(outlines()).toBe(1)
+    expect([narrowed.style.top, narrowed.style.height]).toEqual(["0px", "40px"])
+  })
+
+  test("draws one region around everything the file covers", () => {
+    stamp("app/views/posts/_post.html.erb", 2, 1, { top: 100, left: 20, width: 200, height: 50 })
+    stamp("app/views/posts/_post.html.erb", 9, 1, { top: 400, left: 60, width: 300, height: 80 })
+
+    embed(STACKED)
+    createPanel().open()
+
+    frames()[0].dispatchEvent(new MouseEvent("mouseenter"))
+
+    const boxes = Array.from(document.querySelectorAll(".herb-element-outline")) as HTMLElement[]
+
+    expect(boxes).toHaveLength(1)
+    expect(boxes[0].style.top).toBe("100px")
+    expect(boxes[0].style.left).toBe("20px")
+    expect(boxes[0].style.width).toBe("340px")
+    expect(boxes[0].style.height).toBe("380px")
+  })
+
+  test("covers a sibling in between that the template never stamped", () => {
+    stamp("app/views/posts/_post.html.erb", 2, 1, { top: 0, left: 0, width: 100, height: 40 })
+    stamp("app/views/posts/index.html.erb", 3, 1, { top: 50, left: 0, width: 100, height: 40 })
+    stamp("app/views/posts/_post.html.erb", 9, 1, { top: 100, left: 0, width: 100, height: 40 })
+
+    embed(STACKED)
+    createPanel().open()
+
+    frames()[0].dispatchEvent(new MouseEvent("mouseenter"))
+
+    const box = document.querySelector(".herb-element-outline") as HTMLElement
+
+    expect(box.style.top).toBe("0px")
+    expect(box.style.height).toBe("140px")
+  })
+
+  test("keeps a box per copy for the control that narrows to one element", () => {
+    stamp("app/views/posts/_post.html.erb", 2, 1, { top: 0, left: 0, width: 100, height: 40 })
+    stamp("app/views/posts/_post.html.erb", 2, 1, { top: 200, left: 0, width: 100, height: 40 })
+
+    embed(STACKED)
+    createPanel().open()
+
+    const control = document.querySelector(".herb-dev-tools-highlight") as HTMLElement
+
+    control.dispatchEvent(new MouseEvent("mouseenter"))
+
+    expect(document.querySelectorAll(".herb-element-outline")).toHaveLength(2)
   })
 
   test("outlines nothing for a frame whose file left no mark", () => {
@@ -4564,5 +4628,169 @@ describe("what a tag rendered", () => {
     expect(panel.metricCount).toBe(0)
     expect(cards().some(card => (card.textContent ?? "").includes("Latest posts"))).toBe(false)
     expect(cards().some(card => (card.textContent ?? "").includes("alt attribute"))).toBe(true)
+  })
+})
+
+describe("what was observed behind a count", () => {
+  const OBSERVED = {
+    version: 1,
+    diagnostics: [
+      {
+        template: "app/views/posts/index.html.erb",
+        message: "This ERB tag ran 3 SQL queries while the page rendered.",
+        code: "sql-queries",
+        kind: "metric",
+        origin: "Herb Engine",
+        value: "3 SQL queries",
+        location: { start: { line: 4, column: 5 } },
+        data: {
+          queries: ["SELECT 1 FROM posts", "SELECT 2 FROM posts", "SELECT 3 FROM posts"],
+          render: [{ duration: 1.6, allocations: 3373 }],
+        },
+      },
+      {
+        template: "app/views/posts/index.html.erb",
+        message: "Image is missing an alt attribute.",
+        code: "html-img-require-alt",
+        severity: "warning",
+        origin: "Herb Linter",
+        location: { start: { line: 9, column: 3 } },
+      },
+    ],
+  }
+
+  function observed() {
+    return document.querySelector(".herb-dev-tools-observed") as HTMLDetailsElement | null
+  }
+
+  test("shows the statements a count was counting", () => {
+    embed(OBSERVED)
+    createPanel().open()
+
+    const text = observed()!.textContent ?? ""
+
+    expect(text).toContain("SELECT 1 FROM posts")
+    expect(text).toContain("SELECT 3 FROM posts")
+  })
+
+  test("puts a blank line between statements long enough to wrap into each other", () => {
+    const first = `SELECT "events".* FROM "events" WHERE "events"."id" IN (20, 320, 137, 556, 85) ORDER BY "events"."id"`
+    const second = `SELECT "talks".* FROM "talks" WHERE "talks"."event_id" IN (20, 320, 137, 556, 85) ORDER BY "talks"."id"`
+
+    embed({
+      version: 1,
+      diagnostics: [
+        {
+          template: "app/views/posts/index.html.erb",
+          message: "This ERB tag ran 2 SQL queries while the page rendered.",
+          code: "sql-queries",
+          kind: "metric",
+          origin: "Herb Engine",
+          value: "2 SQL queries",
+          location: { start: { line: 4, column: 5 } },
+          data: { queries: [first, second] },
+        },
+      ],
+    })
+
+    createPanel().open()
+
+    expect(observed()!.querySelector("code")!.textContent).toBe(`${first}\n\n${second}`)
+  })
+
+  test("leaves observations that fit on a line packed together", () => {
+    embed(OBSERVED)
+    createPanel().open()
+
+    const text = observed()!.querySelector("code")!.textContent ?? ""
+
+    expect(text).not.toContain("\n\n")
+  })
+
+  test("spells out an observation recorded as an object", () => {
+    embed(OBSERVED)
+    createPanel().open()
+
+    expect(observed()!.textContent).toContain("duration: 1.6  allocations: 3373")
+    expect(observed()!.textContent).not.toContain("[object Object]")
+  })
+
+  test("counts what it holds, and stays folded until asked", () => {
+    embed(OBSERVED)
+    createPanel().open()
+
+    expect(observed()!.open).toBe(false)
+    expect(observed()!.querySelector("summary")!.textContent).toBe("What was observed (4)")
+    expect(observed()!.querySelectorAll(".herb-dev-tools-observed-key")).toHaveLength(2)
+  })
+
+  test("says nothing for a finding that observed nothing", () => {
+    embed(OBSERVED)
+    createPanel().open()
+
+    const linter = cards().find(card => (card.textContent ?? "").includes("alt attribute"))!
+
+    expect(linter.querySelector(".herb-dev-tools-observed")).toBeNull()
+  })
+})
+
+describe("naming the tag a rendered value came from", () => {
+  function payload(overrides: Record<string, unknown> = {}) {
+    return {
+      version: 1,
+      diagnostics: [
+        {
+          template: "app/views/page/home.html.erb",
+          message: "Hello World from en.yml",
+          code: "rendered-output",
+          kind: "value",
+          origin: "Herb Engine",
+          value: "Hello World from en.yml",
+          location: { start: { line: 5, column: 6 }, end: { line: 5, column: 29 } },
+          ...overrides,
+        },
+      ],
+    }
+  }
+
+  function chip() {
+    return document.querySelector(".herb-dev-tools-metric") as HTMLElement
+  }
+
+  test("wears the tag, and keeps what it rendered on the hover", () => {
+    embed(payload({ tag: '<%= t("hello_world") %>' }))
+    createPanel().open()
+
+    expect(chip().textContent).toBe('<%= t("hello_world") %>')
+    expect(chip().getAttribute("title")).toBe("Hello World from en.yml")
+  })
+
+  test("falls back to what it rendered when the report carried no tag", () => {
+    embed(payload())
+    createPanel().open()
+
+    expect(chip().textContent).toBe("Hello World from en.yml")
+  })
+
+  test("leaves a metric wearing its number", () => {
+    embed({
+      version: 1,
+      diagnostics: [
+        {
+          template: "app/views/page/home.html.erb",
+          message: "This ERB tag ran 3 SQL queries while the page rendered.",
+          code: "sql-queries",
+          kind: "metric",
+          origin: "Herb Engine",
+          value: "3 SQL queries",
+          tag: "<%= render @posts %>",
+          location: { start: { line: 5, column: 6 }, end: { line: 5, column: 29 } },
+        },
+      ],
+    })
+
+    createPanel().open()
+
+    expect(chip().textContent).toBe("3 SQL queries")
   })
 })

--- a/lib/herb/engine/runtime/journal.rb
+++ b/lib/herb/engine/runtime/journal.rb
@@ -9,6 +9,7 @@ require "pathname"
 
 require_relative "../../fingerprint"
 require_relative "../../visitor/context"
+require_relative "observations"
 require_relative "journal/summary"
 
 module Herb
@@ -47,8 +48,6 @@ module Herb
         MAX_RECORDS = 2_000 #: Integer
         MAX_RECORD_BYTES = 4_096 #: Integer
         MIN_RECORD_BYTES = 64 #: Integer
-        MAX_SAMPLED_OBSERVATIONS = 12 #: Integer
-        MAX_OBSERVATION_LENGTH = 240 #: Integer
         KEPT_DIGESTS = 5 #: Integer
 
         attr_reader :root #: Pathname
@@ -220,62 +219,20 @@ module Herb
             message: diagnostic.message,
             description: diagnostic.description,
             value: diagnostic.value,
-            data: jsonable(diagnostic.data),
+            data: Observations.jsonable(diagnostic.data),
           }.compact
 
           line = encode(record)
 
           return line if line.bytesize <= MAX_RECORD_BYTES
 
-          trimmed = encode(record.merge(data: trim(record[:data]), data_trimmed: true))
+          trimmed = encode(record.merge(data: Observations.trim(record[:data]), data_trimmed: true))
 
           return trimmed if trimmed.bytesize <= MAX_RECORD_BYTES
 
           encode(record.except(:data))
         rescue StandardError
           nil
-        end
-
-        #: (untyped) -> untyped
-        def jsonable(value)
-          case value
-          when nil, true, false, String, Integer then value
-          when Float then value.finite? ? value : value.to_s
-          when Symbol then value.to_s
-          when Array then value.map { |entry| jsonable(entry) }
-          when Hash then jsonable_hash(value)
-          else "#<#{value.class.name || "Object"}>"
-          end
-        rescue StandardError
-          nil
-        end
-
-        #: (Hash[untyped, untyped]) -> Hash[String, untyped]
-        def jsonable_hash(value)
-          sanitized = {} #: Hash[String, untyped]
-
-          value.each { |key, entry| sanitized[key.to_s] = jsonable(entry) }
-
-          sanitized
-        end
-
-        #: (Hash[Symbol, untyped]?) -> Hash[Symbol, untyped]
-        def trim(data)
-          return {} unless data.is_a?(Hash)
-
-          data.transform_values do |value|
-            next truncate(value) unless value.is_a?(Array)
-
-            value.first(MAX_SAMPLED_OBSERVATIONS).map { |observed| truncate(observed) }
-          end
-        end
-
-        #: (untyped) -> untyped
-        def truncate(observed)
-          return observed unless observed.is_a?(String)
-          return observed if observed.length <= MAX_OBSERVATION_LENGTH
-
-          "#{observed[0, MAX_OBSERVATION_LENGTH]}…"
         end
 
         #: (String, String, String) -> String

--- a/lib/herb/engine/runtime/observations.rb
+++ b/lib/herb/engine/runtime/observations.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+# typed: true
+
+module Herb
+  class Engine
+    module Runtime
+      # What a producer observed, made fit to be written down.
+      #
+      # An observation is any object its producer chose to record, while both places it ends up are
+      # JSON: the journal on disk and the report a page carries. Anything that is not already a
+      # primitive has to become one, and there is a size past which an observation stops being worth
+      # keeping whole.
+      #
+      #     Observations.jsonable({ queries: [statement, connection] })
+      #     #=> { "queries" => ["SELECT 1", "#<ActiveRecord::ConnectionAdapters::SQLite3Adapter>"] }
+      #
+      # The default `to_s` of an object carries its memory address, which means nothing once the
+      # process is gone and differs on every run, so what is kept is the class name alone. It says
+      # an object was there without pretending to be it.
+      #
+      module Observations
+        MAX_SAMPLED = 12 #: Integer
+        MAX_LENGTH = 240 #: Integer
+
+        class << self
+          #: (untyped) -> untyped
+          def jsonable(value)
+            case value
+            when nil, true, false, String, Integer then value
+            when Float then value.finite? ? value : value.to_s
+            when Symbol then value.to_s
+            when Array then value.map { |entry| jsonable(entry) }
+            when Hash then jsonable_hash(value)
+            else "#<#{value.class.name || "Object"}>"
+            end
+          rescue StandardError
+            nil
+          end
+
+          #: (untyped, ?sampled: Integer, ?length: Integer) -> Hash[untyped, untyped]
+          def trim(data, sampled: MAX_SAMPLED, length: MAX_LENGTH)
+            return {} unless data.is_a?(Hash)
+
+            data.transform_values do |value|
+              next truncate(value, length) unless value.is_a?(Array)
+
+              value.first(sampled).map { |observed| truncate(observed, length) }
+            end
+          end
+
+          #: (untyped, ?Integer) -> untyped
+          def truncate(observed, length = MAX_LENGTH)
+            return observed unless observed.is_a?(String)
+            return observed if observed.length <= length
+
+            "#{observed[0, length]}…"
+          end
+
+          private
+
+          #: (Hash[untyped, untyped]) -> Hash[String, untyped]
+          def jsonable_hash(value)
+            sanitized = {} #: Hash[String, untyped]
+
+            value.each { |key, entry| sanitized[key.to_s] = jsonable(entry) }
+
+            sanitized
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/herb/engine/runtime/report.rb
+++ b/lib/herb/engine/runtime/report.rb
@@ -4,12 +4,14 @@
 require "json"
 
 require_relative "../../diagnostic"
+require_relative "observations"
 
 module Herb
   class Engine
     module Runtime
       class Report
         VERSION = 1 #: Integer
+        MAX_TAG_LENGTH = 120 #: Integer
         MAX_DIAGNOSTICS = 200 #: Integer
         ATTRIBUTE = "data-herb-diagnostics" #: String
 
@@ -126,7 +128,7 @@ module Herb
         def to_h
           {
             version: VERSION,
-            diagnostics: diagnostics.map(&:to_h),
+            diagnostics: diagnostics.map { |diagnostic| serialized(diagnostic) },
             renderTree: @render_tree,
             nodes: @nodes,
             sources: sources,
@@ -146,6 +148,51 @@ module Herb
         end
 
         private
+
+        #: (Herb::Diagnostic) -> Hash[Symbol, untyped]
+        def serialized(diagnostic)
+          observed = Observations.trim(Observations.jsonable(diagnostic.data))
+          tag = tag_source(diagnostic)
+
+          diagnostic.to_h.merge(observed.empty? ? {} : { data: observed }).merge(tag ? { tag: tag } : {})
+        end
+
+        #: (Herb::Diagnostic) -> String?
+        def tag_source(diagnostic)
+          location = diagnostic.location
+          finish = location&.end
+
+          return nil unless location && finish
+          return nil unless location.start.line == finish.line
+
+          line = template_line(diagnostic.template, location.start.line)
+
+          return nil unless line
+
+          text = line[(location.start.column)...(finish.column)].to_s.strip
+
+          text.empty? ? nil : Observations.truncate(text, MAX_TAG_LENGTH)
+        end
+
+        #: (String, Integer) -> String?
+        def template_line(template, line)
+          source = @sources[template] || read_template(template)
+
+          return nil unless source
+
+          source.lines[line - 1]&.chomp
+        end
+
+        #: (String) -> String?
+        def read_template(template)
+          @read ||= {} #: Hash[String, String?]
+
+          @read.fetch(template) do
+            @read[template] = File.exist?(template) ? File.read(template) : nil
+          end
+        rescue SystemCallError, IOError
+          nil
+        end
 
         #: () -> String
         def escaped_json

--- a/sig/herb/engine/runtime/journal.rbs
+++ b/sig/herb/engine/runtime/journal.rbs
@@ -42,10 +42,6 @@ module Herb
 
         MIN_RECORD_BYTES: Integer
 
-        MAX_SAMPLED_OBSERVATIONS: Integer
-
-        MAX_OBSERVATION_LENGTH: Integer
-
         KEPT_DIGESTS: Integer
 
         attr_reader root: Pathname
@@ -85,18 +81,6 @@ module Herb
 
         # : (Herb::Diagnostic, String, String, String?) -> String?
         def finding_line: (Herb::Diagnostic, String, String, String?) -> String?
-
-        # : (untyped) -> untyped
-        def jsonable: (untyped) -> untyped
-
-        # : (Hash[untyped, untyped]) -> Hash[String, untyped]
-        def jsonable_hash: (Hash[untyped, untyped]) -> Hash[String, untyped]
-
-        # : (Hash[Symbol, untyped]?) -> Hash[Symbol, untyped]
-        def trim: (Hash[Symbol, untyped]?) -> Hash[Symbol, untyped]
-
-        # : (untyped) -> untyped
-        def truncate: (untyped) -> untyped
 
         # : (String, String, String) -> String
         def header_for: (String, String, String) -> String

--- a/sig/herb/engine/runtime/observations.rbs
+++ b/sig/herb/engine/runtime/observations.rbs
@@ -1,0 +1,38 @@
+# Generated from lib/herb/engine/runtime/observations.rb with RBS::Inline
+
+module Herb
+  class Engine
+    module Runtime
+      # What a producer observed, made fit to be written down.
+      #
+      # An observation is any object its producer chose to record, while both places it ends up are
+      # JSON: the journal on disk and the report a page carries. Anything that is not already a
+      # primitive has to become one, and there is a size past which an observation stops being worth
+      # keeping whole.
+      #
+      #     Observations.jsonable({ queries: [statement, connection] })
+      #     #=> { "queries" => ["SELECT 1", "#<ActiveRecord::ConnectionAdapters::SQLite3Adapter>"] }
+      #
+      # The default `to_s` of an object carries its memory address, which means nothing once the
+      # process is gone and differs on every run, so what is kept is the class name alone. It says
+      # an object was there without pretending to be it.
+      module Observations
+        MAX_SAMPLED: Integer
+
+        MAX_LENGTH: Integer
+
+        # : (untyped) -> untyped
+        def self.jsonable: (untyped) -> untyped
+
+        # : (untyped, ?sampled: Integer, ?length: Integer) -> Hash[untyped, untyped]
+        def self.trim: (untyped, ?sampled: Integer, ?length: Integer) -> Hash[untyped, untyped]
+
+        # : (untyped, ?Integer) -> untyped
+        def self.truncate: (untyped, ?Integer) -> untyped
+
+        # : (Hash[untyped, untyped]) -> Hash[String, untyped]
+        private def self.jsonable_hash: (Hash[untyped, untyped]) -> Hash[String, untyped]
+      end
+    end
+  end
+end

--- a/sig/herb/engine/runtime/report.rbs
+++ b/sig/herb/engine/runtime/report.rbs
@@ -6,6 +6,8 @@ module Herb
       class Report
         VERSION: Integer
 
+        MAX_TAG_LENGTH: Integer
+
         MAX_DIAGNOSTICS: Integer
 
         ATTRIBUTE: String
@@ -74,6 +76,18 @@ module Herb
         def to_html: () -> String
 
         private
+
+        # : (Herb::Diagnostic) -> Hash[Symbol, untyped]
+        def serialized: (Herb::Diagnostic) -> Hash[Symbol, untyped]
+
+        # : (Herb::Diagnostic) -> String?
+        def tag_source: (Herb::Diagnostic) -> String?
+
+        # : (String, Integer) -> String?
+        def template_line: (String, Integer) -> String?
+
+        # : (String) -> String?
+        def read_template: (String) -> String?
 
         # : () -> String
         def escaped_json: () -> String


### PR DESCRIPTION
This pull request carries what a producer observed into the page's report, so the dev tools can show the statements behind a count instead of only the count.

A page reported `3 SQL queries` and stopped there. The statements were recorded, and they are what tell you whether three is three of the same one, but they never left the server: `Herb::Diagnostic#to_h` leaves the observations out, so only the editor, reading the journal, could see them.

`Herb::Engine::Runtime::Report` carries them now. Each card gained a folded `What was observed`, since a card is read for what is wrong with the page and this is the evidence underneath:

<img width="1106" height="888" alt="CleanShot 2026-09-05 at 15 04 52@2x" src="https://github.com/user-attachments/assets/efb6eab6-864c-4b4d-b24a-ce58b6952084" />


