### PR TITLE
Engine: Introduce `<Fragment>` and `<Fallback>` built-in components

### DIFF
--- a/javascript/packages/client/src/markup/fragments.ts
+++ b/javascript/packages/client/src/markup/fragments.ts
@@ -1,5 +1,5 @@
 import { asList } from "../shared/arrays"
-import { branchKey, branchOf, parseMarker, slotOpenIndex } from "./markers"
+import { branchKey, branchOf, isItemClose, isItemOpen, parseMarker, slotOpenIndex } from "./markers"
 import { anchoredSlots, closingFor, markers, slotOpeners } from "./anchors"
 
 import { DEFAULT_SLOT_TYPE, PART_MARKER } from "./markers"
@@ -89,13 +89,60 @@ export function fillSlots(fragment: DocumentFragment, dynamics: SlotValues, text
   }
 }
 
+function insideItem(node: Node, fragment: DocumentFragment): boolean {
+  let depth = 0
+  const walker = document.createTreeWalker(fragment, NodeFilter.SHOW_COMMENT)
+
+  while (walker.nextNode()) {
+    const comment = walker.currentNode as Comment
+
+    if (comment === node) {
+      return depth > 0
+    }
+
+    const data = comment.data.trim()
+
+    if (isItemOpen(data)) {
+      depth += 1
+    } else if (isItemClose(data)) {
+      depth -= 1
+    }
+  }
+
+  if (node instanceof Element) {
+    let parent: Node | null = node
+
+    while (parent && parent !== fragment) {
+      let sibling: Node | null = parent
+
+      while ((sibling = sibling.previousSibling)) {
+        if (sibling.nodeType === Node.COMMENT_NODE) {
+          const data = (sibling as Comment).data.trim()
+
+          if (isItemOpen(data)) {
+            return true
+          }
+
+          if (isItemClose(data)) {
+            break
+          }
+        }
+      }
+
+      parent = parent.parentNode
+    }
+  }
+
+  return false
+}
+
 export function valuesIn(fragment: DocumentFragment): SlotValues {
   const found: SlotValues = {}
 
   for (const open of slotOpeners(fragment)) {
     const index = slotOpenIndex(open.data.trim())
 
-    if (index === null) {
+    if (index === null || insideItem(open, fragment)) {
       continue
     }
 
@@ -115,6 +162,10 @@ export function valuesIn(fragment: DocumentFragment): SlotValues {
 
   for (const [element, entry] of anchoredSlots(fragment)) {
     if (entry.attribute !== null || entry.type !== DEFAULT_SLOT_TYPE) {
+      continue
+    }
+
+    if (insideItem(element, fragment)) {
       continue
     }
 

--- a/javascript/packages/client/src/markup/markers.ts
+++ b/javascript/packages/client/src/markup/markers.ts
@@ -124,6 +124,14 @@ export function parseMarker(data: string): MarkerData | null {
   return branchOf(data)
 }
 
+export function isItemOpen(data: string): boolean {
+  return ITEM_OPEN.test(data)
+}
+
+export function isItemClose(data: string): boolean {
+  return ITEM_CLOSE.test(data)
+}
+
 export function branchOf(data: string): BranchMarker | null {
   const branch = BRANCH.exec(data)
 

--- a/javascript/packages/client/src/slots/region-index.ts
+++ b/javascript/packages/client/src/slots/region-index.ts
@@ -443,6 +443,7 @@ export class RegionIndex {
       item,
       claimed: false,
       shown: null,
+      captured: null,
     }
 
     state.openSlots.push({ index: slot.index, slot })
@@ -580,6 +581,7 @@ export class RegionIndex {
         item,
         claimed: false,
         shown: null,
+        captured: null,
       }
 
       this.attach(region, slot, result, enclosing, item)

--- a/javascript/packages/client/src/slots/slots.ts
+++ b/javascript/packages/client/src/slots/slots.ts
@@ -31,7 +31,7 @@ import { applyPayload } from "./apply"
 
 import { ancestorsOf, descendantsOf } from "./tree"
 import { branchKey } from "../markup/markers"
-import { interpolateParts, valuesIn, withoutMarkers } from "../markup/fragments"
+import { interpolateParts, valuesIn, withoutMarkers, fillSlots } from "../markup/fragments"
 import { currentHTML, currentText, elementOf, htmlOf, innerRange, rangeOf as rangeOfAnchor } from "../markup/anchors"
 
 import type { StateManifest } from "../state/types"
@@ -281,7 +281,7 @@ export class Slots implements ElementObserverDelegate, JournalDelegate, Collecti
       return true
     }
 
-    const markup = this.materialize(slot.region.file, branchKey(slot.index, branch), { ...(slot.shown?.get(branch) ?? {}), ...dynamics })
+    const markup = this.branchMarkup(slot, branch, dynamics)
 
     if (!markup) {
       return false
@@ -295,6 +295,20 @@ export class Slots implements ElementObserverDelegate, JournalDelegate, Collecti
     this.focusAutofocus(slot)
 
     return true
+  }
+
+  private branchMarkup(slot: Slot, branch: number, dynamics: SlotValues): DocumentFragment | null {
+    const captured = slot.captured?.get(branch)
+
+    if (captured) {
+      const copy = captured.cloneNode(true) as DocumentFragment
+
+      fillSlots(copy, { ...(slot.shown?.get(branch) ?? {}), ...dynamics }, false, (index) => this.manifests.partsForFile(slot.region.file, index))
+
+      return copy
+    }
+
+    return this.materialize(slot.region.file, branchKey(slot.index, branch), { ...(slot.shown?.get(branch) ?? {}), ...dynamics })
   }
 
   private focusAutofocus(slot: Slot): void {
@@ -664,6 +678,10 @@ export class Slots implements ElementObserverDelegate, JournalDelegate, Collecti
     }
 
     const contents = this.rangeOf(slot).cloneContents()
+    const captured = slot.captured ?? new Map<number, DocumentFragment>()
+
+    captured.set(slot.branch, contents.cloneNode(true) as DocumentFragment)
+    slot.captured = captured
 
     this.remember(slot, slot.branch, valuesIn(contents))
 

--- a/javascript/packages/client/src/state/state.ts
+++ b/javascript/packages/client/src/state/state.ts
@@ -21,13 +21,24 @@ import type { Conditional } from "./types"
 import type { RefreshReport } from "./refresh"
 import type { StateKind, StateValue } from "./values"
 import type { Built, Item, Region, Slot } from "../types"
-import type { CountOptions, DeclaredState, DependencyMap, PlacedSlot, ResolvedStateOptions, ScopeStore, ScopedSetOptions, SerializedState, StateChange, StateChangeDetail, StateListener, StateManifest, StateOptions, StateReport, StateScope, StateSlot, StateSnapshot, StateValues } from "./types"
+import type { CountOptions, DeclaredState, DependencyMap, FragmentEntry, PlacedSlot, ResolvedStateOptions, ScopeStore, ScopedSetOptions, SerializedState, StateChange, StateChangeDetail, StateListener, StateManifest, StateOptions, StateReport, StateScope, StateSlot, StateSnapshot, StateValues } from "./types"
 
 import type { SlotsDelegate } from "../types"
 import type { SeedsDelegate } from "./seeds"
 import type { CountsDelegate } from "./counts"
 import type { BoundInputsDelegate } from "./bound-inputs"
 import type { ElementObserverDelegate } from "../shared/element-observer"
+
+const FRAGMENT_DELAY = 150
+const FRAGMENT_HOLD = 300
+
+interface FragmentPresentation {
+  fallback: number
+  hold: number
+  shownAt: number
+  showTimer: ReturnType<typeof setTimeout> | null
+  restoreTimer: ReturnType<typeof setTimeout> | null
+}
 
 export class State implements ElementObserverDelegate, SlotsDelegate, SeedsDelegate, BoundInputsDelegate, CountsDelegate {
   private readonly slots: Slots
@@ -39,6 +50,7 @@ export class State implements ElementObserverDelegate, SlotsDelegate, SeedsDeleg
   private readonly counts: Counts
   private readonly bound = new BoundInputs(this)
   private readonly options: ResolvedStateOptions
+  private readonly fallbacksShowing = new Map<Slot, FragmentPresentation>()
 
   private elements: ElementObserver | null = null
   private unobserveElements: (() => void) | null = null
@@ -236,6 +248,18 @@ export class State implements ElementObserverDelegate, SlotsDelegate, SeedsDeleg
     this.disarmMutationRefresh?.()
     this.disarmMutationRefresh = null
     this.refetch.stop()
+
+    for (const presentation of this.fallbacksShowing.values()) {
+      if (presentation.showTimer !== null) {
+        clearTimeout(presentation.showTimer)
+      }
+
+      if (presentation.restoreTimer !== null) {
+        clearTimeout(presentation.restoreTimer)
+      }
+    }
+
+    this.fallbacksShowing.clear()
 
     if (typeof document === "undefined") {
       return
@@ -535,21 +559,134 @@ export class State implements ElementObserverDelegate, SlotsDelegate, SeedsDeleg
     })
 
     if (changed.length > 0) {
-      this.requestReadRefetch(manifest, changed)
+      this.requestReadRefetch(manifest, regionScope, changed)
     }
 
     return true
   }
 
-  private requestReadRefetch(manifest: StateManifest, names: string[]): void {
+  private requestReadRefetch(manifest: StateManifest, scope: StateScope, names: string[]): void {
     if (this.options.refetch !== "auto") {
       return
     }
 
     const reads = manifest.server?.reads ?? {}
+    const stale = new Set(names.flatMap((name) => (reads[name] ?? []).map((read) => read.index)))
 
-    if (names.some((name) => (reads[name] ?? []).length > 0)) {
-      void this.refetch.request(this.options.refetchDebounce)
+    if (stale.size === 0) {
+      return
+    }
+
+    this.showFallbacks(manifest, scope, stale, names)
+
+    void this.refetch.request(this.options.refetchDebounce).then((outcome) => this.settleFallbacks(outcome))
+  }
+
+  private showFallbacks(manifest: StateManifest, scope: StateScope, stale: Set<number>, names: string[]): void {
+    const entries = Object.entries(manifest.fragments ?? {}).sort(([left], [right]) => Number(left) - Number(right))
+
+    for (const [key, fragment] of entries) {
+      if (!fragment.reads.some((index) => stale.has(index))) {
+        continue
+      }
+
+      if (fragment.on && !fragment.on.some((name) => names.includes(name))) {
+        continue
+      }
+
+      for (const placed of this.placedSlots(scope, Number(key))) {
+        this.presentFallback(placed.slot, fragment)
+      }
+    }
+  }
+
+  private presentFallback(slot: Slot, fragment: FragmentEntry): void {
+    const existing = this.fallbacksShowing.get(slot)
+
+    if (existing) {
+      if (existing.restoreTimer !== null) {
+        clearTimeout(existing.restoreTimer)
+
+        existing.restoreTimer = null
+      }
+
+      return
+    }
+
+    const presentation: FragmentPresentation = {
+      fallback: fragment.fallback,
+      hold: fragment.hold ?? FRAGMENT_HOLD,
+      shownAt: 0,
+      showTimer: null,
+      restoreTimer: null,
+    }
+
+    this.fallbacksShowing.set(slot, presentation)
+
+    const delay = fragment.delay ?? FRAGMENT_DELAY
+
+    if (delay <= 0) {
+      this.swapToFallback(slot, presentation)
+
+      return
+    }
+
+    presentation.showTimer = setTimeout(() => {
+      presentation.showTimer = null
+
+      this.swapToFallback(slot, presentation)
+    }, delay)
+  }
+
+  private swapToFallback(slot: Slot, presentation: FragmentPresentation): void {
+    if (slot.branch !== presentation.fallback) {
+      this.slots.switchBranch(slot, presentation.fallback)
+    }
+
+    presentation.shownAt = Date.now()
+  }
+
+  private settleFallbacks(outcome: RefreshReport): void {
+    if (outcome.stale) {
+      return
+    }
+
+    for (const [slot, presentation] of [...this.fallbacksShowing]) {
+      if (presentation.restoreTimer !== null) {
+        continue
+      }
+
+      if (presentation.showTimer !== null) {
+        clearTimeout(presentation.showTimer)
+
+        presentation.showTimer = null
+      }
+
+      if (presentation.shownAt === 0 || outcome.failed || slot.branch === presentation.fallback) {
+        this.fallbacksShowing.delete(slot)
+
+        continue
+      }
+
+      const remaining = presentation.shownAt + presentation.hold - Date.now()
+
+      if (remaining <= 0) {
+        this.fallbacksShowing.delete(slot)
+
+        continue
+      }
+
+      const restored = slot.branch
+
+      this.slots.switchBranch(slot, presentation.fallback)
+
+      presentation.restoreTimer = setTimeout(() => {
+        this.fallbacksShowing.delete(slot)
+
+        if (slot.branch === presentation.fallback) {
+          this.slots.switchBranch(slot, restored)
+        }
+      }, remaining)
     }
   }
 

--- a/javascript/packages/client/src/state/types.ts
+++ b/javascript/packages/client/src/state/types.ts
@@ -79,6 +79,15 @@ export interface StateManifest {
   presence?: PresenceMap
   computed?: ComputedMap
   server?: ServerMap
+  fragments?: Record<string, FragmentEntry>
+}
+
+export interface FragmentEntry {
+  fallback: number
+  reads: number[]
+  delay?: number
+  hold?: number
+  on?: string[]
 }
 
 export interface StateScope {

--- a/javascript/packages/client/src/types.ts
+++ b/javascript/packages/client/src/types.ts
@@ -96,6 +96,7 @@ export interface Slot {
   item: Item | null
   claimed: boolean
   shown: Map<number, SlotValues> | null
+  captured: Map<number, DocumentFragment> | null
 }
 
 export interface Item extends Bounds {

--- a/javascript/packages/client/test/fixtures/contract/a-boolean-attribute-inside-a-block.json
+++ b/javascript/packages/client/test/fixtures/contract/a-boolean-attribute-inside-a-block.json
@@ -72,7 +72,8 @@
       "server": {
         "branches": {},
         "reads": {}
-      }
+      },
+      "fragments": {}
     }
   },
   "dependencies": {

--- a/javascript/packages/client/test/fixtures/contract/a-keyed-collection-with-declared-item-state.json
+++ b/javascript/packages/client/test/fixtures/contract/a-keyed-collection-with-declared-item-state.json
@@ -136,7 +136,8 @@
       "server": {
         "branches": {},
         "reads": {}
-      }
+      },
+      "fragments": {}
     }
   },
   "dependencies": {

--- a/javascript/packages/client/test/fragment-items.test.ts
+++ b/javascript/packages/client/test/fragment-items.test.ts
@@ -1,0 +1,57 @@
+import { test, expect, afterEach, vi } from "vitest"
+
+import { Runtime } from "../src/runtime"
+
+import type { Payload } from "../src/types"
+
+const FILE = "app/views/test.html.erb"
+const PAGE = "<!--herb-region:app/views/test.html.erb:6c726602:0-->\n<input value=\"a\" data-herb-slot=\"0:attribute:value\">\n<!--herb-slot:1:conditional--><!--herb-branch:1:0-->\n  <ul>\n    <!--herb-slot:2:collection--><!--herb-item:2:one-->\n      \n      <li data-herb-slot=\"3:child\">ONE</li>\n    <!--/herb-item:2--><!--herb-item:2:two-->\n      \n      <li data-herb-slot=\"3:child\">TWO</li>\n    <!--/herb-item:2--><!--/herb-slot:2-->\n  </ul>\n  \n<!--/herb-slot:1-->\n<!--/herb-region:app/views/test.html.erb--><template data-herb-region=\"app/views/test.html.erb:6c726602\"><!--herb-branch:1:0-->\n  <ul>\n    <!--herb-slot:2:collection--><!--/herb-slot:2-->\n  </ul>\n  \n<!--herb-branch:1:1--><p class=\"skel\">loading</p></template>" + `<template data-herb-dependencies>${JSON.stringify({ state: {}, states: { [FILE]: {"version": "6c726602", "declarations": [{"name": "album", "kind": "string", "default": "\"a\"", "derived": null, "line": 2, "column": 16, "scope": "region", "value": "a"}], "reads": {"album": [0]}, "conditionals": {}, "presence": {}, "computed": {}, "server": {"branches": {}, "reads": {"album": [{"index": 2, "node_path": [6, 1, 1]}]}}, "fragments": {"1": {"fallback": 1, "reads": [2], "delay": 0, "hold": 40}}} } })}</template>`
+const PAYLOADS = {"a": {"template": "app/views/test.html.erb", "version": "6c726602", "occurrence": 0, "slots": {"0": "a", "1": {"branch": 0, "slots": {"2": {"items": {"one": {"3": "ONE"}, "two": {"3": "TWO"}}, "order": ["one", "two"]}}}}}, "b": {"template": "app/views/test.html.erb", "version": "6c726602", "occurrence": 0, "slots": {"0": "b", "1": {"branch": 0, "slots": {"2": {"items": {"alpha": {"3": "ALPHA"}, "beta": {"3": "BETA"}, "gamma": {"3": "GAMMA"}}, "order": ["alpha", "beta", "gamma"]}}}}}} as unknown as Record<string, Payload>
+
+let runtime: Runtime | null = null
+
+afterEach(() => {
+  runtime?.stop()
+  runtime = null
+  document.body.innerHTML = ""
+})
+
+test("switching a fragment-masked collection fills every item with its own values", async () => {
+  document.body.innerHTML = PAGE
+
+  const transport = vi.fn(async (state: Record<string, Record<string, unknown>>) => {
+    await new Promise((resolve) => setTimeout(resolve, 20))
+
+    return PAYLOADS[String(state[FILE]?.album ?? "a")]
+  })
+
+  runtime = Runtime.start({ state: { refetchTransport: transport, refetchDebounce: 10 } })
+
+  expect([...document.querySelectorAll("li")].map((li) => li.textContent!.trim())).toEqual(["ONE", "TWO"])
+
+  runtime.state.setState({ album: "b" })
+
+  await vi.waitFor(() => {
+    if (!document.body.innerHTML.includes("GAMMA")) {
+      throw new Error("still waiting")
+    }
+  }, { timeout: 3000 })
+
+  await new Promise((resolve) => setTimeout(resolve, 100))
+
+  const rows = [...document.querySelectorAll("li")].map((li) => li.textContent!.trim())
+
+  expect(rows).toEqual(["ALPHA", "BETA", "GAMMA"])
+
+  runtime.state.setState({ album: "a" })
+
+  await vi.waitFor(() => {
+    if (!document.body.innerHTML.includes("TWO")) {
+      throw new Error("still waiting")
+    }
+  }, { timeout: 3000 })
+
+  await new Promise((resolve) => setTimeout(resolve, 100))
+
+  expect([...document.querySelectorAll("li")].map((li) => li.textContent!.trim())).toEqual(["ONE", "TWO"])
+})

--- a/javascript/packages/client/test/refresh.test.ts
+++ b/javascript/packages/client/test/refresh.test.ts
@@ -114,6 +114,34 @@ describe("refetching server-derived slots", () => {
     expect(transport).not.toHaveBeenCalled()
   })
 
+  test("a fragment scoped with `on` only masks for its named states", async () => {
+    document.body.innerHTML = fragmentPage({ 4: { fallback: 1, reads: [3], delay: 0, hold: 0, on: ["editing"] } })
+
+    let resolveTransport: (payload: Payload) => void = () => {}
+    const transport = vi.fn(() => new Promise<Payload>((resolve) => { resolveTransport = resolve }))
+
+    const live = start({ state: { refetchTransport: transport, refetchDebounce: 0 } })
+
+    live.state.setState({ q: "basel" })
+
+    expect(document.body.innerHTML).toContain("old answer")
+    expect(document.body.innerHTML).not.toContain("looking it up")
+
+    await vi.waitFor(() => {
+      expect(transport).toHaveBeenCalled()
+    })
+
+    expect(document.body.innerHTML).not.toContain("looking it up")
+
+    resolveTransport(payloadFor({ 4: { branch: 0, slots: { 3: "fresh answer" } } }))
+
+    await vi.waitFor(() => {
+      if (!document.body.innerHTML.includes("fresh answer")) {
+        throw new Error("still waiting")
+      }
+    })
+  })
+
   test("writing a state a server read depends on refetches debounced, once", async () => {
     document.body.innerHTML = PAGE
 
@@ -211,6 +239,150 @@ describe("refetching server-derived slots", () => {
     expect(report.applied).toBe(1)
     expect(calls[0]).toEqual({})
     expect(document.body.innerHTML).toContain("fresh")
+  })
+
+  function fragmentPage(fragments: Record<string, unknown>): string {
+    return (
+      `<!--herb-region:${FILE}:aaaaaaaa:0-->` +
+      `<div><!--herb-slot:4:conditional--><!--herb-branch:4:0--><p><!--herb-slot:3-->old answer<!--/herb-slot:3--></p><!--/herb-slot:4--></div>` +
+      `<template data-herb-region="${FILE}:aaaaaaaa">` +
+      `<!--herb-branch:4:0--><p><!--herb-slot:3--><!--/herb-slot:3--></p>` +
+      `<!--herb-branch:4:1--><p class="pulse">looking it up</p>` +
+      `</template>` +
+      `<!--/herb-region:${FILE}-->` +
+      `<template data-herb-dependencies>${JSON.stringify({
+        state: {},
+        states: {
+          [FILE]: {
+            ...STATES,
+            server: { branches: {}, reads: { q: [{ index: 3, node_path: [1, 0] }] } },
+            fragments,
+          },
+        },
+      })}</template>`
+    )
+  }
+
+  test("a stale server read swaps its fragment to the fallback until the refetch lands", async () => {
+    document.body.innerHTML = fragmentPage({ 4: { fallback: 1, reads: [3], delay: 0, hold: 0 } })
+
+    let resolveTransport: (payload: Payload) => void = () => {}
+    const transport = vi.fn(() => new Promise<Payload>((resolve) => { resolveTransport = resolve }))
+
+    const live = start({ state: { refetchTransport: transport, refetchDebounce: 0 } })
+
+    live.state.setState({ q: "basel" })
+
+    expect(document.body.innerHTML).toContain("looking it up")
+    expect(document.body.innerHTML).not.toContain("old answer")
+
+    await vi.waitFor(() => {
+      if (transport.mock.calls.length === 0) {
+        throw new Error("still waiting")
+      }
+    })
+
+    resolveTransport(payloadFor({ 4: { branch: 0, slots: { 3: "fresh answer" } } }))
+
+    await vi.waitFor(() => {
+      if (!document.body.innerHTML.includes("fresh answer")) {
+        throw new Error("still waiting")
+      }
+    })
+
+    expect(document.body.innerHTML).not.toContain("looking it up")
+  })
+
+  test("refetch off never swaps a fragment", async () => {
+    document.body.innerHTML = fragmentPage({ 4: { fallback: 1, reads: [3], delay: 0, hold: 0 } })
+
+    const transport = vi.fn(async () => payloadFor({}))
+    const live = start({ state: { refetchTransport: transport, refetchDebounce: 0, refetch: "off" } })
+
+    live.state.setState({ q: "basel" })
+
+    await new Promise((resolve) => setTimeout(resolve, 20))
+
+    expect(document.body.innerHTML).toContain("old answer")
+    expect(transport).not.toHaveBeenCalled()
+  })
+
+  test("the fallback waits out `delay` before it appears", async () => {
+    document.body.innerHTML = fragmentPage({ 4: { fallback: 1, reads: [3], delay: 40, hold: 0 } })
+
+    let resolveTransport: (payload: Payload) => void = () => {}
+    const transport = vi.fn(() => new Promise<Payload>((resolve) => { resolveTransport = resolve }))
+
+    const live = start({ state: { refetchTransport: transport, refetchDebounce: 0 } })
+
+    live.state.setState({ q: "basel" })
+
+    expect(document.body.innerHTML).toContain("old answer")
+    expect(document.body.innerHTML).not.toContain("looking it up")
+
+    await vi.waitFor(() => {
+      if (!document.body.innerHTML.includes("looking it up")) {
+        throw new Error("still waiting")
+      }
+    })
+
+    resolveTransport(payloadFor({ 4: { branch: 0, slots: { 3: "fresh answer" } } }))
+
+    await vi.waitFor(() => {
+      if (!document.body.innerHTML.includes("fresh answer")) {
+        throw new Error("still waiting")
+      }
+    })
+  })
+
+  test("a refetch that lands inside `delay` never shows the fallback", async () => {
+    document.body.innerHTML = fragmentPage({ 4: { fallback: 1, reads: [3], delay: 60, hold: 0 } })
+
+    const transport = vi.fn(async () => payloadFor({ 4: { branch: 0, slots: { 3: "fresh answer" } } }))
+    const live = start({ state: { refetchTransport: transport, refetchDebounce: 0 } })
+
+    live.state.setState({ q: "basel" })
+
+    await vi.waitFor(() => {
+      if (!document.body.innerHTML.includes("fresh answer")) {
+        throw new Error("still waiting")
+      }
+    })
+
+    await new Promise((resolve) => setTimeout(resolve, 100))
+
+    expect(document.body.innerHTML).toContain("fresh answer")
+    expect(document.body.innerHTML).not.toContain("looking it up")
+  })
+
+  test("`hold` keeps the fallback up after a fast payload", async () => {
+    document.body.innerHTML = fragmentPage({ 4: { fallback: 1, reads: [3], delay: 0, hold: 100 } })
+
+    const transport = vi.fn(async () => payloadFor({ 4: { branch: 0, slots: { 3: "fresh answer" } } }))
+    const live = start({ state: { refetchTransport: transport, refetchDebounce: 0 } })
+
+    live.state.setState({ q: "basel" })
+
+    expect(document.body.innerHTML).toContain("looking it up")
+
+    await vi.waitFor(() => {
+      if (transport.mock.calls.length === 0) {
+        throw new Error("still waiting")
+      }
+    })
+
+    await new Promise((resolve) => setTimeout(resolve, 30))
+
+    expect(document.body.innerHTML).toContain("looking it up")
+    expect(document.body.innerHTML).not.toContain("fresh answer")
+
+    await vi.waitFor(() => {
+      if (!document.body.innerHTML.includes("fresh answer")) {
+        throw new Error("still waiting")
+      }
+    })
+
+    expect(document.body.innerHTML).not.toContain("looking it up")
   })
 
   test("a payload carrying statics materializes a branch the page never parked", () => {

--- a/javascript/packages/linter/docs/rules/html-no-duplicate-ids.md
+++ b/javascript/packages/linter/docs/rules/html-no-duplicate-ids.md
@@ -55,6 +55,15 @@ A dynamic ID can never be statically proven to collide: the same source expressi
 <% end %>
 ```
 
+A component's `<Fallback>` renders in place of the component's body, never alongside it, so the two count as exclusive branches the way `if`/`else` arms do. The same ID may appear once in the body and once in the fallback:
+
+```erb
+<Fragment>
+  <div id="card"></div>
+  <Fallback><div id="card"></div></Fallback>
+</Fragment>
+```
+
 The same dynamic expression repeated within the same scope (same document level, same conditional branch) is surfaced as a hint rather than an error:
 
 ```erb

--- a/javascript/packages/linter/src/rules/html-no-duplicate-ids.ts
+++ b/javascript/packages/linter/src/rules/html-no-duplicate-ids.ts
@@ -2,7 +2,7 @@ import { ParserRule, BaseAutofixContext } from "../types"
 import { ControlFlowTrackingVisitor, ControlFlowType } from "../utils/rule-utils.js"
 import { Printer, IdentityPrinter } from "@herb-tools/printer"
 
-import { hasDynamicOutput, getValidatableStaticContent, getStaticAttributeName, isERBOutputNode, isRubyLiteralNode, isRubyParameterNode, getTagLocalName } from "@herb-tools/core"
+import { hasDynamicOutput, getValidatableStaticContent, getStaticAttributeName, isERBOutputNode, isRubyLiteralNode, isRubyParameterNode, isHTMLElementNode, isKnownHTMLElement, getTagName, getTagLocalName } from "@herb-tools/core"
 
 import type * as Nodes from "@herb-tools/core"
 import type { ParseResult, HTMLAttributeNode, HTMLElementNode, LiteralNode, ERBContentNode, RubyLiteralNode, ParserOptions } from "@herb-tools/core"
@@ -48,7 +48,39 @@ class NoDuplicateIdsVisitor extends ControlFlowTrackingVisitor<BaseAutofixContex
       return
     }
 
+    const fallbacks = this.fallbackChildren(node)
+
+    if (fallbacks.length > 0) {
+      this.visitElementWithFallbacks(node, fallbacks)
+
+      return
+    }
+
     super.visitHTMLElementNode(node)
+  }
+
+  private fallbackChildren(node: HTMLElementNode): HTMLElementNode[] {
+    const name = getTagName(node)
+
+    if (!name || !/^[A-Z]/.test(name) || isKnownHTMLElement(name.toLowerCase())) return []
+
+    return node.body.filter((child): child is HTMLElementNode => isHTMLElementNode(child) && getTagName(child) === "Fallback")
+  }
+
+  private visitElementWithFallbacks(node: HTMLElementNode, fallbacks: HTMLElementNode[]): void {
+    this.handleControlFlowNode(node, ControlFlowType.CONDITIONAL, () => {
+      if (node.open_tag) this.visit(node.open_tag)
+
+      for (const child of node.body) {
+        if (!fallbacks.includes(child as HTMLElementNode)) this.visit(child)
+      }
+
+      for (const fallback of fallbacks) {
+        this.startNewBranch(() => super.visitHTMLElementNode(fallback))
+      }
+
+      if (node.close_tag) this.visit(node.close_tag)
+    })
   }
 
   visitHTMLAttributeNode(node: HTMLAttributeNode): void {

--- a/javascript/packages/linter/src/rules/html-tag-name-lowercase.ts
+++ b/javascript/packages/linter/src/rules/html-tag-name-lowercase.ts
@@ -1,6 +1,6 @@
 import { ParserRule, BaseAutofixContext, Mutable } from "../types.js"
 import { BaseRuleVisitor, ElementStackVisitor, findParent } from "../utils/rule-utils.js"
-import { getTagName, getOpenTag, isHTMLOpenTagNode, isHTMLElementNode } from "@herb-tools/core"
+import { getTagName, getOpenTag, isHTMLOpenTagNode, isHTMLElementNode, isKnownHTMLElement } from "@herb-tools/core"
 
 import type { UnboundLintOffense, LintOffense, LintContext, FullRuleConfig } from "../types.js"
 import type { HTMLOpenTagNode, HTMLCloseTagNode, ParseResult, XMLDeclarationNode, Node } from "@herb-tools/core"
@@ -60,6 +60,8 @@ class TagNameLowercaseVisitor extends ElementStackVisitor<TagNameAutofixContext>
     const tagName = getTagName(node)
 
     if (!tagName) return
+
+    if (/^[A-Z]/.test(tagName) && /[a-z]/.test(tagName) && !isKnownHTMLElement(tagName.toLowerCase())) return
 
     const lowercaseTagName = tagName.toLowerCase()
 

--- a/javascript/packages/linter/test/rules/html-no-duplicate-ids.test.ts
+++ b/javascript/packages/linter/test/rules/html-no-duplicate-ids.test.ts
@@ -1149,6 +1149,73 @@ describe("html-no-duplicate-ids", () => {
     })
   })
 
+  describe("component fallback branches", () => {
+    test("passes for the same ID in a component body and its fallback", () => {
+      expectNoOffenses(dedent`
+        <Fragment>
+          <div id="card"></div>
+          <Fallback>
+            <div id="card"></div>
+          </Fallback>
+        </Fragment>
+      `)
+    })
+
+    test("fails for a duplicate inside one fallback", () => {
+      expectError("Duplicate ID `card` found within the same control flow branch. IDs must be unique within the same control flow branch.")
+
+      assertOffenses(dedent`
+        <Fragment>
+          <span id="loaded"></span>
+          <Fallback>
+            <div id="card"></div>
+            <div id="card"></div>
+          </Fallback>
+        </Fragment>
+      `)
+    })
+
+    test("fails when an ID from a component body repeats after it", () => {
+      expectError("Duplicate ID `card` found. IDs must be unique within a document.")
+
+      assertOffenses(dedent`
+        <Fragment>
+          <div id="card"></div>
+          <Fallback><div id="skeleton"></div></Fallback>
+        </Fragment>
+        <div id="card"></div>
+      `)
+    })
+
+    test("fails for the same ID in two sibling components", () => {
+      expectError("Duplicate ID `card` found. IDs must be unique within a document.")
+
+      assertOffenses(dedent`
+        <Fragment>
+          <div id="card"></div>
+          <Fallback><div id="one"></div></Fallback>
+        </Fragment>
+        <Fragment>
+          <div id="card"></div>
+          <Fallback><div id="two"></div></Fallback>
+        </Fragment>
+      `)
+    })
+
+    test("passes for a fallback sharing an ID inside an ERB branch", () => {
+      expectNoOffenses(dedent`
+        <% if @detailed %>
+          <Fragment>
+            <div id="card"></div>
+            <Fallback><div id="card"></div></Fallback>
+          </Fragment>
+        <% else %>
+          <div id="card"></div>
+        <% end %>
+      `)
+    })
+  })
+
   describe("block iteration nodes (ERBIterationBlockNode)", () => {
     describe("static IDs repeat once per iteration", () => {
       test("fails for a static ID in a single each block", () => {

--- a/javascript/packages/linter/test/rules/html-tag-name-lowercase.test.ts
+++ b/javascript/packages/linter/test/rules/html-tag-name-lowercase.test.ts
@@ -31,6 +31,11 @@ describe("html-tag-name-lowercase", () => {
     assertOffenses('<Div class="container"><Span>Hello</Span></Div>')
   })
 
+  test("passes for component tags, which are not HTML elements", () => {
+    expectNoOffenses("<Fragment><span>content</span><Fallback><div>skeleton</div></Fallback></Fragment>")
+    expectNoOffenses("<MyWidget></MyWidget>")
+  })
+
   test("handles self-closing tags", () => {
     expectError('Opening tag name `<IMG>` should be lowercase. Use `<img>` instead.')
 

--- a/lib/herb/engine/slots/components.rb
+++ b/lib/herb/engine/slots/components.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+# typed: true
+
+require_relative "components/base"
+require_relative "components/fragment"
+require_relative "components/fallback"
+
+module Herb
+  class Engine
+    module Slots
+      # The compile-time components a slots template may use.
+      #
+      # A component is a capitalized wrapper tag the slots visitor recognizes and
+      # transforms away before any slot is recorded, so the rendered page never
+      # carries the tag itself. Each built-in lives in its own file under
+      # `components/` and registers here by name.
+      #
+      module Components
+        NAME = /\A[A-Z][A-Za-z0-9]*\z/ #: Regexp
+        REGISTRY = { Fragment::NAME => Fragment, Fallback::NAME => Fallback }.freeze #: Hash[String, singleton(Base)]
+        BUILT_IN = REGISTRY.keys.freeze #: Array[String]
+
+        #: (String?) -> bool
+        def self.component?(tag_name)
+          return false if tag_name.nil?
+
+          tag_name.match?(NAME) && tag_name.match?(/[a-z]/)
+        end
+
+        #: (String) -> singleton(Base)?
+        def self.for(tag_name)
+          REGISTRY[tag_name]
+        end
+
+        #: (untyped, ?String?) -> bool
+        def self.element?(node, name = nil)
+          return false unless node.is_a?(Herb::AST::HTMLElementNode)
+
+          tag_name = node.tag_name&.value
+
+          return false unless component?(tag_name)
+
+          name.nil? || tag_name == name
+        end
+      end
+    end
+  end
+end

--- a/lib/herb/engine/slots/components/base.rb
+++ b/lib/herb/engine/slots/components/base.rb
@@ -1,0 +1,106 @@
+# frozen_string_literal: true
+# typed: true
+
+module Herb
+  class Engine
+    module Slots
+      module Components
+        # What every built-in component shares.
+        #
+        # A component receives the element it stands on and the slots visitor
+        # transforming the template. It validates its attributes against its
+        # `allowed_attributes` and answers the nodes that replace it.
+        #
+        class Base
+          #: (untyped, untyped) -> Array[untyped]
+          def self.transform(element, visitor)
+            new(element, visitor).transform
+          end
+
+          #: (untyped, untyped) -> void
+          def initialize(element, visitor)
+            @element = element
+            @visitor = visitor
+          end
+
+          #: () -> Array[untyped]
+          def transform
+            raise NotImplementedError, "#{self.class} does not transform"
+          end
+
+          #: () -> Array[String]
+          def allowed_attributes
+            []
+          end
+
+          #: () -> void
+          def refuse_unknown_attributes
+            allowed = allowed_attributes
+
+            return if attributes.all? { |attribute|
+              name = attribute_name(attribute).to_s
+
+              name.start_with?("data-herb-") || allowed.include?(name)
+            }
+
+            if allowed.empty?
+              error("`<#{tag_name}>` takes no attributes yet.", @element.location, suggestion: "Remove the attributes.")
+            else
+              error("`<#{tag_name}>` only takes #{allowed.map { |name| "`#{name}`" }.join(" and ")}.", @element.location, suggestion: "Remove the other attributes.")
+            end
+          end
+
+          private
+
+          #: () -> String
+          def tag_name
+            @element.tag_name&.value.to_s
+          end
+
+          #: () -> Array[untyped]
+          def children
+            @element.body || []
+          end
+
+          #: () -> Array[untyped]
+          def attributes
+            open_tag = @element.open_tag
+
+            return [] unless open_tag.is_a?(Herb::AST::HTMLOpenTagNode)
+
+            (open_tag.children || []).grep(Herb::AST::HTMLAttributeNode)
+          end
+
+          #: (untyped) -> String?
+          def attribute_name(attribute)
+            parts = attribute.name&.children || []
+
+            return nil if parts.empty?
+            return nil unless parts.all?(Herb::AST::LiteralNode)
+
+            parts.filter_map { |part| part.content if part.respond_to?(:content) }.join
+          end
+
+          #: (untyped) -> String?
+          def static_value(attribute)
+            parts = attribute.value&.children || []
+
+            return nil unless parts.all?(Herb::AST::LiteralNode)
+
+            parts.map { |part| part.content.to_s }.join.strip
+          end
+
+          #: (String, untyped, ?suggestion: String?) -> nil
+          def error(message, location, suggestion: nil)
+            @visitor.slot_error(message, location, :component, suggestion: suggestion)
+          end
+
+          #: (String, untyped, ?suggestion: String?) -> void
+          def warning(message, location, suggestion: nil)
+            @visitor.slot_warning(message, location, :component, suggestion: suggestion)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/herb/engine/slots/components/fallback.rb
+++ b/lib/herb/engine/slots/components/fallback.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+# typed: true
+
+module Herb
+  class Engine
+    module Slots
+      module Components
+        # The markup a `<Fragment>` shows while its content is stale.
+        #
+        # A fallback only means something inside a `<Fragment>`, which consumes
+        # it during its own transform, so a fallback reaching its own transform
+        # stands outside one and errors.
+        #
+        class Fallback < Base
+          NAME = "Fallback" #: String
+
+          #: () -> Array[untyped]
+          def transform
+            error("`<Fallback>` sits outside a `<Fragment>`, so there is nothing for it to stand in for.", @element.location, suggestion: "Wrap the content it replaces and the `<Fallback>` together in a `<Fragment>`.")
+
+            []
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/herb/engine/slots/components/fragment.rb
+++ b/lib/herb/engine/slots/components/fragment.rb
@@ -1,0 +1,127 @@
+# frozen_string_literal: true
+# typed: true
+
+module Herb
+  class Engine
+    module Slots
+      module Components
+        # Suspense-like fallbacks for server-derived content.
+        #
+        # A fragment compiles its primary children into a synthesized single-arm
+        # conditional the page renders on first load, and parks its `<Fallback>`
+        # for the client to show the instant a state write invalidates a server
+        # read inside it. `delay` and `hold` tune when the fallback appears and
+        # how long it stays.
+        #
+        class Fragment < Base
+          NAME = "Fragment" #: String
+          ATTRIBUTES = ["delay", "hold", "on"].freeze #: Array[String]
+          TIMING_ATTRIBUTES = ["delay", "hold"].freeze #: Array[String]
+
+          #: () -> Array[String]
+          def allowed_attributes
+            ATTRIBUTES
+          end
+
+          #: () -> Array[untyped]
+          def transform
+            refuse_unknown_attributes
+
+            timing = self.timing
+            fallbacks, primary = children.partition { |child| Components.element?(child, Fallback::NAME) }
+
+            primary = @visitor.transform_component_children(primary)
+
+            if fallbacks.size > 1
+              error("A `<Fragment>` holds #{fallbacks.size} `<Fallback>` elements, and it can only stand one in.", @element.location, suggestion: "Keep one `<Fallback>` per `<Fragment>`.")
+            end
+
+            fallback = fallbacks.first
+
+            unless fallback
+              warning("`<Fragment>` holds no `<Fallback>`, so it wraps nothing and compiles away.", @element.location, suggestion: "Add a `<Fallback>` to stand in while its content is stale, or unwrap the children.")
+
+              return primary
+            end
+
+            Fallback.new(fallback, @visitor).refuse_unknown_attributes
+            refuse_nested_fragment(fallback)
+
+            if_node = synthesized_conditional(primary)
+
+            @visitor.record_fragment(if_node, fallback.body || [], timing.merge(masking))
+
+            [if_node]
+          end
+
+          private
+
+          #: () -> Hash[String, untyped]
+          def masking
+            named = attributes.find { |attribute| attribute_name(attribute) == "on" }
+
+            return {} unless named
+
+            states = static_value(named).to_s.split(/[,\s]+/).reject(&:empty?)
+
+            if states.empty?
+              error("`on` names the states that mask this `<Fragment>`, and it names none.", named.location, suggestion: %(Name at least one state, like `on="album"`.))
+
+              return {}
+            end
+
+            { "on" => states }
+          end
+
+          #: () -> Hash[String, Integer]
+          def timing
+            timed = {} #: Hash[String, Integer]
+
+            attributes.each do |attribute|
+              name = attribute_name(attribute).to_s
+
+              next unless TIMING_ATTRIBUTES.include?(name)
+
+              value = static_value(attribute)
+
+              if value&.match?(/\A\d+\z/)
+                timed[name] = Integer(value, 10)
+              else
+                error("`#{name}` on a `<Fragment>` takes a whole number of milliseconds.", attribute.location, suggestion: %(Write it like `#{name}="150"`.))
+              end
+            end
+
+            timed
+          end
+
+          #: (untyped) -> void
+          def refuse_nested_fragment(fallback)
+            (fallback.body || []).each do |child|
+              next unless Components.element?(child, NAME)
+
+              error("A `<Fragment>` sits inside a `<Fallback>`, which renders once and stays static, so nothing inside it can stay live.", child.location, suggestion: "Move the inner `<Fragment>` next to the outer one.")
+            end
+          end
+
+          #: (Array[untyped]) -> untyped
+          def synthesized_conditional(statements)
+            Herb::AST::ERBIfNode.build(
+              location: @element.location,
+              tag_opening: Herb::Token.from(:erb_start, "<%"),
+              content: Herb::Token.from(:erb_content, " if true "),
+              tag_closing: Herb::Token.from(:erb_end, "%>"),
+              statements: statements,
+              subsequent: nil,
+              end_node: Herb::AST::ERBEndNode.build(
+                location: @element.location,
+                tag_opening: Herb::Token.from(:erb_start, "<%"),
+                content: Herb::Token.from(:erb_content, " end "),
+                tag_closing: Herb::Token.from(:erb_end, "%>")
+              )
+            )
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/herb/engine/slots/state_compiler.rb
+++ b/lib/herb/engine/slots/state_compiler.rb
@@ -136,6 +136,7 @@ module Herb
             "presence" => presence,
             "computed" => computed,
             "server" => { "branches" => branch_orphans(reads, computed, presence, steerable_names(declarations)), "reads" => @server_reads },
+            "fragments" => fragment_entries,
           }
         end
 
@@ -201,6 +202,20 @@ module Herb
             :unknown,
             suggestion: "Spell the state's name, or declare `#{name}` in `herb:state`."
           )
+        end
+
+        #: () -> Hash[String, untyped]
+        def fragment_entries
+          refetchable = @server_reads.values.flatten.to_set { |entry| entry["index"] }
+          entries = {} #: Hash[String, untyped]
+
+          @visitor.fragment_indexes.each do |index|
+            inside = (@visitor.slots_by_branch(index)[0] || []).select { |slot_index| refetchable.include?(slot_index) }
+
+            entries[index.to_s] = { "fallback" => 1, "reads" => inside }.merge(@visitor.fragment_timing_for(index)) unless inside.empty?
+          end
+
+          entries
         end
 
         #: (Array[Hash[String, untyped]]) -> Set[String]
@@ -578,12 +593,35 @@ module Herb
             parent[position] = @visitor.erb_code_node(seeds ? "; #{assignments}; #{seeds}" : "; #{assignments}")
           end
 
-          return if @region_states.empty? && @item_states.empty?
+          if @region_states.empty? && @item_states.empty?
+            check_fragments
+
+            return
+          end
 
           classify_state_conditionals
           check_state_value_reads
           check_collection_reads
           check_state_count_reads
+          check_fragments
+        end
+
+        #: () -> void
+        def check_fragments
+          refetchable = @server_reads.values.flatten.to_set { |entry| entry["index"] }
+
+          @visitor.fragment_indexes.each do |index|
+            inside = @visitor.slots_by_branch(index)[0] || []
+
+            next if inside.any? { |slot_index| refetchable.include?(slot_index) }
+
+            @visitor.slot_warning(
+              "Nothing inside this `<Fragment>` is derived on the server, so its `<Fallback>` can never appear.",
+              @visitor.slot_nodes[index]&.location,
+              :component,
+              suggestion: "Compute something with a declared state inside the fragment, or unwrap it."
+            )
+          end
         end
 
         #: (Array[StateDirectives::Declaration]) -> String?

--- a/lib/herb/engine/slots/visitor.rb
+++ b/lib/herb/engine/slots/visitor.rb
@@ -11,6 +11,7 @@ require_relative "../../visitor/experimental"
 require_relative "annotation"
 require_relative "identifier"
 require_relative "manifest/channel"
+require_relative "components"
 require_relative "types"
 require_relative "state_compiler"
 require_relative "markers"
@@ -190,6 +191,12 @@ module Herb
           listener_written = {} #: Hash[untyped, Array[String]]
           @listener_written = listener_written.compare_by_identity
           @current_open_tag = nil
+
+          fragment_nodes = {} #: Hash[untyped, Hash[String, untyped]]
+          fragment_fallbacks = {} #: Hash[untyped, Array[untyped]]
+
+          @fragment_nodes = fragment_nodes.compare_by_identity
+          @fragment_fallbacks = fragment_fallbacks.compare_by_identity
         end
 
         #: () -> bool
@@ -226,6 +233,36 @@ module Herb
           return [] unless node
 
           branch_bodies(node).flat_map { |body| slot_indices_within(body) }.uniq
+        end
+
+        #: (untyped) -> bool
+        def fragment?(node)
+          @fragment_nodes.key?(node)
+        end
+
+        #: () -> Array[Integer]
+        def fragment_indexes
+          @fragment_nodes.keys.filter_map { |node| @indices[node] }
+        end
+
+        #: (Integer) -> Hash[String, untyped]
+        def fragment_timing_for(index)
+          node = @slot_nodes[index]
+
+          return {} unless node
+
+          @fragment_nodes[node] || {}
+        end
+
+        #: (Array[untyped]) -> Array[untyped]
+        def transform_component_children(children)
+          children.flat_map { |child| transformed(child) }
+        end
+
+        #: (untyped, Array[untyped], Hash[String, untyped]) -> void
+        def record_fragment(node, fallback_children, timing)
+          @fragment_nodes[node] = timing
+          @fragment_fallbacks[node] = fallback_children
         end
 
         #: (Integer) -> Array[Array[Integer]]
@@ -511,6 +548,8 @@ module Herb
         def visit_document_node(node)
           @document = node
 
+          transform_components(node) if declares_slots?(node)
+
           visit_children_with_paths(node.children)
 
           collapse_invariant_conditionals
@@ -683,8 +722,10 @@ module Herb
         end
 
         def visit_erb_if_node(node)
-          return if @states.register_count_fold(node)
-          return if convert_helper_boolean_attribute(node)
+          unless fragment?(node)
+            return if @states.register_count_fold(node)
+            return if convert_helper_boolean_attribute(node)
+          end
 
           record_slot(node, :conditional) unless continuation?(node)
 
@@ -867,10 +908,73 @@ module Herb
           @container_depth -= 1
         end
 
+        #: (untyped) -> bool
+        def declares_slots?(node)
+          node.children.any? { |child|
+            case child
+            when Herb::AST::HerbDirectiveNode
+              child.key&.value.to_s == "slots"
+            when Herb::AST::ERBContentNode
+              child.tag_opening&.value.to_s.include?("#") && child.content&.value.to_s.match?(/\bherb:slots\b/)
+            else
+              false
+            end
+          }
+        end
+
+        #: (untyped) -> void
+        def transform_components(node)
+          return unless node.is_a?(Herb::AST::Node)
+
+          BRANCH_BODY_PROPERTIES.each do |property|
+            next unless node.respond_to?(property)
+
+            value = node.send(property)
+
+            case value
+            when Array
+              if property == :conditions
+                value.each { |arm| transform_components(arm) }
+              else
+                value.replace(value.flat_map { |child| transformed(child) })
+              end
+            when Herb::AST::Node
+              transform_components(value)
+            end
+          end
+
+          BRANCH_CONTINUATION_PROPERTIES.each do |property|
+            next unless node.respond_to?(property)
+
+            continuation = node.send(property)
+
+            transform_components(continuation) if continuation
+          end
+        end
+
+        #: (untyped) -> Array[untyped]
+        def transformed(child)
+          unless Components.element?(child)
+            transform_components(child)
+
+            return [child]
+          end
+
+          name = child.tag_name&.value.to_s
+          component = Components.for(name)
+
+          return component.transform(child, self) if component
+
+          slot_error("`<#{name}>` is not a component Herb knows.", child.location, :component, suggestion: "The built-in components are #{Components::BUILT_IN.map { |built_in| "`<#{built_in}>`" }.join(" and ")}.")
+
+          [child]
+        end
+
         #: () -> void
         def collapse_invariant_conditionals
           @standing.each_value do |annotation|
             next unless annotation.type == :conditional
+            next if fragment?(annotation.node)
             next unless exhaustive?(annotation.node)
 
             bodies = branch_bodies(annotation.node)
@@ -1444,26 +1548,48 @@ module Herb
           return unless client?
 
           statics = @statics
-          return if statics.nil? || statics.empty?
+          entries = (statics || {}).sort_by { |key, _| key.split(":").map(&:to_i) } #: Array[[String, (String | Array[untyped])]]
 
-          branches = statics.sort_by { |key, _| key.split(":").map(&:to_i) }
-          seen = branches.map { |key, _| "#{COVERED}[#{covered_key(key).inspect}]" }.join(" && ")
+          entries.concat(fallback_statics_entries)
+
+          return if entries.empty?
+
+          seen = entries.map { |key, _| "#{COVERED}[#{covered_key(key).inspect}]" }.join(" && ")
 
           nodes = [
             erb_code_node("unless #{seen}"),
             text_node(@markers.statics_open(identifier, version))
           ] #: Array[Herb::AST::Node]
 
-          branches.each do |key, markup|
+          entries.each do |key, parked|
             reference = "#{COVERED}[#{covered_key(key).inspect}]"
 
-            nodes.push(erb_code_node("unless #{reference}"), text_node(markup), erb_code_node("#{reference} = true"), erb_code_node("end"))
+            nodes.push(erb_code_node("unless #{reference}"))
+
+            if parked.is_a?(String)
+              nodes.push(text_node(parked))
+            else
+              nodes.concat(parked)
+            end
+
+            nodes.push(erb_code_node("#{reference} = true"), erb_code_node("end"))
           end
 
           nodes.push(text_node(@markers.statics_close), erb_code_node("end"))
 
           document_node.children.unshift(erb_code_node("#{COVERED} ||= {}"))
           document_node.children.concat(nodes)
+        end
+
+        #: () -> Array[[String, Array[untyped]]]
+        def fallback_statics_entries
+          @fragment_fallbacks.filter_map { |node, body|
+            index = @indices[node]
+
+            next unless index
+
+            [@markers.statics_key(index, 1), [text_node(@markers.branch(index, 1)), *body]]
+          }
         end
 
         #: (String) -> String

--- a/sig/herb/engine/slots/components.rbs
+++ b/sig/herb/engine/slots/components.rbs
@@ -1,0 +1,30 @@
+# Generated from lib/herb/engine/slots/components.rb with RBS::Inline
+
+module Herb
+  class Engine
+    module Slots
+      # The compile-time components a slots template may use.
+      #
+      # A component is a capitalized wrapper tag the slots visitor recognizes and
+      # transforms away before any slot is recorded, so the rendered page never
+      # carries the tag itself. Each built-in lives in its own file under
+      # `components/` and registers here by name.
+      module Components
+        NAME: Regexp
+
+        REGISTRY: Hash[String, singleton(Base)]
+
+        BUILT_IN: Array[String]
+
+        # : (String?) -> bool
+        def self.component?: (String?) -> bool
+
+        # : (String) -> singleton(Base)?
+        def self.for: (String) -> singleton(Base)?
+
+        # : (untyped, ?String?) -> bool
+        def self.element?: (untyped, ?String?) -> bool
+      end
+    end
+  end
+end

--- a/sig/herb/engine/slots/components/base.rbs
+++ b/sig/herb/engine/slots/components/base.rbs
@@ -1,0 +1,54 @@
+# Generated from lib/herb/engine/slots/components/base.rb with RBS::Inline
+
+module Herb
+  class Engine
+    module Slots
+      module Components
+        # What every built-in component shares.
+        #
+        # A component receives the element it stands on and the slots visitor
+        # transforming the template. It validates its attributes against its
+        # `allowed_attributes` and answers the nodes that replace it.
+        class Base
+          # : (untyped, untyped) -> Array[untyped]
+          def self.transform: (untyped, untyped) -> Array[untyped]
+
+          # : (untyped, untyped) -> void
+          def initialize: (untyped, untyped) -> void
+
+          # : () -> Array[untyped]
+          def transform: () -> Array[untyped]
+
+          # : () -> Array[String]
+          def allowed_attributes: () -> Array[String]
+
+          # : () -> void
+          def refuse_unknown_attributes: () -> void
+
+          private
+
+          # : () -> String
+          def tag_name: () -> String
+
+          # : () -> Array[untyped]
+          def children: () -> Array[untyped]
+
+          # : () -> Array[untyped]
+          def attributes: () -> Array[untyped]
+
+          # : (untyped) -> String?
+          def attribute_name: (untyped) -> String?
+
+          # : (untyped) -> String?
+          def static_value: (untyped) -> String?
+
+          # : (String, untyped, ?suggestion: String?) -> nil
+          def error: (String, untyped, ?suggestion: String?) -> nil
+
+          # : (String, untyped, ?suggestion: String?) -> void
+          def warning: (String, untyped, ?suggestion: String?) -> void
+        end
+      end
+    end
+  end
+end

--- a/sig/herb/engine/slots/components/fallback.rbs
+++ b/sig/herb/engine/slots/components/fallback.rbs
@@ -1,0 +1,21 @@
+# Generated from lib/herb/engine/slots/components/fallback.rb with RBS::Inline
+
+module Herb
+  class Engine
+    module Slots
+      module Components
+        # The markup a `<Fragment>` shows while its content is stale.
+        #
+        # A fallback only means something inside a `<Fragment>`, which consumes
+        # it during its own transform, so a fallback reaching its own transform
+        # stands outside one and errors.
+        class Fallback < Base
+          NAME: String
+
+          # : () -> Array[untyped]
+          def transform: () -> Array[untyped]
+        end
+      end
+    end
+  end
+end

--- a/sig/herb/engine/slots/components/fragment.rbs
+++ b/sig/herb/engine/slots/components/fragment.rbs
@@ -1,0 +1,44 @@
+# Generated from lib/herb/engine/slots/components/fragment.rb with RBS::Inline
+
+module Herb
+  class Engine
+    module Slots
+      module Components
+        # Suspense-like fallbacks for server-derived content.
+        #
+        # A fragment compiles its primary children into a synthesized single-arm
+        # conditional the page renders on first load, and parks its `<Fallback>`
+        # for the client to show the instant a state write invalidates a server
+        # read inside it. `delay` and `hold` tune when the fallback appears and
+        # how long it stays.
+        class Fragment < Base
+          NAME: String
+
+          ATTRIBUTES: Array[String]
+
+          TIMING_ATTRIBUTES: Array[String]
+
+          # : () -> Array[String]
+          def allowed_attributes: () -> Array[String]
+
+          # : () -> Array[untyped]
+          def transform: () -> Array[untyped]
+
+          private
+
+          # : () -> Hash[String, untyped]
+          def masking: () -> Hash[String, untyped]
+
+          # : () -> Hash[String, Integer]
+          def timing: () -> Hash[String, Integer]
+
+          # : (untyped) -> void
+          def refuse_nested_fragment: (untyped) -> void
+
+          # : (Array[untyped]) -> untyped
+          def synthesized_conditional: (Array[untyped]) -> untyped
+        end
+      end
+    end
+  end
+end

--- a/sig/herb/engine/slots/state_compiler.rbs
+++ b/sig/herb/engine/slots/state_compiler.rbs
@@ -53,6 +53,9 @@ module Herb
         # : (untyped, String, Array[String]) -> void
         def warn_near_miss: (untyped, String, Array[String]) -> void
 
+        # : () -> Hash[String, untyped]
+        def fragment_entries: () -> Hash[String, untyped]
+
         # : (Array[Hash[String, untyped]]) -> Set[String]
         def steerable_names: (Array[Hash[String, untyped]]) -> Set[String]
 
@@ -127,6 +130,9 @@ module Herb
 
         # : () -> void
         def apply_states: () -> void
+
+        # : () -> void
+        def check_fragments: () -> void
 
         # : (Array[StateDirectives::Declaration]) -> String?
         def seeds_marker: (Array[StateDirectives::Declaration]) -> String?

--- a/sig/herb/engine/slots/visitor.rbs
+++ b/sig/herb/engine/slots/visitor.rbs
@@ -151,6 +151,21 @@ module Herb
         # : (Integer) -> Array[Integer]
         def slots_inside: (Integer) -> Array[Integer]
 
+        # : (untyped) -> bool
+        def fragment?: (untyped) -> bool
+
+        # : () -> Array[Integer]
+        def fragment_indexes: () -> Array[Integer]
+
+        # : (Integer) -> Hash[String, untyped]
+        def fragment_timing_for: (Integer) -> Hash[String, untyped]
+
+        # : (Array[untyped]) -> Array[untyped]
+        def transform_component_children: (Array[untyped]) -> Array[untyped]
+
+        # : (untyped, Array[untyped], Hash[String, untyped]) -> void
+        def record_fragment: (untyped, Array[untyped], Hash[String, untyped]) -> void
+
         # : (Integer) -> Array[Array[Integer]]
         def slots_by_branch: (Integer) -> Array[Array[Integer]]
 
@@ -342,6 +357,15 @@ module Herb
 
         def visit_branching_node: (untyped node) -> untyped
 
+        # : (untyped) -> bool
+        def declares_slots?: (untyped) -> bool
+
+        # : (untyped) -> void
+        def transform_components: (untyped) -> void
+
+        # : (untyped) -> Array[untyped]
+        def transformed: (untyped) -> Array[untyped]
+
         # : () -> void
         def collapse_invariant_conditionals: () -> void
 
@@ -450,6 +474,9 @@ module Herb
 
         # : (Herb::AST::DocumentNode) -> void
         def append_statics: (Herb::AST::DocumentNode) -> void
+
+        # : () -> Array[[String, Array[untyped]]]
+        def fallback_statics_entries: () -> Array[[ String, Array[untyped] ]]
 
         # : (String) -> String
         def covered_key: (String) -> String

--- a/test/engine/dynamics_compiler_test.rb
+++ b/test/engine/dynamics_compiler_test.rb
@@ -389,6 +389,39 @@ module Engine
         assert_equal :attribute_interpolation, compiler.slot_visitor.slots.fetch(0).type
       end
 
+      test "a fragment's values always take the primary branch and skip the fallback" do
+        source = <<~ERB
+          <%# herb:slots client %>
+          <Fragment>
+            <p><%= helper_with_argument(1) %></p>
+            <Fallback><p>waiting for <%= @never %></p></Fallback>
+          </Fragment>
+        ERB
+
+        values = dynamics(source)
+
+        assert_equal({ 0 => { branch: 0, slots: { 1 => "helper(1)" } } }, values)
+      end
+
+      test "a fragment numbers identically in the values and page compiles" do
+        source = <<~ERB
+          <%# herb:slots client %>
+          <span><%= @before %></span>
+          <Fragment>
+            <p><%= @inside %></p>
+            <Fallback><p>waiting</p></Fallback>
+          </Fragment>
+          <em><%= @after %></em>
+        ERB
+
+        values_visitor = Herb::Engine::Slots::DynamicsCompiler.new(source, filename: "app/views/test.html.erb").slot_visitor
+
+        page_visitor = Herb::Engine::Slots::Visitor.new(mode: :client, fatal: false)
+        Herb::Engine.new(source, visitors: [page_visitor], filename: "app/views/test.html.erb")
+
+        assert_equal(page_visitor.slots.map { |slot| [slot.index, slot.type] }, values_visitor.slots.map { |slot| [slot.index, slot.type] })
+      end
+
       test "a whole-value attribute conditional assigns the scalar the visitor expects" do
         source = %(<%# herb:slots client %>\n<span class="<%= @on ? "is-\#{@tone}" : "off" %>"></span>)
 

--- a/test/engine/slots/components_test.rb
+++ b/test/engine/slots/components_test.rb
@@ -1,0 +1,220 @@
+# frozen_string_literal: true
+
+require_relative "../../test_helper"
+require_relative "../../../lib/herb/engine/slots/visitor"
+
+module Engine
+  module Slots
+    class ComponentsTest < Minitest::Spec
+      include SnapshotUtils
+
+      FRAGMENT = <<~ERB
+        <%# herb:slots client %>
+        <%# herb:state (peek: "") %>
+        <input value="<%= peek %>">
+        <Fragment>
+          <p id="card"><%= Geo.locate(peek) %></p>
+          <Fallback>
+            <p id="card" class="pulse">Looking it up</p>
+          </Fallback>
+        </Fragment>
+      ERB
+
+      PAGE = <<~ERB
+        <%# herb:slots client %>
+        <%# herb:state (peek: "basel") %>
+        <input value="<%= peek %>">
+        <Fragment>
+          <p id="card">located <%= peek.upcase %></p>
+          <Fallback>
+            <p id="card" class="pulse">Looking up <%= @hint %> now</p>
+          </Fallback>
+        </Fragment>
+      ERB
+
+      def compile(source, mode: :client)
+        visitor = Herb::Engine::Slots::Visitor.new(mode: mode, fatal: false)
+        engine = Herb::Engine.new(source, visitors: [visitor], filename: "app/views/test.html.erb")
+
+        [visitor, engine]
+      end
+
+      def page_options
+        { visitors: [Herb::Engine::Slots::Visitor.new(mode: :client, fatal: false)], filename: "app/views/test.html.erb" }
+      end
+
+      test "a fragment compiles to a conditional slot holding only the primary" do
+        visitor, = compile(FRAGMENT)
+
+        assert_equal [:attribute, :conditional, :child], visitor.slots.map(&:type)
+        assert_equal [1], visitor.fragment_indexes
+        assert_empty visitor.diagnostics
+      end
+
+      test "the compiled program holds the fragment as a conditional and no component tags" do
+        _, engine = compile(PAGE)
+
+        assert_snapshot_matches(engine.src, PAGE, { mode: "client" })
+      end
+
+      test "the rendered page shows the primary and parks the fallback with its ERB evaluated" do
+        assert_evaluated_snapshot(PAGE, { "@hint" => "Basel" }, page_options)
+      end
+
+      test "the fallback holds no slot indexes" do
+        with_hint = FRAGMENT.sub("Looking it up", "Looking up <%= @hint %> now")
+
+        plain, = compile(FRAGMENT)
+        seeded, = compile(with_hint)
+
+        assert_equal plain.slots.map(&:type), seeded.slots.map(&:type)
+      end
+
+      test "the manifest maps the fragment to the reads inside it" do
+        visitor, = compile(FRAGMENT)
+
+        assert_equal({ "1" => { "fallback" => 1, "reads" => [2] } }, visitor.manifest["states"]["fragments"])
+      end
+
+      test "a fragment stays out of the server branch map, so no orphan warnings fire" do
+        visitor, = compile(FRAGMENT)
+
+        assert_empty visitor.manifest["states"]["server"]["branches"]
+        assert_empty visitor.diagnostics
+      end
+
+      test "a fragment without a fallback unwraps, reserves no slot, and warns" do
+        source = <<~ERB
+          <%# herb:slots client %>
+          <Fragment>
+            <p><%= @value %></p>
+          </Fragment>
+        ERB
+
+        visitor, = compile(source)
+
+        assert_equal [:child], visitor.slots.map(&:type)
+        assert_equal ["herb-slots-component"], visitor.diagnostics.map(&:code)
+        assert_equal ["`<Fragment>` holds no `<Fallback>`, so it wraps nothing and compiles away."], visitor.diagnostics.map(&:message)
+      end
+
+      test "a fragment with nothing server-derived warns that the fallback can never appear" do
+        source = <<~ERB
+          <%# herb:slots client %>
+          <%# herb:state (peek: "") %>
+          <input value="<%= peek %>">
+          <Fragment>
+            <p><%= @value %></p>
+            <Fallback><p>waiting</p></Fallback>
+          </Fragment>
+        ERB
+
+        visitor, = compile(source)
+
+        assert_equal ["Nothing inside this `<Fragment>` is derived on the server, so its `<Fallback>` can never appear."], visitor.diagnostics.map(&:message)
+      end
+
+      test "a fragment on a template with no states warns the same way" do
+        source = <<~ERB
+          <%# herb:slots client %>
+          <Fragment>
+            <p><%= @value %></p>
+            <Fallback><p>waiting</p></Fallback>
+          </Fragment>
+        ERB
+
+        visitor, = compile(source)
+
+        assert_equal ["Nothing inside this `<Fragment>` is derived on the server, so its `<Fallback>` can never appear."], visitor.diagnostics.map(&:message)
+      end
+
+      test "a fallback outside a fragment errors" do
+        visitor, = compile(%(<%# herb:slots client %>\n<Fallback><p>alone</p></Fallback>))
+
+        assert_equal ["herb-slots-component"], visitor.diagnostics.map(&:code)
+        assert_equal ["`<Fallback>` sits outside a `<Fragment>`, so there is nothing for it to stand in for."], visitor.diagnostics.map(&:message)
+      end
+
+      test "two fallbacks in one fragment error" do
+        source = <<~ERB
+          <%# herb:slots client %>
+          <Fragment>
+            <p><%= @value %></p>
+            <Fallback><p>one</p></Fallback>
+            <Fallback><p>two</p></Fallback>
+          </Fragment>
+        ERB
+
+        visitor, = compile(source)
+
+        assert_equal(
+          [
+            "A `<Fragment>` holds 2 `<Fallback>` elements, and it can only stand one in.",
+            "Nothing inside this `<Fragment>` is derived on the server, so its `<Fallback>` can never appear."
+          ],
+          visitor.diagnostics.map(&:message)
+        )
+      end
+
+      test "an unknown component errors and lists the built-ins" do
+        visitor, = compile(%(<%# herb:slots client %>\n<Skeleton><p>x</p></Skeleton>))
+
+        diagnostic = visitor.diagnostics.fetch(0)
+
+        assert_equal "herb-slots-component", diagnostic.code
+        assert_equal "`<Skeleton>` is not a component Herb knows.", diagnostic.message
+        assert_equal "The built-in components are `<Fragment>` and `<Fallback>`.", diagnostic.suggestion
+      end
+
+      test "an unknown attribute on a fragment errors" do
+        visitor, = compile(%(<%# herb:slots client %>\n<Fragment id="x"><p><%= @a %></p><Fallback>f</Fallback></Fragment>))
+
+        assert_equal(
+          [
+            "`<Fragment>` only takes `delay` and `hold` and `on`.",
+            "Nothing inside this `<Fragment>` is derived on the server, so its `<Fallback>` can never appear."
+          ],
+          visitor.diagnostics.map(&:message)
+        )
+      end
+
+      test "attributes on a fallback error" do
+        visitor, = compile(%(<%# herb:slots client %>\n<Fragment><p><%= @a %></p><Fallback delay="150">f</Fallback></Fragment>))
+
+        assert_equal(
+          [
+            "`<Fallback>` takes no attributes yet.",
+            "Nothing inside this `<Fragment>` is derived on the server, so its `<Fallback>` can never appear."
+          ],
+          visitor.diagnostics.map(&:message)
+        )
+      end
+
+      test "delay and hold flow into the manifest" do
+        source = FRAGMENT.sub("<Fragment>", %(<Fragment delay="0" hold="600">))
+
+        visitor, = compile(source)
+
+        assert_empty visitor.diagnostics
+        assert_equal({ "1" => { "fallback" => 1, "reads" => [2], "delay" => 0, "hold" => 600 } }, visitor.manifest["states"]["fragments"])
+      end
+
+      test "the `on` attribute names the masking states" do
+        source = FRAGMENT.sub("<Fragment>", %(<Fragment on="peek">))
+
+        visitor, = compile(source)
+
+        assert_empty visitor.diagnostics
+        assert_equal ["peek"], visitor.manifest["states"]["fragments"]["1"]["on"]
+      end
+
+      test "an empty `on` errors" do
+        source = FRAGMENT.sub("<Fragment>", %(<Fragment on="">))
+
+        visitor, = compile(source)
+
+        assert_equal ["`on` names the states that mask this `<Fragment>`, and it names none."], visitor.diagnostics.map(&:message)
+      end
+    end
+  end
+end

--- a/test/snapshots/engine/slots/components_test/test_0002_the_compiled_program_holds_the_fragment_as_a_conditional_and_no_component_tags_df09214b2012a9b354f3945b68ae34d0-a9cb59907c52c76361b09c6726e10d00.txt
+++ b/test/snapshots/engine/slots/components_test/test_0002_the_compiled_program_holds_the_fragment_as_a_conditional_and_no_component_tags_df09214b2012a9b354f3945b68ae34d0-a9cb59907c52c76361b09c6726e10d00.txt
@@ -1,0 +1,27 @@
+---
+source: "Engine::Slots::ComponentsTest#test_0002_the compiled program holds the fragment as a conditional and no component tags"
+input: |2-
+<%# herb:slots client %>
+<%# herb:state (peek: "basel") %>
+<input value="<%= peek %>">
+<Fragment>
+  <p id="card">located <%= peek.upcase %></p>
+  <Fallback>
+    <p id="card" class="pulse">Looking up <%= @hint %> now</p>
+  </Fallback>
+</Fragment>
+options: {mode: "client"}
+---
+_buf = ::String.new; @_herb_covered ||= {} ; _herb_occurrence = ((@_herb_region_occurrences ||= ::Hash.new(0))["app/views/test.html.erb"] += 1) - 1; _buf << '<!--herb-region:app/views/test.html.erb:22caf89f:'.freeze; _buf << (_herb_occurrence).to_s; _buf << '-->
+'.freeze; ; peek = "basel" ; _buf << '<input value="'.freeze; _buf << ::Herb::Engine.attr((peek)); _buf << '" data-herb-slot="0:attribute:value">
+<!--herb-slot:1:conditional-->'.freeze; if true; _buf << '<!--herb-branch:1:0-->
+  <p id="card">located <!--herb-slot:2-->'.freeze; _buf << (peek.upcase).to_s; _buf << '<!--/herb-slot:2--></p>
+  
+'.freeze; end ; _buf << '<!--/herb-slot:1-->
+<!--/herb-region:app/views/test.html.erb-->'.freeze; unless @_herb_covered["app/views/test.html.erb:1:0"] && @_herb_covered["app/views/test.html.erb:1:1"]; _buf << '<template data-herb-region="app/views/test.html.erb:22caf89f">'.freeze; unless @_herb_covered["app/views/test.html.erb:1:0"]; _buf << '<!--herb-branch:1:0-->
+  <p id="card">located <!--herb-slot:2--><!--/herb-slot:2--></p>
+  
+'.freeze; @_herb_covered["app/views/test.html.erb:1:0"] = true ; end; unless @_herb_covered["app/views/test.html.erb:1:1"]; _buf << '<!--herb-branch:1:1-->
+    <p id="card" class="pulse">Looking up '.freeze; _buf << (@hint).to_s; _buf << ' now</p>
+  '.freeze;   @_herb_covered["app/views/test.html.erb:1:1"] = true ; end; _buf << '</template>'.freeze; end; ::Herb::Engine::Slots::Manifest::Channel.record("app/views/test.html.erb:22caf89f", "{\"file\":\"app\\/views\\/test.html.erb\",\"identifier\":\"app\\/views\\/test.html.erb\",\"version\":\"22caf89f\",\"names\":{},\"parts\":{},\"states\":{\"version\":\"22caf89f\",\"declarations\":[{\"name\":\"peek\",\"kind\":\"string\",\"default\":\"\\\"basel\\\"\",\"derived\":null,\"line\":2,\"column\":16,\"scope\":\"region\",\"value\":\"basel\"}],\"reads\":{\"peek\":[0]},\"conditionals\":{},\"presence\":{},\"computed\":{},\"server\":{\"branches\":{},\"reads\":{\"peek\":[{\"index\":2,\"node_path\":[6,1,1]}]}},\"fragments\":{\"1\":{\"fallback\":1,\"reads\":[2]}}}}");
+_buf.to_s

--- a/test/snapshots/engine/slots/components_test/test_0003_the_rendered_page_shows_the_primary_and_parks_the_fallback_with_its_ERB_evaluated_a04680cbd4d1140c029db6eb996db5cf.txt
+++ b/test/snapshots/engine/slots/components_test/test_0003_the_rendered_page_shows_the_primary_and_parks_the_fallback_with_its_ERB_evaluated_a04680cbd4d1140c029db6eb996db5cf.txt
@@ -1,0 +1,16 @@
+---
+source: "Engine::Slots::ComponentsTest#test_0003_the rendered page shows the primary and parks the fallback with its ERB evaluated"
+input: "{source: \"<%# herb:slots client %>\\n<%# herb:state (peek: \\\"basel\\\") %>\\n<input value=\\\"<%= peek %>\\\">\\n<Fragment>\\n  <p id=\\\"card\\\">located <%= peek.upcase %></p>\\n  <Fallback>\\n    <p id=\\\"card\\\" class=\\\"pulse\\\">Looking up <%= @hint %> now</p>\\n  </Fallback>\\n</Fragment>\\n\", locals: {\"@hint\" => \"Basel\"}, options: {visitors: [#<Herb::Engine::Slots::Visitor client fatal=false>], filename: \"app/views/test.html.erb\"}}"
+---
+<!--herb-region:app/views/test.html.erb:22caf89f:0-->
+<input value="basel" data-herb-slot="0:attribute:value">
+<!--herb-slot:1:conditional--><!--herb-branch:1:0-->
+  <p id="card">located <!--herb-slot:2-->BASEL<!--/herb-slot:2--></p>
+  
+<!--/herb-slot:1-->
+<!--/herb-region:app/views/test.html.erb--><template data-herb-region="app/views/test.html.erb:22caf89f"><!--herb-branch:1:0-->
+  <p id="card">located <!--herb-slot:2--><!--/herb-slot:2--></p>
+  
+<!--herb-branch:1:1-->
+    <p id="card" class="pulse">Looking up Basel now</p>
+  </template>


### PR DESCRIPTION
This pull request introduces compile-time components to `herb:slots` templates, starting with `<Fragment>` and `<Fallback>`, a Suspense-like pair for server-derived content.

A server-derived expression inside a slots template refreshes one steered refetch behind a state write, and the stale window shows the old value until the response lands. A template can now declare what that window should look like.

```erb
<Fragment>
  <p id="card"><%= Geo.locate(peek) %></p>

  <Fallback>
    <p id="card" class="h-11 w-96 animate-pulse rounded bg-gray-200"></p>
  </Fallback>
</Fragment>
```

The instant a state write invalidates a server read inside the fragment, the client swaps the fragment to the fallback markup. The refetch response swaps the primary back in with the fresh values.