### PR TITLE
Engine: Let a values request steer state initialization

### DIFF
--- a/javascript/packages/client/test/fixtures/contract/a-boolean-attribute-inside-a-block.json
+++ b/javascript/packages/client/test/fixtures/contract/a-boolean-attribute-inside-a-block.json
@@ -69,7 +69,10 @@
         ]
       },
       "computed": {},
-      "server": {}
+      "server": {
+        "branches": {},
+        "reads": {}
+      }
     }
   },
   "dependencies": {

--- a/javascript/packages/client/test/fixtures/contract/a-keyed-collection-with-declared-item-state.json
+++ b/javascript/packages/client/test/fixtures/contract/a-keyed-collection-with-declared-item-state.json
@@ -133,7 +133,10 @@
         }
       },
       "computed": {},
-      "server": {}
+      "server": {
+        "branches": {},
+        "reads": {}
+      }
     }
   },
   "dependencies": {

--- a/lib/herb/engine/slots/dynamics_compiler.rb
+++ b/lib/herb/engine/slots/dynamics_compiler.rb
@@ -4,6 +4,7 @@
 require_relative "../../../herb"
 require_relative "../../engine"
 require_relative "visitor"
+require_relative "state_overrides"
 
 module Herb
   class Engine
@@ -441,6 +442,7 @@ module Herb
           @block_depth = 0
           @scopes = [] #: Array[Integer]
           @slot_visitor = properties[:slot_visitor] || Visitor.new(mode: :server, mark: false)
+          @slot_visitor.state_overrides!
           visitors = [*properties[:visitors], @slot_visitor]
 
           super(

--- a/lib/herb/engine/slots/state_compiler.rb
+++ b/lib/herb/engine/slots/state_compiler.rb
@@ -3,6 +3,7 @@
 require "did_you_mean"
 
 require_relative "state_directives"
+require_relative "state_overrides"
 
 module Herb
   class Engine
@@ -24,6 +25,7 @@ module Herb
         }.freeze #: Hash[String, Symbol]
 
         SEEDS_LOCAL = "_herb_seeds" #: String
+        OVERRIDES_LOCAL = "_herb_state_overrides" #: String
         BARE_IDENTIFIER = /\A[a-z_][a-zA-Z0-9_]*\z/ #: Regexp
         BINDABLE_ATTRIBUTES = ["value", "checked", "selected"].freeze #: Array[String]
         BINDABLE_ELEMENTS = ["input", "textarea", "select", "option"].freeze #: Array[String]
@@ -47,6 +49,7 @@ module Herb
           @state_counts = [] #: Array[Hash[Symbol, untyped]]
           @state_presence = {} #: Hash[Integer, untyped]
           @state_values = {} #: Hash[Integer, untyped]
+          @server_reads = {} #: Hash[String, Array[Hash[String, untyped]]]
         end
 
         #: () -> bool
@@ -86,6 +89,10 @@ module Herb
               next
             end
 
+            scope_and_depth = @visitor.scope_of(@visitor.slot_nodes[slot.index])
+
+            next if scope_and_depth && @visitor.block_locals(scope_and_depth[0]).include?(name)
+
             (reads[name] ||= []) << slot.index
 
             warn_unbindable(slot, name) if slot.interpolated?
@@ -121,8 +128,6 @@ module Herb
             declaration["count"] = { "collection" => count[:collection], "when" => count[:when], "by" => count[:by] }
           end
 
-          warn_branch_orphans(reads, computed, presence)
-
           {
             "version" => @visitor.version,
             "declarations" => declarations,
@@ -130,7 +135,7 @@ module Herb
             "conditionals" => conditionals,
             "presence" => presence,
             "computed" => computed,
-            "server" => {},
+            "server" => { "branches" => branch_orphans(reads, computed, presence, steerable_names(declarations)), "reads" => @server_reads },
           }
         end
 
@@ -198,22 +203,172 @@ module Herb
           )
         end
 
