### PR TITLE
Client: Take one payload per action clause

### DIFF
--- a/javascript/packages/client/src/actions/actions.ts
+++ b/javascript/packages/client/src/actions/actions.ts
@@ -276,30 +276,30 @@ export class Actions implements ElementObserverDelegate, InstructionsDelegate {
   }
 
   private set(element: Element, rest: string, event: Event): void {
-    const groups: StateGroups = new Map()
-
-    for (const assignment of splitOutsideQuotes(rest, ",")) {
-      const pair = this.pairOf(element, assignment)
-
-      if (!pair) {
-        return
-      }
-
-      const resolved = this.declaration(element, pair.name)
-
-      if (!resolved) {
-        return
-      }
-
-      const assigned = this.assignedValue(element, pair.name, resolved, pair.raw, event)
-
-      if (!assigned) {
-        return
-      }
-
-      this.group(groups, resolved.scope, pair.name, assigned.value)
+    if (splitOutsideQuotes(rest, ",").length > 1) {
+      return
     }
 
+    const groups: StateGroups = new Map()
+    const pair = this.pairOf(element, rest)
+
+    if (!pair) {
+      return
+    }
+
+    const resolved = this.declaration(element, pair.name)
+
+    if (!resolved) {
+      return
+    }
+
+    const assigned = this.assignedValue(element, pair.name, resolved, pair.raw, event)
+
+    if (!assigned) {
+      return
+    }
+
+    this.group(groups, resolved.scope, pair.name, assigned.value)
     this.apply(groups)
   }
 

--- a/javascript/packages/client/src/actions/instructions.ts
+++ b/javascript/packages/client/src/actions/instructions.ts
@@ -108,14 +108,27 @@ export class Instructions {
       return
     }
 
+    if (splitOutsideQuotes(clause.rest, ",").length > 1) {
+      const what = schema.operation === "set" ? "assignment" : "name"
+
+      report({
+        template: this.delegate.templateOf(element),
+        element,
+        message: `\`${attribute}\` lists several ${what}s in one clause. A clause takes one ${what}, and each clause carries its own event or the element's default.`,
+        code: "herb-invalid-action",
+        severity: "error",
+        suggestion: `separate the clauses with spaces, like \`${attribute}="a b"\``,
+      })
+
+      return
+    }
+
     if (schema.operation === "action") {
       return
     }
 
     if (schema.operation === "set") {
-      for (const assignment of splitOutsideQuotes(clause.rest, ",")) {
-        this.validateAssignment(element, assignment)
-      }
+      this.validateAssignment(element, clause.rest)
 
       return
     }

--- a/javascript/packages/client/src/grammar/parsing.ts
+++ b/javascript/packages/client/src/grammar/parsing.ts
@@ -18,7 +18,9 @@ export function clauses(value: string): Clause[] {
 }
 
 export function names(rest: string): string[] {
-  return splitOutsideQuotes(rest, ",").map((name) => name.trim()).filter((name) => name.length > 0)
+  const name = rest.trim()
+
+  return name.length > 0 ? [name] : []
 }
 
 export function balancedQuotes(source: string): boolean {

--- a/javascript/packages/client/test/actions.test.ts
+++ b/javascript/packages/client/test/actions.test.ts
@@ -11,7 +11,8 @@ const PAGE =
   `<!--herb-region:${FILE}:aaaaaaaa:0-->` +
   `<section>` +
   `<button id="toggle" data-herb-toggle="open">Details</button>` +
-  `<button id="both" data-herb-set="pending=false,failed=true">Fail</button>` +
+  `<button id="both" data-herb-set="pending=false failed=true">Fail</button>` +
+  `<button id="blank" data-herb-set="sort=''">Clear</button>` +
   `<button id="bump" data-herb-increment="attempts" data-herb-by="2">More</button>` +
   `<button id="combo" data-herb-increment="attempts" data-herb-set="open=true">Both</button>` +
   `<button id="same" data-herb-increment="attempts" data-herb-set="attempts=10">Same</button>` +
@@ -97,7 +98,7 @@ describe("declarative actions", () => {
     expect(state.getState("open")).toBe(false)
   })
 
-  test("a comma pair lands as one transition", () => {
+  test("two clauses on one attribute both write", () => {
     const order: string[] = []
     const handler = (event: Event): void => {
       order.push((event as CustomEvent<{ name: string }>).detail.name)
@@ -110,6 +111,42 @@ describe("declarative actions", () => {
     expect(state.getState("pending")).toBe(false)
     expect(state.getState("failed")).toBe(true)
     expect(order).toEqual(["pending", "failed"])
+  })
+
+  test("a comma list is no longer a clause, and writes nothing", () => {
+    const entries: { code?: string }[] = []
+
+    ;(window as unknown as { HerbDevTools?: unknown }).HerbDevTools = {
+      report: (input: unknown) => entries.push(...[input].flat() as { code?: string }[]),
+    }
+
+    const legacy = document.createElement("button")
+
+    legacy.id = "legacy"
+    legacy.setAttribute("data-herb-set", "pending=true,failed=true")
+    document.querySelector("section")!.append(legacy)
+
+    actions.stop()
+    actions = new Actions(state)
+    actions.start(document.body)
+
+    click("#legacy")
+
+    expect(state.getState("pending")).not.toBe(true)
+    expect(state.getState("failed")).not.toBe(true)
+    expect(entries.some((entry) => entry.code === "herb-invalid-action")).toBe(true)
+
+    delete (window as unknown as { HerbDevTools?: unknown }).HerbDevTools
+  })
+
+  test("an empty quoted value sets the state to the empty string", () => {
+    click("#tab-a")
+
+    expect(state.getState("sort")).toBe("name")
+
+    click("#blank")
+
+    expect(state.getState("sort")).toBe("")
   })
 
   test("a set writes through to the bound input", () => {
@@ -345,7 +382,7 @@ describe("declarative actions", () => {
 
     const rogue = document.createElement("button")
 
-    rogue.setAttribute("data-herb-toggle", "sort,open")
+    rogue.setAttribute("data-herb-toggle", "sort")
     document.querySelector("section")!.append(rogue)
     rogue.dispatchEvent(new MouseEvent("click", { bubbles: true }))
 

--- a/lib/herb/engine/slots/visitor.rb
+++ b/lib/herb/engine/slots/visitor.rb
@@ -1034,15 +1034,12 @@ module Herb
 
             next [] unless value
 
-            value.split.flat_map { |clause|
+            value.split.filter_map { |clause|
               rest = clause.split("->", 2).last.to_s
+              target = name == "data-herb-set" ? rest.split("=", 2).first : rest
+              cleaned = target.to_s.strip
 
-              rest.split(",").filter_map { |piece|
-                target = name == "data-herb-set" ? piece.split("=", 2).first : piece
-                cleaned = target.to_s.strip
-
-                cleaned unless cleaned.empty?
-              }
+              cleaned unless cleaned.empty?
             }
           }
         end


### PR DESCRIPTION
This pull request makes the action attribute grammar uniform. 

An attribute's value is a space-separated list of clauses, every clause carries its own event or falls back to the element's default, and a clause holds exactly one payload, a single assignment for `data-herb-set` and a single name everywhere else.

```html
<select value="<%= continent %>" data-herb-set="continent=$value country='' state=''">
```

Three clauses, all riding the select's default `change` event, each writing one state. The comma lists that used to live inside a clause (`data-herb-set="pending=false,failed=true"`, `data-herb-reset="a,b"`) are gone. A comma outside quotes now reports a `herb-invalid-action` diagnostic at scan naming the migration, and the dispatcher refuses the clause so nothing half-applies. Quoted values keep their commas and spaces (`sort='hello, world'` still parses as one clause).