### PR TITLE
Engine: Evaluate an attribute value conditional as the attribute's value

### DIFF
--- a/lib/herb/engine/slots/dynamics_compiler.rb
+++ b/lib/herb/engine/slots/dynamics_compiler.rb
@@ -136,6 +136,7 @@ module Herb
             @current_attribute = nil
             @current_rcdata = nil
             @rendering = false
+            @capturing_part = false
             @block_depth = 0
 
             branch_counts = {} #: Hash[Integer, Integer]
@@ -324,6 +325,8 @@ module Herb
 
           #: (untyped) -> Integer?
           def claim(node)
+            return nil if @capturing_part
+
             @slot_visitor.index_for(@current_attribute || @current_rcdata || node)
           end
 
@@ -360,6 +363,24 @@ module Herb
           #: (untyped) { () -> void } -> void
           def conditional(node)
             return yield if branch?(node)
+
+            if @current_attribute || @current_rcdata
+              return yield if @capturing_part
+
+              index = claim(node)
+
+              return yield unless index
+
+              @capturing_part = true
+              @tokens << [:scope, "", nil, [:part_open]]
+
+              yield
+
+              @tokens << [:scope, "", nil, [:part_close, index]]
+              @capturing_part = false
+
+              return
+            end
 
             index = claim(node)
 
@@ -687,6 +708,20 @@ module Herb
         #: (String) -> void
         def add_block_dynamic(value)
           @src << "; " << @bufvar << " << (" << value << ");"
+        end
+
+        #: () -> void
+        def scope_part_open
+          open_block
+        end
+
+        #: (Integer) -> void
+        def scope_part_close(index)
+          buffer = @bufvar
+
+          close_block
+
+          @src << "; " << assignment(index, buffer) << ";"
         end
 
         #: () -> void

--- a/lib/herb/engine/slots/state_compiler.rb
+++ b/lib/herb/engine/slots/state_compiler.rb
@@ -997,15 +997,59 @@ module Herb
           outputs.one? ? outputs.fetch(0).content : nil
         end
 
+        #: (untyped) -> Array[untyped]
+        def interpolation_children(node)
+          if node.is_a?(Herb::AST::HTMLElementNode)
+            Array(node.body)
+          elsif node.respond_to?(:value)
+            node.value&.children || []
+          else
+            [] #: Array[untyped]
+          end
+        end
+
+        #: (untyped, Integer, untyped) -> void
+        def register_segment_reads(node, index, slot)
+          segments = interpolation_children(node).select { |child| child.is_a?(Herb::AST::ERBIfNode) || child.is_a?(Herb::AST::ERBUnlessNode) || child.is_a?(Herb::AST::ERBCaseNode) }
+
+          return if segments.empty?
+
+          code = segments.map { |segment| segment_code(segment) }.join(" ")
+          mentioned = @region_states.each_value.select { |declaration| mentioned_state(code, { declaration.name => declaration }) } # steep:ignore UnannotatedEmptyCollection
+
+          return if mentioned.empty?
+
+          entry = { "index" => index, "node_path" => slot.node_path }
+
+          mentioned.each do |declaration|
+            @server_reads[declaration.name] ||= [] # steep:ignore UnannotatedEmptyCollection
+            @server_reads.fetch(declaration.name) << entry
+          end
+        end
+
+        #: (untyped) -> String
+        def segment_code(node)
+          collected = [] #: Array[String]
+
+          gather = lambda do |current|
+            content = current.respond_to?(:content) ? current.content : nil #: untyped
+
+            collected << content.value.to_s if content.respond_to?(:value)
+
+            none = [] #: Array[untyped]
+            children = current.respond_to?(:child_nodes) ? current.child_nodes : none
+
+            children.compact.each { |child| gather.call(child) }
+          end
+
+          gather.call(node)
+
+          collected.join(" ")
+        end
+
         #: (untyped, Hash[String, StateDirectives::Declaration]) -> void
         def check_interpolated_state_read(node, states)
-          children = if node.is_a?(Herb::AST::HTMLElementNode)
-                       Array(node.body)
-                     elsif node.respond_to?(:value)
-                       node.value&.children || []
-                     else
-                       [] #: Array[untyped]
-                     end
+          children = interpolation_children(node)
 
           outputs = children.grep(Herb::AST::ERBContentNode)
           read = outputs.map { |output| output.content&.value.to_s.strip }.find { |expression| StateDirectives.mentions_any?(expression, states) }
@@ -1037,6 +1081,8 @@ module Herb
 
             if slot.interpolated? && slot.expression.to_s.strip.empty?
               check_interpolated_state_read(node, states)
+              register_segment_reads(node, index, slot)
+
               next
             end
 

--- a/lib/herb/engine/slots/visitor.rb
+++ b/lib/herb/engine/slots/visitor.rb
@@ -1532,6 +1532,8 @@ module Herb
               return nil unless erb_outputs?(child)
 
               segments << +""
+            when Herb::AST::ERBIfNode, Herb::AST::ERBUnlessNode, Herb::AST::ERBCaseNode
+              segments << +""
             else
               return nil
             end

--- a/sig/herb/engine/slots/dynamics_compiler.rbs
+++ b/sig/herb/engine/slots/dynamics_compiler.rbs
@@ -302,6 +302,12 @@ module Herb
         def add_block_dynamic: (String) -> void
 
         # : () -> void