-        #: (Hash[String, Array[Integer]], Hash[String, untyped], Hash[String, untyped]) -> void
-        def warn_branch_orphans(reads, computed, presence)
-          return unless @visitor.client?
+        #: (Array[Hash[String, untyped]]) -> Set[String]
+        def steerable_names(declarations)
+          declarations.filter_map { |entry| entry["name"] if entry["scope"] == "region" && !entry["derived"] && !entry["count"] }.to_set
+        end
+
+        #: (untyped) -> Array[String]
+        def condition_names(condition)
+          if condition.is_a?(Hash)
+            parts = condition["all"] || condition["any"]
+
+            return parts.to_a.flat_map { |part| condition_names(part) }
+          end
+
+          return [] unless condition.is_a?(Array)
+
+          names = [] #: Array[String]
+          names << condition[0] if condition[0].is_a?(String)
+
+          comparand = condition[1]
+          names << comparand["state"] if comparand.is_a?(Hash) && comparand["state"].is_a?(String)
+
+          names
+        end
+
+        #: (Hash[Symbol, untyped], Set[String]) -> bool
+        def steered_conditional?(info, steerable)
+          names = info[:arms].flat_map { |arm| condition_names(arm["condition"]) }
+
+          !names.empty? && names.all? { |name| steerable.include?(name) }
+        end
+
+        #: (Integer, Hash[Symbol, untyped]) -> Set[Integer]
+        def default_branch_slots(index, info)
+          none = Set.new #: Set[Integer]
+          node = @visitor.slot_nodes[index]
+
+          return none unless node
+
+          scope, = @visitor.scope_of(node)
+          states = states_for(scope)
+
+          info[:arms].each do |arm|
+            verdict = static_condition(arm["condition"], states)
+
+            return none if verdict.nil?
+            next unless verdict
+            return none if arm["branch"].nil?
+
+            return branch_slot_set(index, arm.fetch("branch"))
+          end
+
+          return none if info[:else].nil?
+
+          branch_slot_set(index, info.fetch(:else))
+        end
+
+        #: (Integer, Integer) -> Set[Integer]
+        def branch_slot_set(index, branch)
+          slots = @visitor.slots_by_branch(index)[branch] || [] #: Array[Integer]
+
+          slots.to_set
+        end
+
+        #: (untyped, Hash[String, StateDirectives::Declaration]) -> bool?
+        def static_condition(condition, states)
+          return static_combo(condition, states) if condition.is_a?(Hash)
+          return nil unless condition.is_a?(Array)
+          return nil if condition[3]
+
+          name, comparand, operator = condition
+          value = static_default(name, states)
+
+          return nil if value == :__herb_undecided
+
+          if comparand.nil?
+            case operator
+            when nil then return !value.nil? && value != false
+            when "blank" then return value.nil? || value == false || value == ""
+            when "present" then return !(value.nil? || value == false || value == "")
+            else return nil
+            end
+          end
+
+          return nil unless comparand.is_a?(Hash)
+
+          against = static_comparand(comparand, states)
+
+          return nil if against == :__herb_undecided
+
+          compare_statics(value, against, operator || "==")
+        end
+
+        #: (Hash[String, untyped], Hash[String, StateDirectives::Declaration]) -> untyped
+        def static_comparand(comparand, states)
+          return comparand["value"] if comparand.key?("value")
+          return :__herb_undecided if comparand["transform"] || !comparand["state"].is_a?(String)
+
+          static_default(comparand.fetch("state"), states)
+        end
+
+        #: (Hash[String, untyped], Hash[String, StateDirectives::Declaration]) -> bool?
+        def static_combo(condition, states)
+          parts = (condition["all"] || condition["any"]).to_a.map { |part| static_condition(part, states) }
+
+          if condition.key?("all")
+            return false if parts.any? { |part| part == false }
+            return true if parts.all? { |part| part == true }
+          else
+            return true if parts.any? { |part| part == true }
+            return false if parts.all? { |part| part == false }
+          end
+
+          nil
+        end
+
+        #: (String, Hash[String, StateDirectives::Declaration]) -> untyped
+        def static_default(name, states)
+          declaration = states[name]
+
+          return :__herb_undecided if declaration.nil? || declaration.derived
+          return :__herb_undecided if @state_counts.any? { |count| count[:name] == name }
+          return :__herb_undecided unless StateDirectives.literal?(declaration.default)
+
+          StateDirectives.literal_value(declaration.default)
+        end
+
+        #: (untyped, untyped, String) -> bool?
+        def compare_statics(value, against, operator)
+          case operator
+          when "==" then value == against
+          when "!=" then value != against
+          when ">", ">=", "<", "<="
+            return nil unless value.is_a?(Integer) && against.is_a?(Integer)
+
+            value.public_send(operator, against)
+          end
+        end
+
+        #: (Hash[String, Array[Integer]], Hash[String, untyped], Hash[String, untyped], Set[String]) -> void
+        def branch_orphans(reads, computed, presence, steerable)
+          branches = {} #: Hash[String, Array[Hash[String, untyped]]]
+
+          return branches unless @visitor.client?
 
           covered = (reads.values.flatten + computed.keys.map(&:to_i) + presence.keys.map(&:to_i)).to_set
-          warned = Set.new #: Set[Integer]
+          refetchable = @server_reads.values.flatten.to_set { |entry| entry["index"] }
+          seen = Set.new #: Set[Integer]
 
-          state_conditional_entries.each_key do |index|
+          state_conditional_entries.each do |index, info|
+            steered = steered_conditional?(info, steerable)
+            served = default_branch_slots(index, info)
+
             @visitor.slots_inside(index).each do |inside|
-              next unless warned.add?(inside)
+              next unless seen.add?(inside)
 
               slot = @visitor.slots[inside]
 
               next unless slot&.valued?
               next if covered.include?(inside)
               next if @near_missed.include?(inside)
+
+              (branches[index.to_s] ||= []) << { "index" => inside, "node_path" => slot.node_path }
+
+              next if steered
+              next if served.include?(inside)
+              next if refetchable.include?(inside)
 
               expression = slot.expression.to_s.strip
 
@@ -225,6 +380,8 @@ module Herb
               )
             end
           end
+
+          branches
         end
 
         #: (Hash[Symbol, untyped], (String | Integer)) -> Hash[String, untyped]
@@ -397,7 +554,11 @@ module Herb
 
         #: (untyped) -> Hash[String, StateDirectives::Declaration]
         def states_for(scope)
-          scope ? @region_states.merge(@item_states[scope] || {}) : @region_states.dup
+          states = scope ? @region_states.merge(@item_states[scope] || {}) : @region_states.dup
+          none = [] #: Array[String]
+          shadowed = scope ? @visitor.block_locals(scope) : none
+
+          shadowed.empty? ? states : states.except(*shadowed)
         end
 
         #: () -> void
@@ -411,15 +572,17 @@ module Herb
             scope = directive[:scope]
             bucket = scope ? (@item_states[scope] || {}) : @region_states
             assignments = bucket.values.map { |declaration| state_assignment(declaration) }.join("; ")
