### PR TITLE
Client: Read a negated presence right when hydrating a state

### DIFF
--- a/javascript/packages/client/src/state/seeds.ts
+++ b/javascript/packages/client/src/state/seeds.ts
@@ -193,6 +193,10 @@ export class Seeds {
     const declaration = this.delegate.declarationFor(manifest, scope, name)
 
     for (const index of manifest.reads[name] ?? []) {
+      if (manifest.computed?.[String(index)]) {
+        continue
+      }
+
       for (const slot of this.delegate.scopedSlots(scope, index)) {
         if (slot.claimed) {
           continue
@@ -211,7 +215,26 @@ export class Seeds {
             continue
           }
 
-          return element.hasAttribute(slot.attribute)
+          const operator = entry[2]
+          const present = element.hasAttribute(slot.attribute)
+
+          if (operator === undefined || operator === null) {
+            return present
+          }
+
+          if (declaration?.kind !== "boolean") {
+            continue
+          }
+
+          if (operator === "falsy" || operator === "blank") {
+            return !present
+          }
+
+          if (operator === "truthy" || operator === "present") {
+            return present
+          }
+
+          continue
         }
 
         return coerceState(this.slots.currentText(slot), declaration?.kind ?? "string")

--- a/javascript/packages/client/test/presence-hydration.test.ts
+++ b/javascript/packages/client/test/presence-hydration.test.ts
@@ -1,0 +1,69 @@
+import { describe, test, expect, beforeEach } from "vitest"
+
+import { Slots } from "../src/slots/slots"
+import { State } from "../src/state/state"
+
+const FILE = "app/views/page/panel.html.erb"
+
+const PAGE =
+  `<!--herb-region:${FILE}:dddddddd:0-->` +
+  `<p data-herb-slot="1:boolean_attribute:hidden">secret</p>` +
+  `<input type="checkbox" data-herb-slot="2:boolean_attribute:checked" checked>` +
+  `<b data-herb-slot="3:boolean_attribute:hidden" hidden>note</b>` +
+  `<button data-herb-slot="4:attribute:aria-selected" aria-selected="true">Profile</button>` +
+  `<!--/herb-region:${FILE}-->`
+
+const MANIFEST = {
+  state: {},
+  states: {
+    [FILE]: {
+      version: "dddddddd",
+      declarations: [
+        { name: "open", kind: "boolean", default: "false", scope: "region" },
+        { name: "news", kind: "boolean", default: "false", scope: "region" },
+        { name: "note", kind: "string", default: '""', scope: "region" },
+        { name: "tab", kind: "string", default: '"profile"', scope: "region" },
+      ],
+      reads: { open: [1], news: [2], note: [3], tab: [4] },
+      conditionals: {},
+      presence: { 1: ["open", null, "falsy"], 2: ["news", null], 3: ["note", null, "blank"] },
+      computed: { 4: ["tab", { value: "profile" }] },
+    },
+  },
+}
+
+let state: State
+
+beforeEach(() => {
+  document.body.innerHTML = PAGE + `<template data-herb-dependencies>${JSON.stringify(MANIFEST)}</template>`
+
+  const slots = new Slots()
+
+  slots.scan(document.body)
+
+  state = new State(slots, {
+    transport: () => {
+      throw new Error("a declared state must never reach the transport")
+    },
+  })
+
+  state.adopt()
+})
+
+describe("hydrating a state from a presence attribute", () => {
+  test("a negated presence reads inverted, so a missing `hidden` means true", () => {
+    expect(state.getState("open")).toBe(true)
+  })
+
+  test("a bare presence reads straight", () => {
+    expect(state.getState("news")).toBe(true)
+  })
+
+  test("a non-boolean behind an operator falls back to its default", () => {
+    expect(state.getState("note")).toBe("")
+  })
+
+  test("a comparison read never hydrates, so a rendered `true` is not a value", () => {
+    expect(state.getState("tab")).toBe("profile")
+  })
+})


### PR DESCRIPTION
This pull request fixes an inverted hydration that made the first interaction with certain states silently do nothing.

When a state has no shipped seed, the client infers its value from what the page shows, and one source is a boolean attribute whose presence follows the state. The reader checked that the presence condition had no comparand but never looked at its operator, so a negated read came out backwards. A template like this poisoned the state on first touch.

```erb
<%# herb:state (open: false) %>
<p hidden="<%= !open %>"><%= answer %></p>
```

The server renders `hidden` because `open` is false, hydration saw the attribute and answered `open` is true, and the first `data-herb-toggle` click "toggled" the phantom true down to false, a visual no-op. Every second click worked, which made it look like a scan or scope problem instead of a polarity one.

Hydration now honors the operator. A bare presence reads straight, `falsy` and `blank` on a boolean read inverted, `truthy` and `present` on a boolean read straight, and anything else falls back to the declared default instead of guessing.