### PR TITLE
Client: Refetch server-derived slot values in production

### DIFF
--- a/javascript/packages/client/src/actions/actions.ts
+++ b/javascript/packages/client/src/actions/actions.ts
@@ -188,6 +188,8 @@ export class Actions implements ElementObserverDelegate, InstructionsDelegate {
         this.toggle(element, rest)
       } else if (schema.operation === "reset") {
         this.reset(element, rest)
+      } else if (schema.operation === "action") {
+        this.invoke(element, rest)
       } else {
         this.count(element, rest, schema.step ?? 1)
       }
@@ -397,6 +399,24 @@ export class Actions implements ElementObserverDelegate, InstructionsDelegate {
       }
 
       this.state.increment(name, { scope: resolved.scope, by: step })
+    }
+  }
+
+  private invoke(element: Element, rest: string): void {
+    for (const name of names(rest)) {
+      if (name === "$refresh") {
+        void this.state.refresh()
+
+        continue
+      }
+
+      report({
+        template: this.templateOf(element),
+        element,
+        message: name.startsWith("$") ? `\`${name}\` is not a built-in action` : `\`${name}\` names a user-defined action, and those are not available yet`,
+        code: "herb-invalid-action",
+        severity: "error",
+      })
     }
   }
 

--- a/javascript/packages/client/src/actions/instructions.ts
+++ b/javascript/packages/client/src/actions/instructions.ts
@@ -108,6 +108,10 @@ export class Instructions {
       return
     }
 
