### PR TITLE
Client: Report a failed slots request to the dev tools

### DIFF
--- a/javascript/packages/client/src/shared/mutation-refresh.ts
+++ b/javascript/packages/client/src/shared/mutation-refresh.ts
@@ -1,0 +1,17 @@
+type MutationRefresh = () => void
+
+let hook: MutationRefresh | null = null
+
+export function armMutationRefresh(fn: MutationRefresh): () => void {
+  hook = fn
+
+  return () => {
+    if (hook === fn) {
+      hook = null
+    }
+  }
+}
+
+export function mutationSettled(): void {
+  hook?.()
+}

--- a/javascript/packages/client/src/shared/slots-request.ts
+++ b/javascript/packages/client/src/shared/slots-request.ts
@@ -1,4 +1,8 @@
+import { mutationSettled } from "./mutation-refresh"
+import { report } from "./report"
+
 import type { Payload } from "../types"
+import type { RuntimeDiagnostic } from "./types"
 
 export const SLOTS_MIME_TYPE = "application/vnd.herb.slots+json"
 export const SCHEMA_HEADER = "Herb-Schema"
@@ -37,13 +41,15 @@ export interface SchemaEnvelope {
 
 export interface SlotsRequestOptions {
   method?: string
-  body?: FormData | URLSearchParams
+  body?: FormData | URLSearchParams | Record<string, unknown>
   headers?: Record<string, string>
   format?: string
   schema?: boolean
   nodePath?: number[]
   state?: Record<string, Record<string, unknown>>
   signal?: AbortSignal
+  report?: boolean
+  refresh?: boolean
 }
 
 export function slotsHeaders(options: SlotsRequestOptions = {}): Record<string, string> {
@@ -68,24 +74,73 @@ function asciiJSON(value: unknown): string {
   return JSON.stringify(value).replace(/[\u007f-\uffff]/g, (character) => `\\u${character.charCodeAt(0).toString(16).padStart(4, "0")}`)
 }
 
-// TODO: should this use @rails/request.js?
 export async function slotsRequest(url: string | URL, options: SlotsRequestOptions = {}): Promise<SlotsResponse> {
   const target = new URL(url.toString(), window.location.href)
+  const method = (options.method ?? "GET").toUpperCase()
+  const headers = slotsHeaders(options)
+
+  let body: FormData | URLSearchParams | string | undefined
+
+  if (options.body instanceof FormData || options.body instanceof URLSearchParams) {
+    body = options.body
+  } else if (options.body) {
+    body = JSON.stringify(options.body)
+    headers["Content-Type"] ??= "application/json"
+  }
+
+  if (method !== "GET" && method !== "HEAD") {
+    const token = csrfToken()
+
+    if (token) {
+      headers["X-CSRF-Token"] ??= token
+    }
+  }
 
   target.searchParams.set("format", options.format ?? "slots")
 
-  const response = await fetch(target.toString(), {
-    method: options.method ?? "GET",
-    body: options.body,
-    headers: slotsHeaders(options),
-    signal: options.signal,
-  })
+  const response = await fetch(target.toString(), { method, body, headers, signal: options.signal })
 
   if (!response.ok) {
-    throw new SlotsRequestError(response.status, await failureOf(response))
+    const failure = await failureOf(response)
+
+    if (options.report !== false) {
+      report(failureDiagnostic(response.status, failure))
+    }
+
+    throw new SlotsRequestError(response.status, failure)
+  }
+
+  if (method !== "GET" && method !== "HEAD" && options.refresh !== false) {
+    mutationSettled()
+  }
+
+  if (response.status === 204) {
+    return { template: "", version: "", occurrence: 0, slots: {} }
   }
 
   return (await response.json()) as SlotsResponse
+}
+
+function csrfToken(): string | null {
+  if (typeof document === "undefined") {
+    return null
+  }
+
+  return document.querySelector<HTMLMetaElement>('meta[name="csrf-token"]')?.content ?? null
+}
+
+function failureDiagnostic(status: number, failure: SlotsRequestFailure | null): RuntimeDiagnostic {
+  return {
+    template: failure?.template ?? "",
+    message: failure?.message ?? `The application answered ${status}. Check the server log.`,
+    code: failure?.class ?? "RuntimeError",
+    severity: "error",
+    origin: "Web Application",
+    phase: "runtime",
+    overlay: "dismissible",
+    ...(failure?.line ? { location: { start: { line: failure.line, column: 1 } } } : {}),
+    ...(failure?.backtrace?.length ? { backtrace: failure.backtrace } : {}),
+  }
 }
 
 async function failureOf(response: Response): Promise<SlotsRequestFailure | null> {

--- a/javascript/packages/client/src/shared/types.ts
+++ b/javascript/packages/client/src/shared/types.ts
@@ -24,6 +24,8 @@ export interface RuntimeDiagnostic extends DiagnosticSpot {
   value?: string
   overlay?: "blocking" | "dismissible" | false
   element?: Element | null
+  phase?: string
+  backtrace?: string[]
 }
 
 export interface DevToolsGlobal {

--- a/javascript/packages/client/src/state/state.ts
+++ b/javascript/packages/client/src/state/state.ts
@@ -4,6 +4,7 @@ import { DEPENDENCIES_SELECTOR } from "../grammar/attributes"
 import { Seeds } from "./seeds"
 import { Counts } from "./counts"
 import { Refresh } from "./refresh"
+import { armMutationRefresh } from "../shared/mutation-refresh"
 import { ServerState } from "./server"
 import { BoundInputs } from "./bound-inputs"
 import { ElementObserver } from "../shared/element-observer"
@@ -42,6 +43,7 @@ export class State implements ElementObserverDelegate, SlotsDelegate, SeedsDeleg
   private elements: ElementObserver | null = null
   private unobserveElements: (() => void) | null = null
   private unsubscribe: (() => void) | null = null
+  private disarmMutationRefresh: (() => void) | null = null
 
   constructor(slots: Slots, options: StateOptions = {}) {
     this.options = {
@@ -61,11 +63,32 @@ export class State implements ElementObserverDelegate, SlotsDelegate, SeedsDeleg
       manifestFor: (region) => this.manifestFor(region),
       steeringValue: (region, name) => this.valueAt(name, scopeOf(region)),
     }, { transport: this.options.refetchTransport, format: this.options.format })
+    this.disarmMutationRefresh = armMutationRefresh(() => this.refreshAfterMutation())
     this.unsubscribe = slots.subscribe(this)
   }
 
   refresh(): Promise<RefreshReport> {
     return this.refetch.flush()
+  }
+
+  refreshAfterMutation(): void {
+    if (this.options.refetch === "off") {
+      return
+    }
+
+    for (const region of this.slots.regions()) {
+      const server = this.manifestFor(region)?.server
+
+      if (!server) {
+        continue
+      }
+
+      if (Object.keys(server.reads ?? {}).length > 0 || Object.keys(server.branches ?? {}).length > 0) {
+        void this.refetch.request(0)
+
+        return
+      }
+    }
   }
 
   set(key: string | SerializedState, value?: string): Promise<StateReport> {
@@ -205,6 +228,10 @@ export class State implements ElementObserverDelegate, SlotsDelegate, SeedsDeleg
 
     this.unsubscribe?.()
     this.unsubscribe = null
+
+    this.disarmMutationRefresh?.()
+    this.disarmMutationRefresh = null
+    this.refetch.stop()
 
     if (typeof document === "undefined") {
       return

--- a/javascript/packages/client/test/refresh.test.ts
+++ b/javascript/packages/client/test/refresh.test.ts
@@ -1,6 +1,7 @@
 import { describe, test, expect, afterEach, vi } from "vitest"
 
 import { Runtime } from "../src/runtime"
+import { mutationSettled } from "../src/shared/mutation-refresh"
 
 import type { Payload } from "../src/types"
 
@@ -137,6 +138,44 @@ describe("refetching server-derived slots", () => {
 
     expect(transport).toHaveBeenCalledTimes(1)
     expect(calls[0][FILE].q).toBe("abc")
+  })
+
+  test("a settled mutation refetches the server reads, steered", async () => {
+    document.body.innerHTML = PAGE
+
+    const calls: Array<Record<string, Record<string, unknown>>> = []
+    const transport = vi.fn(async (state: Record<string, Record<string, unknown>>) => {
+      calls.push(state)
+
+      return payloadFor({ 3: "2 results" })
+    })
+
+    start({ state: { refetchTransport: transport, refetchDebounce: 0 } })
+
+    mutationSettled()
+
+    await vi.waitFor(() => {
+      if (!document.body.innerHTML.includes("2 results")) {
+        throw new Error("still waiting")
+      }
+    })
+
+    expect(transport).toHaveBeenCalledTimes(1)
+    expect(calls[0][FILE]).toBeDefined()
+  })
+
+  test("a settled mutation stays quiet with refetch off", async () => {
+    document.body.innerHTML = PAGE
+
+    const transport = vi.fn(async () => payloadFor({}))
+
+    start({ state: { refetchTransport: transport, refetchDebounce: 0, refetch: "off" } })
+
+    mutationSettled()
+
+    await new Promise((resolve) => setTimeout(resolve, 20))
+
+    expect(transport).not.toHaveBeenCalled()
   })
 
   test("refetch off leaves the network alone", async () => {

--- a/javascript/packages/client/test/slots-request.test.ts
+++ b/javascript/packages/client/test/slots-request.test.ts
@@ -1,0 +1,123 @@
+import { describe, test, expect, beforeEach, afterEach, vi } from "vitest"
+
+import { slotsRequest, SlotsRequestError } from "../src/shared/slots-request"
+import { armMutationRefresh } from "../src/shared/mutation-refresh"
+import { resetReport } from "../src/shared/report"
+
+import type { RuntimeDiagnostic } from "../src/shared/types"
+
+const PAYLOAD = { template: "a.html.erb", version: "v1", occurrence: 0, slots: { 0: "x" } }
+
+function respond(body: unknown, init: ResponseInit = {}): Response {
+  return new Response(body === null ? null : JSON.stringify(body), init)
+}
+
+let fetchMock: ReturnType<typeof vi.fn>
+let reported: RuntimeDiagnostic[]
+
+beforeEach(() => {
+  reported = []
+  fetchMock = vi.fn(async () => respond(PAYLOAD))
+
+  vi.stubGlobal("fetch", fetchMock)
+  vi.stubGlobal("HerbDevTools", { report: (input: RuntimeDiagnostic | RuntimeDiagnostic[]) => reported.push(...[input].flat()) })
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  resetReport()
+  document.head.innerHTML = ""
+})
+
+describe("slotsRequest", () => {
+  test("a server failure reports the error envelope and throws", async () => {
+    fetchMock.mockResolvedValueOnce(respond({
+      error: { class: "NoMethodError", message: "undefined method 'search'", template: "app/views/chat/show.html.erb", backtrace: ["app/views/chat/show.html.erb:56"] },
+    }, { status: 500 }))
+
+    const failed = slotsRequest("/chat")
+
+    await expect(failed).rejects.toBeInstanceOf(SlotsRequestError)
+
+    expect(reported).toHaveLength(1)
+    expect(reported[0].code).toBe("NoMethodError")
+    expect(reported[0].message).toBe("undefined method 'search'")
+    expect(reported[0].template).toBe("app/views/chat/show.html.erb")
+    expect(reported[0].backtrace).toEqual(["app/views/chat/show.html.erb:56"])
+    expect(reported[0].overlay).toBe("dismissible")
+  })
+
+  test("a failure without an envelope still reports the status", async () => {
+    fetchMock.mockResolvedValueOnce(respond(null, { status: 503 }))
+
+    await expect(slotsRequest("/chat")).rejects.toBeInstanceOf(SlotsRequestError)
+
+    expect(reported).toHaveLength(1)
+    expect(reported[0].message).toBe("The application answered 503. Check the server log.")
+  })
+
+  test("report false leaves the overlay alone", async () => {
+    fetchMock.mockResolvedValueOnce(respond(null, { status: 500 }))
+
+    await expect(slotsRequest("/chat", { report: false })).rejects.toBeInstanceOf(SlotsRequestError)
+
+    expect(reported).toHaveLength(0)
+  })
+
+  test("a mutation carries the page's CSRF token, a read does not", async () => {
+    document.head.innerHTML = '<meta name="csrf-token" content="tok123">'
+
+    await slotsRequest("/chat/messages/1", { method: "PATCH", body: { body: "hi" } })
+    await slotsRequest("/chat")
+
+    const patchHeaders = fetchMock.mock.calls[0][1].headers
+    const getHeaders = fetchMock.mock.calls[1][1].headers
+
+    expect(patchHeaders["X-CSRF-Token"]).toBe("tok123")
+    expect(getHeaders["X-CSRF-Token"]).toBeUndefined()
+  })
+
+  test("a plain object body goes out as JSON", async () => {
+    await slotsRequest("/chat/messages/1", { method: "PATCH", body: { starred: true } })
+
+    const [, init] = fetchMock.mock.calls[0]
+
+    expect(init.body).toBe('{"starred":true}')
+    expect(init.headers["Content-Type"]).toBe("application/json")
+  })
+
+  test("a 204 answer hands back an empty payload", async () => {
+    fetchMock.mockResolvedValueOnce(respond(null, { status: 204 }))
+
+    const payload = await slotsRequest("/chat/messages/1", { method: "DELETE" })
+
+    expect(payload).toEqual({ template: "", version: "", occurrence: 0, slots: {} })
+  })
+
+  test("a settled mutation asks for a refresh, a read or a failure does not", async () => {
+    const settled = vi.fn()
+    const disarm = armMutationRefresh(settled)
+
+    try {
+      await slotsRequest("/chat")
+
+      expect(settled).not.toHaveBeenCalled()
+
+      await slotsRequest("/chat/messages/1", { method: "PATCH", body: { body: "hi" } })
+
+      expect(settled).toHaveBeenCalledTimes(1)
+
+      fetchMock.mockResolvedValueOnce(respond(null, { status: 500 }))
+
+      await expect(slotsRequest("/chat/messages/1", { method: "PATCH", report: false })).rejects.toBeInstanceOf(SlotsRequestError)
+
+      expect(settled).toHaveBeenCalledTimes(1)
+
+      await slotsRequest("/chat/messages/1", { method: "PATCH", refresh: false })
+
+      expect(settled).toHaveBeenCalledTimes(1)
+    } finally {
+      disarm()
+    }
+  })
+})

--- a/javascript/packages/dev-tools/src/dev-server/refresher.ts
+++ b/javascript/packages/dev-tools/src/dev-server/refresher.ts
@@ -75,6 +75,7 @@ export async function refresh(runtime: Runtime, file: string, options: RefreshOp
     schema: options.needSchema,
     nodePath: options.nodePath,
     signal: options.signal,
+    report: false,
   })
 
   if (response.schema && typeof runtime.slots.holdStatics === "function") {


### PR DESCRIPTION
This pull request makes `slotsRequest` the one fetch an application needs for slot mutations, and makes every failure it sees reach the dev tools overlay.

Until now the structured error a raising slots re-render answers with only surfaced through the hot reload path. An application driving its own mutations, a Stimulus controller calling `patch` from `@rails/request.js` for instance, got a bare rejected response and the overlay stayed dark. 

Now `slotsRequest` parses the error envelope on any failed response and reports it through the runtime's diagnostic channel, so the overlay shows the exception class, message, template, and backtrace no matter who made the request. A failure without an envelope still reports the status. Passing `report: false` opts out, which the dev server's own refresher uses since it reports a richer diagnostic with schema context.