+            assignments = "#{overrides_prelude}; #{assignments}" if @visitor.state_overrides?
             seeds = directive[:inline] || @visitor.degraded? ? nil : seeds_marker(bucket.values)
 
-            parent[position] = @visitor.erb_code_node(seeds ? "#{assignments}; #{seeds}" : assignments)
+            parent[position] = @visitor.erb_code_node(seeds ? "; #{assignments}; #{seeds}" : "; #{assignments}")
           end
 
           return if @region_states.empty? && @item_states.empty?
 
           classify_state_conditionals
           check_state_value_reads
+          check_collection_reads
           check_state_count_reads
         end
 
@@ -446,9 +609,24 @@ module Herb
             end
           end
 
-          return "#{declaration.name} = !!(#{source})" if declaration.kind == :boolean
+          default = declaration.kind == :boolean ? "!!(#{source})" : source
 
-          "#{declaration.name} = #{source}"
+          return "#{declaration.name} = #{default}" unless overridable?(declaration)
+
+          "#{declaration.name} = ::Herb::Engine::Slots::StateOverrides.fetch(#{OVERRIDES_LOCAL}, #{declaration.name.inspect}, #{declaration.kind.inspect}) { #{default} }"
+        end
+
+        #: (StateDirectives::Declaration) -> bool
+        def overridable?(declaration)
+          return false unless @visitor.state_overrides?
+          return false if declaration.derived
+
+          @state_counts.none? { |count| count[:name] == declaration.name }
+        end
+
+        #: () -> String
+        def overrides_prelude
+          "#{OVERRIDES_LOCAL} = ::Herb::Engine::Slots::StateOverrides.resolve((#{StateOverrides::HOOK} if defined?(#{StateOverrides::HOOK})), #{@visitor.identifier.inspect})"
         end
 
         #: () -> void
@@ -888,12 +1066,58 @@ module Herb
           return if read == :reported
 
           unless read.is_a?(StateDirectives::Read) || read.is_a?(StateDirectives::Combo)
-            return @visitor.slot_error("`#{expression}` computes with the state `#{mentioned_state(expression, states)&.name}`. The client cannot run Ruby to keep the result current.", condition_anchor(node, expression).location, :read, suggestion: "Show the value with `<%= #{mentioned_state(expression, states)&.name} %>`, or declare a second state for the computed answer and set it from app code.")
+            return register_server_read(node, index, slot, expression, states)
           end
 
           StateDirectives.read_names(read).each { |name| rewrite_predicate(node, name) }
 
           @state_values[index] = read
+        end
+
+        #: () -> void
+        def check_collection_reads
+          @visitor.slot_nodes.each do |node|
+            index = @visitor.index_for(node)
+
+            next unless index
+
+            slot = @visitor.slots[index]
+
+            next unless slot.type == :collection
+
+            expression = slot.expression.to_s.strip
+
+            next if expression.empty?
+
+            mentioned = @region_states.each_value.select { |declaration| mentioned_state(expression, { declaration.name => declaration }) } # steep:ignore UnannotatedEmptyCollection
+
+            next if mentioned.empty?
+
+            entry = { "index" => index, "node_path" => slot.node_path }
+
+            mentioned.each do |declaration|
+              @server_reads[declaration.name] ||= [] # steep:ignore UnannotatedEmptyCollection
+              @server_reads.fetch(declaration.name) << entry
+            end
+          end
+        end
+
+        #: (untyped, Integer, untyped, String, Hash[String, StateDirectives::Declaration]) -> nil
+        def register_server_read(node, index, slot, expression, states)
+          mentioned = @region_states.each_value.select { |declaration| mentioned_state(expression, { declaration.name => declaration }) } # steep:ignore UnannotatedEmptyCollection
+
+          if mentioned.empty?
+            return @visitor.slot_error("`#{expression}` computes with the state `#{mentioned_state(expression, states)&.name}`, which lives on an item. The server cannot be asked for an item's answer yet.", condition_anchor(node, expression).location, :read, suggestion: "Show the value with `<%= #{mentioned_state(expression, states)&.name} %>`, or declare a second state for the computed answer and set it from app code.")
+          end
+
+          entry = { "index" => index, "node_path" => slot.node_path }
+
+          mentioned.each do |declaration|
+            @server_reads[declaration.name] ||= [] # steep:ignore UnannotatedEmptyCollection
+            @server_reads.fetch(declaration.name) << entry
+          end
+
+          nil
         end
 
         #: (untyped, untyped, String) -> Symbol?