+    if (schema.operation === "action") {
+      return
+    }
+
     if (schema.operation === "set") {
       for (const assignment of splitOutsideQuotes(clause.rest, ",")) {
         this.validateAssignment(element, assignment)

--- a/javascript/packages/client/src/grammar/attributes.ts
+++ b/javascript/packages/client/src/grammar/attributes.ts
@@ -2,7 +2,7 @@ export type ActionName = keyof typeof ACTION_SCHEMA
 export type HerbAttribute = keyof typeof HERB_ATTRIBUTES
 
 export interface ActionSchema {
-  operation: "set" | "toggle" | "count" | "reset"
+  operation: "set" | "toggle" | "count" | "reset" | "action"
   needs?: "boolean" | "integer"
   step?: number
   bare?: boolean
@@ -16,6 +16,7 @@ export const HERB_ATTRIBUTES = {
   dependencies: "data-herb-dependencies",
   manifests: "data-herb-manifests",
   into: "data-herb-into",
+  action: "data-herb-action",
   set: "data-herb-set",
   toggle: "data-herb-toggle",
   increment: "data-herb-increment",
@@ -25,6 +26,7 @@ export const HERB_ATTRIBUTES = {
 } as const
 
 export const ACTION_SCHEMA = {
+  action: { operation: "action" },
   set: { operation: "set" },
   toggle: { operation: "toggle", needs: "boolean" },
   increment: { operation: "count", needs: "integer", step: 1 },

--- a/javascript/packages/client/src/runtime.ts
+++ b/javascript/packages/client/src/runtime.ts
@@ -91,6 +91,10 @@ export class Runtime {
     return instance
   }
 
+  refresh(): ReturnType<State["refresh"]> {
+    return this.state.refresh()
+  }
+
   stop(): void {
     this.slots.disconnect()
     this.state.disconnect()

--- a/javascript/packages/client/src/shared/slots-request.ts
+++ b/javascript/packages/client/src/shared/slots-request.ts
@@ -3,6 +3,7 @@ import type { Payload } from "../types"
 export const SLOTS_MIME_TYPE = "application/vnd.herb.slots+json"
 export const SCHEMA_HEADER = "Herb-Schema"
 export const NODE_PATH_HEADER = "Herb-Node-Path"
+export const STATE_HEADER = "Herb-State"
 
 export type SlotsResponse = Payload & { schema?: SchemaEnvelope }
 
@@ -41,6 +42,7 @@ export interface SlotsRequestOptions {
   format?: string
   schema?: boolean
   nodePath?: number[]
+  state?: Record<string, Record<string, unknown>>
   signal?: AbortSignal
 }
 
@@ -55,7 +57,15 @@ export function slotsHeaders(options: SlotsRequestOptions = {}): Record<string, 
     headers[NODE_PATH_HEADER] = options.nodePath.join(",")
   }
 
+  if (options.state && Object.keys(options.state).length > 0) {
+    headers[STATE_HEADER] = asciiJSON(options.state)
+  }
+
   return headers
+}
+
+function asciiJSON(value: unknown): string {
+  return JSON.stringify(value).replace(/[\u007f-\uffff]/g, (character) => `\\u${character.charCodeAt(0).toString(16).padStart(4, "0")}`)
 }
 
 // TODO: should this use @rails/request.js?

--- a/javascript/packages/client/src/state/refresh.ts
+++ b/javascript/packages/client/src/state/refresh.ts
@@ -1,0 +1,211 @@
+import { armOf } from "./conditions"
+import { slotsRequest } from "../shared/slots-request"
+
+import type { Slots } from "../slots/slots"
+import type { Payload, Region } from "../types"
+import type { ComboCondition, RefreshTransport, StateCondition, StateManifest } from "./types"
+
+export interface RefreshDelegate {
+  manifestFor(region: Region): StateManifest | null
+  steeringValue(region: Region, name: string): unknown
+}
+
+export interface RefreshOptions {
+  transport?: RefreshTransport
+  format?: string
+}
+
+export interface RefreshReport {
+  applied: number
+  deferred: number
+  stale: boolean
+  failed: boolean
+}
+
+type RefreshWaiter = (report: RefreshReport) => void
+
+const HEADER_BUDGET = 4096
+
+export class Refresh {
+  private slots: Slots
+  private delegate: RefreshDelegate
+  private options: RefreshOptions
+  private timer: ReturnType<typeof setTimeout> | null = null
+  private due = Infinity
+  private epoch = 0
+  private controller: AbortController | null = null
+  private waiting: RefreshWaiter[] = []
+
+  constructor(slots: Slots, delegate: RefreshDelegate, options: RefreshOptions = {}) {
+    this.slots = slots
+    this.delegate = delegate
+    this.options = options
+  }
+
+  request(delay = 0): Promise<RefreshReport> {
+    const promise = new Promise<RefreshReport>((resolve) => this.waiting.push(resolve))
+    const at = Date.now() + delay
+
+    if (this.timer === null || at < this.due) {
+      if (this.timer !== null) {
+        clearTimeout(this.timer)
+      }
+
+      this.due = at
+      this.timer = setTimeout(() => void this.run(), delay)
+    }
+
+    return promise
+  }
+
+  flush(): Promise<RefreshReport> {
+    return this.request(0)
+  }
+
+  stop(): void {
+    if (this.timer !== null) {
+      clearTimeout(this.timer)
+
+      this.timer = null
+    }
+
+    this.due = Infinity
+    this.controller?.abort()
+    this.settle({ applied: 0, deferred: 0, stale: true, failed: false })
+  }
+
+  private async run(): Promise<void> {
+    this.timer = null
+    this.due = Infinity
+
+    this.controller?.abort()
+
+    const controller = new AbortController()
+    const epoch = (this.epoch += 1)
+
+    this.controller = controller
+
+    let payload: Payload
+
+    try {
+      payload = await this.transport()(this.steering(), controller.signal)
+    } catch {
+      this.settle({ applied: 0, deferred: 0, stale: epoch !== this.epoch, failed: epoch === this.epoch })
+
+      return
+    }
+
+    if (epoch !== this.epoch) {
+      this.settle({ applied: 0, deferred: 0, stale: true, failed: false })
+
+      return
+    }
+
+    const report = this.slots.apply(payload)
+
+    this.settle({ applied: report.applied, deferred: report.deferred.length, stale: false, failed: false })
+  }
+
+  private settle(report: RefreshReport): void {
+    const waiting = this.waiting.splice(0)
+
+    for (const waiter of waiting) {
+      waiter(report)
+    }
+  }
+
+  private transport(): RefreshTransport {
+    if (this.options.transport) {
+      return this.options.transport
+    }
+
+    return (state, signal) => slotsRequest(window.location.href, { format: this.options.format, state, signal })
+  }
+
+  private steering(): Record<string, Record<string, unknown>> {
+    const steering: Record<string, Record<string, unknown>> = {}
+
+    let budget = HEADER_BUDGET
+
+    for (const region of this.slots.regions()) {
+      const manifest = this.delegate.manifestFor(region)
+
+      if (!manifest || steering[region.file]) {
+        continue
+      }
+
+      const values: Record<string, unknown> = {}
+
+      for (const name of steeringNames(manifest)) {
+        const value = this.delegate.steeringValue(region, name)
+
+        if (value === undefined) {
+          continue
+        }
+
+        const cost = name.length + JSON.stringify(value ?? null).length + 8
+
+        if (cost > budget) {
+          continue
+        }
+
+        budget -= cost
+        values[name] = value
+      }
+
+      if (Object.keys(values).length > 0) {
+        steering[region.file] = values
+      }
+    }
+
+    return steering
+  }
+}
+
+function steeringNames(manifest: StateManifest): Set<string> {
+  const names = new Set<string>()
+
+  for (const conditional of Object.values(manifest.conditionals ?? {})) {
+    for (const entry of conditional.arms) {
+      collectNames(armOf(entry).condition, names)
+    }
+  }
+
+  for (const name of Object.keys(manifest.server?.reads ?? {})) {
+    names.add(name)
+  }
+
+  const writable = new Set<string>()
+
+  for (const declaration of manifest.declarations) {
+    if (declaration.scope === "region" && !declaration.derived && !declaration.count) {
+      writable.add(declaration.name)
+    }
+  }
+
+  return new Set([...names].filter((name) => writable.has(name)))
+}
+
+function collectNames(condition: StateCondition, names: Set<string>): void {
+  if (Array.isArray(condition)) {
+    if (typeof condition[0] === "string") {
+      names.add(condition[0])
+    }
+
+    const comparand = condition[1]
+
+    if (comparand && typeof comparand === "object" && "state" in comparand && typeof comparand.state === "string") {
+      names.add(comparand.state)
+    }
+
+    return
+  }
+
+  for (const part of partsOf(condition)) {
+    collectNames(part, names)
+  }
+}
+
+function partsOf(combo: ComboCondition): StateCondition[] {
+  return combo.all ?? combo.any ?? []
+}

--- a/javascript/packages/client/src/state/state.ts
+++ b/javascript/packages/client/src/state/state.ts
@@ -3,6 +3,7 @@ import { DEPENDENCIES_SELECTOR } from "../grammar/attributes"
 
 import { Seeds } from "./seeds"
 import { Counts } from "./counts"
+import { Refresh } from "./refresh"
 import { ServerState } from "./server"
 import { BoundInputs } from "./bound-inputs"
 import { ElementObserver } from "../shared/element-observer"
@@ -16,6 +17,7 @@ import { declarationSpot, declared, declaredValue } from "./declarations"
 
 import type { Slots } from "../slots/slots"
 import type { Conditional } from "./types"
+import type { RefreshReport } from "./refresh"
 import type { StateKind, StateValue } from "./values"
 import type { Built, Item, Region, Slot } from "../types"
 import type { CountOptions, DeclaredState, DependencyMap, PlacedSlot, ResolvedStateOptions, ScopeStore, ScopedSetOptions, SerializedState, StateChange, StateChangeDetail, StateListener, StateManifest, StateOptions, StateReport, StateScope, StateSlot, StateSnapshot, StateValues } from "./types"
@@ -29,6 +31,7 @@ import type { ElementObserverDelegate } from "../shared/element-observer"
 export class State implements ElementObserverDelegate, SlotsDelegate, SeedsDelegate, BoundInputsDelegate, CountsDelegate {
   private readonly slots: Slots
   private readonly server: ServerState
+  private readonly refetch: Refresh
   private readonly declared = new Map<string, StateManifest>()
   private readonly scoped: ScopeStore = new Map()
   private readonly seeds: Seeds
@@ -45,13 +48,24 @@ export class State implements ElementObserverDelegate, SlotsDelegate, SeedsDeleg
       transport: options.transport ?? ((request, signal) => this.server.fetch(request, signal)),
       debounce: options.debounce ?? 0,
       format: options.format ?? "slots",
+      refetch: options.refetch ?? "auto",
+      refetchDebounce: options.refetchDebounce ?? 150,
+      refetchTransport: options.refetchTransport,
     }
 
     this.slots = slots
     this.seeds = new Seeds(this, slots)
     this.counts = new Counts(this, slots)
     this.server = new ServerState(slots, this.options)
+    this.refetch = new Refresh(slots, {
+      manifestFor: (region) => this.manifestFor(region),
+      steeringValue: (region, name) => this.valueAt(name, scopeOf(region)),
+    }, { transport: this.options.refetchTransport, format: this.options.format })
     this.unsubscribe = slots.subscribe(this)
+  }
+
+  refresh(): Promise<RefreshReport> {
+    return this.refetch.flush()
   }
 
   set(key: string | SerializedState, value?: string): Promise<StateReport> {
@@ -483,7 +497,21 @@ export class State implements ElementObserverDelegate, SlotsDelegate, SeedsDeleg
       }
     }
 
+    this.requestReadRefetch(manifest, names)
+
     return true
+  }
+
+  private requestReadRefetch(manifest: StateManifest, names: string[]): void {
+    if (this.options.refetch !== "auto") {
+      return
+    }
+
+    const reads = manifest.server?.reads ?? {}
+
+    if (names.some((name) => (reads[name] ?? []).length > 0)) {
+      void this.refetch.request(this.options.refetchDebounce)
+    }
   }
 
   toggle(name: string, options: ScopedSetOptions = {}): boolean {
@@ -970,6 +998,37 @@ export class State implements ElementObserverDelegate, SlotsDelegate, SeedsDeleg
     this.writePresence(manifest, at, declared)
     this.writeComputed(manifest, at, declared)
     this.writeConditionals(manifest, at, declared)
+
+    this.requestBranchRefetch(manifest, slot)
+  }
+
+  private requestBranchRefetch(manifest: StateManifest, slot: Slot): void {
+    if (this.options.refetch !== "auto" || slot.branch === null) {
+      return
+    }
+
+    const reads = manifest.server?.branches?.[String(slot.index)] ?? []
+
+    if (reads.length === 0) {
+      return
+    }
+
+    const stash = slot.shown?.get(slot.branch) ?? {}
+    const descendants = this.slots.descendantsOf(slot)
+
+    const missing = reads.some((read) => {
+      if (read.index in stash) {
+        return false
+      }
+
+      const live = descendants.find((child) => child.index === read.index)
+
+      return live !== undefined && !live.claimed && this.slots.currentText(live) === ""
+    })
+
+    if (missing) {
+      void this.refetch.request(0)
+    }
   }
 
   private settleItem(collection: Slot, item: Item): void {

--- a/javascript/packages/client/src/state/state.ts
+++ b/javascript/packages/client/src/state/state.ts
@@ -497,7 +497,15 @@ export class State implements ElementObserverDelegate, SlotsDelegate, SeedsDeleg
       }
     }
 
