### PR TITLE
Client: Focus an autofocus element when its branch materializes

### DIFF
--- a/javascript/packages/client/src/slots/slots.ts
+++ b/javascript/packages/client/src/slots/slots.ts
@@ -292,8 +292,29 @@ export class Slots implements ElementObserverDelegate, JournalDelegate, Collecti
     slot.branch = branch
 
     this.built?.branches.push(slot)
+    this.focusAutofocus(slot)
 
     return true
+  }
+
+  private focusAutofocus(slot: Slot): void {
+    if (typeof document === "undefined") {
+      return
+    }
+
+    if (slot.anchor.kind !== "range" || !slot.anchor.start.isConnected) {
+      return
+    }
+
+    const range = this.rangeOf(slot)
+    const holder = range.commonAncestorContainer
+    const root = holder instanceof Element ? holder : holder.parentElement
+
+    const target = root?.querySelector<HTMLElement>("[autofocus]")
+
+    if (target && range.intersectsNode(target) && document.activeElement !== target) {
+      target.focus()
+    }
   }
 
   private partsFor(region: Region, index: number): AttributeParts | null {

--- a/javascript/packages/client/test/refresh.test.ts
+++ b/javascript/packages/client/test/refresh.test.ts
@@ -282,6 +282,21 @@ describe("refetching server-derived slots", () => {
     expect(document.body.innerHTML).not.toContain("<p>off</p>")
   })
 
+  test("a materialized branch focuses its autofocus element", () => {
+    document.body.innerHTML =
+      `<!--herb-region:${FILE}:aaaaaaaa:0-->` +
+      `<div><!--herb-slot:0:conditional--><p>off</p><!--/herb-slot:0--></div>` +
+      `<!--/herb-region:${FILE}-->`
+
+    const live = start()
+
+    live.slots.apply(payloadFor({
+      0: { branch: 0, statics: "<!--herb-branch:0:0--><input autofocus placeholder=\"draft\">", slots: {} },
+    }))
+
+    expect((document.activeElement as HTMLInputElement)?.placeholder).toBe("draft")
+  })
+
   test("a branch flip with no material defers and says so", () => {
     document.body.innerHTML =
       `<!--herb-region:${FILE}:aaaaaaaa:0-->` +


### PR DESCRIPTION
This pull request makes `autofocus` work inside client-materialized branches.

Browsers honor the attribute during page load and a few dialog paths, and ignore it on elements a script inserts later, which is exactly how a materialized branch arrives. A command palette opened by a state write rendered its input unfocused, so every open cost an extra click.

`switchBranch` now looks for an `[autofocus]` element inside the fragment it just wrote and focuses it, the way LiveView treats the attribute. The lookup stays inside the slot's own range, skips detached anchors, and leaves focus alone when the element already has it.

```erb
<% if palette %>
  <input value="<%= query %>" autofocus placeholder="Search">
<% end %>
```

Opening the palette focuses the input, on the first open and on every one after.