+        def scope_part_open: () -> void
+
+        # : (Integer) -> void
+        def scope_part_close: (Integer) -> void
+
+        # : () -> void
         def open_block: () -> void
 
         # : () -> void

--- a/sig/herb/engine/slots/state_compiler.rbs
+++ b/sig/herb/engine/slots/state_compiler.rbs
@@ -197,6 +197,15 @@ module Herb
         # : (untyped) -> untyped
         def predicate_token_for: (untyped) -> untyped
 
+        # : (untyped) -> Array[untyped]
+        def interpolation_children: (untyped) -> Array[untyped]
+
+        # : (untyped, Integer, untyped) -> void
+        def register_segment_reads: (untyped, Integer, untyped) -> void
+
+        # : (untyped) -> String
+        def segment_code: (untyped) -> String
+
         # : (untyped, Hash[String, StateDirectives::Declaration]) -> void
         def check_interpolated_state_read: (untyped, Hash[String, StateDirectives::Declaration]) -> void
 

--- a/test/engine/dynamics_compiler_test.rb
+++ b/test/engine/dynamics_compiler_test.rb
@@ -374,5 +374,27 @@ module Engine
         refute entry.key?(:statics)
       end
     end
+
+    KNOB = %(<%# herb:slots client %>\n<span class="knob <%= @dark ? "far" : "" %>" id="k"></span>) #: String
+
+    describe "a conditional inside an attribute" do
+      test "the payload carries the taken branch's text as the attribute's part" do
+        assert_equal ["far"], dynamics(KNOB, dark: true).fetch(0)
+        assert_equal [""], dynamics(KNOB, dark: false).fetch(0)
+      end
+
+      test "the slot the payload fills is the attribute the visitor modeled" do
+        compiler = Herb::Engine::Slots::DynamicsCompiler.new(KNOB, filename: "app/views/test.html.erb")
+
+        assert_equal :attribute_interpolation, compiler.slot_visitor.slots.fetch(0).type
+      end
+
+      test "a whole-value attribute conditional assigns the scalar the visitor expects" do
+        source = %(<%# herb:slots client %>\n<span class="<%= @on ? "is-\#{@tone}" : "off" %>"></span>)
+
+        assert_equal "is-calm", dynamics(source, on: true, tone: "calm").fetch(0)
+        assert_equal "off", dynamics(source, on: false).fetch(0)
+      end
+    end
   end
 end

--- a/test/engine/slots/states_test.rb
+++ b/test/engine/slots/states_test.rb
@@ -1484,6 +1484,42 @@ module Engine
         assert_equal ["track"], visitor.manifest["states"]["reads"].keys
         assert_equal 1, visitor.manifest["states"]["reads"]["track"].length
       end
+
+      test "an attribute conditional joins the manifest parts" do
+        source = <<~ERB
+          <%# herb:slots client %>
+          <%# herb:state (track: "") %>
+          <input value="<%= track %>">
+          <% Catalog.tracks.each do |entry| %>
+            <%# herb:key entry %>
+            <li class="row <%= "is-on" if track == entry %>"><%= entry %></li>
+          <% end %>
+        ERB
+
+        visitor = Herb::Engine::Slots::Visitor.new(mode: :client, fatal: false)
+        Herb::Engine.new(source, visitors: [visitor], filename: "app/views/test.html.erb")
+
+        assert_empty visitor.diagnostics
+        assert_equal ["row ", ""], visitor.manifest["parts"]["2"]
+      end
+
+      test "an attribute conditional registers its states as server reads" do
+        source = <<~ERB
+          <%# herb:slots client %>
+          <%# herb:state (view: "list") %>
+          <button data-herb-set="view=grid" aria-pressed="<%= view == "grid" %>">Grid</button>
+          <ul class="entries <%= "is-grid" if view == "grid" %>"></ul>
+        ERB
+
+        visitor = Herb::Engine::Slots::Visitor.new(mode: :client, fatal: false)
+        Herb::Engine.new(source, visitors: [visitor], filename: "app/views/test.html.erb")
+
+        server_reads = visitor.manifest["states"]["server"]["reads"]["view"].map { |read| read["index"] }
+        parts_key = visitor.manifest["parts"].keys.last
+
+        assert_empty visitor.diagnostics
+        assert_includes server_reads, parts_key.to_i
+      end
     end
   end
 end


### PR DESCRIPTION
This pull request aligns the values program with the client's slot model for a conditional living inside an attribute.

The parser unrolls a ternary like this into a template-level if, whether it sits in text or in an attribute value.

```erb
<span class="knob <%= dark ? "translate-x-5" : "" %>">
```

The values program treated every unrolled conditional as structural (`{ branch: 0, slots: {} }`), while the visitor models the slot as an attribute interpolation expecting a parts array. 

The client received a branch entry for a slot that has no branches, could not apply it, and a `herb-slots-materialize` warning fired on every refetch for a template that compiled with zero diagnostics. Worse, the branch entry carried no value at all, since a literal branch body is plain text and the values compile drops text outside a capture.

A conditional standing inside an attribute value now counts as one dynamic segment when the attribute's parts are recorded, so a class like `class="row <%= "is-on" if track == entry %>"` joins the manifest parts and the client can restore the attribute around it.

A conditional standing as one segment of an interpolation is evaluated on the server, so its states now register as server reads of the attribute slot. Without the registration, a template like `class="entries <%= "is-grid" if view == "grid" %>"` never updated when `view` was the only thing written, because nothing marked the attribute as depending on it and no refetch fired.