### PR TITLE
VS Code: Stop charging Node startup to the Project Analysis timeout

### DIFF
--- a/javascript/packages/vscode/src/analysis-service.ts
+++ b/javascript/packages/vscode/src/analysis-service.ts
@@ -8,6 +8,23 @@ import type { AnalysisResult, FileStatus } from './types'
 
 const execFileAsync = promisify(execFile)
 
+/**
+ * How long a parse worker may run before it is killed and the file reported as
+ * timed out.
+ *
+ * This only has to catch a worker that hangs. The parse itself is already
+ * bounded: the parser enforces `ParserOptions.timeout` (1 s by default) and a
+ * parse that overruns it comes back with a `TIMEOUT_ERROR`, which the worker
+ * reports as `timedOut`.
+ *
+ * It must not be tight, because every worker is a fresh Node process that has
+ * to boot and load the WASM bundle before it reads the file. That costs about
+ * half a second on an idle Apple Silicon Mac, more when `cpus()` workers start
+ * at once. With a 1 s limit most of a large project was reported as "Timed Out"
+ * on startup cost alone (#2552).
+ */
+const WORKER_TIMEOUT_MS = 30_000
+
 export class AnalysisService {
   private workerPath: string
   private onVersionUpdate?: (version: string) => void
@@ -56,7 +73,7 @@ export class AnalysisService {
         JSON.stringify(linterRules),
         workspaceRoot,
         formatterIndentStyle
-      ], { timeout: 1000 })
+      ], { timeout: WORKER_TIMEOUT_MS })
 
       const result = JSON.parse(stdout.trim())
       const failed = result.errors > 0 || result.lintErrors > 0
@@ -66,7 +83,7 @@ export class AnalysisService {
       }
 
       return {
-        status: failed ? 'failed' : 'ok',
+        status: result.timedOut ? 'timeout' : failed ? 'failed' : 'ok',
         errors: result.errors as number,
         lintWarnings: result.lintWarnings as number || 0,
         lintErrors: result.lintErrors as number || 0,

--- a/javascript/packages/vscode/src/parse-worker.js
+++ b/javascript/packages/vscode/src/parse-worker.js
@@ -56,7 +56,9 @@ const { Config } = require('@herb-tools/config');
 
     const content = fs.readFileSync(file, 'utf8');
     const parseResult = Herb.parse(content, parserOptions);
-    const parseErrors = parseResult.recursiveErrors().length;
+    const errors = parseResult.recursiveErrors();
+    const parseErrors = errors.length;
+    const timedOut = errors.some(error => error.type === 'TIMEOUT_ERROR');
 
     let lintOffenses = [];
     let lintErrors = 0;
@@ -137,6 +139,7 @@ const { Config } = require('@herb-tools/config');
       linterDisabled: !linterEnabled,
       formatterIssues,
       formatterDisabled: !formatterEnabled,
+      timedOut,
       version: Herb.version
     };
 


### PR DESCRIPTION
Fixes #2552.

## Problem

Project Analysis in the VS Code extension spawns a fresh Node process per file (`os.cpus().length` at once) and kills each after **1 s**. Every worker first has to boot Node and load the WASM bundle before it reads the file: ~0.45 s on an idle Apple Silicon Mac, ~0.7 s with the formatter enabled. Under any CPU contention most of a large project is reported as "Timed Out". On a 460-template Rails app the count was 452, 238 and 275 on the same tree, tracking machine load rather than the files; the native parser needs at most 24 ms on the largest template.

## Change

- **`analysis-service.ts`** — the process-level limit becomes a 30 s hang guard (`WORKER_TIMEOUT_MS`) with a comment on why it must not be tight. The parse itself is already bounded by `ParserOptions.timeout` (1 s by default), so runaway parses are still caught.
- **`parse-worker.js`** — reports `timedOut: true` when the parse result carries a `TIMEOUT_ERROR`, and the service maps that to the `timeout` status. The "Timed Out" group therefore keeps meaning "the parser gave up on this file" rather than "Node did not finish booting".

No new settings, no change to the worker's arguments.

## Verification

- With the bundled `extension.js` patched to the same larger timeout, all 460 files pass Project Analysis on the machine that reported the timeouts.
- `node --check` on the worker; the TypeScript change is a constant, one option, and one ternary.
- I could not run the monorepo build locally (it needs the native toolchain), so CI is the typecheck here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
