### PR TITLE
Client: Unroll server-rendered branches from the values payload

### DIFF
--- a/javascript/packages/client/src/slots/apply.ts
+++ b/javascript/packages/client/src/slots/apply.ts
@@ -1,4 +1,5 @@
 import { attributeValue } from "../markup/fragments"
+import { report as reportDiagnostic } from "../shared/report"
 
 import type { Slots } from "./slots"
 import type { AppliedValue, ApplyMode, ApplyReport, Branched, Collected, DeferredReason, Payload, PayloadSlots, PayloadValue, SeededSlots, Slot, SlotMap, SlotValue, SlotValues } from "../types"
@@ -82,6 +83,8 @@ function applySlots(slots: Slots, payload: Payload, container: SlotMap, values: 
           !("items" in value) &&
           value.slots
         ) {
+          const parked = parkBranchStatics(slots, payload, slot, value as Branched)
+
           if (value.branch === slot.branch) {
             applySlots(slots, payload, owner(slot), value.slots, report, mode)
           } else if (value.branch !== null) {
@@ -89,6 +92,10 @@ function applySlots(slots: Slots, payload: Payload, container: SlotMap, values: 
 
             shown.set(value.branch, { ...(shown.get(value.branch) ?? {}), ...leaves(value.slots) })
             slot.shown = shown
+          }
+
+          if (parked) {
+            slots.announceBranchMaterial(slot)
           }
         }
 
@@ -173,9 +180,31 @@ function applyLeaf(slots: Slots, payload: Payload, slot: Slot, index: number, va
     report.applied += 1
   }
 
+function parkBranchStatics(slots: Slots, payload: Payload, slot: Slot, value: Branched): boolean {
+    if (value.branch === null || !value.statics) {
+      return false
+    }
+
+    slots.holdStatics(
+      { file: payload.template, version: payload.version },
+      { [`${slot.index}:${value.branch}`]: value.statics },
+    )
+
+    return true
+  }
+
 function applyBranch(slots: Slots, payload: Payload, slot: Slot, value: Branched, report: ApplyReport, mode: ApplyMode): void {
+    parkBranchStatics(slots, payload, slot, value)
+
     if (value.branch !== slot.branch) {
       if (!slots.switchBranch(slot, value.branch, leaves(value.slots))) {
+        reportDiagnostic({
+          template: payload.template,
+          message: `The payload picked branch ${value.branch} of a conditional this page has no material for, so the branch cannot be shown.`,
+          code: "herb-slots-materialize",
+          severity: "warning",
+          suggestion: "Render the page with `herb:slots client` to park every branch, or serve the values from a build that sends the branch statics along.",
+        })
         defer(report, payload, slot.index, "branch")
 
         return

--- a/javascript/packages/client/src/slots/slots.ts
+++ b/javascript/packages/client/src/slots/slots.ts
@@ -689,6 +689,10 @@ export class Slots implements ElementObserverDelegate, JournalDelegate, Collecti
     this.built?.items.push({ slot, item })
   }
 
+  announceBranchMaterial(slot: Slot): void {
+    this.announce(slot, "branch-material", (delegate) => delegate.branchMaterial?.(slot), {})
+  }
+
   announceItemAdded(slot: Slot, key: string, item: Item | null): void {
     this.announce(slot, "item-added", (delegate) => delegate.itemAdded?.(slot, key, item), { key, item })
   }

--- a/javascript/packages/client/src/state/state.ts
+++ b/javascript/packages/client/src/state/state.ts
@@ -99,6 +99,10 @@ export class State implements ElementObserverDelegate, SlotsDelegate, SeedsDeleg
     this.settle(built)
   }
 
+  branchMaterial(slot: Slot): void {
+    this.settleBranch(slot)
+  }
+
   itemAdded(slot: Slot): void {
     this.counts.itemsChanged(slot)
   }
@@ -870,13 +874,19 @@ export class State implements ElementObserverDelegate, SlotsDelegate, SeedsDeleg
         this.slots.claim(slot)
 
         if (!this.slots.switchBranch(slot, target) && slot.branch !== target) {
+          if (this.options.refetch !== "off") {
+            void this.refetch.request(this.options.refetchDebounce)
+
+            continue
+          }
+
           report({
             template: scope.region.file,
             element: hostOf(slot.anchor),
             message: `branch ${target ?? "else"} of slot ${slot.index} was never parked, so it cannot be shown`,
             code: "herb-no-parked-branch",
             severity: "warning",
-            suggestion: "the template renders in server mode; compile it with `herb:slots client`",
+            suggestion: "the template renders in server mode; compile it with `herb:slots client`, or leave `refetch` on to pull the branch from the server",
           })
         }
       }

--- a/javascript/packages/client/src/types.ts
+++ b/javascript/packages/client/src/types.ts
@@ -15,6 +15,7 @@ export type SlotOperation =
   | "value"
   | "attribute"
   | "branch"
+  | "branch-material"
   | "item-added"
   | "item-rekeyed"
   | "item-removed"
@@ -55,6 +56,7 @@ export interface SlotsDelegate {
   valueWritten?(slot: Slot): void
   attributeWritten?(slot: Slot): void
   branchSwitched?(slot: Slot): void
+  branchMaterial?(slot: Slot): void
   itemAdded?(slot: Slot, key: string, item: Item | null): void
   itemRemoved?(slot: Slot, key: string, item: Item | null): void
   itemUpdated?(slot: Slot, key: string, item: Item | null): void
@@ -214,6 +216,7 @@ export interface PayloadSlots {
 
 export interface Branched {
   branch: number | null
+  statics?: string
   slots?: PayloadSlots
 }
 

--- a/javascript/packages/client/test/refresh.test.ts
+++ b/javascript/packages/client/test/refresh.test.ts
@@ -213,6 +213,99 @@ describe("refetching server-derived slots", () => {
     expect(document.body.innerHTML).toContain("fresh")
   })
 
+  test("a payload carrying statics materializes a branch the page never parked", () => {
+    document.body.innerHTML =
+      `<!--herb-region:${FILE}:aaaaaaaa:0-->` +
+      `<div><!--herb-slot:0:conditional--><p>off</p><!--/herb-slot:0--></div>` +
+      `<!--/herb-region:${FILE}-->`
+
+    const live = start()
+    const report = live.slots.apply(payloadFor({
+      0: { branch: 0, statics: "<!--herb-branch:0:0--><em><!--herb-slot:1--><!--/herb-slot:1--></em>", slots: { 1: "unrolled" } },
+    }))
+
+    expect(report.deferred).toEqual([])
+    expect(document.body.innerHTML).toContain("<em>")
+    expect(document.body.innerHTML).toContain("unrolled")
+  })
+
+  test("a payload's statics let a stuck state branch finally flip", async () => {
+    document.body.innerHTML =
+      `<!--herb-region:${FILE}:aaaaaaaa:0-->` +
+      `<div><!--herb-slot:0:conditional--><p>off</p><!--/herb-slot:0--></div>` +
+      `<b><!--herb-slot:3--><!--/herb-slot:3--></b>` +
+      `<!--/herb-region:${FILE}-->` +
+      dependencies(STATES)
+
+    const live = start({ state: { refetchTransport: async () => payloadFor({}), refetchDebounce: 0 } })
+
+    live.state.setState({ editing: true })
+
+    expect(document.body.innerHTML).toContain("off")
+
+    live.slots.apply(payloadFor({
+      0: { branch: 0, statics: "<!--herb-branch:0:0--><em><!--herb-slot:2--><!--/herb-slot:2--></em>", slots: { 2: "arrived" } },
+    }))
+
+    await vi.waitFor(() => {
+      if (!document.body.innerHTML.includes("arrived")) {
+        throw new Error("still waiting")
+      }
+    })
+
+    expect(document.body.innerHTML).not.toContain("<p>off</p>")
+  })
+
+  test("a state flip with no material refetches and unrolls the branch", async () => {
+    document.body.innerHTML =
+      `<!--herb-region:${FILE}:aaaaaaaa:0-->` +
+      `<div><!--herb-slot:0:conditional--><p>off</p><!--/herb-slot:0--></div>` +
+      `<b><!--herb-slot:3--><!--/herb-slot:3--></b>` +
+      `<!--/herb-region:${FILE}-->` +
+      dependencies(STATES)
+
+    const transport = vi.fn(async () => payloadFor({
+      0: { branch: 0, statics: "<!--herb-branch:0:0--><em><!--herb-slot:2--><!--/herb-slot:2--></em>", slots: { 2: "fetched" } },
+    }))
+
+    const live = start({ state: { refetchTransport: transport, refetchDebounce: 0 } })
+
+    live.state.setState({ editing: true })
+
+    await vi.waitFor(() => {
+      if (!document.body.innerHTML.includes("fetched")) {
+        throw new Error("still waiting")
+      }
+    })
+
+    expect(transport).toHaveBeenCalled()
+    expect(document.body.innerHTML).not.toContain("<p>off</p>")
+  })
+
+  test("a branch flip with no material defers and says so", () => {
+    document.body.innerHTML =
+      `<!--herb-region:${FILE}:aaaaaaaa:0-->` +
+      `<div><!--herb-slot:0:conditional--><p>off</p><!--/herb-slot:0--></div>` +
+      `<!--/herb-region:${FILE}-->`
+
+    const reportSink = vi.fn()
+
+    vi.stubGlobal("HerbDevTools", { report: reportSink })
+
+    try {
+      const live = start()
+      const report = live.slots.apply(payloadFor({ 0: { branch: 0, slots: {} } }))
+
+      expect(report.deferred).toHaveLength(1)
+
+      const reported = reportSink.mock.calls.flat(2) as Array<{ code?: string }>
+
+      expect(reported.some((diagnostic) => diagnostic.code === "herb-slots-materialize")).toBe(true)
+    } finally {
+      vi.unstubAllGlobals()
+    }
+  })
+
   test("data-herb-action fires $refresh and reports unknown actions", async () => {
     document.body.innerHTML =
       PAGE +
@@ -247,6 +340,7 @@ describe("refetching server-derived slots", () => {
       const entry = reported.find((diagnostic) => diagnostic.code === "herb-invalid-action")
 
       expect(entry?.message).toContain("somethingCustom")
+      expect(reported.every((diagnostic) => diagnostic.code !== "herb-unknown-state")).toBe(true)
     } finally {
       vi.unstubAllGlobals()
     }

--- a/lib/herb/engine/slots/dynamics_compiler.rb
+++ b/lib/herb/engine/slots/dynamics_compiler.rb
@@ -586,11 +586,6 @@ module Herb
           @scopes.push(index)
         end
 
-        # A client-mode page carries every branch's statics itself. A server-mode
-        # page carries none, so the payload brings the taken branch's markup along
-        # and the client parks it on arrival, the way LiveView unrolls a new branch.
-        # The values visitor never marks the tree, so the markup comes from one
-        # extra marking pass, run lazily and only for templates with conditionals.
         #: (Integer, Integer) -> String?
         def payload_statics(index, branch)
           return nil unless @input.is_a?(String) && Visitor.directive_mode(@input) == :server

--- a/lib/herb/engine/slots/dynamics_compiler.rb
+++ b/lib/herb/engine/slots/dynamics_compiler.rb
@@ -441,6 +441,8 @@ module Herb
         def initialize(input, properties = {})
           @block_depth = 0
           @scopes = [] #: Array[Integer]
+          @input = input
+          @filename = properties[:filename]
           @slot_visitor = properties[:slot_visitor] || Visitor.new(mode: :server, mark: false)
           @slot_visitor.state_overrides!
           visitors = [*properties[:visitors], @slot_visitor]
@@ -576,9 +578,35 @@ module Herb
         def scope_branch(index, branch)
           leave_scope(index)
 
-          @src << "; #{SLOT_BUFFER}#{index} = { branch: #{branch}, slots: (#{SCOPE_BUFFER}#{index} = ::Hash.new) };"
+          statics = payload_statics(index, branch)
+          parked = statics ? " statics: #{statics.inspect}," : ""
+
+          @src << "; #{SLOT_BUFFER}#{index} = { branch: #{branch},#{parked} slots: (#{SCOPE_BUFFER}#{index} = ::Hash.new) };"
 
           @scopes.push(index)
+        end
+
+        # A client-mode page carries every branch's statics itself. A server-mode
+        # page carries none, so the payload brings the taken branch's markup along
+        # and the client parks it on arrival, the way LiveView unrolls a new branch.
+        # The values visitor never marks the tree, so the markup comes from one
+        # extra marking pass, run lazily and only for templates with conditionals.
+        #: (Integer, Integer) -> String?
+        def payload_statics(index, branch)
+          return nil unless @input.is_a?(String) && Visitor.directive_mode(@input) == :server
+
+          branch_statics["#{index}:#{branch}"]
+        end
+
+        #: () -> Hash[String, String]
+        def branch_statics
+          @branch_statics ||= begin
+            visitor = Visitor.new(fatal: false)
+
+            Herb::Engine.new(@input, visitors: [visitor], filename: @filename)
+
+            visitor.statics || {}
+          end
         end
 
         #: (Integer) -> void

--- a/lib/herb/engine/slots/visitor.rb
+++ b/lib/herb/engine/slots/visitor.rb
@@ -144,7 +144,7 @@ module Herb
           @static_markup = nil #: String?
           @bufvar = "_buf"
           @mode = mode
-          @statics = mode == :client ? {} : nil #: Hash[String, String]?
+          @statics = {} #: Hash[String, String]?
           @identify = identifier
 
           @slots = [] #: Array[Slot]
@@ -1444,6 +1444,8 @@ module Herb
 
         #: (Herb::AST::DocumentNode) -> void
         def append_statics(document_node)
+          return unless client?
+
           statics = @statics
           return if statics.nil? || statics.empty?
 
@@ -1515,7 +1517,7 @@ module Herb
               text_node(@markers.item_open_suffix)
             )
 
-            body.insert(3, erb_code_node(%(#{COVERED}[#{covered_key(key).inspect}] = true))) if parked
+            body.insert(3, erb_code_node(%(#{COVERED}[#{covered_key(key).inspect}] = true))) if parked && client?
 
             body.push(text_node(@markers.item_close(slot_index)))
           end

--- a/sig/herb/engine/slots/dynamics_compiler.rbs
+++ b/sig/herb/engine/slots/dynamics_compiler.rbs
@@ -259,6 +259,12 @@ module Herb
         # : (Integer, Integer) -> void
         def scope_branch: (Integer, Integer) -> void
 
+        # : (Integer, Integer) -> String?
+        def payload_statics: (Integer, Integer) -> String?
+
+        # : () -> Hash[String, String]
+        def branch_statics: () -> Hash[String, String]
+
         # : (Integer) -> void
         def scope_close_conditional: (Integer) -> void
 

--- a/test/engine/dynamics_compiler_test.rb
+++ b/test/engine/dynamics_compiler_test.rb
@@ -343,5 +343,36 @@ module Engine
         assert_equal 0, values[:slots][0][:branch]
       end
     end
+
+    describe "branch statics in the payload" do
+      def parity(mode)
+        <<~ERB
+          <%# herb:slots #{mode} %>
+          <% if @on %>
+            <b>lit <%= @watts %></b>
+          <% else %>
+            <i>dark</i>
+          <% end %>
+        ERB
+      end
+
+      test "a server-mode payload brings the taken branch's markup along" do
+        entry = dynamics(parity("server"), on: false).fetch(0)
+
+        assert_equal 1, entry.fetch(:branch)
+        assert_includes entry.fetch(:statics), "<i>dark</i>"
+
+        lit = dynamics(parity("server"), on: true, watts: 60).fetch(0)
+
+        assert_equal 0, lit.fetch(:branch)
+        assert_includes lit.fetch(:statics), "<b>"
+      end
+
+      test "a client-mode payload sends no statics, since the page parks them" do
+        entry = dynamics(parity("client"), on: false).fetch(0)
+
+        refute entry.key?(:statics)
+      end
+    end
   end
 end


### PR DESCRIPTION
This pull request makes `herb:slots server` templates fully live, similar to the way LiveView unrolls a branch the client has never seen.

A client-mode page parks every branch's statics up front, so the client can flip any conditional itself. A server-mode page parks none, which kept it lean but left a dead end. The values program evaluates the branch the client's state picks, answers `{ branch: 1 }`, and the client had no material to show it. A state write updated every bound value instantly while the conditional next to them sat stuck, silently.

Now a server-mode values payload brings the taken branch's markup along.

```json
{ "branch": 1, "statics": "<span>Noted!</span>", "slots": {} }
```

The branch statics are compile-time constants, so the values program embeds the taken arm's markup as a string literal. The values visitor never marks the tree, so the markup comes from one extra marking pass over the source, run lazily and only for server-mode templates with conditionals. Client-mode payloads are unchanged, and a template with no `herb:slots` directive sends nothing.

On the client, `apply` parks arriving statics before switching, so a payload can materialize a branch the page never carried. For a state-owned conditional, which `apply` does not touch, the statics still park and a `branch-material` announcement lets the state system re-settle the conditional with the material it was missing. Once a branch has arrived once it stays parked, so every later flip is instant and client-side. First flip one round trip behind the state write, every flip after that free.