--- a/lib/herb/engine/slots/state_overrides.rb
+++ b/lib/herb/engine/slots/state_overrides.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+# typed: true
+
+module Herb
+  class Engine
+    module Slots
+      # Resolves the state values a client sent along with a values request.
+      #
+      # The values program evaluates the branch the state picks, so a client that wants the
+      # values for its own branches sends its state and the program initializes each declared
+      # state from it. A host makes that possible by answering `__herb_state_overrides` in the
+      # render context with a hash keyed by template identifier. Everything here degrades to
+      # the compiled defaults, since a missing, malformed or wrongly typed override must never
+      # break a render the defaults could serve.
+      #
+      module StateOverrides
+        HOOK = "__herb_state_overrides" #: String
+
+        #: (untyped, String) -> Hash[String, untyped]?
+        def self.resolve(raw, identifier)
+          return nil unless raw.is_a?(Hash)
+
+          overrides = raw[identifier]
+
+          overrides.is_a?(Hash) ? overrides : nil
+        end
+
+        #: (Hash[String, untyped]?, String, Symbol) { () -> untyped } -> untyped
+        def self.fetch(overrides, name, kind)
+          return yield if overrides.nil? || !overrides.key?(name)
+
+          coerced = coerce(overrides[name], kind)
+
+          coerced == :__herb_uncoercible ? yield : coerced
+        end
+
+        #: (untyped, Symbol) -> untyped
+        def self.coerce(value, kind)
+          return :__herb_uncoercible unless value.nil? || value.is_a?(String) || value.is_a?(Integer) || value.is_a?(Float) || value == true || value == false
+
+          case kind
+          when :boolean
+            return value if [true, false].include?(value)
+            return value == "true" if ["true", "false"].include?(value)
+
+            :__herb_uncoercible
+          when :integer
+            return value if value.is_a?(Integer)
+            return value.to_i if value.is_a?(String) && value.strip.match?(/\A-?\d+\z/)
+
+            :__herb_uncoercible
+          when :string, :symbol
+            return :__herb_uncoercible if value.nil?
+
+            string = value.is_a?(String) ? value : value.to_s
+
+            kind == :symbol ? string.to_sym : string
+          else
+            value
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/herb/engine/slots/visitor.rb
+++ b/lib/herb/engine/slots/visitor.rb
@@ -202,6 +202,16 @@ module Herb
           @mode == :client
         end
 
+        #: () -> void
+        def state_overrides!
+          @state_overrides = true
+        end
+
+        #: () -> bool
+        def state_overrides?
+          !!@state_overrides
+        end
+
         #: (Integer, Array[String]) -> bool
         def listener_writes?(index, names)
           written = @listener_written[@slot_nodes[index]]
@@ -216,6 +226,15 @@ module Herb
           return [] unless node
 
           branch_bodies(node).flat_map { |body| slot_indices_within(body) }.uniq
+        end
+
+        #: (Integer) -> Array[Array[Integer]]
+        def slots_by_branch(index)
+          node = @slot_nodes[index]
+
+          return [] unless node
+
+          branch_bodies(node).map { |body| slot_indices_within(body) }
         end
 
         #: (String, Herb::Location?, Symbol, ?suggestion: String?) -> nil
@@ -290,6 +309,20 @@ module Herb
         #: () -> untyped
         def current_collection
           @collection_nodes.last
+        end
+
+        #: (untyped) -> Array[String]
+        def block_locals(scope)
+          nodes = @collection_nodes.include?(scope) ? @collection_nodes.take(@collection_nodes.index(scope) + 1) : [scope]
+
+          nodes.compact.flat_map { |node| parameter_names(node) }
+        end
+
+        #: (untyped) -> Array[String]
+        def parameter_names(node)
+          return [] unless node.respond_to?(:block_arguments)
+
+          (node.block_arguments || []).filter_map { |parameter| parameter.name&.value&.to_s if parameter.respond_to?(:name) }
         end
 
         #: () -> bool

--- a/sig/herb/engine/slots/state_compiler.rbs
+++ b/sig/herb/engine/slots/state_compiler.rbs
@@ -14,6 +14,8 @@ module Herb
 
         SEEDS_LOCAL: String
 
+        OVERRIDES_LOCAL: String
+
         BARE_IDENTIFIER: Regexp
 
         BINDABLE_ATTRIBUTES: Array[String]
@@ -51,8 +53,38 @@ module Herb
         # : (untyped, String, Array[String]) -> void
         def warn_near_miss: (untyped, String, Array[String]) -> void
 
-        # : (Hash[String, Array[Integer]], Hash[String, untyped], Hash[String, untyped]) -> void
-        def warn_branch_orphans: (Hash[String, Array[Integer]], Hash[String, untyped], Hash[String, untyped]) -> void
+        # : (Array[Hash[String, untyped]]) -> Set[String]
+        def steerable_names: (Array[Hash[String, untyped]]) -> Set[String]
+
+        # : (untyped) -> Array[String]
+        def condition_names: (untyped) -> Array[String]
+
+        # : (Hash[Symbol, untyped], Set[String]) -> bool
+        def steered_conditional?: (Hash[Symbol, untyped], Set[String]) -> bool
+
+        # : (Integer, Hash[Symbol, untyped]) -> Set[Integer]
+        def default_branch_slots: (Integer, Hash[Symbol, untyped]) -> Set[Integer]
+
+        # : (Integer, Integer) -> Set[Integer]
+        def branch_slot_set: (Integer, Integer) -> Set[Integer]
+
+        # : (untyped, Hash[String, StateDirectives::Declaration]) -> bool?
+        def static_condition: (untyped, Hash[String, StateDirectives::Declaration]) -> bool?
+
+        # : (Hash[String, untyped], Hash[String, StateDirectives::Declaration]) -> untyped
+        def static_comparand: (Hash[String, untyped], Hash[String, StateDirectives::Declaration]) -> untyped
+
+        # : (Hash[String, untyped], Hash[String, StateDirectives::Declaration]) -> bool?
+        def static_combo: (Hash[String, untyped], Hash[String, StateDirectives::Declaration]) -> bool?
+
+        # : (String, Hash[String, StateDirectives::Declaration]) -> untyped
+        def static_default: (String, Hash[String, StateDirectives::Declaration]) -> untyped
+
+        # : (untyped, untyped, String) -> bool?
+        def compare_statics: (untyped, untyped, String) -> bool?
+
+        # : (Hash[String, Array[Integer]], Hash[String, untyped], Hash[String, untyped], Set[String]) -> void
+        def branch_orphans: (Hash[String, Array[Integer]], Hash[String, untyped], Hash[String, untyped], Set[String]) -> void
 
         # : (Hash[Symbol, untyped], (String | Integer)) -> Hash[String, untyped]
         def declared_entry: (Hash[Symbol, untyped], String | Integer) -> Hash[String, untyped]
