### PR TITLE
Client: Add key filters, window targets and pacing to action events

### DIFF
--- a/javascript/packages/client/src/actions/actions.ts
+++ b/javascript/packages/client/src/actions/actions.ts
@@ -1,4 +1,4 @@
-import { DIRECT_EVENTS } from "./events"
+import { DIRECT_EVENTS, eventMatches, parseEventSpec } from "./events"
 import { ACTION_ATTRIBUTES, ACTION_SCHEMA, ACTION_SELECTOR, HERB_ATTRIBUTES } from "../grammar/attributes"
 
 import { Instructions } from "./instructions"
@@ -16,16 +16,24 @@ import type { ElementObserverDelegate } from "../shared/element-observer"
 import type { ActionName, ActionSchema } from "../grammar/attributes"
 import type { Instruction, ResolvedDeclaration, StateGroups } from "./types"
 
+interface Timing {
+  timer?: ReturnType<typeof setTimeout>
+  last?: number
+}
+
 export class Actions implements ElementObserverDelegate, InstructionsDelegate {
   private readonly state: State
   private readonly instructions = new Instructions(this)
 
   private events = new Set<string>()
+  private globalEvents = new Set<string>()
   private direct = new Map<Element, () => void>()
   private elements: ElementObserver | null = null
   private unobserve: (() => void) | null = null
   private pinned: Map<string, StateScope> | null = null
   private listeners: [string, (event: Event) => void][] = []
+  private globalListeners: [string, (event: Event) => void][] = []
+  private timings = new WeakMap<Element, Map<string, Timing>>()
 
   constructor(state: State) {
     this.state = state
@@ -71,12 +79,18 @@ export class Actions implements ElementObserverDelegate, InstructionsDelegate {
       document.removeEventListener(event, listener, true)
     }
 
+    for (const [event, listener] of this.globalListeners) {
+      window.removeEventListener(event, listener, true)
+    }
+
     for (const detach of this.direct.values()) {
       detach()
     }
 
     this.listeners = []
+    this.globalListeners = []
     this.events = new Set()
+    this.globalEvents = new Set()
     this.direct = new Map()
   }
 
@@ -91,10 +105,14 @@ export class Actions implements ElementObserverDelegate, InstructionsDelegate {
 
     for (const element of elements) {
       for (const instruction of this.instructions.of(element)) {
-        if (DIRECT_EVENTS.includes(instruction.event)) {
-          this.attach(element, instruction.event)
+        const spec = parseEventSpec(instruction.event)
+
+        if (DIRECT_EVENTS.includes(spec.type)) {
+          this.attach(element, spec.type)
+        } else if (spec.global) {
+          this.delegateGlobal(spec.type)
         } else {
-          this.delegate(instruction.event)
+          this.delegate(spec.type)
         }
       }
 
@@ -117,6 +135,25 @@ export class Actions implements ElementObserverDelegate, InstructionsDelegate {
 
     document.addEventListener(event, listener, true)
     this.listeners.push([event, listener])
+  }
+
+  private delegateGlobal(event: string): void {
+    if (this.globalEvents.has(event)) {
+      return
+    }
+
+    this.globalEvents.add(event)
+
+    const listener = (fired: Event): void => this.dispatchGlobal(fired)
+
+    window.addEventListener(event, listener, true)
+    this.globalListeners.push([event, listener])
+  }
+
+  private dispatchGlobal(event: Event): void {
+    for (const element of document.querySelectorAll(ACTION_SELECTOR)) {
+      this.run(element, event, true)
+    }
   }
 
   private attach(element: Element, _event: string): void {
@@ -157,9 +194,29 @@ export class Actions implements ElementObserverDelegate, InstructionsDelegate {
     }
   }
 
-  private run(element: Element, event: Event): boolean {
-    const pending = this.instructions.of(element).filter((instruction) => instruction.event === event.type)
+  private run(element: Element, event: Event, global = false): boolean {
+    let shortcut = false
+
+    const pending = this.instructions.of(element).filter((instruction) => {
+      const spec = parseEventSpec(instruction.event)
+
+      if (spec.global !== global || !eventMatches(spec, event)) {
+        return false
+      }
+
+      if (spec.outside && event.target instanceof Node && element.contains(event.target)) {
+        return false
+      }
+
+      shortcut ||= spec.modifiers.length > 0
+
+      return true
+    })
     const handled = pending.length > 0
+
+    if (shortcut && event.cancelable) {
+      event.preventDefault()
+    }
 
     this.pinned = null
 
@@ -169,13 +226,75 @@ export class Actions implements ElementObserverDelegate, InstructionsDelegate {
 
     try {
       for (const entry of pending) {
-        this.execute(element, entry.action, entry.rest, event)
+        this.schedule(element, entry, event)
       }
     } finally {
       this.pinned = null
     }
 
     return handled
+  }
+
+  private schedule(element: Element, entry: Instruction, event: Event): void {
+    const key = `${entry.action}:${entry.event}:${entry.rest}`
+    const timing = this.timings.get(element) ?? new Map<string, Timing>()
+    const held = timing.get(key) ?? {}
+
+    this.timings.set(element, timing)
+    timing.set(key, held)
+
+    const throttle = this.timingOf(element, HERB_ATTRIBUTES.throttle)
+
+    if (throttle !== null) {
+      const now = Date.now()
+
+      if (held.last !== undefined && now - held.last < throttle) {
+        return
+      }
+
+      held.last = now
+      this.execute(element, entry.action, entry.rest, event)
+
+      return
+    }
+
+    const debounce = this.timingOf(element, HERB_ATTRIBUTES.debounce)
+
+    if (debounce !== null) {
+      if (held.timer !== undefined) {
+        clearTimeout(held.timer)
+      }
+
+      held.timer = setTimeout(() => {
+        held.timer = undefined
+
+        const pinned = this.pinScopes(element, [entry])
+
+        this.pinned = pinned
+
+        try {
+          this.execute(element, entry.action, entry.rest, event)
+        } finally {
+          this.pinned = null
+        }
+      }, debounce)
+
+      return
+    }
+
+    this.execute(element, entry.action, entry.rest, event)
+  }
+
+  private timingOf(element: Element, attribute: string): number | null {
+    const raw = element.getAttribute(attribute)
+
+    if (raw === null) {
+      return null
+    }
+
+    const parsed = Number(raw)
+
+    return Number.isFinite(parsed) && parsed >= 0 ? parsed : null
   }
 
   private execute(element: Element, action: ActionName, rest: string, event: Event): void {

--- a/javascript/packages/client/src/actions/events.ts
+++ b/javascript/packages/client/src/actions/events.ts
@@ -1,5 +1,19 @@
+export interface EventSpec {
+  type: string
+  key: string | null
+  modifiers: string[]
+  global: boolean
+  outside: boolean
+}
+
 export const DIRECT_EVENTS = ["mouseenter", "mouseleave"]
 export const CLICK_INPUT_TYPES = ["submit", "button", "reset"]
+
+const MODIFIERS = ["meta", "ctrl", "alt", "shift"] as const
+const KEY_EVENTS = ["keydown", "keyup", "keypress"]
+
+const PRINTABLE_ASCII = /^[ -~]$/
+const LAYOUT_KEYS = /^(?:Key([A-Z])|Digit([0-9]))$/
 
 const DEFAULT_EVENTS: Record<string, string> = {
   form: "submit",
@@ -9,10 +23,142 @@ const DEFAULT_EVENTS: Record<string, string> = {
   details: "toggle",
 }
 
+const KEY_ALIASES: Record<string, string> = {
+  esc: "escape",
+  return: "enter",
+  space: " ",
+  up: "arrowup",
+  down: "arrowdown",
+  left: "arrowleft",
+  right: "arrowright",
+  page_up: "pageup",
+  page_down: "pagedown",
+}
+
+const MODIFIER_ALIASES: Record<string, string> = {
+  meta: "meta",
+  cmd: "meta",
+  ctrl: "ctrl",
+  alt: "alt",
+  shift: "shift",
+}
+
 export function defaultEventFor(element: Element): string {
   if (element instanceof HTMLInputElement && CLICK_INPUT_TYPES.includes(element.type)) {
     return "click"
   }
 
   return DEFAULT_EVENTS[element.localName] ?? "click"
+}
+
+export function parseEventSpec(event: string): EventSpec {
+  const [scoped, target] = event.split("@", 2)
+  const { head, filter } = splitKeyFilter(scoped)
+  const held = head.split("+")
+  const type = held.pop()!
+
+  let key: string | null = null
+  const modifiers: string[] = []
+
+  for (const token of [...held, ...filter]) {
+    const lowered = token.toLowerCase()
+    const modifier = MODIFIER_ALIASES[lowered]
+
+    if (modifier) {
+      modifiers.push(modifier)
+    } else {
+      key = KEY_ALIASES[lowered] ?? lowered
+    }
+  }
+
+  return {
+    type,
+    key,
+    modifiers,
+    global: target === "window" || target === "document" || target === "outside",
+    outside: target === "outside",
+  }
+}
+
+export function eventSpecProblem(event: string): string | null {
+  const [scoped, target] = event.split("@", 2)
+
+  if (target !== undefined && target !== "window" && target !== "document" && target !== "outside") {
+    return `names \`@${target}\` as its target. Use \`@window\`, \`@document\` or \`@outside\`, or drop the target to listen on the element.`
+  }
+
+  const { head, filter } = splitKeyFilter(scoped)
+  const held = head.split("+").slice(0, -1)
+  const stray = held.find((token) => !MODIFIER_ALIASES[token.toLowerCase()])
+
+  if (stray !== undefined) {
+    return `prefixes the event with \`${stray}+\`, which is not a modifier. Use \`ctrl\`, \`alt\`, \`shift\`, \`meta\` or \`cmd\`.`
+  }
+
+  if (filter.includes("")) {
+    return `has an empty key filter. Name the key after the dot, like \`keydown.esc\`, or drop the dot.`
+  }
+
+  const keys = filter.filter((token) => !MODIFIER_ALIASES[token.toLowerCase()])
+
+  if (keys.length > 1) {
+    return `filters on ${keys.length} keys. Name one key per clause, with modifiers joined by \`+\`, like \`keydown.ctrl+k\`.`
+  }
+
+  if (keys[0]?.includes(".")) {
+    return `joins its filter with \`.\`. Join modifiers and key with \`+\`, like \`keydown.meta+k\`.`
+  }
+
+  return null
+}
+
+function splitKeyFilter(scoped: string): { head: string; filter: string[] } {
+  const separator = scoped.indexOf(".")
+  const head = separator === -1 ? scoped : scoped.slice(0, separator)
+
+  if (separator === -1 || !KEY_EVENTS.includes(head)) {
+    return { head: scoped, filter: [] }
+  }
+
+  return { head, filter: scoped.slice(separator + 1).split("+") }
+}
+
+export function eventMatches(spec: EventSpec, fired: Event): boolean {
+  if (spec.type !== fired.type) {
+    return false
+  }
+
+  const filtered = spec.key !== null || spec.modifiers.length > 0
+
+  if (filtered && !heldModifiersMatch(spec, fired as KeyboardEvent)) {
+    return false
+  }
+
+  return spec.key === null || keyMatches(spec.key, fired as KeyboardEvent)
+}
+
+function heldModifiersMatch(spec: EventSpec, fired: KeyboardEvent): boolean {
+  return MODIFIERS.every((modifier) => Boolean(fired[`${modifier}Key` as "metaKey"]) === spec.modifiers.includes(modifier))
+}
+
+function keyMatches(expected: string, fired: KeyboardEvent): boolean {
+  if (typeof fired.key !== "string") {
+    return false
+  }
+
+  if (fired.key.toLowerCase() === expected) {
+    return true
+  }
+
+  if (fired.isComposing || !PRINTABLE_ASCII.test(expected) || PRINTABLE_ASCII.test(fired.key)) {
+    return false
+  }
+
+  return typeof fired.code === "string" && keyFromCode(fired.code) === expected
+}
+
+function keyFromCode(code: string): string | null {
+  const [, letter, digit] = code.match(LAYOUT_KEYS) ?? []
+
+  return letter?.toLowerCase() ?? digit ?? null
 }

--- a/javascript/packages/client/src/actions/instructions.ts
+++ b/javascript/packages/client/src/actions/instructions.ts
@@ -1,7 +1,7 @@
 import { ACTION_NAMES, ACTION_SCHEMA, HERB_ATTRIBUTES } from "../grammar/attributes"
 
 import { report } from "../shared/report"
-import { defaultEventFor } from "./events"
+import { defaultEventFor, eventSpecProblem } from "./events"
 import { balancedQuotes, clauses, names, splitOutsideQuotes, unquote } from "../grammar/parsing"
 
 import type { Clause } from "../grammar/parsing"
@@ -101,6 +101,20 @@ export class Instructions {
         template: this.delegate.templateOf(element),
         element,
         message: `\`${attribute}\` has a clause with ${problem}`,
+        code: "herb-invalid-action",
+        severity: "error",
+      })
+
+      return
+    }
+
+    const problem = clause.event === null ? null : eventSpecProblem(clause.event)
+
+    if (problem !== null) {
+      report({
+        template: this.delegate.templateOf(element),
+        element,
+        message: `\`${clause.event}\` in \`${attribute}\` ${problem}`,
         code: "herb-invalid-action",
         severity: "error",
       })

--- a/javascript/packages/client/src/directives.ts
+++ b/javascript/packages/client/src/directives.ts
@@ -17,6 +17,7 @@ export { STATE_DEFAULT_KINDS, LITERAL_STATE_KINDS, UNKNOWN_STATE_KINDS, FALSY_ST
 export { stateKindArticle } from "./state-kinds"
 export { isMarker, parseMarker } from "./markup/markers"
 export { clauses, names, balancedQuotes, splitOutsideQuotes, unquote } from "./grammar/parsing"
+export { eventSpecProblem } from "./actions/events"
 
 export type { Clause } from "./grammar/parsing"
 export type { StatePredicate } from "./state-predicates"

--- a/javascript/packages/client/src/grammar/attributes.ts
+++ b/javascript/packages/client/src/grammar/attributes.ts
@@ -23,6 +23,8 @@ export const HERB_ATTRIBUTES = {
   decrement: "data-herb-decrement",
   reset: "data-herb-reset",
   by: "data-herb-by",
+  debounce: "data-herb-debounce",
+  throttle: "data-herb-throttle",
 } as const
 
 export const ACTION_SCHEMA = {

--- a/javascript/packages/client/test/actions.test.ts
+++ b/javascript/packages/client/test/actions.test.ts
@@ -13,6 +13,10 @@ const PAGE =
   `<button id="toggle" data-herb-toggle="open">Details</button>` +
   `<button id="both" data-herb-set="pending=false failed=true">Fail</button>` +
   `<button id="blank" data-herb-set="sort=''">Clear</button>` +
+  `<div id="esc" data-herb-set="keydown.escape@window->open=false"></div>` +
+  `<input id="enter-input" data-herb-set="keydown.enter->sort=$value">` +
+  `<input id="debounced" data-herb-set="sort=$value" data-herb-debounce="30">` +
+  `<button id="throttled" data-herb-increment="attempts" data-herb-throttle="1000">T</button>` +
   `<button id="bump" data-herb-increment="attempts" data-herb-by="2">More</button>` +
   `<button id="combo" data-herb-increment="attempts" data-herb-set="open=true">Both</button>` +
   `<button id="same" data-herb-increment="attempts" data-herb-set="attempts=10">Same</button>` +
@@ -137,6 +141,238 @@ describe("declarative actions", () => {
     expect(entries.some((entry) => entry.code === "herb-invalid-action")).toBe(true)
 
     delete (window as unknown as { HerbDevTools?: unknown }).HerbDevTools
+  })
+
+  test("a clause with the old dot chord reports what to write instead", () => {
+    const entries: { code?: string; message?: string }[] = []
+
+    ;(window as unknown as { HerbDevTools?: unknown }).HerbDevTools = {
+      report: (input: unknown) => entries.push(...[input].flat() as { code?: string; message?: string }[]),
+    }
+
+    const chord = document.createElement("button")
+
+    chord.id = "chord"
+    chord.setAttribute("data-herb-set", "keydown.meta.k@window->open=true")
+    document.querySelector("section")!.append(chord)
+
+    actions.stop()
+    actions = new Actions(state)
+    actions.start(document.body)
+
+    const entry = entries.find((held) => held.code === "herb-invalid-action")
+
+    expect(entry?.message).toContain("`keydown.meta+k`")
+
+    delete (window as unknown as { HerbDevTools?: unknown }).HerbDevTools
+  })
+
+  test("an outside clause fires for a click anywhere but inside the element", () => {
+    const panel = document.createElement("div")
+
+    panel.id = "panel"
+    panel.setAttribute("data-herb-set", "click@outside->open=false")
+    panel.innerHTML = `<button id="inside">stay</button>`
+    document.querySelector("section")!.append(panel)
+
+    actions.stop()
+    actions = new Actions(state)
+    actions.start(document.body)
+
+    click("#toggle")
+
+    expect(state.getState("open")).toBe(true)
+
+    click("#inside")
+
+    expect(state.getState("open")).toBe(true)
+
+    click("#blank")
+
+    expect(state.getState("open")).toBe(false)
+  })
+
+  test("a window-scoped key clause fires from anywhere, filtered by key", () => {
+    click("#toggle")
+
+    expect(state.getState("open")).toBe(true)
+
+    window.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter" }))
+
+    expect(state.getState("open")).toBe(true)
+
+    window.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }))
+
+    expect(state.getState("open")).toBe(false)
+  })
+
+  test("a modifier key clause fires only with the modifier held", () => {
+    const shortcut = document.createElement("button")
+
+    shortcut.id = "shortcut"
+    shortcut.setAttribute("data-herb-set", "keydown.meta+k@window->open=true")
+    document.querySelector("section")!.append(shortcut)
+
+    actions.stop()
+    actions = new Actions(state)
+    actions.start(document.body)
+
+    window.dispatchEvent(new KeyboardEvent("keydown", { key: "k" }))
+
+    expect(state.getState("open")).not.toBe(true)
+
+    const chord = new KeyboardEvent("keydown", { key: "k", metaKey: true, cancelable: true })
+
+    window.dispatchEvent(chord)
+
+    expect(state.getState("open")).toBe(true)
+    expect(chord.defaultPrevented).toBe(true)
+  })
+
+  test("a key clause without modifiers ignores the key inside a chord", () => {
+    click("#toggle")
+
+    expect(state.getState("open")).toBe(true)
+
+    window.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", metaKey: true }))
+
+    expect(state.getState("open")).toBe(true)
+
+    window.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }))
+
+    expect(state.getState("open")).toBe(false)
+  })
+
+  test("a modifier key clause ignores a chord holding more than it names", () => {
+    const shortcut = document.createElement("button")
+
+    shortcut.id = "strict"
+    shortcut.setAttribute("data-herb-set", "keydown.ctrl+k@window->open=true")
+    document.querySelector("section")!.append(shortcut)
+
+    actions.stop()
+    actions = new Actions(state)
+    actions.start(document.body)
+
+    window.dispatchEvent(new KeyboardEvent("keydown", { key: "k", ctrlKey: true, shiftKey: true }))
+
+    expect(state.getState("open")).not.toBe(true)
+
+    window.dispatchEvent(new KeyboardEvent("keydown", { key: "k", ctrlKey: true }))
+
+    expect(state.getState("open")).toBe(true)
+  })
+
+  test("a letter filter still matches when the layout types another alphabet", () => {
+    const shortcut = document.createElement("button")
+
+    shortcut.id = "layout"
+    shortcut.setAttribute("data-herb-set", "keydown.j@window->open=true")
+    document.querySelector("section")!.append(shortcut)
+
+    actions.stop()
+    actions = new Actions(state)
+    actions.start(document.body)
+
+    window.dispatchEvent(new KeyboardEvent("keydown", { key: "й", code: "KeyQ" }))
+
+    expect(state.getState("open")).not.toBe(true)
+
+    window.dispatchEvent(new KeyboardEvent("keydown", { key: "й", code: "KeyJ" }))
+
+    expect(state.getState("open")).toBe(true)
+  })
+
+  test("a dotted name outside the keyboard events stays one event name", () => {
+    const custom = document.createElement("button")
+
+    custom.id = "custom"
+    custom.setAttribute("data-herb-set", "library.change->open=true")
+    document.querySelector("section")!.append(custom)
+
+    actions.stop()
+    actions = new Actions(state)
+    actions.start(document.body)
+
+    custom.dispatchEvent(new CustomEvent("library.change", { bubbles: true }))
+
+    expect(state.getState("open")).toBe(true)
+  })
+
+  test("a modifier prefixed to a mouse event filters the click", () => {
+    const picker = document.createElement("button")
+
+    picker.id = "picker"
+    picker.setAttribute("data-herb-set", "meta+click->open=true")
+    document.querySelector("section")!.append(picker)
+
+    actions.stop()
+    actions = new Actions(state)
+    actions.start(document.body)
+
+    picker.dispatchEvent(new MouseEvent("click", { bubbles: true }))
+
+    expect(state.getState("open")).not.toBe(true)
+
+    picker.dispatchEvent(new MouseEvent("click", { bubbles: true, metaKey: true }))
+
+    expect(state.getState("open")).toBe(true)
+  })
+
+  test("the arrow key names Stimulus uses filter on the arrow keys", () => {
+    const stepper = document.createElement("button")
+
+    stepper.id = "stepper"
+    stepper.setAttribute("data-herb-set", "keydown.up@window->open=true")
+    document.querySelector("section")!.append(stepper)
+
+    actions.stop()
+    actions = new Actions(state)
+    actions.start(document.body)
+
+    window.dispatchEvent(new KeyboardEvent("keydown", { key: "Up" }))
+
+    expect(state.getState("open")).not.toBe(true)
+
+    window.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowUp" }))
+
+    expect(state.getState("open")).toBe(true)
+  })
+
+  test("an element-scoped key clause fires only for its key", () => {
+    const input = document.querySelector<HTMLInputElement>("#enter-input")!
+
+    input.value = "typed"
+    input.dispatchEvent(new KeyboardEvent("keydown", { key: "a", bubbles: true }))
+
+    expect(state.getState("sort")).not.toBe("typed")
+
+    input.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true }))
+
+    expect(state.getState("sort")).toBe("typed")
+  })
+
+  test("data-herb-debounce holds a write until the input settles", async () => {
+    const input = document.querySelector<HTMLInputElement>("#debounced")!
+
+    input.value = "dr"
+    input.dispatchEvent(new Event("input", { bubbles: true }))
+    input.value = "draft"
+    input.dispatchEvent(new Event("input", { bubbles: true }))
+
+    expect(state.getState("sort")).not.toBe("draft")
+
+    await new Promise((resolve) => setTimeout(resolve, 80))
+
+    expect(state.getState("sort")).toBe("draft")
+  })
+
+  test("data-herb-throttle lets the first click through and swallows the burst", () => {
+    click("#throttled")
+    click("#throttled")
+    click("#throttled")
+
+    expect(state.getState("attempts")).toBe(1)
   })
 
   test("an empty quoted value sets the state to the empty string", () => {

--- a/javascript/packages/client/test/event-specs.test.ts
+++ b/javascript/packages/client/test/event-specs.test.ts
@@ -1,0 +1,155 @@
+import { describe, test, expect } from "vitest"
+
+import { parseEventSpec, eventMatches, eventSpecProblem } from "../src/actions/events"
+
+const keydown = (init: KeyboardEventInit) => new KeyboardEvent("keydown", init)
+
+describe("reading an event spec", () => {
+  test("reads a bare event name", () => {
+    expect(parseEventSpec("click")).toEqual({ type: "click", key: null, modifiers: [], global: false, outside: false })
+  })
+
+  test("reads a key filter with a chord of modifiers", () => {
+    expect(parseEventSpec("keydown.ctrl+shift+f@window")).toEqual({
+      type: "keydown",
+      key: "f",
+      modifiers: ["ctrl", "shift"],
+      global: true,
+      outside: false,
+    })
+  })
+
+  test("accepts a filter on every keyboard event", () => {
+    expect(parseEventSpec("keyup.enter").key).toBe("enter")
+    expect(parseEventSpec("keypress.a").key).toBe("a")
+  })
+
+  test("maps the key names Stimulus maps", () => {
+    expect(parseEventSpec("keydown.esc").key).toBe("escape")
+    expect(parseEventSpec("keydown.space").key).toBe(" ")
+    expect(parseEventSpec("keydown.up").key).toBe("arrowup")
+    expect(parseEventSpec("keydown.down").key).toBe("arrowdown")
+    expect(parseEventSpec("keydown.left").key).toBe("arrowleft")
+    expect(parseEventSpec("keydown.right").key).toBe("arrowright")
+    expect(parseEventSpec("keydown.page_up").key).toBe("pageup")
+    expect(parseEventSpec("keydown.page_down").key).toBe("pagedown")
+  })
+
+  test("treats cmd as the meta key", () => {
+    expect(parseEventSpec("keydown.cmd+k").modifiers).toEqual(["meta"])
+  })
+
+  test("keeps a dotted name on other events as one event name", () => {
+    expect(parseEventSpec("library.change")).toEqual({ type: "library.change", key: null, modifiers: [], global: false, outside: false })
+  })
+
+  test("reads a modifier prefixed to a mouse event", () => {
+    expect(parseEventSpec("meta+click")).toEqual({ type: "click", key: null, modifiers: ["meta"], global: false, outside: false })
+  })
+
+  test("marks a document target as global", () => {
+    expect(parseEventSpec("keydown.esc@document").global).toBe(true)
+  })
+
+  test("marks an outside target as a global listener that excludes the element", () => {
+    expect(parseEventSpec("click@outside")).toEqual({ type: "click", key: null, modifiers: [], global: true, outside: true })
+  })
+})
+
+describe("matching a key filter", () => {
+  const spec = (event: string) => parseEventSpec(event)
+
+  test("matches a capital letter against a lowercase filter", () => {
+    expect(eventMatches(spec("keydown.j"), keydown({ key: "J" }))).toBe(true)
+  })
+
+  test("requires every named modifier and no others", () => {
+    expect(eventMatches(spec("keydown.ctrl+k"), keydown({ key: "k", ctrlKey: true }))).toBe(true)
+    expect(eventMatches(spec("keydown.ctrl+k"), keydown({ key: "k" }))).toBe(false)
+    expect(eventMatches(spec("keydown.ctrl+k"), keydown({ key: "k", ctrlKey: true, altKey: true }))).toBe(false)
+    expect(eventMatches(spec("keydown.k"), keydown({ key: "k", metaKey: true }))).toBe(false)
+  })
+
+  test("leaves an unfiltered event alone whatever is held", () => {
+    expect(eventMatches(spec("keydown"), keydown({ key: "k", metaKey: true, shiftKey: true }))).toBe(true)
+  })
+
+  test("falls back to the physical key when the layout types another alphabet", () => {
+    expect(eventMatches(spec("keydown.j"), keydown({ key: "й", code: "KeyJ" }))).toBe(true)
+    expect(eventMatches(spec("keydown.j"), keydown({ key: "ξ", code: "KeyJ" }))).toBe(true)
+    expect(eventMatches(spec("keydown.j"), keydown({ key: "ח", code: "KeyJ" }))).toBe(true)
+    expect(eventMatches(spec("keydown.j"), keydown({ key: "й", code: "KeyQ" }))).toBe(false)
+  })
+
+  test("falls back for a digit the layout hides behind another character", () => {
+    expect(eventMatches(spec("keydown.2"), keydown({ key: "é", code: "Digit2" }))).toBe(true)
+    expect(eventMatches(spec("keydown.2"), keydown({ key: "é", code: "Digit3" }))).toBe(false)
+  })
+
+  test("never falls back while composing", () => {
+    expect(eventMatches(spec("keydown.j"), keydown({ key: "й", code: "KeyJ", isComposing: true }))).toBe(false)
+  })
+
+  test("never falls back when the typed key is printable ascii", () => {
+    expect(eventMatches(spec("keydown.a"), keydown({ key: "q", code: "KeyA" }))).toBe(false)
+  })
+
+  test("never falls back for a filter outside ascii", () => {
+    expect(eventMatches(spec("keydown.й"), keydown({ key: "й" }))).toBe(true)
+    expect(eventMatches(spec("keydown.й"), keydown({ key: "j", code: "KeyJ" }))).toBe(false)
+  })
+
+  test("never falls back from a key with no letter or digit position", () => {
+    expect(eventMatches(spec("keydown.1"), keydown({ key: "ω", code: "Semicolon" }))).toBe(false)
+    expect(eventMatches(spec("keydown.f"), keydown({ key: "ф", code: "F1" }))).toBe(false)
+    expect(eventMatches(spec("keydown.5"), keydown({ key: "ت", code: "Numpad5" }))).toBe(false)
+  })
+
+  test("matches the space alias against the space bar", () => {
+    expect(eventMatches(spec("keydown.space"), keydown({ key: " " }))).toBe(true)
+  })
+
+  test("matches an arrow alias against the arrow key", () => {
+    expect(eventMatches(spec("keydown.left"), keydown({ key: "ArrowLeft" }))).toBe(true)
+    expect(eventMatches(spec("keydown.left"), keydown({ key: "Left" }))).toBe(false)
+  })
+
+  test("ignores an event of another type entirely", () => {
+    expect(eventMatches(spec("keydown.j"), new KeyboardEvent("keyup", { key: "j" }))).toBe(false)
+  })
+})
+
+describe("naming what is wrong with an event spec", () => {
+  test("accepts every valid form quietly", () => {
+    expect(eventSpecProblem("click")).toBeNull()
+    expect(eventSpecProblem("keydown.esc")).toBeNull()
+    expect(eventSpecProblem("keydown.ctrl+shift+f@window")).toBeNull()
+    expect(eventSpecProblem("keydown.escape@document")).toBeNull()
+    expect(eventSpecProblem("meta+click")).toBeNull()
+    expect(eventSpecProblem("library.change")).toBeNull()
+    expect(eventSpecProblem("keydown.f1")).toBeNull()
+    expect(eventSpecProblem("click@outside")).toBeNull()
+  })
+
+  test("flags a target it will never listen on", () => {
+    expect(eventSpecProblem("keydown.esc@body")).toBe("names `@body` as its target. Use `@window`, `@document` or `@outside`, or drop the target to listen on the element.")
+    expect(eventSpecProblem("click@")).toBe("names `@` as its target. Use `@window`, `@document` or `@outside`, or drop the target to listen on the element.")
+  })
+
+  test("flags a prefix that is not a modifier", () => {
+    expect(eventSpecProblem("primary+click")).toBe("prefixes the event with `primary+`, which is not a modifier. Use `ctrl`, `alt`, `shift`, `meta` or `cmd`.")
+  })
+
+  test("flags an empty key filter", () => {
+    expect(eventSpecProblem("keydown.")).toBe("has an empty key filter. Name the key after the dot, like `keydown.esc`, or drop the dot.")
+    expect(eventSpecProblem("keydown.ctrl+")).toBe("has an empty key filter. Name the key after the dot, like `keydown.esc`, or drop the dot.")
+  })
+
+  test("flags a filter naming more than one key", () => {
+    expect(eventSpecProblem("keydown.a+b")).toBe("filters on 2 keys. Name one key per clause, with modifiers joined by `+`, like `keydown.ctrl+k`.")
+  })
+
+  test("points the old dot chord at the plus form", () => {
+    expect(eventSpecProblem("keydown.meta.k")).toBe("joins its filter with `.`. Join modifiers and key with `+`, like `keydown.meta+k`.")
+  })
+})

--- a/javascript/packages/linter/docs/rules/herb-state-valid-actions.md
+++ b/javascript/packages/linter/docs/rules/herb-state-valid-actions.md
@@ -4,13 +4,15 @@
 
 ## Description
 
-Validates the declarative action attributes `data-herb-set`, `data-herb-toggle`, `data-herb-increment`, `data-herb-decrement`, `data-herb-reset` and `data-herb-by`. Clause syntax must parse, quotes must balance, a named state must be declared in a scope enclosing the element, the operation must match the state's declared kind, and a `set` value must parse to that kind. A derived state cannot be the target of any action, since its value follows from the states it reads.
+Validates the declarative action attributes `data-herb-set`, `data-herb-toggle`, `data-herb-increment`, `data-herb-decrement`, `data-herb-reset` and `data-herb-by`. Clause syntax must parse, quotes must balance, the event spec must follow the Stimulus grammar, a named state must be declared in a scope enclosing the element, the operation must match the state's declared kind, and a `set` value must parse to that kind. A derived state cannot be the target of any action, since its value follows from the states it reads.
 
 ## Rationale
 
 An action attribute is wiring the browser executes, so a typo in it fails silently at runtime. The client runtime reports these same problems as diagnostics when the page runs in debug mode. This rule reports them in the editor, using the same messages, before the page runs at all.
 
 Type checks come from the declaration. `toggle` needs a boolean, `increment` and `decrement` need an integer, and a `set` value is read as whatever the state was declared to hold, so `attempts=lots` against `attempts: 0` can never parse. A state seeded from an expression has no static kind and is exempt.
+
+The event check covers what can never fire. Modifiers join the key with `+`, as in `keydown.meta+k`, a key filter belongs to `keydown`, `keyup` and `keypress`, and an event listens on the element, `@window`, `@document` or `@outside`, which listens globally and fires only when the event lands outside the element. A dotted name on any other event stays a custom event name, so `library.change` is fine and never flagged.
 
 The scope check follows the runtime's resolution. A name resolves through the scopes enclosing the element, the loop body for an item-scoped state and the template for a region-scoped one. When the template declares no states at all the rule stays quiet, since the states an element writes may be declared by an enclosing template.
 
@@ -26,6 +28,7 @@ The scope check follows the runtime's resolution. A name resolves through the sc
 <button data-herb-set="open=true,sort=date">Both</button>
 <button data-herb-increment="attempts" data-herb-by="2">More</button>
 <select data-herb-set="change->sort=$value"></select>
+<button data-herb-set="keydown.meta+k@window->open=true">Palette</button>
 <input data-herb-reset="blur->draft" autocomplete="off">
 <button data-herb-set="draft='hello, world'">Quote</button>
 ```
@@ -42,6 +45,8 @@ The scope check follows the runtime's resolution. A name resolves through the sc
 <button data-herb-set="attempts=lots">More</button>
 <button data-herb-increment="attempts" data-herb-by="two">More</button>
 <button data-herb-set="sort='oops">Sort</button>
+<button data-herb-set="keydown.meta.k@window->open=true">Palette</button>
+<button data-herb-set="keydown.esc@body->open=false">Close</button>
 ```
 
 ## References

--- a/javascript/packages/linter/src/rules/herb-state-valid-actions.ts
+++ b/javascript/packages/linter/src/rules/herb-state-valid-actions.ts
@@ -1,7 +1,7 @@
 import { BaseRuleVisitor } from "../utils/rule-utils.js"
 import { ParserRule } from "../types.js"
 import { ACTION_ATTRIBUTE_SCHEMA, BY_ATTRIBUTE, StateScopeMap, collectCountedFolds, declaredKind, isActionAttribute, isDerived, kindWithArticle } from "../utils/state-directives-utils.js"
-import { balancedQuotes, clauses, names, splitOutsideQuotes, unquote } from "@herb-tools/client/directives"
+import { balancedQuotes, clauses, eventSpecProblem, names, splitOutsideQuotes, unquote } from "@herb-tools/client/directives"
 
 import { forEachAttribute, getAttributeName, getStaticAttributeValueContent, hasDynamicOutput, getAttributeValueNodes } from "@herb-tools/core"
 
@@ -81,6 +81,17 @@ class StateValidActionsVisitor extends BaseRuleVisitor {
         clause.event === ""
           ? `\`${name}\` has a clause with no event before the arrow. Name one, like \`click->\`, or drop the arrow to use the element's default event.`
           : `\`${name}\` has a clause with nothing after the event. Name the state to write, like \`${clause.event}->open\`.`,
+        attribute.location,
+      )
+
+      return
+    }
+
+    const problem = clause.event === null ? null : eventSpecProblem(clause.event)
+
+    if (problem !== null) {
+      this.addOffense(
+        `\`${clause.event}\` in \`${name}\` ${problem}`,
         attribute.location,
       )
 

--- a/javascript/packages/linter/test/rules/herb-state-valid-actions.test.ts
+++ b/javascript/packages/linter/test/rules/herb-state-valid-actions.test.ts
@@ -50,6 +50,58 @@ describe("HerbStateValidActionsRule", () => {
     `)
   })
 
+  test("allows key filters in the Stimulus syntax", () => {
+    expectNoOffenses(dedent`
+      <%# herb:state (open: false) %>
+      <button data-herb-set="keydown.esc@window->open=false keydown.ctrl+shift+f@document->open=true meta+click->open=true click@outside->open=false">x</button>
+    `)
+  })
+
+  test("points the old dot chord at the plus form", () => {
+    expectError("`keydown.meta.k@window` in `data-herb-set` joins its filter with `.`. Join modifiers and key with `+`, like `keydown.meta+k`.")
+
+    assertOffenses(dedent`
+      <%# herb:state (open: false) %>
+      <button data-herb-set="keydown.meta.k@window->open=true">x</button>
+    `)
+  })
+
+  test("flags a target the runtime will never listen on", () => {
+    expectError("`keydown.esc@body` in `data-herb-set` names `@body` as its target. Use `@window`, `@document` or `@outside`, or drop the target to listen on the element.")
+
+    assertOffenses(dedent`
+      <%# herb:state (open: false) %>
+      <button data-herb-set="keydown.esc@body->open=false">x</button>
+    `)
+  })
+
+  test("flags a filter naming two keys", () => {
+    expectError("`keydown.a+b` in `data-herb-toggle` filters on 2 keys. Name one key per clause, with modifiers joined by `+`, like `keydown.ctrl+k`.")
+
+    assertOffenses(dedent`
+      <%# herb:state (open: false) %>
+      <button data-herb-toggle="keydown.a+b->open">x</button>
+    `)
+  })
+
+  test("flags a prefix that is not a modifier", () => {
+    expectError("`primary+click` in `data-herb-set` prefixes the event with `primary+`, which is not a modifier. Use `ctrl`, `alt`, `shift`, `meta` or `cmd`.")
+
+    assertOffenses(dedent`
+      <%# herb:state (open: false) %>
+      <button data-herb-set="primary+click->open=true">x</button>
+    `)
+  })
+
+  test("flags an empty key filter", () => {
+    expectError("`keydown.` in `data-herb-set` has an empty key filter. Name the key after the dot, like `keydown.esc`, or drop the dot.")
+
+    assertOffenses(dedent`
+      <%# herb:state (open: false) %>
+      <button data-herb-set="keydown.->open=true">x</button>
+    `)
+  })
+
   test("flags a clause with no event before the arrow", () => {
     expectError("`data-herb-toggle` has a clause with no event before the arrow. Name one, like `click->`, or drop the arrow to use the element's default event.")
 


### PR DESCRIPTION
This pull request grows the action event grammar in three small, composable directions, all discovered while building overlay and tooltip demos, and aligns the whole grammar with Stimulus.

An event in a clause can now filter by key and retarget to the window.

```html
<div data-herb-set="keydown.escape@window->modal=false">
```

The filter follows the Stimulus grammar. A key name matches `KeyboardEvent#key` case-insensitively, with the Stimulus mappings recognized, `esc`, `space`, `up`, `down`, `left`, `right`, `page_up` and `page_down`, plus `return` and `cmd` as extras. 

Modifiers join the key with `+`, so `keydown.meta+k@window` is the classic command palette shortcut, and matching is exact the way Stimulus matches.

The `@window` segment registers a capture listener on the window and runs the clause on every element declaring it, which is what an overlay needs, since a page-level Escape targets `<body>` and never reaches an element-delegated listener. A branch-mounted overlay gets the right lifecycle for free, its clause only exists while the overlay does. `@outside` is the popover primitive on the same wiring, a global listener whose clause fires only when the event lands outside the element.

```html
<div class="menu" data-herb-set="click@outside->menu=false">
```


Two modifier attributes pace an element's clauses:

```html
<span data-herb-set="mouseenter->peek='<%= city %>'" data-herb-debounce="100">
<button data-herb-increment="attempts" data-herb-throttle="1000">
```

`data-herb-debounce` holds each clause until the events settle for the given milliseconds, so sweeping across hovercard chips writes one `peek` instead of ten. `data-herb-throttle` lets the first firing through and swallows the burst, the double-click guard. Timings are tracked per element and clause, and a debounced run re-pins its scopes at fire time.