-    this.requestReadRefetch(manifest, names)
+    const changed = names.filter((name) => {
+      const value = this.valueAt(name, scopes.get(name) ?? resolved)
+
+      return value !== (previous.get(name) ?? null)
+    })
+
+    if (changed.length > 0) {
+      this.requestReadRefetch(manifest, changed)
+    }
 
     return true
   }

--- a/javascript/packages/client/src/state/types.ts
+++ b/javascript/packages/client/src/state/types.ts
@@ -37,7 +37,7 @@ export type StateIndices = Record<string, number[]>
 export type ConditionalMap = Record<string, Conditional>
 export type PresenceMap = Record<string, StateCondition>
 export type ComputedMap = Record<string, StateCondition>
-export type ResolvedStateOptions = Required<Omit<StateOptions, "transport">> & { transport: StateTransport }
+export type ResolvedStateOptions = Required<Omit<StateOptions, "transport" | "refetchTransport">> & { transport: StateTransport; refetchTransport?: RefreshTransport }
 
 export type StateBucket = Map<string, StateValue>
 export type ScopeStore = Map<Region, Map<string, StateBucket>>
@@ -60,6 +60,11 @@ export interface StateCount {
   by?: number
 }
 
+export interface ServerMap {
+  branches?: Record<string, ServerRead[]>
+  reads?: Record<string, ServerRead[]>
+}
+
 export interface ServerRead {
   index: number
   node_path: number[]
@@ -73,7 +78,7 @@ export interface StateManifest {
   conditionals: ConditionalMap
   presence?: PresenceMap
   computed?: ComputedMap
-  server?: Record<string, ServerRead[]>
+  server?: ServerMap
 }
 
 export interface StateScope {
@@ -139,7 +144,12 @@ export interface StateOptions {
   transport?: StateTransport
   debounce?: number
   format?: string
+  refetch?: "auto" | "off"
+  refetchDebounce?: number
+  refetchTransport?: RefreshTransport
 }
+
+export type RefreshTransport = (state: Record<string, Record<string, unknown>>, signal: AbortSignal) => Promise<Payload>
 
 export interface StateReport extends ApplyReport {
   written: number

--- a/javascript/packages/client/test/refresh.test.ts
+++ b/javascript/packages/client/test/refresh.test.ts
@@ -100,6 +100,19 @@ describe("refetching server-derived slots", () => {
     expect(transport).not.toHaveBeenCalled()
   })
 
+  test("writing a state its current value refetches nothing", async () => {
+    document.body.innerHTML = PAGE
+
+    const transport = vi.fn(async () => payloadFor({}))
+    const live = start({ state: { refetchTransport: transport, refetchDebounce: 0 } })
+
+    live.state.setState({ q: "" })
+
+    await new Promise((resolve) => setTimeout(resolve, 30))
+
+    expect(transport).not.toHaveBeenCalled()
+  })
+
   test("writing a state a server read depends on refetches debounced, once", async () => {
     document.body.innerHTML = PAGE
 

--- a/javascript/packages/client/test/refresh.test.ts
+++ b/javascript/packages/client/test/refresh.test.ts
@@ -1,0 +1,202 @@
+import { describe, test, expect, afterEach, vi } from "vitest"
+
+import { Runtime } from "../src/runtime"
+
+import type { Payload } from "../src/types"
+
+const FILE = "app/views/chat/show.html.erb"
+
+function dependencies(states: Record<string, unknown>): string {
+  return `<template data-herb-dependencies>${JSON.stringify({ state: {}, states: { [FILE]: states } })}</template>`
+}
+
+const STATES = {
+  version: "aaaaaaaa",
+  declarations: [
+    { name: "editing", kind: "boolean", default: "false", scope: "region" },
+    { name: "q", kind: "string", default: '""', scope: "region" },
+  ],
+  reads: { q: [] },
+  conditionals: { 0: { arms: [["editing", null, 0]], else: 1 } },
+  presence: {},
+  computed: {},
+  server: {
+    branches: { 0: [{ index: 2, node_path: [1, 0] }] },
+    reads: { q: [{ index: 3, node_path: [2, 0] }] },
+  },
+}
+
+const PAGE =
+  `<!--herb-region:${FILE}:aaaaaaaa:0-->` +
+  `<div><!--herb-slot:0:conditional--><p>off</p><!--/herb-slot:0--></div>` +
+  `<b><!--herb-slot:3--><!--/herb-slot:3--></b>` +
+  `<template data-herb-region="${FILE}:aaaaaaaa">` +
+  `<!--herb-branch:0:0--><em><!--herb-slot:2--><!--/herb-slot:2--></em>` +
+  `<!--herb-branch:0:1--><p>off</p>` +
+  `</template>` +
+  `<!--/herb-region:${FILE}-->` +
+  dependencies(STATES)
+
+function payloadFor(slots: Payload["slots"]): Payload {
+  return { template: FILE, version: "aaaaaaaa", occurrence: 0, slots }
+}
+
+let runtime: Runtime | null = null
+
+function start(options: Parameters<typeof Runtime.start>[0] = {}): Runtime {
+  runtime = Runtime.start(options)
+
+  return runtime
+}
+
+afterEach(() => {
+  runtime?.stop()
+  runtime = null
+  document.body.innerHTML = ""
+})
+
+describe("refetching server-derived slots", () => {
+  test("materializing a branch with an empty server read refetches once, steered", async () => {
+    document.body.innerHTML = PAGE
+
+    const calls: Array<Record<string, Record<string, unknown>>> = []
+    const transport = vi.fn(async (state: Record<string, Record<string, unknown>>) => {
+      calls.push(state)
+
+      return payloadFor({ 0: { branch: 0, slots: { 2: "served" } } })
+    })
+
+    const live = start({ state: { refetchTransport: transport, refetchDebounce: 0 } })
+
+    live.state.setState({ editing: true })
+
+    await vi.waitFor(() => {
+      if (!document.body.innerHTML.includes("served")) {
+        throw new Error("still waiting")
+      }
+    })
+
+    expect(transport).toHaveBeenCalledTimes(1)
+    expect(calls[0][FILE].editing).toBe(true)
+  })
+
+  test("a branch whose values are remembered does not refetch", async () => {
+    document.body.innerHTML = PAGE
+
+    const transport = vi.fn(async () => payloadFor({}))
+    const live = start({ state: { refetchTransport: transport, refetchDebounce: 0 } })
+
+    live.slots.apply(payloadFor({ 0: { branch: 0, slots: { 2: "remembered" } } }))
+    live.state.setState({ editing: true })
+
+    await vi.waitFor(() => {
+      if (!document.body.innerHTML.includes("remembered")) {
+        throw new Error("still waiting")
+      }
+    })
+
+    await new Promise((resolve) => setTimeout(resolve, 20))
+
+    expect(transport).not.toHaveBeenCalled()
+  })
+
+  test("writing a state a server read depends on refetches debounced, once", async () => {
+    document.body.innerHTML = PAGE
+
+    const calls: Array<Record<string, Record<string, unknown>>> = []
+    const transport = vi.fn(async (state: Record<string, Record<string, unknown>>) => {
+      calls.push(state)
+
+      return payloadFor({ 3: "3 results" })
+    })
+
+    const live = start({ state: { refetchTransport: transport, refetchDebounce: 10 } })
+
+    live.state.setState({ q: "a" })
+    live.state.setState({ q: "ab" })
+    live.state.setState({ q: "abc" })
+
+    await vi.waitFor(() => {
+      if (!document.body.innerHTML.includes("3 results")) {
+        throw new Error("still waiting")
+      }
+    })
+
+    expect(transport).toHaveBeenCalledTimes(1)
+    expect(calls[0][FILE].q).toBe("abc")
+  })
+
+  test("refetch off leaves the network alone", async () => {
+    document.body.innerHTML = PAGE
+
+    const transport = vi.fn(async () => payloadFor({}))
+    const live = start({ state: { refetchTransport: transport, refetchDebounce: 0, refetch: "off" } })
+
+    live.state.setState({ editing: true })
+    live.state.setState({ q: "abc" })
+
+    await new Promise((resolve) => setTimeout(resolve, 30))
+
+    expect(transport).not.toHaveBeenCalled()
+  })
+
+  test("a manual refresh works without any state manifest", async () => {
+    document.body.innerHTML =
+      `<!--herb-region:${FILE}:aaaaaaaa:0-->` +
+      `<p><!--herb-slot:0--><!--/herb-slot:0--></p>` +
+      `<!--/herb-region:${FILE}-->`
+
+    const calls: Array<Record<string, Record<string, unknown>>> = []
+    const transport = vi.fn(async (state: Record<string, Record<string, unknown>>) => {
+      calls.push(state)
+
+      return payloadFor({ 0: "fresh" })
+    })
+
+    const live = start({ state: { refetchTransport: transport } })
+    const report = await live.refresh()
+
+    expect(report.applied).toBe(1)
+    expect(calls[0]).toEqual({})
+    expect(document.body.innerHTML).toContain("fresh")
+  })
+
+  test("data-herb-action fires $refresh and reports unknown actions", async () => {
+    document.body.innerHTML =
+      PAGE +
+      `<button id="go" data-herb-action="$refresh">refresh</button>` +
+      `<button id="bad" data-herb-action="somethingCustom">nope</button>`
+
+    const transport = vi.fn(async () => payloadFor({}))
+    const reportSink = vi.fn()
+
+    vi.stubGlobal("HerbDevTools", { report: reportSink })
+
+    try {
+      start({ state: { refetchTransport: transport, refetchDebounce: 0 } })
+
+      document.querySelector<HTMLButtonElement>("#go")!.click()
+
+      await vi.waitFor(() => {
+        if (transport.mock.calls.length === 0) {
+          throw new Error("still waiting")
+        }
+      })
+
+      document.querySelector<HTMLButtonElement>("#bad")!.click()
+
+      await vi.waitFor(() => {
+        if (reportSink.mock.calls.length === 0) {
+          throw new Error("still waiting")
+        }
+      })
+
+      const reported = reportSink.mock.calls.flat(2) as Array<{ code?: string, message?: string }>
+      const entry = reported.find((diagnostic) => diagnostic.code === "herb-invalid-action")
+
+      expect(entry?.message).toContain("somethingCustom")
+    } finally {
+      vi.unstubAllGlobals()
+    }
+  })
+})

--- a/javascript/packages/dev-tools/src/dev-server/manifest-diff.ts
+++ b/javascript/packages/dev-tools/src/dev-server/manifest-diff.ts
@@ -16,7 +16,11 @@ function keysWhereDifferent(before: Record<string, unknown>, after: Record<strin
 }
 
 function serverReads(manifest: StateManifest): number {
-  return Object.values(manifest.server ?? {}).reduce((count, reads) => count + reads.length, 0)
+  const server = manifest.server ?? {}
+
+  return [server.reads ?? {}, server.branches ?? {}]
+    .flatMap((group) => Object.values(group))
+    .reduce((count, reads) => count + reads.length, 0)
 }
 
 export function diffStateManifests(before: StateManifest | null, after: StateManifest | null): ManifestDelta {

--- a/javascript/packages/dev-tools/test/hot-reload.test.ts
+++ b/javascript/packages/dev-tools/test/hot-reload.test.ts
@@ -306,7 +306,13 @@ describe("diffStateManifests", () => {
   })
 
   test("a server read is never derivable", () => {
-    const delta = diffStateManifests(manifest(), manifest({ server: { count: [{ index: 1, node_path: [0] }] } }))
+    const delta = diffStateManifests(manifest(), manifest({ server: { reads: { count: [{ index: 1, node_path: [0] }] } } }))
+
+    expect(delta.stateDerivable).toBe(false)
+  })
+
+  test("a server branch read is never derivable", () => {
+    const delta = diffStateManifests(manifest(), manifest({ server: { branches: { view: [{ index: 2, node_path: [0] }] } } }))
 
     expect(delta.stateDerivable).toBe(false)
   })


### PR DESCRIPTION
This pull request closes the production gap the hot reload closed for development. 

When the client materializes a conditional branch the server never rendered, the server-owned expressions inside it render empty. The client now detects that and refetches the values from the application, sending its state in a `Herb-State` request header so the server's values program evaluates the client's branches.

Two triggers feed one coalesced `Refresh`.

1. Branch materialization. After `settleBranch`, any server read listed in `manifest.server.branches` for the switched conditional that has no remembered value in the branch stash and is still unclaimed and empty schedules a refetch.
2. Server reads. Writing a state that keys `manifest.server.reads` schedules a debounced refetch (`refetchDebounce`, default 150ms), so this template is a working live search in one line of Ruby.

```erb
<%# herb:state (q: "") %>

<input value="<%= q %>">
<%= Message.where("body LIKE ?", "%#{q}%").count %>
```

Requests coalesce to the earliest due timer, and an in-flight response is superseded by epoch and aborted via `AbortController`. The steering payload carries only the states that can change the outcome, the conditional arm names plus the server read keys, filtered to region-scoped writable declarations and capped at 4KB so the header stays well under server limits. Applying the payload reuses the existing semantics. Claimed slots are skipped and foreign branches stash into `slot.shown`.

`StateOptions.refetch: "auto" | "off"` gates both triggers, and `runtime.refresh()` is the manual path. A manual refresh needs no state manifest, so on a stateless page it doubles as a re-pull of every server value.

The declarative surface is a new `data-herb-action` attribute using the existing clause grammar.

```html
<button data-herb-action="$refresh">Refresh</button>
<body data-herb-action="focus->$refresh">
```

The `$` sigil keeps its existing meaning of "the runtime supplies this". `$refresh` is the first built-in action, unknown `$` names report a diagnostic, and bare names are reserved for user-defined actions in a later release.

Based on the state initialization overrides from the pull request below this one. The ReActionView side threads the `Herb-State` header into the render context.

Writing a state the value it already holds now refetches nothing. `setState` compares each written name against its previous value and only stale names reach the coalesced refetch, so clicking the already-selected item in a demo no longer masks and refetches a page that cannot change.