@@ -101,6 +133,12 @@ module Herb
 
         # : (StateDirectives::Declaration) -> String
         def state_assignment: (StateDirectives::Declaration) -> String
+
+        # : (StateDirectives::Declaration) -> bool
+        def overridable?: (StateDirectives::Declaration) -> bool
+
+        # : () -> String
+        def overrides_prelude: () -> String
 
         # : () -> void
         def classify_state_conditionals: () -> void
@@ -167,6 +205,12 @@ module Herb
 
         # : (untyped, Integer, untyped, String, Hash[String, StateDirectives::Declaration]) -> void
         def register_state_value: (untyped, Integer, untyped, String, Hash[String, StateDirectives::Declaration]) -> void
+
+        # : () -> void
+        def check_collection_reads: () -> void
+
+        # : (untyped, Integer, untyped, String, Hash[String, StateDirectives::Declaration]) -> nil
+        def register_server_read: (untyped, Integer, untyped, String, Hash[String, StateDirectives::Declaration]) -> nil
 
         # : (untyped, untyped, String) -> Symbol?
         def refuse_mixed_boolean: (untyped, untyped, String) -> Symbol?

--- a/sig/herb/engine/slots/state_overrides.rbs
+++ b/sig/herb/engine/slots/state_overrides.rbs
@@ -1,0 +1,28 @@
+# Generated from lib/herb/engine/slots/state_overrides.rb with RBS::Inline
+
+module Herb
+  class Engine
+    module Slots
+      # Resolves the state values a client sent along with a values request.
+      #
+      # The values program evaluates the branch the state picks, so a client that wants the
+      # values for its own branches sends its state and the program initializes each declared
+      # state from it. A host makes that possible by answering `__herb_state_overrides` in the
+      # render context with a hash keyed by template identifier. Everything here degrades to
+      # the compiled defaults, since a missing, malformed or wrongly typed override must never
+      # break a render the defaults could serve.
+      module StateOverrides
+        HOOK: String
+
+        # : (untyped, String) -> Hash[String, untyped]?
+        def self.resolve: (untyped, String) -> Hash[String, untyped]?
+
+        # : (Hash[String, untyped]?, String, Symbol) { () -> untyped } -> untyped
+        def self.fetch: (Hash[String, untyped]?, String, Symbol) { () -> untyped } -> untyped
+
+        # : (untyped, Symbol) -> untyped
+        def self.coerce: (untyped, Symbol) -> untyped
+      end
+    end
+  end
+end

--- a/sig/herb/engine/slots/visitor.rbs
+++ b/sig/herb/engine/slots/visitor.rbs
@@ -139,11 +139,20 @@ module Herb
         # : () -> bool
         def client?: () -> bool
 
+        # : () -> void
+        def state_overrides!: () -> void
+
+        # : () -> bool
+        def state_overrides?: () -> bool
+
         # : (Integer, Array[String]) -> bool
         def listener_writes?: (Integer, Array[String]) -> bool
 
         # : (Integer) -> Array[Integer]
         def slots_inside: (Integer) -> Array[Integer]
+
+        # : (Integer) -> Array[Array[Integer]]
+        def slots_by_branch: (Integer) -> Array[Array[Integer]]
 
         # : (String, Herb::Location?, Symbol, ?suggestion: String?) -> nil
         def slot_error: (String, Herb::Location?, Symbol, ?suggestion: String?) -> nil
@@ -186,6 +195,12 @@ module Herb
 
         # : () -> untyped
         def current_collection: () -> untyped
+
+        # : (untyped) -> Array[String]
+        def block_locals: (untyped) -> Array[String]
+
+        # : (untyped) -> Array[String]
+        def parameter_names: (untyped) -> Array[String]
 
         # : () -> bool
         def in_item_body?: () -> bool

--- a/test/engine/dynamics_compiler_test.rb
+++ b/test/engine/dynamics_compiler_test.rb
@@ -38,6 +38,18 @@ module Engine
       View.new(**assigns).instance_eval(compiled)
     end
 
+    class SteeredView < View
+      attr_accessor :__herb_state_overrides
+    end
+
+    def steered(source, overrides, **assigns)
+      compiled = Herb::Engine::Slots::DynamicsCompiler.new(source, filename: "app/views/test.html.erb").src
+      view = SteeredView.new(**assigns)
+      view.__herb_state_overrides = overrides
+
+      view.instance_eval(compiled)
+    end
+
     def dynamics(source, **assigns)
       payload(source, **assigns)[:slots]
     end
@@ -293,6 +305,42 @@ module Engine
 
       test "leaves the static markup out" do
         refute_includes Herb::Engine::Slots::DynamicsCompiler.new("<p>hello</p>").src, "hello"
