### PR TITLE
Ruby: Upgrade Steep to 2.1 and RBS to 4.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,17 +22,14 @@ gem "nokogiri", "~> 1.19"
 gem "rake", "~> 13.4"
 gem "rake-compiler", "~> 1.3"
 gem "rake-compiler-dock", "~> 1.12"
-gem "rbs", "~> 4.1"
+gem "rbs", "~> 4.2"
 gem "rbs-inline", "~> 0.14"
 gem "reactionview", "~> 0.4.0"
 gem "reline", "~> 0.7"
 gem "rubocop", "~> 1.71"
 gem "sorbet"
+gem "steep", "~> 2.1"
 gem "turbo-rails", "~> 2.0", require: false
 gem "webrick", "~> 1.9", require: false
 gem "websocket", "~> 1.2"
 gem "yerba", "~> 0.9"
-
-# TODO: remove once https://github.com/soutaro/steep/pull/2255 ships
-# gem "steep", "~> 2.0"
-gem "steep", github: "marcoroth/steep", branch: "enum-self-type"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,26 +1,4 @@
 GIT
-  remote: https://github.com/marcoroth/steep.git
-  revision: 4f663b53b04c241245fa4e5db9565be0a8665e70
-  branch: enum-self-type
-  specs:
-    steep (2.1.0.dev)
-      concurrent-ruby (>= 1.1.10)
-      csv (>= 3.0.9)
-      fileutils (>= 1.1.0)
-      json (>= 2.1.0)
-      language_server-protocol (>= 3.17.0.4, < 4.0)
-      listen (~> 3.0)
-      logger (>= 1.3.0)
-      parser (>= 3.2)
-      prism (>= 0.25.0)
-      rainbow (>= 2.2.2, < 4.0)
-      rbs (~> 4.0)
-      securerandom (>= 0.1)
-      strscan (>= 1.0.0)
-      terminal-table (>= 2, < 5)
-      uri (>= 0.12.0)
-
-GIT
   remote: https://github.com/ruby/prism.git
   revision: c0e37816e97e23e92524a4070e1b99a4025bc63f
   tag: v1.9.0
@@ -249,7 +227,7 @@ GEM
     rb-fsevent (0.11.2)
     rb-inotify (0.11.1)
       ffi (~> 1.0)
-    rbs (4.1.3)
+    rbs (4.2.0)
       logger
       prism (>= 1.6.0)
       tsort
@@ -288,6 +266,22 @@ GEM
     sorbet-static (0.6.13444-aarch64-linux)
     sorbet-static (0.6.13444-universal-darwin)
     sorbet-static (0.6.13444-x86_64-linux)
+    steep (2.1.0)
+      concurrent-ruby (>= 1.1.10)
+      csv (>= 3.0.9)
+      fileutils (>= 1.1.0)
+      json (>= 2.1.0)
+      language_server-protocol (>= 3.17.0.4, < 4.0)
+      listen (~> 3.0)
+      logger (>= 1.3.0)
+      parser (>= 3.2)
+      prism (>= 0.25.0)
+      rainbow (>= 2.2.2, < 4.0)
+      rbs (~> 4.2)
+      securerandom (>= 0.1)
+      strscan (>= 1.0.0)
+      terminal-table (>= 2, < 5)
+      uri (>= 0.12.0)
     stringio (3.2.0)
     strscan (3.1.7)
     terminal-table (4.0.0)
@@ -344,13 +338,13 @@ DEPENDENCIES
   rake (~> 13.4)
   rake-compiler (~> 1.3)
   rake-compiler-dock (~> 1.12)
-  rbs (~> 4.1)
+  rbs (~> 4.2)
   rbs-inline (~> 0.14)
   reactionview (~> 0.4.0)
   reline (~> 0.7)
   rubocop (~> 1.71)
   sorbet
-  steep!
+  steep (~> 2.1)
   turbo-rails (~> 2.0)
   webrick (~> 1.9)
   websocket (~> 1.2)

--- a/rbs_collection.lock.yaml
+++ b/rbs_collection.lock.yaml
@@ -6,7 +6,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 82762423fc5694b82888ea89a972847cf19838c2
+    revision: 31250b67b9dadaeaccdb65c55d64a20dca7a812e
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: actionview
@@ -58,7 +58,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 82762423fc5694b82888ea89a972847cf19838c2
+    revision: 31250b67b9dadaeaccdb65c55d64a20dca7a812e
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: charm
@@ -86,6 +86,10 @@ gems:
   source:
     type: rubygems
 - name: date
+  version: '0'
+  source:
+    type: stdlib
+- name: dbm
   version: '0'
   source:
     type: stdlib
@@ -129,6 +133,10 @@ gems:
   version: '0'
   source:
     type: stdlib
+- name: lightningcss
+  version: 0.1.1
+  source:
+    type: rubygems
 - name: lint_roller
   version: '1.1'
   source:
@@ -209,12 +217,24 @@ gems:
   version: 1.9.0
   source:
     type: rubygems
+- name: pstore
+  version: '0.2'
+  source:
+    type: git
+    name: ruby/gem_rbs_collection
+    revision: 31250b67b9dadaeaccdb65c55d64a20dca7a812e
+    remote: https://github.com/ruby/gem_rbs_collection.git
+    repo_dir: gems
+- name: psych
+  version: '0'
+  source:
+    type: stdlib
 - name: rack
   version: '2.2'
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 82762423fc5694b82888ea89a972847cf19838c2
+    revision: 31250b67b9dadaeaccdb65c55d64a20dca7a812e
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: rails-dom-testing
@@ -227,14 +247,6 @@ gems:
     repo_dir: gems
 - name: rails-html-sanitizer
   version: '1.6'
-  source:
-    type: git
-    name: ruby/gem_rbs_collection
-    revision: 82762423fc5694b82888ea89a972847cf19838c2
-    remote: https://github.com/ruby/gem_rbs_collection.git
-    repo_dir: gems
-- name: railties
-  version: '6.0'
   source:
     type: git
     name: ruby/gem_rbs_collection
@@ -325,14 +337,6 @@ gems:
   version: '0'
   source:
     type: stdlib
-- name: thor
-  version: '1.2'
-  source:
-    type: git
-    name: ruby/gem_rbs_collection
-    revision: 82762423fc5694b82888ea89a972847cf19838c2
-    remote: https://github.com/ruby/gem_rbs_collection.git
-    repo_dir: gems
 - name: time
   version: '0'
   source:
@@ -361,4 +365,8 @@ gems:
   version: '0'
   source:
     type: stdlib
+- name: yerba
+  version: 0.9.0
+  source:
+    type: rubygems
 gemfile_lock_path: Gemfile.lock

--- a/rbs_collection.yaml
+++ b/rbs_collection.yaml
@@ -14,4 +14,8 @@ gems:
   - name: steep
     ignore: true
 
+  - name: actionpack
+
+  - name: optparse
+
   - name: strscan


### PR DESCRIPTION
This pull request removes the `marcoroth/steep` fork from the `Gemfile` and moves the type checking stack to released Steep 2.1 and RBS 4.2.