### PR TITLE
Engine: Introduce deferred `<Async>` and `<Lazy>` built-in components

### DIFF
--- a/javascript/packages/client/src/slots/region-index.ts
+++ b/javascript/packages/client/src/slots/region-index.ts
@@ -389,11 +389,15 @@ export class RegionIndex {
     const range: RegionRange = { start: comment, end: null }
     const existing = this.held.find((candidate) => candidate.file === marker.file && candidate.occurrence === marker.occurrence && candidate.version === marker.version)
 
-    if (existing) {
+    if (existing && existing.ranges.some((candidate) => candidate.start.isConnected)) {
       existing.ranges.push(range)
       state.openRegions.push({ region: existing, range })
 
       return
+    }
+
+    if (existing) {
+      this.held = this.held.filter((candidate) => candidate !== existing)
     }
 
     const region: Region = {

--- a/javascript/packages/client/src/state/fragments.ts
+++ b/javascript/packages/client/src/state/fragments.ts
@@ -1,0 +1,274 @@
+import { scopeOf } from "./scopes"
+import { hostOf } from "../markup/anchors"
+
+import type { Slots } from "../slots/slots"
+import type { RefreshReport } from "./refresh"
+import type { Region, Slot } from "../types"
+import type { FragmentEntry, PlacedSlot, StateManifest, StateScope } from "./types"
+
+const FRAGMENT_DELAY = 150
+const FRAGMENT_HOLD = 300
+
+interface FragmentPresentation {
+  fallback: number
+  hold: number
+  deferred: boolean
+  shownAt: number
+  showTimer: ReturnType<typeof setTimeout> | null
+  restoreTimer: ReturnType<typeof setTimeout> | null
+}
+
+export interface FragmentsDelegate {
+  manifestFor(region: Region): StateManifest | null
+  placedSlots(scope: StateScope, index: number): PlacedSlot[]
+  writeInternal(name: string, scope: StateScope): void
+  requestRefetch(): void
+  resettle(slot: Slot): void
+}
+
+export class Fragments {
+  private readonly slots: Slots
+  private readonly delegate: FragmentsDelegate
+  private readonly showing = new Map<Slot, FragmentPresentation>()
+  private readonly armed = new Set<Slot>()
+  private readonly observers = new Map<Slot, IntersectionObserver>()
+
+  constructor(slots: Slots, delegate: FragmentsDelegate) {
+    this.slots = slots
+    this.delegate = delegate
+  }
+
+  showFallbacks(manifest: StateManifest, scope: StateScope, stale: Set<number>, names: string[] = []): void {
+    const entries = Object.entries(manifest.fragments ?? {}).sort(([left], [right]) => Number(left) - Number(right))
+
+    for (const [key, fragment] of entries) {
+      if (!fragment.reads?.some((index) => stale.has(index))) {
+        continue
+      }
+
+      if (fragment.on && !fragment.on.some((name) => names.includes(name))) {
+        continue
+      }
+
+      for (const placed of this.delegate.placedSlots(scope, Number(key))) {
+        this.present(placed.slot, fragment)
+      }
+    }
+  }
+
+  settle(outcome: RefreshReport): void {
+    if (outcome.stale) {
+      return
+    }
+
+    for (const [slot, presentation] of this.showing) {
+      if (presentation.restoreTimer !== null) {
+        continue
+      }
+
+      if (presentation.showTimer !== null) {
+        clearTimeout(presentation.showTimer)
+
+        presentation.showTimer = null
+      }
+
+      if (presentation.shownAt === 0 || outcome.failed) {
+        this.showing.delete(slot)
+
+        continue
+      }
+
+      const remaining = presentation.shownAt + presentation.hold - Date.now()
+
+      if (slot.branch === presentation.fallback) {
+        if (!presentation.deferred) {
+          this.showing.delete(slot)
+
+          continue
+        }
+
+        presentation.restoreTimer = setTimeout(() => {
+          this.showing.delete(slot)
+          this.delegate.resettle(slot)
+        }, Math.max(remaining, 0))
+
+        continue
+      }
+
+      if (remaining <= 0) {
+        this.showing.delete(slot)
+
+        continue
+      }
+
+      const restored = slot.branch
+
+      presentation.restoreTimer = setTimeout(() => {
+        this.showing.delete(slot)
+
+        if (slot.branch === presentation.fallback) {
+          this.slots.switchBranch(slot, restored)
+        }
+      }, remaining)
+
+      this.slots.switchBranch(slot, presentation.fallback)
+    }
+  }
+
+  holding(slot: Slot): boolean {
+    return (this.showing.get(slot)?.shownAt ?? 0) > 0
+  }
+
+  hydrated(): void {
+    for (const region of this.slots.regions()) {
+      const fragments = this.delegate.manifestFor(region)?.fragments
+
+      if (!fragments) {
+        continue
+      }
+
+      const scope = scopeOf(region)
+
+      for (const [key, entry] of Object.entries(fragments)) {
+        if (!entry.mode || !entry.state) {
+          continue
+        }
+
+        for (const placed of this.delegate.placedSlots(scope, Number(key))) {
+          this.arm(placed.slot, entry, placed.scope)
+        }
+      }
+    }
+  }
+
+  disconnect(): void {
+    for (const presentation of this.showing.values()) {
+      if (presentation.showTimer !== null) {
+        clearTimeout(presentation.showTimer)
+      }
+
+      if (presentation.restoreTimer !== null) {
+        clearTimeout(presentation.restoreTimer)
+      }
+    }
+
+    this.showing.clear()
+
+    for (const observer of this.observers.values()) {
+      observer.disconnect()
+    }
+
+    this.observers.clear()
+    this.armed.clear()
+  }
+
+  private present(slot: Slot, fragment: FragmentEntry): void {
+    const existing = this.showing.get(slot)
+
+    if (existing) {
+      if (existing.restoreTimer !== null) {
+        clearTimeout(existing.restoreTimer)
+
+        existing.restoreTimer = null
+      }
+
+      return
+    }
+
+    const presentation: FragmentPresentation = {
+      fallback: fragment.fallback,
+      hold: fragment.hold ?? FRAGMENT_HOLD,
+      deferred: Boolean(fragment.mode),
+      shownAt: 0,
+      showTimer: null,
+      restoreTimer: null,
+    }
+
+    this.showing.set(slot, presentation)
+
+    const delay = fragment.delay ?? FRAGMENT_DELAY
+
+    if (delay <= 0) {
+      this.swapToFallback(slot, presentation)
+
+      return
+    }
+
+    presentation.showTimer = setTimeout(() => {
+      presentation.showTimer = null
+
+      this.swapToFallback(slot, presentation)
+    }, delay)
+  }
+
+  private swapToFallback(slot: Slot, presentation: FragmentPresentation): void {
+    presentation.shownAt = Date.now()
+
+    if (slot.branch !== presentation.fallback) {
+      this.slots.switchBranch(slot, presentation.fallback)
+    }
+  }
+
+  private arm(slot: Slot, entry: FragmentEntry, scope: StateScope): void {
+    if (this.armed.has(slot)) {
+      return
+    }
+
+    this.armed.add(slot)
+
+    if (slot.branch !== entry.fallback) {
+      return
+    }
+
+    const state = entry.state as string
+
+    if (entry.mode === "async" || typeof IntersectionObserver === "undefined") {
+      this.present(slot, entry)
+      this.delegate.writeInternal(state, scope)
+      this.delegate.requestRefetch()
+
+      return
+    }
+
+    const sentinel = this.sentinelFor(slot)
+
+    if (!sentinel) {
+      this.delegate.writeInternal(state, scope)
+
+      return
+    }
+
+    const observer = new IntersectionObserver((entries) => {
+      if (!entries.some((entry) => entry.isIntersecting)) {
+        return
+      }
+
+      observer.disconnect()
+      this.observers.delete(slot)
+      this.present(slot, entry)
+      this.delegate.writeInternal(state, scope)
+      this.delegate.requestRefetch()
+    })
+
+    observer.observe(sentinel)
+    this.observers.set(slot, observer)
+  }
+
+  private sentinelFor(slot: Slot): Element | null {
+    const anchor = slot.anchor
+
+    if (anchor.kind === "range") {
+      let node: Node | null = anchor.start.nextSibling
+
+      while (node && node !== anchor.end) {
+        if (node instanceof Element) {
+          return node
+        }
+
+        node = node.nextSibling
+      }
+    }
+
+    return hostOf(anchor)
+  }
+}

--- a/javascript/packages/client/src/state/state.ts
+++ b/javascript/packages/client/src/state/state.ts
@@ -4,7 +4,7 @@ import { DEPENDENCIES_SELECTOR } from "../grammar/attributes"
 import { Seeds } from "./seeds"
 import { Counts } from "./counts"
 import { Refresh } from "./refresh"
-import { armMutationRefresh } from "../shared/mutation-refresh"
+import { Fragments } from "./fragments"
 import { ServerState } from "./server"
 import { BoundInputs } from "./bound-inputs"
 import { ElementObserver } from "../shared/element-observer"
@@ -12,6 +12,7 @@ import { ElementObserver } from "../shared/element-observer"
 import { report } from "../shared/report"
 import { printValue } from "./values"
 import { elementOf, hostOf } from "../markup/anchors"
+import { armMutationRefresh } from "../shared/mutation-refresh"
 import { armOf, evaluate, matches, mentions } from "./conditions"
 import { collectionIn, scopeOf, scoped } from "./scopes"
 import { declarationSpot, declared, declaredValue } from "./declarations"
@@ -21,24 +22,13 @@ import type { Conditional } from "./types"
 import type { RefreshReport } from "./refresh"
 import type { StateKind, StateValue } from "./values"
 import type { Built, Item, Region, Slot } from "../types"
-import type { CountOptions, DeclaredState, DependencyMap, FragmentEntry, PlacedSlot, ResolvedStateOptions, ScopeStore, ScopedSetOptions, SerializedState, StateChange, StateChangeDetail, StateListener, StateManifest, StateOptions, StateReport, StateScope, StateSlot, StateSnapshot, StateValues } from "./types"
+import type { CountOptions, DeclaredState, DependencyMap, PlacedSlot, ResolvedStateOptions, ScopeStore, ScopedSetOptions, SerializedState, StateChange, StateChangeDetail, StateListener, StateManifest, StateOptions, StateReport, StateScope, StateSlot, StateSnapshot, StateValues } from "./types"
 
 import type { SlotsDelegate } from "../types"
 import type { SeedsDelegate } from "./seeds"
 import type { CountsDelegate } from "./counts"
 import type { BoundInputsDelegate } from "./bound-inputs"
 import type { ElementObserverDelegate } from "../shared/element-observer"
-
-const FRAGMENT_DELAY = 150
-const FRAGMENT_HOLD = 300
-
-interface FragmentPresentation {
-  fallback: number
-  hold: number
-  shownAt: number
-  showTimer: ReturnType<typeof setTimeout> | null
-  restoreTimer: ReturnType<typeof setTimeout> | null
-}
 
 export class State implements ElementObserverDelegate, SlotsDelegate, SeedsDelegate, BoundInputsDelegate, CountsDelegate {
   private readonly slots: Slots
@@ -50,7 +40,7 @@ export class State implements ElementObserverDelegate, SlotsDelegate, SeedsDeleg
   private readonly counts: Counts
   private readonly bound = new BoundInputs(this)
   private readonly options: ResolvedStateOptions
-  private readonly fallbacksShowing = new Map<Slot, FragmentPresentation>()
+  private readonly fragments: Fragments
 
   private elements: ElementObserver | null = null
   private unobserveElements: (() => void) | null = null
@@ -75,6 +65,13 @@ export class State implements ElementObserverDelegate, SlotsDelegate, SeedsDeleg
       manifestFor: (region) => this.manifestFor(region),
       steeringValue: (region, name) => this.valueAt(name, scopeOf(region)),
     }, { transport: this.options.refetchTransport, format: this.options.format })
+    this.fragments = new Fragments(slots, {
+      manifestFor: (region) => this.manifestFor(region),
+      placedSlots: (scope, index) => this.placedSlots(scope, index),
+      writeInternal: (name, scope) => void this.setState({ [name]: true }, { scope }),
+      requestRefetch: () => void this.refetch.request(this.options.refetchDebounce).then((outcome) => this.fragments.settle(outcome)),
+      resettle: (slot) => this.settleBranch(slot),
+    })
     this.disarmMutationRefresh = armMutationRefresh(() => this.refreshAfterMutation())
     this.unsubscribe = slots.subscribe(this)
   }
@@ -109,6 +106,7 @@ export class State implements ElementObserverDelegate, SlotsDelegate, SeedsDeleg
 
   built(built: Built): void {
     this.settle(built)
+    this.fragments.hydrated()
   }
 
   branchMaterial(slot: Slot): void {
@@ -203,6 +201,10 @@ export class State implements ElementObserverDelegate, SlotsDelegate, SeedsDeleg
       template.remove()
     }
 
+    if (templates.length > 0) {
+      this.fragments.hydrated()
+    }
+
     return templates.length
   }
 