+      end
+    end
+
+    STEERABLE = %(<%# herb:state (editing: false, q: "") %><% if editing %><b>on</b><% else %><i>off</i><% end %><span><%= q.length + 1 %></span>)
+
+    describe "state overrides" do
+      test "the values program initializes states through the override channel" do
+        source = Herb::Engine::Slots::DynamicsCompiler.new(STEERABLE, filename: "app/views/test.html.erb").src
+
+        assert_includes source, "StateOverrides.resolve"
+        assert_includes source, %(StateOverrides.fetch(_herb_state_overrides, "editing", :boolean))
+      end
+
+      test "an override steers the branch and the dependent reads" do
+        values = steered(STEERABLE, { "app/views/test.html.erb" => { "editing" => true, "q" => "abc" } })
+
+        assert_equal 0, values[:slots][0][:branch]
+        assert_equal "4", values[:slots][1]
+      end
+
+      test "no hook and no overrides both fall back to the defaults" do
+        assert_equal 1, payload(STEERABLE)[:slots][0][:branch]
+        assert_equal 1, steered(STEERABLE, nil)[:slots][0][:branch]
+      end
+
+      test "a wrongly typed override falls back to the default" do
+        values = steered(STEERABLE, { "app/views/test.html.erb" => { "editing" => "sideways" } })
+
+        assert_equal 1, values[:slots][0][:branch]
+      end
+
+      test "a derived state re-derives from its overridden base" do
+        template = %(<%# herb:state (count: 0, loud: count > 2) %><% if loud %>a<% else %>b<% end %>)
+        values = steered(template, { "app/views/test.html.erb" => { "count" => 5 } })
+
+        assert_equal 0, values[:slots][0][:branch]
       end
     end
   end

--- a/test/engine/slots/diagnostics_test.rb
+++ b/test/engine/slots/diagnostics_test.rb
@@ -340,8 +340,43 @@ module Engine
         </div>
       ERB
 
-      test "a server value inside a client branch warns while state reads and top-level values stay silent" do
+      test "a server value inside a steerable client branch stays silent, since a refetch fills it" do
         diagnostics, = report(CLIENT_BRANCH)
+
+        assert_empty diagnostics
+      end
+
+      test "a server-driven conditional keeps its branches silent" do
+        diagnostics, = report(CLIENT_BRANCH.sub("<% if editing %>", "<% if message.editable? %>"))
+
+        assert_empty diagnostics
+      end
+
+      ITEM_BRANCH = <<~ERB
+        <%# herb:state (filter: "all") %>
+        <ul>
+        <% @messages.each do |message| %>
+          <%# herb:key message.id %>
+          <%# herb:state (pending: false) %>
+          <li>
+            <% if pending %>
+              Sending
+            <% else %>
+              <span><%= message.sent_label %></span>
+            <% end %>
+          </li>
+        <% end %>
+        </ul>
+      ERB
+
+      test "a server value in the branch the item defaults pick stays silent, since any refetch fills it" do
+        diagnostics, = report(ITEM_BRANCH)
+
+        assert_empty diagnostics
+      end
+
+      test "a server value in a branch the item defaults never pick still warns" do
+        diagnostics, = report(ITEM_BRANCH.sub("Sending", "<b><%= message.queued_label %></b>").sub("<span><%= message.sent_label %></span>", "Sent"))
 
         assert_equal 1, diagnostics.length
 
@@ -349,14 +384,39 @@ module Engine
 
         assert_equal :warning, warning.severity
         assert_equal "herb-slots-branch", warning.code
-        assert_equal "`<%= message.sent_label %>` sits inside a branch the client can show on its own, but its value comes from the server. The server only computes values for the branch it renders, so showing this branch ahead of the server leaves the value empty.", warning.message
-        assert_equal 4, warning.location.start.line
+        assert_equal "`<%= message.queued_label %>` sits inside a branch the client can show on its own, but its value comes from the server. The server only computes values for the branch it renders, so showing this branch ahead of the server leaves the value empty.", warning.message
       end
 
-      test "a server-driven conditional keeps its branches silent" do
-        diagnostics, = report(CLIENT_BRANCH.sub("<% if editing %>", "<% if message.editable? %>"))
+      test "a server value behind a seeded item default still warns, since each item picks its own branch" do
+        diagnostics, = report(<<~ERB)
+          <%# herb:state (filter: "all") %>
+          <ul>
+          <% @messages.each do |message| %>
+            <%# herb:key message.id %>
+            <%# herb:state (starred: message.starred) %>
+            <li>
+              <% if starred %>
+                <span><%= message.starred_label %></span>
+              <% end %>
+            </li>
+          <% end %>
+          </ul>
+        ERB
 
-        assert_empty diagnostics
+        assert_equal 1, diagnostics.length
+        assert_equal "herb-slots-branch", diagnostics.first.code
+      end
+
+      test "a server value inside a derived-state branch still warns, since the derived name never rides the header" do
+        diagnostics, = report(<<~ERB)
+          <%# herb:state (unread: 0, alerting: unread > 3) %>
+          <% if alerting %>
+            <span><%= message.sent_label %></span>
+          <% end %>
+        ERB
+
+        assert_equal 1, diagnostics.length
+        assert_equal "herb-slots-branch", diagnostics.first.code
       end
 
       test "a computed boolean attribute on a form control warns that it cannot bind" do

--- a/test/engine/slots/state_overrides_test.rb
+++ b/test/engine/slots/state_overrides_test.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require_relative "../../test_helper"
+require_relative "../../../lib/herb/engine/slots/state_overrides"
+
+module Engine
+  module Slots
+    class StateOverridesTest < Minitest::Spec
+      Overrides = Herb::Engine::Slots::StateOverrides
+
+      test "resolve digs the template's own overrides and rejects every other shape" do
+        raw = { "app/views/a.html.erb" => { "open" => true } }
+
+        assert_equal({ "open" => true }, Overrides.resolve(raw, "app/views/a.html.erb"))
+        assert_nil Overrides.resolve(raw, "app/views/b.html.erb")
+        assert_nil Overrides.resolve(nil, "app/views/a.html.erb")
+        assert_nil Overrides.resolve("junk", "app/views/a.html.erb")
+        assert_nil Overrides.resolve({ "app/views/a.html.erb" => "junk" }, "app/views/a.html.erb")
+      end
+
+      test "fetch yields the default when there is nothing to say" do
+        assert_equal :fallback, Overrides.fetch(nil, "open", :boolean) { :fallback }
+        assert_equal :fallback, Overrides.fetch({}, "open", :boolean) { :fallback }
+      end
+
+      test "booleans accept booleans and their strings" do
+        assert_equal true, Overrides.fetch({ "open" => true }, "open", :boolean) { :fallback }
+        assert_equal true, Overrides.fetch({ "open" => "true" }, "open", :boolean) { :fallback }
+        assert_equal false, Overrides.fetch({ "open" => "false" }, "open", :boolean) { :fallback }
+        assert_equal :fallback, Overrides.fetch({ "open" => "yes" }, "open", :boolean) { :fallback }
+        assert_equal :fallback, Overrides.fetch({ "open" => 1 }, "open", :boolean) { :fallback }
+      end
+
+      test "integers accept integers and integer strings" do
+        assert_equal 7, Overrides.fetch({ "n" => 7 }, "n", :integer) { :fallback }
+        assert_equal(-3, Overrides.fetch({ "n" => "-3" }, "n", :integer) { :fallback })
+        assert_equal :fallback, Overrides.fetch({ "n" => 3.9 }, "n", :integer) { :fallback }
+        assert_equal :fallback, Overrides.fetch({ "n" => "3.9" }, "n", :integer) { :fallback }
+      end
+
+      test "strings and symbols stringify scalars and refuse nil" do
+        assert_equal "a", Overrides.fetch({ "q" => "a" }, "q", :string) { :fallback }
+        assert_equal "7", Overrides.fetch({ "q" => 7 }, "q", :string) { :fallback }
+        assert_equal :a, Overrides.fetch({ "s" => "a" }, "s", :symbol) { :fallback }
+        assert_equal :fallback, Overrides.fetch({ "q" => nil }, "q", :string) { :fallback }
+      end
+
+      test "structured values never pass through" do
+        assert_equal :fallback, Overrides.fetch({ "q" => ["a"] }, "q", :seeded) { :fallback }
+        assert_equal :fallback, Overrides.fetch({ "q" => { "a" => 1 } }, "q", :seeded) { :fallback }
+      end
+
+      test "seeded and nil kinds carry the seeds envelope through" do
+        assert_nil Overrides.fetch({ "q" => nil }, "q", :seeded) { :fallback }
+        assert_equal 7, Overrides.fetch({ "q" => 7 }, "q", :seeded) { :fallback }
+        assert_equal "a", Overrides.fetch({ "q" => "a" }, "q", :nil) { :fallback }
+      end
+    end
+  end
+end

--- a/test/engine/slots/states_test.rb
+++ b/test/engine/slots/states_test.rb
@@ -206,11 +206,6 @@ module Engine
         )
 
         refuse(
-          "<%# herb:state (attempts: 0) %><p><%= attempts + 1 %></p>",
-          "`attempts + 1` computes with the state `attempts`. The client cannot run Ruby to keep the result current."
-        )
-
-        refuse(
           "<%# herb:state (sort: \"name\") %><div><% if sort == 3 %>a<% end %></div>",
           "`sort == 3` compares the String state `sort` against an Integer literal, so it can never match."
         )
@@ -747,15 +742,10 @@ module Engine
         assert_includes rendered, ">true<"
       end
 
-      test "a computed read in a textarea still raises" do
-        error = assert_raises(Herb::Engine::CompilationError) do
-          compile(%(<%# herb:state (draft: "") %><textarea><%= draft.upcase %></textarea>))
-        end
+      test "a computed read in a textarea becomes a server read" do
+        visitor, = compile(%(<%# herb:state (draft: "") %><textarea><%= draft.upcase %></textarea>))
 
-        assert_equal(
-          ["`draft.upcase` computes with the state `draft`. The client cannot run Ruby to keep the result current."],
-          compiler_findings(error)
-        )
+        assert_equal({ "draft" => [{ "index" => 0, "node_path" => [1, 0] }] }, visitor.manifest["states"]["server"]["reads"])
       end
 
       test "a string literal that spells a state name is not a read" do
@@ -1215,11 +1205,10 @@ module Engine
         assert_includes render(template, { "done" => false }), %(<input data-herb-slot="0:boolean_attribute:disabled">)
       end
 
-      test "a computed tag helper attribute raises" do
-        refuse(
-          %(<%# herb:slots client %><%# herb:state (draft: "") %><%= tag.input value: draft.upcase %>),
-          "`draft.upcase` computes with the state `draft`. The client cannot run Ruby to keep the result current."
-        )
+      test "a computed tag helper attribute becomes a server read" do
+        visitor, = compile(%(<%# herb:slots client %><%# herb:state (draft: "") %><%= tag.input value: draft.upcase %>))
+
+        assert_equal ["draft"], visitor.manifest["states"]["server"]["reads"].keys
       end
 
       SEEDED = <<~ERB
@@ -1401,15 +1390,65 @@ module Engine
         )
       end
 
-      test "a computed read in a boolean attribute still raises" do
+      test "a computed read in a boolean attribute becomes a server read" do
+        visitor, = compile(<<~ERB)
+          <%# herb:state (draft: "") %>
+          <button disabled="<%= draft.upcase %>">Send</button>
+        ERB
+
+        assert_equal ["draft"], visitor.manifest["states"]["server"]["reads"].keys
+      end
+
+      test "a value computing with a region state becomes a server read" do
+        visitor, = compile(%(<%# herb:state (q: "") %><p><%= User.search(q).count %></p>))
+
+        assert_equal({ "q" => [{ "index" => 0, "node_path" => [1, 0] }] }, visitor.manifest["states"]["server"]["reads"])
+        assert_empty visitor.diagnostics
+      end
+
+      test "a keyed collection computing with a region state becomes a server read" do
+        visitor, = compile(<<~ERB)
+          <%# herb:state (q: "") %>
+          <ul>
+          <% @messages.search(q).each do |message| %>
+            <%# herb:key message.id %>
+            <li id="<%= message.id %>"><%= message.body %></li>
+          <% end %>
+          </ul>
+        ERB
+
+        reads = visitor.manifest["states"]["server"]["reads"]
+
+        assert_equal ["q"], reads.keys
+        assert_equal 1, reads["q"].length
+        assert_empty visitor.diagnostics
+      end
+
+      test "a collection reading no region state registers nothing" do
+        visitor, = compile(<<~ERB)
+          <%# herb:state (q: "") %>
+          <ul>
+          <% @messages.each do |message| %>
+            <%# herb:key message.id %>
+            <li id="<%= message.id %>"><%= message.body %></li>
+          <% end %>
+          </ul>
+        ERB
+
+        assert_empty visitor.manifest["states"]["server"]["reads"]
+      end
+
+      test "a value computing with an item state still raises" do
         error = assert_raises(Herb::Engine::CompilationError) do
           compile(<<~ERB)
-            <%# herb:state (draft: "") %>
-            <button disabled="<%= draft.upcase %>">Send</button>
+            <% @posts.each do |post| %>
+              <%# herb:state (likes: 0) %>
+              <li id="<%= post.id %>"><%= likes * 2 %></li>
+            <% end %>
           ERB
         end
 
-        assert_includes error.message, "computes with the state `draft`"
+        assert_includes error.message, "which lives on an item"
       end
 
       test "a mismatched comparand in a boolean attribute still raises" do
@@ -1421,6 +1460,29 @@ module Engine
         end
 
         assert_includes error.message, "Integer literal"
+      end
+
+      test "a block argument shadows a state inside its body" do
+        source = <<~ERB
+          <%# herb:slots client %>
+          <%# herb:state (track: "", album: "a") %>
+          <input value="<%= track %>">
+          <ul>
+            <% Catalog.tracks(album).each do |track| %>
+              <%# herb:key track[:number] %>
+              <li>
+                <button data-herb-set="track='<%= track[:album] %>'"><%= track[:title] %></button>
+              </li>
+            <% end %>
+          </ul>
+        ERB
+
+        visitor = Herb::Engine::Slots::Visitor.new(mode: :client, fatal: false)
+        Herb::Engine.new(source, visitors: [visitor], filename: "app/views/test.html.erb")
+
+        assert_empty visitor.diagnostics
+        assert_equal ["track"], visitor.manifest["states"]["reads"].keys
+        assert_equal 1, visitor.manifest["states"]["reads"]["track"].length
       end
     end
   end


### PR DESCRIPTION
This pull request makes the values program steerable. 

The program evaluates only the conditional branch the state picks, and until now every state initialized from its compiled default, so a values request could never produce the values for a branch the client is showing. Now a host can answer `__herb_state_overrides` in the render context with a hash keyed by template identifier, and each declared state initializes from the client's value instead of its default.

Only the values codegen honors overrides. The HTML render is structurally unsteerable, so it stays untouched. `Herb::Engine::Slots::StateOverrides` shape-validates the hash and coerces each value to the declared kind, mirroring the client's `coerceSeed`. Anything missing, malformed, or wrongly typed falls back to the compiled default, so a bad override can never break a render the defaults could serve. Overrides bind only declared state names, and a state only picks among branches the template already contains.

The manifest's `server` map, which shipped empty until now, is also populated with two channels the client needs for refetching.

```ruby
"server" => {
  "branches" => { "<conditionalIndex>" => [{ "index" => 2, "node_path" => [1, 0] }] },
  "reads"    => { "<stateName>"        => [{ "index" => 3, "node_path" => [2, 0] }] }
}
```

`branches` lists the server-owned value slots inside each conditional branch, the ones the existing `herb-slots-branch` warning is about. `reads` comes from a reclassification. A server expression that computes with a region state used to be a compile error that degraded the template.

```erb
<%# herb:state (q: "") %>

<input value="<%= q %>">
<%= User.search(q).count %>
```

This now compiles. The expression stays a plain server-owned value slot and is recorded as a server read of `q`, so the client can refetch it whenever `q` changes, with the new value steering the re-render. Expressions computing with item states still error, since the values program computes item keys inside the loop and cannot be steered to one item yet. Conditional conditions computing with states also still error, because branch picking happens on the client.
