### PR TITLE
Dev Tools: Put what a file measured on its outline

### DIFF
--- a/javascript/packages/dev-tools/src/herb-dev-tools.ts
+++ b/javascript/packages/dev-tools/src/herb-dev-tools.ts
@@ -155,6 +155,7 @@ export class HerbDevTools {
         isRuntimePanelVisible: runtimePanelEnabled ? () => this.panel === null || !this.panel.dismissed : undefined,
         onRuntimePanelToggle: runtimePanelEnabled ? visible => (visible ? this.panel?.show() : this.panel?.dismiss()) : undefined,
         reportedFor: runtimePanelEnabled ? template => this.panel?.reportedFor(template) ?? null : undefined,
+        measuredFor: runtimePanelEnabled ? template => this.panel?.measuredFor(template) ?? null : undefined,
       })
     }
 

--- a/javascript/packages/dev-tools/src/overlay/overlay.css
+++ b/javascript/packages/dev-tools/src/overlay/overlay.css
@@ -556,6 +556,16 @@
   font-weight: 500;
 }
 
+.herb-overlay-label-measured {
+  margin-left: 6px;
+  padding: 0 5px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.22);
+  font-variant-numeric: tabular-nums;
+  font-weight: 500;
+  white-space: nowrap;
+}
+
 .herb-outline-preview {
   padding: 2px 8px;
   border: 2px dotted transparent;

--- a/javascript/packages/dev-tools/src/overlay/overlay.ts
+++ b/javascript/packages/dev-tools/src/overlay/overlay.ts
@@ -15,6 +15,7 @@ export interface HerbOverlayOptions {
   onRuntimePanelToggle?: (visible: boolean) => void;
   onHotReloadingToggle?: (enabled: boolean) => void;
   reportedFor?: (template: string) => { count: number, tone: string } | null;
+  measuredFor?: (template: string) => string | null;
 }
 
 export class HerbOverlay {
@@ -25,6 +26,7 @@ export class HerbOverlay {
   private showingViewOutlines = false;
   private showingPartialOutlines = false;
   private showingComponentOutlines = false;
+  private showingOutlineMetrics = false;
   private menuOpen = false;
   private projectPath = '';
   private preferredEditor = 'auto';
@@ -147,6 +149,7 @@ export class HerbOverlay {
         this.showingViewOutlines = settings.showingViewOutlines || false;
         this.showingPartialOutlines = settings.showingPartialOutlines || false;
         this.showingComponentOutlines = settings.showingComponentOutlines || false;
+        this.showingOutlineMetrics = settings.showingOutlineMetrics || false;
         this.showingSlotUpdates = settings.showingSlotUpdates || false;
         this.runningLinter = settings.runningLinter !== undefined ? settings.runningLinter : true;
         this.hotReloading = settings.hotReloading !== undefined ? settings.hotReloading : true;
@@ -177,6 +180,7 @@ export class HerbOverlay {
       showingViewOutlines: this.showingViewOutlines,
       showingPartialOutlines: this.showingPartialOutlines,
       showingComponentOutlines: this.showingComponentOutlines,
+      showingOutlineMetrics: this.showingOutlineMetrics,
       showingSlotUpdates: this.showingSlotUpdates,
       runningLinter: this.runningLinter,
       hotReloading: this.hotReloading,
@@ -373,6 +377,14 @@ export class HerbOverlay {
             </label>
           </div>
 
+          <div class="herb-toggle-item">
+            <label class="herb-toggle-label">
+              <input type="checkbox" id="herbToggleOutlineMetrics" class="herb-toggle-input">
+              <span class="herb-toggle-switch"></span>
+              <span class="herb-toggle-text">Measurements on Outlines</span>
+            </label>
+          </div>
+
           ${devServer ? `<div class="herb-toggle-item" id="herbHotReloadingItem">
             <label class="herb-toggle-label">
               <input type="checkbox" id="herbToggleHotReloading" class="herb-toggle-input">
@@ -561,6 +573,15 @@ export class HerbOverlay {
       toggleHotReloadFlashesSwitch.addEventListener('change', () => {
         this.toggleHotReloadFlashes(toggleHotReloadFlashesSwitch.checked);
         this.syncFlashUpdatesToggle();
+      });
+    }
+
+    const toggleOutlineMetricsSwitch = document.getElementById('herbToggleOutlineMetrics') as HTMLInputElement;
+
+    if (toggleOutlineMetricsSwitch) {
+      toggleOutlineMetricsSwitch.checked = this.showingOutlineMetrics;
+      toggleOutlineMetricsSwitch.addEventListener('change', () => {
+        this.toggleOutlineMetrics(toggleOutlineMetricsSwitch.checked);
       });
     }
 
@@ -778,6 +799,43 @@ export class HerbOverlay {
     this.saveSettings();
   }
 
+  private appendMeasurements(label: HTMLElement, relativePath: string) {
+    label.querySelector('.herb-overlay-label-measured')?.remove();
+
+    if (!this.showingOutlineMetrics) {
+      return;
+    }
+
+    const measured = this.options.measuredFor?.(relativePath) ?? null;
+
+    if (measured === null) {
+      return;
+    }
+
+    const chip = document.createElement('span');
+
+    chip.className = 'herb-overlay-label-measured';
+    chip.textContent = measured;
+    chip.title = `Measured for ${relativePath}`;
+
+    label.appendChild(chip);
+  }
+
+  private toggleOutlineMetrics(show?: boolean) {
+    this.showingOutlineMetrics = show !== undefined ? show : !this.showingOutlineMetrics;
+
+    document.querySelectorAll('.herb-overlay-label').forEach((label) => {
+      const element = label.parentElement;
+      const relativePath = element?.getAttribute('data-herb-debug-file-relative-path')
+        || element?.getAttribute('data-herb-debug-file-name')
+        || '';
+
+      this.appendMeasurements(label as HTMLElement, relativePath);
+    });
+
+    this.saveSettings();
+  }
+
   private createOverlayLabel(element: HTMLElement, type: 'view' | 'partial' | 'component') {
     if (element.querySelector('.herb-overlay-label')) {
       return;
@@ -809,6 +867,8 @@ export class HerbOverlay {
 
       label.appendChild(badge);
     }
+
+    this.appendMeasurements(label, relativePath);
 
     label.addEventListener('mouseenter', () => {
       name.textContent = relativePath;

--- a/javascript/packages/dev-tools/src/runtime/panel.ts
+++ b/javascript/packages/dev-tools/src/runtime/panel.ts
@@ -14,6 +14,7 @@ import type { NormalizedDiagnostic, NormalizedRuntimeReport, OverlayMode, Runtim
 export type BadgeTone = RuntimeSeverity | 'metric'
 
 const WRAPPING_OBSERVATION = 80
+const MAX_LABEL_READINGS = 3
 const ALL_ORIGINS = '*'
 const ALL_SEVERITIES = '*'
 const ALL_METRICS = '*'
@@ -850,6 +851,28 @@ export class RuntimePanel {
     const count = matching.reduce((total, entry) => total + entry.count, 0)
 
     return { count, tone: severityOf(matching) ?? 'metric' }
+  }
+
+  public measuredFor(template: string): string | null {
+    const readings = this.shown.filter(entry => isReading(entry.diagnostic) && entry.diagnostic.template === template)
+
+    if (readings.length === 0) {
+      return null
+    }
+
+    const counted = new Map<string, number>()
+
+    for (const entry of readings) {
+      const value = entry.diagnostic.value
+
+      if (value === null) continue
+
+      counted.set(value, (counted.get(value) ?? 0) + entry.count)
+    }
+
+    const parts = Array.from(counted).slice(0, MAX_LABEL_READINGS).map(([value, count]) => count === 1 ? value : `${value} ×${count}`)
+
+    return parts.length === 0 ? null : parts.join(' · ')
   }
 
   public refresh() {

--- a/javascript/packages/dev-tools/test/menu-toggle.test.ts
+++ b/javascript/packages/dev-tools/test/menu-toggle.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect, afterEach, vi } from "vitest"
+import { describe, test, expect, afterEach, beforeEach, vi } from "vitest"
 
 import { HerbDevTools } from "../src/herb-dev-tools.js"
 
@@ -53,5 +53,115 @@ describe("the dev tools menu", () => {
     trigger().click()
 
     expect(isOpen()).toBe(false)
+  })
+})
+
+describe("measurements on outlines", () => {
+  const PAYLOAD = {
+    version: 1,
+    diagnostics: [
+      {
+        template: "app/views/posts/_post.html.erb",
+        message: "This ERB tag ran 5 SQL queries while the page rendered.",
+        code: "sql-queries",
+        kind: "metric",
+        origin: "Herb Engine",
+        value: "5 SQL queries",
+        location: { start: { line: 2, column: 1 } },
+      },
+      {
+        template: "app/views/posts/_post.html.erb",
+        message: "This tag rendered once, taking 1.4 ms.",
+        code: "render-time",
+        kind: "metric",
+        origin: "Herb Engine",
+        value: "1.4 ms",
+        location: { start: { line: 6, column: 1 } },
+      },
+      {
+        template: "app/views/posts/index.html.erb",
+        message: "Image is missing an alt attribute.",
+        code: "html-img-require-alt",
+        severity: "warning",
+        origin: "Herb Linter",
+        location: { start: { line: 3, column: 3 } },
+      },
+    ],
+  }
+
+  function embedReport() {
+    const script = document.createElement("script")
+
+    script.type = "application/json"
+    script.setAttribute("data-herb-diagnostics", "")
+    script.textContent = JSON.stringify(PAYLOAD)
+
+    document.body.appendChild(script)
+  }
+
+  function outlined(template: string) {
+    const element = document.createElement("section")
+
+    element.setAttribute("data-herb-debug-outline-type", "partial")
+    element.setAttribute("data-herb-debug-file-name", template.split("/").pop()!)
+    element.setAttribute("data-herb-debug-file-relative-path", template)
+
+    document.body.appendChild(element)
+
+    return element
+  }
+
+  function measured(element: HTMLElement) {
+    return element.querySelector(".herb-overlay-label-measured") as HTMLElement | null
+  }
+
+  beforeEach(() => {
+    document.body.innerHTML = ""
+  })
+
+  test("says nothing until the toggle is on", () => {
+    embedReport()
+
+    const element = outlined("app/views/posts/_post.html.erb")
+
+    HerbDevTools.start()
+    overlayOf().togglePartialOutlines(true)
+
+    expect(element.querySelector(".herb-overlay-label")).not.toBeNull()
+    expect(measured(element)).toBeNull()
+
+    overlayOf().toggleOutlineMetrics(true)
+
+    expect(measured(element)!.textContent).toBe("5 SQL queries · 1.4 ms")
+  })
+
+  test("takes it away again, and remembers either way", () => {
+    embedReport()
+
+    const element = outlined("app/views/posts/_post.html.erb")
+
+    HerbDevTools.start()
+    overlayOf().togglePartialOutlines(true)
+    overlayOf().toggleOutlineMetrics(true)
+
+    expect(JSON.parse(localStorage.getItem("herb-dev-tools-settings")!).showingOutlineMetrics).toBe(true)
+
+    overlayOf().toggleOutlineMetrics(false)
+
+    expect(measured(element)).toBeNull()
+    expect(JSON.parse(localStorage.getItem("herb-dev-tools-settings")!).showingOutlineMetrics).toBe(false)
+  })
+
+  test("says nothing for a file that measured nothing", () => {
+    embedReport()
+
+    const element = outlined("app/views/posts/index.html.erb")
+
+    HerbDevTools.start()
+    overlayOf().togglePartialOutlines(true)
+    overlayOf().toggleOutlineMetrics(true)
+
+    expect(element.querySelector(".herb-overlay-label")).not.toBeNull()
+    expect(measured(element)).toBeNull()
   })
 })


### PR DESCRIPTION
This pull request adds a `Measurements on Outlines` switch to the Herb menu, so the outlines and the runtime panel can be read in one glance instead of two.

The outlines say which file drew which region of a page. The panel says what those files cost while they rendered. Reading one meant leaving the other, and this writes the measurements onto the labels the outlines already draw:

<img width="3232" height="1830" alt="CleanShot 2026-09-05 at 13 07 39@2x" src="https://github.com/user-attachments/assets/ed8ca987-eab5-433c-82a4-442c0b053a74" />

Closes https://github.com/marcoroth/reactionview/pull/55