@@ -248,18 +250,7 @@ export class State implements ElementObserverDelegate, SlotsDelegate, SeedsDeleg
     this.disarmMutationRefresh?.()
     this.disarmMutationRefresh = null
     this.refetch.stop()
-
-    for (const presentation of this.fallbacksShowing.values()) {
-      if (presentation.showTimer !== null) {
-        clearTimeout(presentation.showTimer)
-      }
-
-      if (presentation.restoreTimer !== null) {
-        clearTimeout(presentation.restoreTimer)
-      }
-    }
-
-    this.fallbacksShowing.clear()
+    this.fragments.disconnect()
 
     if (typeof document === "undefined") {
       return
@@ -577,117 +568,9 @@ export class State implements ElementObserverDelegate, SlotsDelegate, SeedsDeleg
       return
     }
 
-    this.showFallbacks(manifest, scope, stale, names)
+    this.fragments.showFallbacks(manifest, scope, stale, names)
 
-    void this.refetch.request(this.options.refetchDebounce).then((outcome) => this.settleFallbacks(outcome))
-  }
-
-  private showFallbacks(manifest: StateManifest, scope: StateScope, stale: Set<number>, names: string[]): void {
-    const entries = Object.entries(manifest.fragments ?? {}).sort(([left], [right]) => Number(left) - Number(right))
-
-    for (const [key, fragment] of entries) {
-      if (!fragment.reads.some((index) => stale.has(index))) {
-        continue
-      }
-
-      if (fragment.on && !fragment.on.some((name) => names.includes(name))) {
-        continue
-      }
-
-      for (const placed of this.placedSlots(scope, Number(key))) {
-        this.presentFallback(placed.slot, fragment)
-      }
-    }
-  }
-
-  private presentFallback(slot: Slot, fragment: FragmentEntry): void {
-    const existing = this.fallbacksShowing.get(slot)
-
-    if (existing) {
-      if (existing.restoreTimer !== null) {
-        clearTimeout(existing.restoreTimer)
-
-        existing.restoreTimer = null
-      }
-
-      return
-    }
-
-    const presentation: FragmentPresentation = {
-      fallback: fragment.fallback,
-      hold: fragment.hold ?? FRAGMENT_HOLD,
-      shownAt: 0,
-      showTimer: null,
-      restoreTimer: null,
-    }
-
-    this.fallbacksShowing.set(slot, presentation)
-
-    const delay = fragment.delay ?? FRAGMENT_DELAY
-
-    if (delay <= 0) {
-      this.swapToFallback(slot, presentation)
-
-      return
-    }
-
-    presentation.showTimer = setTimeout(() => {
-      presentation.showTimer = null
-
-      this.swapToFallback(slot, presentation)
-    }, delay)
-  }
-
-  private swapToFallback(slot: Slot, presentation: FragmentPresentation): void {
-    if (slot.branch !== presentation.fallback) {
-      this.slots.switchBranch(slot, presentation.fallback)
-    }
-
-    presentation.shownAt = Date.now()
-  }
-
-  private settleFallbacks(outcome: RefreshReport): void {
-    if (outcome.stale) {
-      return
-    }
-
-    for (const [slot, presentation] of [...this.fallbacksShowing]) {
-      if (presentation.restoreTimer !== null) {
-        continue
-      }
-
-      if (presentation.showTimer !== null) {
-        clearTimeout(presentation.showTimer)
-
-        presentation.showTimer = null
-      }
-
-      if (presentation.shownAt === 0 || outcome.failed || slot.branch === presentation.fallback) {
-        this.fallbacksShowing.delete(slot)
-
-        continue
-      }
-
-      const remaining = presentation.shownAt + presentation.hold - Date.now()
-
-      if (remaining <= 0) {
-        this.fallbacksShowing.delete(slot)
-
-        continue
-      }
-
-      const restored = slot.branch
-
-      this.slots.switchBranch(slot, presentation.fallback)
-
-      presentation.restoreTimer = setTimeout(() => {
-        this.fallbacksShowing.delete(slot)
-
-        if (slot.branch === presentation.fallback) {
-          this.slots.switchBranch(slot, restored)
-        }
-      }, remaining)
-    }
+    void this.refetch.request(this.options.refetchDebounce).then((outcome) => this.fragments.settle(outcome))
   }
 
   toggle(name: string, options: ScopedSetOptions = {}): boolean {
@@ -1006,13 +889,18 @@ export class State implements ElementObserverDelegate, SlotsDelegate, SeedsDeleg
 
       for (const placed of this.placedSlots(scope, Number(indexKey))) {
         const slot = placed.slot
+
+        if (this.fragments.holding(slot)) {
+          continue
+        }
+
         const target = this.targetBranch(conditional, placed.scope)
 
         this.slots.claim(slot)
 
         if (!this.slots.switchBranch(slot, target) && slot.branch !== target) {
           if (this.options.refetch !== "off") {
-            void this.refetch.request(this.options.refetchDebounce)
+            void this.refetch.request(this.options.refetchDebounce).then((outcome) => this.fragments.settle(outcome))
 
             continue
           }

--- a/javascript/packages/client/src/state/types.ts
+++ b/javascript/packages/client/src/state/types.ts
@@ -84,9 +84,11 @@ export interface StateManifest {
 
 export interface FragmentEntry {
   fallback: number
-  reads: number[]
+  reads?: number[]
   delay?: number
   hold?: number
+  mode?: "lazy" | "async"
+  state?: string
   on?: string[]
 }
 

--- a/javascript/packages/client/test/deferred.test.ts
+++ b/javascript/packages/client/test/deferred.test.ts
@@ -1,0 +1,247 @@
+import { describe, test, expect, afterEach, vi } from "vitest"
+
+import { Runtime } from "../src/runtime"
+
+import type { Payload } from "../src/types"
+
+const FILE = "app/views/chat/deferred.html.erb"
+
+function deferredPage(mode: "lazy" | "async", spacer = ""): string {
+  return (
+    spacer +
+    `<!--herb-region:${FILE}:aaaaaaaa:0-->` +
+    `<div><!--herb-slot:0:conditional--><!--herb-branch:0:1--><p class="pulse">loading stats</p><!--/herb-slot:0--></div>` +
+    `<!--/herb-region:${FILE}-->` +
+    `<template data-herb-dependencies>${JSON.stringify({
+      state: {},
+      states: {
+        [FILE]: {
+          version: "aaaaaaaa",
+          declarations: [{ name: "_herb_block_0", kind: "boolean", default: "false", value: false, scope: "region", internal: true }],
+          reads: {},
+          conditionals: { 0: { arms: [{ branch: 0, condition: ["_herb_block_0", null] }], else: 1 } },
+          presence: {},
+          computed: {},
+          server: { branches: { 0: [{ index: 1, node_path: [1, 0] }] }, reads: {} },
+          fragments: { 0: { mode, state: "_herb_block_0", fallback: 1 } },
+        },
+      },
+    })}</template>`
+  )
+}
+
+const PRIMARY: Payload = {
+  template: FILE,
+  version: "aaaaaaaa",
+  occurrence: 0,
+  slots: {
+    0: { branch: 0, statics: `<!--herb-branch:0:0--><p id="stats"><!--herb-slot:1--><!--/herb-slot:1--></p>`, slots: { 1: "42 things" } },
+  },
+}
+
+let runtime: Runtime | null = null
+
+function start(options: Parameters<typeof Runtime.start>[0] = {}): Runtime {
+  runtime = Runtime.start(options)
+
+  return runtime
+}
+
+afterEach(() => {
+  runtime?.stop()
+  runtime = null
+  document.body.innerHTML = ""
+})
+
+describe("deferred blocks", () => {
+  test("an async block requests once on mount, steered, and materializes the primary", async () => {
+    document.body.innerHTML = deferredPage("async")
+
+    const calls: Array<Record<string, Record<string, unknown>>> = []
+    const transport = vi.fn(async (state: Record<string, Record<string, unknown>>, _signal?: AbortSignal, _block?: unknown) => {
+      calls.push(state)
+
+      return PRIMARY
+    })
+
+    start({ state: { refetchTransport: transport, refetchDebounce: 0 } })
+
+    expect(document.body.innerHTML).toContain("loading stats")
+
+    await vi.waitFor(() => {
+      if (!document.body.innerHTML.includes("42 things")) {
+        throw new Error("still waiting")
+      }
+    })
+
+    expect(transport).toHaveBeenCalledTimes(1)
+    expect(calls[0][FILE]._herb_block_0).toBe(true)
+    expect(document.body.innerHTML).not.toContain("loading stats")
+  })
+
+  test("a deferred block re-requests when its page comes back", async () => {
+    const page = deferredPage("async")
+
+    document.body.innerHTML = page
+
+    const transport = vi.fn(async () => PRIMARY)
+
+    start({ state: { refetchTransport: transport, refetchDebounce: 0 } })
+
+    await vi.waitFor(() => {
+      if (!document.body.innerHTML.includes("42 things")) {
+        throw new Error("still waiting")
+      }
+    })
+
+    document.body.innerHTML = "<p>another page</p>"
+
+    await new Promise((resolve) => setTimeout(resolve, 20))
+
+    document.body.innerHTML = page
+
+    expect(document.body.innerHTML).toContain("loading stats")
+
+    await vi.waitFor(() => {
+      if (!document.body.innerHTML.includes("42 things")) {
+        throw new Error("still waiting")
+      }
+    })
+
+    expect(transport).toHaveBeenCalledTimes(2)
+  })
+
+  test("a lazy block waits for the viewport and then materializes", async () => {
+    document.body.innerHTML = deferredPage("lazy", `<div id="spacer" style="height:3000px"></div>`)
+
+    const transport = vi.fn(async () => PRIMARY)
+
+    start({ state: { refetchTransport: transport, refetchDebounce: 0 } })
+
+    await new Promise((resolve) => setTimeout(resolve, 100))
+
+    expect(transport).not.toHaveBeenCalled()
+    expect(document.body.innerHTML).toContain("loading stats")
+
+    document.querySelector(".pulse")?.scrollIntoView()
+
+    await vi.waitFor(() => {
+      if (!document.body.innerHTML.includes("42 things")) {
+        throw new Error("still waiting")
+      }
+    })
+
+    expect(transport).toHaveBeenCalledTimes(1)
+  })
+
+  test("a lazy block inside a hidden container waits for it to show", async () => {
+    document.body.innerHTML = `<div id="wrap" hidden>${deferredPage("lazy")}</div>`
+
+    const calls: Array<Record<string, Record<string, unknown>>> = []
+    const transport = vi.fn(async (state: Record<string, Record<string, unknown>>) => {
+      calls.push(state)
+
+      return PRIMARY
+    })
+
+    start({ state: { refetchTransport: transport, refetchDebounce: 0 } })
+
+    await new Promise((resolve) => setTimeout(resolve, 100))
+
+    expect(transport).not.toHaveBeenCalled()
+
+    document.getElementById("wrap")!.hidden = false
+
+    await vi.waitFor(() => {
+      if (!document.body.innerHTML.includes("42 things")) {
+        throw new Error("still waiting")
+      }
+    })
+
+    expect(calls[0][FILE]._herb_block_0).toBe(true)
+  })
+
+  test("`hold` keeps the skeleton up when the block request lands fast", async () => {
+    document.body.innerHTML =
+      `<div id="wrap" hidden>` +
+      `<!--herb-region:${FILE}:aaaaaaaa:0-->` +
+      `<div><!--herb-slot:0:conditional--><!--herb-branch:0:1--><p class="pulse">loading stats</p><!--/herb-slot:0--></div>` +
+      `<!--/herb-region:${FILE}-->` +
+      `<template data-herb-dependencies>${JSON.stringify({
+        state: {},
+        states: {
+          [FILE]: {
+            version: "aaaaaaaa",
+            declarations: [
+              { name: "q", kind: "string", default: '""', scope: "region" },
+              { name: "_herb_block_0", kind: "boolean", default: "false", value: false, scope: "region", internal: true },
+            ],
+            reads: {},
+            conditionals: { 0: { arms: [{ branch: 0, condition: ["_herb_block_0", null] }], else: 1 } },
+            presence: {},
+            computed: {},
+            server: { branches: {}, reads: { q: [{ index: 1, node_path: [1, 0] }] } },
+            fragments: { 0: { mode: "lazy", state: "_herb_block_0", fallback: 1, reads: [1], delay: 0, hold: 200 } },
+          },
+        },
+      })}</template>` +
+      `</div>`
+
+    const calls: Array<Record<string, Record<string, unknown>>> = []
+    const transport = vi.fn(async (state: Record<string, Record<string, unknown>>) => {
+      calls.push(state)
+
+      if (state[FILE]?._herb_block_0 === true) {
+        return PRIMARY
+      }
+
+      return { template: FILE, version: "aaaaaaaa", occurrence: 0, slots: { 0: { branch: 1, slots: {} } } }
+    })
+
+    const live = start({ state: { refetchTransport: transport, refetchDebounce: 30 } })
+
+    await new Promise((resolve) => setTimeout(resolve, 80))
+
+    expect(transport).not.toHaveBeenCalled()
+
+    live.state.setState({ q: "x" })
+    document.getElementById("wrap")!.hidden = false
+
+    await vi.waitFor(() => {
+      if (transport.mock.calls.length === 0) {
+        throw new Error("still waiting")
+      }
+    })
+
+    await new Promise((resolve) => setTimeout(resolve, 40))
+
+    expect(document.body.innerHTML).toContain("loading stats")
+    expect(document.body.innerHTML).not.toContain("42 things")
+
+    await vi.waitFor(() => {
+      if (!document.body.innerHTML.includes("42 things")) {
+        throw new Error("still waiting")
+      }
+    })
+
+    expect(calls[calls.length - 1][FILE]._herb_block_0).toBe(true)
+  })
+
+  test("a refetch before the trigger keeps the fallback", async () => {
+    document.body.innerHTML = deferredPage("lazy", `<div id="spacer" style="height:3000px"></div>`)
+
+    const transport = vi.fn(async () => ({
+      template: FILE,
+      version: "aaaaaaaa",
+      occurrence: 0,
+      slots: { 0: { branch: 1, slots: {} } },
+    }))
+
+    const live = start({ state: { refetchTransport: transport, refetchDebounce: 0 } })
+
+    await live.refresh()
+
+    expect(document.body.innerHTML).toContain("loading stats")
+    expect(document.body.innerHTML).not.toContain("42 things")
+  })
+})

--- a/javascript/packages/client/test/hover-cycle.test.ts
+++ b/javascript/packages/client/test/hover-cycle.test.ts
@@ -1,0 +1,76 @@
+import { test, expect, afterEach, vi } from "vitest"
+
+import { Runtime } from "../src/runtime"
+
+import type { Payload } from "../src/types"
+
+const FILE = "app/views/test.html.erb"
+const PAGE = "<!--herb-region:app/views/test.html.erb:64993c84:0-->\n<span data-herb-set=\"mouseenter->peek='basel'\">basel</span>\n<!--herb-slot:0:conditional--><!--/herb-slot:0-->\n<!--/herb-region:app/views/test.html.erb--><template data-herb-region=\"app/views/test.html.erb:64993c84\"><!--herb-branch:0:0-->\n  <p id=\"card\">\n    <!--herb-slot:1:conditional--><!--/herb-slot:1-->\n  </p>\n<!--herb-branch:1:1--><span class=\"skel\">skeleton</span></template>" + `<template data-herb-dependencies>${JSON.stringify({ state: {}, states: { [FILE]: {"version": "64993c84", "declarations": [{"name": "peek", "kind": "string", "default": "\"\"", "derived": null, "line": 2, "column": 16, "scope": "region", "value": ""}, {"name": "_herb_block_0", "kind": "boolean", "default": "false", "derived": null, "line": null, "column": null, "scope": "region", "value": false, "internal": true}], "reads": {}, "conditionals": {"0": {"arms": [{"branch": 0, "condition": ["peek", null, "present"]}], "else": null}, "1": {"arms": [{"branch": 0, "condition": ["_herb_block_0", null]}], "else": 1}}, "presence": {}, "computed": {}, "server": {"branches": {"0": [{"index": 2, "node_path": [6, 1, 2, 1]}]}, "reads": {"peek": [{"index": 2, "node_path": [6, 1, 2, 1]}]}}, "fragments": {"1": {"mode": "lazy", "state": "_herb_block_0", "fallback": 1, "reads": [2], "delay": 0, "hold": 80}}} } })}</template>`
+const PAYLOADS = {":false": {"template": "app/views/test.html.erb", "version": "64993c84", "occurrence": 0, "slots": {"0": {"branch": null}}}, "basel:false": {"template": "app/views/test.html.erb", "version": "64993c84", "occurrence": 0, "slots": {"0": {"branch": 0, "slots": {"1": {"branch": 1, "slots": {}}}}}}, "basel:true": {"template": "app/views/test.html.erb", "version": "64993c84", "occurrence": 0, "slots": {"0": {"branch": 0, "slots": {"1": {"branch": 0, "statics": "<!--herb-branch:1:0-->\n      <!--herb-slot:2--><!--/herb-slot:2-->\n      \n    ", "slots": {"2": "located basel"}}}}}}, "zurich:true": {"template": "app/views/test.html.erb", "version": "64993c84", "occurrence": 0, "slots": {"0": {"branch": 0, "slots": {"1": {"branch": 0, "statics": "<!--herb-branch:1:0-->\n      <!--herb-slot:2--><!--/herb-slot:2-->\n      \n    ", "slots": {"2": "located zurich"}}}}}}} as unknown as Record<string, Payload>
+
+let runtime: Runtime | null = null
+
+afterEach(() => {
+  runtime?.stop()
+  runtime = null
+  document.body.innerHTML = ""
+})
+
+test("subsequent hovers never repaint the previous text", async () => {
+  document.body.innerHTML = PAGE
+
+  const transport = vi.fn(async (state: Record<string, Record<string, unknown>>) => {
+    await new Promise((resolve) => setTimeout(resolve, 30))
+
+    const peek = String(state[FILE]?.peek ?? "")
+    const block = state[FILE]?._herb_block_0 === true
+
+    return PAYLOADS[`${peek}:${block}`] ?? PAYLOADS[":false"]
+  })
+
+  runtime = Runtime.start({ state: { refetchTransport: transport, refetchDebounce: 10 } })
+  const live = runtime
+  const seen: string[] = []
+
+  const classify = () => {
+    const html = document.body.innerHTML
+    if (html.includes("located basel")) return "basel"
+    if (html.includes("located zurich")) return "zurich"
+    if (html.includes("skeleton")) return "skeleton"
+    return "empty"
+  }
+
+  const observer = new MutationObserver(() => {
+    const state = classify()
+    if (seen[seen.length - 1] !== state) seen.push(state)
+  })
+
+  observer.observe(document.body, { childList: true, subtree: true, characterData: true })
+
+  live.state.setState({ peek: "basel" })
+
+  await vi.waitFor(() => {
+    if (!document.body.innerHTML.includes("located basel")) throw new Error("waiting")
+  })
+
+  await new Promise((resolve) => setTimeout(resolve, 150))
+
+  live.state.setState({ peek: "" })
+
+  await new Promise((resolve) => setTimeout(resolve, 100))
+
+  const before = seen.length
+  live.state.setState({ peek: "zurich" })
+
+  await vi.waitFor(() => {
+    if (!document.body.innerHTML.includes("located zurich")) throw new Error("waiting")
+  })
+
+  await new Promise((resolve) => setTimeout(resolve, 150))
+  observer.disconnect()
+
+  console.log("[dbg] full:", JSON.stringify(seen))
+  console.log("[dbg] rehover:", JSON.stringify(seen.slice(before)))
+
+  expect(seen.slice(before)).not.toContain("basel")
+})

--- a/lib/herb/engine/slots/components.rb
+++ b/lib/herb/engine/slots/components.rb
@@ -4,6 +4,9 @@
 require_relative "components/base"
 require_relative "components/fragment"
 require_relative "components/fallback"
+require_relative "components/deferred"
+require_relative "components/async"
+require_relative "components/lazy"
 
 module Herb
   class Engine
@@ -17,7 +20,7 @@ module Herb
       #
       module Components
         NAME = /\A[A-Z][A-Za-z0-9]*\z/ #: Regexp
-        REGISTRY = { Fragment::NAME => Fragment, Fallback::NAME => Fallback }.freeze #: Hash[String, singleton(Base)]
+        REGISTRY = { Fragment::NAME => Fragment, Fallback::NAME => Fallback, Async::NAME => Async, Lazy::NAME => Lazy }.freeze #: Hash[String, singleton(Base)]
         BUILT_IN = REGISTRY.keys.freeze #: Array[String]
 
         #: (String?) -> bool

--- a/lib/herb/engine/slots/components/async.rb
+++ b/lib/herb/engine/slots/components/async.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+# typed: true
+
+module Herb
+  class Engine
+    module Slots
+      module Components
+        # A deferred block the client requests immediately on mount, so expensive
+        # content loads in parallel with the page instead of blocking it.
+        #
+        class Async < Deferred
+          NAME = "Async" #: String
+
+          private
+
+          #: () -> String
+          def mode
+            "async"
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/herb/engine/slots/components/base.rb
+++ b/lib/herb/engine/slots/components/base.rb
@@ -50,7 +50,30 @@ module Herb
             end
           end
 
+          TIMING_ATTRIBUTES = ["delay", "hold"].freeze #: Array[String]
+
           private
+
+          #: () -> Hash[String, Integer]
+          def timing
+            timed = {} #: Hash[String, Integer]
+
+            attributes.each do |attribute|
+              name = attribute_name(attribute).to_s
+
+              next unless TIMING_ATTRIBUTES.include?(name) && allowed_attributes.include?(name)
+
+              value = static_value(attribute)
+
+              if value&.match?(/\A\d+\z/)
+                timed[name] = Integer(value, 10)
+              else
+                error("`#{name}` on a `<#{tag_name}>` takes a whole number of milliseconds.", attribute.location, suggestion: %(Write it like `#{name}="150"`.))
+              end
+            end
+
+            timed
+          end
 
           #: () -> String
           def tag_name

--- a/lib/herb/engine/slots/components/deferred.rb
+++ b/lib/herb/engine/slots/components/deferred.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+# typed: true
+
+module Herb
+  class Engine
+    module Slots
+      module Components
+        # A block whose primary content stays out of the initial response.
+        #
+        # The transform conditions the primary on an internal boolean state the
+        # client steers, so the first render shows only the `<Fallback>` and the
+        # block request is an ordinary steered refetch answering the primary
+        # branch with its statics. `Async` requests on mount and `Lazy` when the
+        # block nears the viewport.
+        #
+        class Deferred < Base
+          ATTRIBUTES = Fragment::ATTRIBUTES #: Array[String]
+
+          #: () -> Array[String]
+          def allowed_attributes
+            ATTRIBUTES
+          end
+
+          #: () -> Array[untyped]
+          def transform
+            refuse_unknown_attributes
+
+            fallbacks, primary = children.partition { |child| Components.element?(child, Fallback::NAME) }
+
+            primary = @visitor.transform_component_children(primary)
+
+            if fallbacks.size > 1
+              error("A `<#{tag_name}>` holds #{fallbacks.size} `<Fallback>` elements, and it can only stand one in.", @element.location, suggestion: "Keep one `<Fallback>` per `<#{tag_name}>`.")
+            end
+
+            fallback = fallbacks.first
+
+            Fallback.new(fallback, @visitor).refuse_unknown_attributes if fallback
+
+            state = @visitor.states.declare_internal_block
+            if_node = deferred_conditional(state, primary, fallback)
+
+            @visitor.record_deferred(if_node, mode: mode, state: state, timing: timing)
+
+            [@visitor.erb_code_node(@visitor.states.internal_assignment(state)), if_node]
+          end
+
+          private
+
+          #: () -> String
+          def mode
+            raise NotImplementedError, "#{self.class} names no mode"
+          end
+
+          #: (String, Array[untyped], untyped) -> untyped
+          def deferred_conditional(state, primary, fallback)
+            subsequent = nil
+
+            if fallback
+              subsequent = Herb::AST::ERBElseNode.build(
+                location: fallback.location,
+                tag_opening: Herb::Token.from(:erb_start, "<%"),
+                content: Herb::Token.from(:erb_content, " else "),
+                tag_closing: Herb::Token.from(:erb_end, "%>"),
+                statements: @visitor.transform_component_children(fallback.body || [])
+              )
+            end
+
+            Herb::AST::ERBIfNode.build(
+              location: @element.location,
+              tag_opening: Herb::Token.from(:erb_start, "<%"),
+              content: Herb::Token.from(:erb_content, " if #{state} "),
+              tag_closing: Herb::Token.from(:erb_end, "%>"),
+              statements: primary,
+              subsequent: subsequent,
+              end_node: Herb::AST::ERBEndNode.build(
+                location: @element.location,
+                tag_opening: Herb::Token.from(:erb_start, "<%"),
+                content: Herb::Token.from(:erb_content, " end "),
+                tag_closing: Herb::Token.from(:erb_end, "%>")
+              )
+            )
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/herb/engine/slots/components/fragment.rb
+++ b/lib/herb/engine/slots/components/fragment.rb
@@ -16,7 +16,6 @@ module Herb
         class Fragment < Base
           NAME = "Fragment" #: String
           ATTRIBUTES = ["delay", "hold", "on"].freeze #: Array[String]
-          TIMING_ATTRIBUTES = ["delay", "hold"].freeze #: Array[String]
 
           #: () -> Array[String]
           def allowed_attributes
@@ -71,27 +70,6 @@ module Herb
             end
 
             { "on" => states }
-          end
-
-          #: () -> Hash[String, Integer]
-          def timing
-            timed = {} #: Hash[String, Integer]
-
-            attributes.each do |attribute|
-              name = attribute_name(attribute).to_s
-
-              next unless TIMING_ATTRIBUTES.include?(name)
-
-              value = static_value(attribute)
-
-              if value&.match?(/\A\d+\z/)
-                timed[name] = Integer(value, 10)
-              else
-                error("`#{name}` on a `<Fragment>` takes a whole number of milliseconds.", attribute.location, suggestion: %(Write it like `#{name}="150"`.))
-              end
-            end
-
-            timed
           end
 
           #: (untyped) -> void

--- a/lib/herb/engine/slots/components/lazy.rb
+++ b/lib/herb/engine/slots/components/lazy.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+# typed: true
+
+module Herb
+  class Engine
+    module Slots
+      module Components
+        # A deferred block the client requests when it nears the viewport, and
+        # never requests for content the reader never reaches.
+        #
+        class Lazy < Deferred
+          NAME = "Lazy" #: String
+
+          private
+
+          #: () -> String
+          def mode
+            "lazy"
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/herb/engine/slots/dynamics_compiler.rb
+++ b/lib/herb/engine/slots/dynamics_compiler.rb
@@ -609,7 +609,10 @@ module Herb
 
         #: (Integer, Integer) -> String?
         def payload_statics(index, branch)
-          return nil unless @input.is_a?(String) && Visitor.directive_mode(@input) == :server
+          server = @input.is_a?(String) && Visitor.directive_mode(@input) == :server
+          withheld = branch.zero? && @slot_visitor.deferred_entries.key?(index)
+
+          return nil unless server || withheld
 
           branch_statics["#{index}:#{branch}"]
         end

--- a/lib/herb/engine/slots/state_compiler.rb
+++ b/lib/herb/engine/slots/state_compiler.rb
@@ -50,11 +50,29 @@ module Herb
           @state_presence = {} #: Hash[Integer, untyped]
           @state_values = {} #: Hash[Integer, untyped]
           @server_reads = {} #: Hash[String, Array[Hash[String, untyped]]]
+          @internal_states = {} #: Hash[String, StateDirectives::Declaration]
         end
 
         #: () -> bool
         def any?
-          !(@region_states.empty? && @item_states.empty?)
+          !(@region_states.empty? && @item_states.empty? && @internal_states.empty?)
+        end
+
+        #: () -> String
+        def declare_internal_block
+          name = "_herb_block_#{@internal_states.size}"
+
+          @internal_states[name] = StateDirectives::Declaration.new(name: name, kind: :boolean, default: "false", derived: nil, line: nil, column: nil)
+
+          name
+        end
+
+        #: (String) -> String
+        def internal_assignment(name)
+          declaration = @internal_states.fetch(name)
+          assignment = state_assignment(declaration)
+
+          @visitor.state_overrides? ? "#{overrides_prelude}; #{assignment}" : assignment
         end
 
         #: () -> Array[String]
@@ -71,12 +89,14 @@ module Herb
         #: () -> Hash[String, untyped]?
         def manifest
           declared = state_declarations
-          names = declared[:region].map { |declaration| declaration[:name] } + declared[:items].values.flatten.map { |declaration| declaration[:name] }
+          names = declared[:region].map { |declaration| declaration[:name] } + declared[:items].values.flatten.map { |declaration| declaration[:name] } + @internal_states.keys
 
           return nil if names.empty?
 
           reads = {} #: Hash[String, Array[Integer]]
           declarations = declared[:region].map { |declaration| declared_entry(declaration, "region") } + declared[:items].flat_map { |index, list| list.map { |declaration| declared_entry(declaration, index) } }
+
+          declarations += @internal_states.values.map { |declaration| declared_entry(declaration.to_h, "region").merge("internal" => true) }
 
           @visitor.slots.each do |slot|
             next unless slot.valued?
@@ -213,6 +233,12 @@ module Herb
             inside = (@visitor.slots_by_branch(index)[0] || []).select { |slot_index| refetchable.include?(slot_index) }
 
             entries[index.to_s] = { "fallback" => 1, "reads" => inside }.merge(@visitor.fragment_timing_for(index)) unless inside.empty?
+          end
+
+          @visitor.deferred_entries.each do |index, info|
+            inside = (@visitor.slots_by_branch(index)[0] || []).select { |slot_index| refetchable.include?(slot_index) }
+
+            entries[index.to_s] = { "mode" => info[:mode], "state" => info[:state], "fallback" => 1, "reads" => inside }.merge(info[:timing])
           end
 
           entries
@@ -569,7 +595,8 @@ module Herb
 
         #: (untyped) -> Hash[String, StateDirectives::Declaration]
         def states_for(scope)
-          states = scope ? @region_states.merge(@item_states[scope] || {}) : @region_states.dup
+          region = @region_states.merge(@internal_states)
+          states = scope ? region.merge(@item_states[scope] || {}) : region
           none = [] #: Array[String]
           shadowed = scope ? @visitor.block_locals(scope) : none
 
@@ -593,7 +620,7 @@ module Herb
             parent[position] = @visitor.erb_code_node(seeds ? "; #{assignments}; #{seeds}" : "; #{assignments}")
           end
 
-          if @region_states.empty? && @item_states.empty?
+          if @region_states.empty? && @item_states.empty? && @internal_states.empty?
             check_fragments
 
             return
@@ -604,6 +631,26 @@ module Herb
           check_collection_reads
           check_state_count_reads
           check_fragments
+          check_deferred_placement
+        end
+
+        #: () -> void
+        def check_deferred_placement
+          collections = @visitor.slots.select { |slot| slot.type == :collection }
+
+          @visitor.deferred_entries.each do |index, info|
+            slot = @visitor.slots[index]
+
+            next unless slot
+            next if collections.none? { |collection| slot.node_path.first(collection.node_path.length) == collection.node_path }
+
+            @visitor.slot_error(
+              "A `<#{info[:mode].capitalize}>` sits inside a collection, and a deferred block cannot stand per item yet.",
+              @visitor.slot_nodes[index]&.location,
+              :component,
+              suggestion: "Move the block outside the loop, or defer around the whole collection."
+            )
+          end
         end
 
         #: () -> void
@@ -918,7 +965,7 @@ module Herb
           return if states.empty?
 
           content = node.content&.value.to_s
-          assigned = StateDirectives.assigned_state_names(content, states)
+          assigned = StateDirectives.assigned_state_names(content, states) - @internal_states.keys
 
           return if assigned.empty?
 

--- a/lib/herb/engine/slots/visitor.rb
+++ b/lib/herb/engine/slots/visitor.rb
@@ -194,9 +194,11 @@ module Herb
 
           fragment_nodes = {} #: Hash[untyped, Hash[String, untyped]]
           fragment_fallbacks = {} #: Hash[untyped, Array[untyped]]
+          deferred_nodes = {} #: Hash[untyped, Hash[Symbol, untyped]]
 
           @fragment_nodes = fragment_nodes.compare_by_identity
           @fragment_fallbacks = fragment_fallbacks.compare_by_identity
+          @deferred_nodes = deferred_nodes.compare_by_identity
         end
 
         #: () -> bool
@@ -263,6 +265,24 @@ module Herb
         def record_fragment(node, fallback_children, timing)
           @fragment_nodes[node] = timing
           @fragment_fallbacks[node] = fallback_children
+        end
+
+        #: (untyped, mode: String, state: String, timing: Hash[String, Integer]) -> void
+        def record_deferred(node, mode:, state:, timing:)
+          @deferred_nodes[node] = { mode: mode, state: state, timing: timing }
+        end
+
+        #: () -> Hash[Integer, Hash[Symbol, untyped]]
+        def deferred_entries
+          entries = {} #: Hash[Integer, Hash[Symbol, untyped]]
+
+          @deferred_nodes.each do |node, info|
+            index = @indices[node]
+
+            entries[index] = info if index
+          end
+
+          entries
         end
 
         #: (Integer) -> Array[Array[Integer]]
@@ -1549,6 +1569,9 @@ module Herb
 
           statics = @statics
           entries = (statics || {}).sort_by { |key, _| key.split(":").map(&:to_i) } #: Array[[String, (String | Array[untyped])]]
+
+          withheld = deferred_entries.keys.to_set { |index| "#{index}:0" }
+          entries.reject! { |key, _| withheld.include?(key) }
 
           entries.concat(fallback_statics_entries)
 

--- a/sig/herb/engine/slots/components/async.rbs
+++ b/sig/herb/engine/slots/components/async.rbs
@@ -1,0 +1,20 @@
+# Generated from lib/herb/engine/slots/components/async.rb with RBS::Inline
+
+module Herb
+  class Engine
+    module Slots
+      module Components
+        # A deferred block the client requests immediately on mount, so expensive
+        # content loads in parallel with the page instead of blocking it.
+        class Async < Deferred
+          NAME: String
+
+          private
+
+          # : () -> String
+          def mode: () -> String
+        end
+      end
+    end
+  end
+end

--- a/sig/herb/engine/slots/components/base.rbs
+++ b/sig/herb/engine/slots/components/base.rbs
@@ -25,7 +25,12 @@ module Herb
           # : () -> void
           def refuse_unknown_attributes: () -> void
 
+          TIMING_ATTRIBUTES: Array[String]
+
           private
+
+          # : () -> Hash[String, Integer]
+          def timing: () -> Hash[String, Integer]
 
           # : () -> String
           def tag_name: () -> String

--- a/sig/herb/engine/slots/components/deferred.rbs
+++ b/sig/herb/engine/slots/components/deferred.rbs
@@ -1,0 +1,34 @@
+# Generated from lib/herb/engine/slots/components/deferred.rb with RBS::Inline
+
+module Herb
+  class Engine
+    module Slots
+      module Components
+        # A block whose primary content stays out of the initial response.
+        #
+        # The transform conditions the primary on an internal boolean state the
+        # client steers, so the first render shows only the `<Fallback>` and the
+        # block request is an ordinary steered refetch answering the primary
+        # branch with its statics. `Async` requests on mount and `Lazy` when the
+        # block nears the viewport.
+        class Deferred < Base
+          ATTRIBUTES: Array[String]
+
+          # : () -> Array[String]
+          def allowed_attributes: () -> Array[String]
+
+          # : () -> Array[untyped]
+          def transform: () -> Array[untyped]
+
+          private
+
+          # : () -> String
+          def mode: () -> String
+
+          # : (String, Array[untyped], untyped) -> untyped
+          def deferred_conditional: (String, Array[untyped], untyped) -> untyped
+        end
+      end
+    end
+  end
+end

--- a/sig/herb/engine/slots/components/fragment.rbs
+++ b/sig/herb/engine/slots/components/fragment.rbs
@@ -16,8 +16,6 @@ module Herb
 
           ATTRIBUTES: Array[String]
 
-          TIMING_ATTRIBUTES: Array[String]
-
           # : () -> Array[String]
           def allowed_attributes: () -> Array[String]
 
@@ -28,9 +26,6 @@ module Herb
 
           # : () -> Hash[String, untyped]
           def masking: () -> Hash[String, untyped]
-
-          # : () -> Hash[String, Integer]
-          def timing: () -> Hash[String, Integer]
 
           # : (untyped) -> void
           def refuse_nested_fragment: (untyped) -> void

--- a/sig/herb/engine/slots/components/lazy.rbs
+++ b/sig/herb/engine/slots/components/lazy.rbs
@@ -1,0 +1,20 @@
+# Generated from lib/herb/engine/slots/components/lazy.rb with RBS::Inline
+
+module Herb
+  class Engine
+    module Slots
+      module Components
+        # A deferred block the client requests when it nears the viewport, and
+        # never requests for content the reader never reaches.
+        class Lazy < Deferred
+          NAME: String
+
+          private
+
+          # : () -> String
+          def mode: () -> String
+        end
+      end
+    end
+  end
+end

--- a/sig/herb/engine/slots/state_compiler.rbs
+++ b/sig/herb/engine/slots/state_compiler.rbs
@@ -32,6 +32,12 @@ module Herb
         # : () -> bool
         def any?: () -> bool
 
+        # : () -> String
+        def declare_internal_block: () -> String
+
+        # : (String) -> String
+        def internal_assignment: (String) -> String
+
         # : () -> Array[String]
         def count_signatures: () -> Array[String]
 
@@ -130,6 +136,9 @@ module Herb
 
         # : () -> void
         def apply_states: () -> void
+
+        # : () -> void
+        def check_deferred_placement: () -> void
 
         # : () -> void
         def check_fragments: () -> void

--- a/sig/herb/engine/slots/visitor.rbs
+++ b/sig/herb/engine/slots/visitor.rbs
@@ -166,6 +166,12 @@ module Herb
         # : (untyped, Array[untyped], Hash[String, untyped]) -> void
         def record_fragment: (untyped, Array[untyped], Hash[String, untyped]) -> void
 
+        # : (untyped, mode: String, state: String, timing: Hash[String, Integer]) -> void
+        def record_deferred: (untyped, mode: String, state: String, timing: Hash[String, Integer]) -> void
+
+        # : () -> Hash[Integer, Hash[Symbol, untyped]]
+        def deferred_entries: () -> Hash[Integer, Hash[Symbol, untyped]]
+
         # : (Integer) -> Array[Array[Integer]]
         def slots_by_branch: (Integer) -> Array[Array[Integer]]
 

--- a/test/engine/slots/components_test.rb
+++ b/test/engine/slots/components_test.rb
@@ -163,7 +163,7 @@ module Engine
 
         assert_equal "herb-slots-component", diagnostic.code
         assert_equal "`<Skeleton>` is not a component Herb knows.", diagnostic.message
-        assert_equal "The built-in components are `<Fragment>` and `<Fallback>`.", diagnostic.suggestion
+        assert_equal "The built-in components are `<Fragment>` and `<Fallback>` and `<Async>` and `<Lazy>`.", diagnostic.suggestion
       end
 
       test "an unknown attribute on a fragment errors" do

--- a/test/engine/slots/deferred_test.rb
+++ b/test/engine/slots/deferred_test.rb
@@ -1,0 +1,218 @@
+# frozen_string_literal: true
+
+require "json"
+
+require_relative "../../test_helper"
+require_relative "../../../lib/herb/engine/slots/visitor"
+require_relative "../../../lib/herb/engine/slots/dynamics_compiler"
+
+module Engine
+  module Slots
+    class DeferredTest < Minitest::Spec
+      include SnapshotUtils
+
+      ASYNC = <<~ERB
+        <%# herb:slots client %>
+        <Async>
+          <p id="stats"><%= @stats %></p>
+          <Fallback><p class="pulse">crunching <%= @hint %></p></Fallback>
+        </Async>
+      ERB
+
+      class OverridableView
+        def initialize(overrides)
+          @overrides = overrides
+        end
+
+        def __herb_state_overrides
+          @overrides
+        end
+      end
+
+      def page_options
+        { visitors: [Herb::Engine::Slots::Visitor.new(mode: :client, fatal: false)], filename: "app/views/test.html.erb" }
+      end
+
+      def compile(source, mode: :client)
+        visitor = Herb::Engine::Slots::Visitor.new(mode: mode, fatal: false)
+        engine = Herb::Engine.new(source, visitors: [visitor], filename: "app/views/test.html.erb")
+
+        [visitor, engine]
+      end
+
+      test "an async block compiles to a steered conditional on an internal state" do
+        visitor, = compile(ASYNC)
+
+        assert_equal [:conditional, :child, :child], visitor.slots.map(&:type)
+        assert_equal({ 0 => { mode: "async", state: "_herb_block_0", timing: {} } }, visitor.deferred_entries)
+        assert_empty visitor.diagnostics
+      end
+
+      test "the first render carries the fallback and withholds the primary" do
+        assert_evaluated_snapshot(ASYNC, { "__herb_state_overrides" => nil, "@stats" => "42 things", "@hint" => "soon" }, page_options)
+      end
+
+      test "the fallback's ERB evaluates on every render" do
+        _, engine = compile(ASYNC)
+
+        first = OverridableView.new(nil)
+        first.instance_variable_set(:@hint, "later")
+
+        second = OverridableView.new(nil)
+        second.instance_variable_set(:@hint, "sooner")
+
+        assert_equal first.instance_eval(engine.src).sub("later", "sooner"), second.instance_eval(engine.src)
+      end
+
+      test "the manifest declares the internal state and maps the block" do
+        visitor, = compile(ASYNC)
+        states = visitor.manifest["states"]
+
+        assert_equal({ "0" => { "mode" => "async", "state" => "_herb_block_0", "fallback" => 1, "reads" => [] } }, states["fragments"])
+
+        declaration = states["declarations"].fetch(0)
+
+        assert_equal "_herb_block_0", declaration["name"]
+        assert declaration["internal"]
+        assert_equal({ "arms" => [{ "branch" => 0, "condition" => ["_herb_block_0", nil] }], "else" => 1 }, states["conditionals"]["0"])
+      end
+
+      test "a lazy block records its own mode" do
+        visitor, = compile(ASYNC.gsub("Async", "Lazy"))
+
+        assert_equal "lazy", visitor.deferred_entries.fetch(0)[:mode]
+        assert_equal "lazy", visitor.manifest["states"]["fragments"]["0"]["mode"]
+      end
+
+      test "two deferred blocks number their states in document order" do
+        source = ASYNC + ASYNC.gsub("Async", "Lazy").gsub("stats", "extra")
+
+        visitor, = compile(source)
+        names = visitor.deferred_entries.values.map { |info| info[:state] }
+
+        assert_equal ["_herb_block_0", "_herb_block_1"], names
+      end
+
+      test "the values program answers the fallback branch until steered" do
+        compiler = Herb::Engine::Slots::DynamicsCompiler.new(ASYNC, filename: "app/views/test.html.erb")
+
+        view = OverridableView.new(nil)
+        view.instance_variable_set(:@hint, "soon")
+        values = view.instance_eval(compiler.src)
+
+        assert_equal({ "branch" => 1, "slots" => { "2" => "soon" } }, JSON.parse(JSON.generate(values))["slots"]["0"])
+      end
+
+      test "steering the internal state answers the primary with its statics" do
+        compiler = Herb::Engine::Slots::DynamicsCompiler.new(ASYNC, filename: "app/views/test.html.erb")
+
+        view = OverridableView.new({ "app/views/test.html.erb" => { "_herb_block_0" => true } })
+        view.instance_variable_set(:@stats, "42 things")
+        values = JSON.parse(JSON.generate(view.instance_eval(compiler.src)))
+
+        assert_snapshot_matches(JSON.pretty_generate(values), ASYNC, { probe: "steered values" })
+      end
+
+      test "a deferred block without a fallback renders nothing initially" do
+        source = <<~ERB
+          <%# herb:slots client %>
+          <Async>
+            <p id="stats"><%= @stats %></p>
+          </Async>
+        ERB
+
+        visitor, = compile(source)
+
+        assert_empty visitor.diagnostics
+        assert_evaluated_snapshot(source, { "__herb_state_overrides" => nil, "@stats" => "42 things" }, page_options)
+      end
+
+      test "two fallbacks in a deferred block error" do
+        source = <<~ERB
+          <%# herb:slots client %>
+          <Lazy>
+            <p><%= @a %></p>
+            <Fallback><p>one</p></Fallback>
+            <Fallback><p>two</p></Fallback>
+          </Lazy>
+        ERB
+
+        visitor, = compile(source)
+
+        assert_equal ["A `<Lazy>` holds 2 `<Fallback>` elements, and it can only stand one in."], visitor.diagnostics.map(&:message)
+      end
+
+      test "an unknown attribute on a deferred block errors" do
+        visitor, = compile(%(<%# herb:slots client %>\n<Async id="x"><p><%= @a %></p></Async>))
+
+        assert_equal ["`<Async>` only takes `delay` and `hold` and `on`."], visitor.diagnostics.map(&:message)
+      end
+
+      test "timing attributes and state reads flow into a deferred entry" do
+        source = <<~ERB
+          <%# herb:slots client %>
+          <%# herb:state (peek: "") %>
+          <input value="<%= peek %>">
+          <Lazy delay="0" hold="500">
+            <p><%= Geo.locate(peek) %></p>
+            <Fallback><p class="pulse">wait</p></Fallback>
+          </Lazy>
+        ERB
+
+        visitor, = compile(source)
+        entry = visitor.manifest["states"]["fragments"].fetch("1")
+
+        assert_equal "lazy", entry["mode"]
+        assert_equal 0, entry["delay"]
+        assert_equal 500, entry["hold"]
+        assert_equal [2], entry["reads"]
+        assert_empty visitor.diagnostics
+      end
+
+      test "a deferred block inside a collection errors" do
+        source = <<~ERB
+          <%# herb:slots client %>
+          <ul>
+            <% @tiles.each do |tile| %>
+              <li>
+                <Async>
+                  <p><%= Metrics.load(tile) %></p>
+                  <Fallback><p class="pulse">tile loading</p></Fallback>
+                </Async>
+              </li>
+            <% end %>
+          </ul>
+        ERB
+
+        visitor, = compile(source)
+
+        assert_equal ["A `<Async>` sits inside a collection, and a deferred block cannot stand per item yet."], visitor.diagnostics.map(&:message)
+      end
+
+      test "a deferred block wrapping a collection passes" do
+        source = <<~ERB
+          <%# herb:slots client %>
+          <Lazy>
+            <ul>
+              <% @tiles.each do |tile| %>
+                <li><%= tile %></li>
+              <% end %>
+            </ul>
+            <Fallback><p class="pulse">tiles loading</p></Fallback>
+          </Lazy>
+        ERB
+
+        visitor, = compile(source)
+
+        assert_empty visitor.diagnostics
+      end
+
+      test "the page and values compiles agree on indexes and state names" do
+        compiler = Herb::Engine::Slots::DynamicsCompiler.new(ASYNC, filename: "app/views/test.html.erb")
+        page_visitor, = compile(ASYNC)
+
+        assert_equal page_visitor.deferred_entries, compiler.slot_visitor.deferred_entries
+      end
+    end
+  end
+end

--- a/test/snapshots/engine/slots/deferred_test/test_0002_the_first_render_carries_the_fallback_and_withholds_the_primary_e8da3ea5de8386adac1bb4d96282ade2.txt
+++ b/test/snapshots/engine/slots/deferred_test/test_0002_the_first_render_carries_the_fallback_and_withholds_the_primary_e8da3ea5de8386adac1bb4d96282ade2.txt
@@ -1,0 +1,7 @@
+---
+source: "Engine::Slots::DeferredTest#test_0002_the first render carries the fallback and withholds the primary"
+input: "{source: \"<%# herb:slots client %>\\n<Async>\\n  <p id=\\\"stats\\\"><%= @stats %></p>\\n  <Fallback><p class=\\\"pulse\\\">crunching <%= @hint %></p></Fallback>\\n</Async>\\n\", locals: {\"__herb_state_overrides\" => nil, \"@stats\" => \"42 things\", \"@hint\" => \"soon\"}, options: {visitors: [#<Herb::Engine::Slots::Visitor client fatal=false>], filename: \"app/views/test.html.erb\"}}"
+---
+<!--herb-region:app/views/test.html.erb:c5bdc02c:0-->
+<!--herb-slot:0:conditional--><!--herb-branch:0:1--><p class="pulse">crunching <!--herb-slot:2-->soon<!--/herb-slot:2--></p><!--/herb-slot:0-->
+<!--/herb-region:app/views/test.html.erb--><template data-herb-region="app/views/test.html.erb:c5bdc02c"><!--herb-branch:0:1--><p class="pulse">crunching <!--herb-slot:2--><!--/herb-slot:2--></p></template>

--- a/test/snapshots/engine/slots/deferred_test/test_0008_steering_the_internal_state_answers_the_primary_with_its_statics_252063606818de4cbc228aed383ffa0a-0c1562b4227066bd0c18353c7a7c19b7.txt
+++ b/test/snapshots/engine/slots/deferred_test/test_0008_steering_the_internal_state_answers_the_primary_with_its_statics_252063606818de4cbc228aed383ffa0a-0c1562b4227066bd0c18353c7a7c19b7.txt
@@ -1,0 +1,24 @@
+---
+source: "Engine::Slots::DeferredTest#test_0008_steering the internal state answers the primary with its statics"
+input: |2-
+<%# herb:slots client %>
+<Async>
+  <p id="stats"><%= @stats %></p>
+  <Fallback><p class="pulse">crunching <%= @hint %></p></Fallback>
+</Async>
+options: {probe: "steered values"}
+---
+{
+  "template": "app/views/test.html.erb",
+  "version": "c5bdc02c",
+  "occurrence": 0,
+  "slots": {
+    "0": {
+      "branch": 0,
+      "statics": "<!--herb-branch:0:0-->\n  <p id=\"stats\" data-herb-slot=\"1:child\"></p>\n  \n",
+      "slots": {
+        "1": "42 things"
+      }
+    }
+  }
+}

--- a/test/snapshots/engine/slots/deferred_test/test_0009_a_deferred_block_without_a_fallback_renders_nothing_initially_01be5d6da33e55209bc23ae2b03c9e31.txt
+++ b/test/snapshots/engine/slots/deferred_test/test_0009_a_deferred_block_without_a_fallback_renders_nothing_initially_01be5d6da33e55209bc23ae2b03c9e31.txt
@@ -1,0 +1,7 @@
+---
+source: "Engine::Slots::DeferredTest#test_0009_a deferred block without a fallback renders nothing initially"
+input: "{source: \"<%# herb:slots client %>\\n<Async>\\n  <p id=\\\"stats\\\"><%= @stats %></p>\\n</Async>\\n\", locals: {\"__herb_state_overrides\" => nil, \"@stats\" => \"42 things\"}, options: {visitors: [#<Herb::Engine::Slots::Visitor client fatal=false>], filename: \"app/views/test.html.erb\"}}"
+---
+<!--herb-region:app/views/test.html.erb:a42ab833:0-->
+<!--herb-slot:0:conditional--><!--/herb-slot:0-->
+<!--/herb-region:app/views/test.html.erb-->


### PR DESCRIPTION
This pull request introduces the second pair of built-in components. 

A deferred block's primary content stays out of the initial response entirely, the `<Fallback>` renders in its place, and the client requests the block later with the page's `herb:state` riding along. 

`<Async>` requests immediately on mount, so expensive content loads in parallel with the page. `<Lazy>` waits until the block nears the viewport.

```erb
<Async>
  <p><%= Dashboard.expensive_stats %></p>

  <Fallback>
    <p class="animate-pulse h-11 rounded bg-gray-200"></p>
  </Fallback>
</Async>
```