### PR TITLE
Client: Fetch deferred blocks in parallel and let them `poll`

### DIFF
--- a/javascript/packages/client/src/shared/slots-request.ts
+++ b/javascript/packages/client/src/shared/slots-request.ts
@@ -7,6 +7,7 @@ import type { RuntimeDiagnostic } from "./types"
 export const SLOTS_MIME_TYPE = "application/vnd.herb.slots+json"
 export const SCHEMA_HEADER = "Herb-Schema"
 export const NODE_PATH_HEADER = "Herb-Node-Path"
+export const BLOCK_HEADER = "Herb-Block"
 export const STATE_HEADER = "Herb-State"
 
 export type SlotsResponse = Payload & { schema?: SchemaEnvelope }
@@ -46,6 +47,7 @@ export interface SlotsRequestOptions {
   format?: string
   schema?: boolean
   nodePath?: number[]
+  block?: number
   state?: Record<string, Record<string, unknown>>
   signal?: AbortSignal
   report?: boolean
@@ -61,6 +63,10 @@ export function slotsHeaders(options: SlotsRequestOptions = {}): Record<string, 
 
   if (options.nodePath) {
     headers[NODE_PATH_HEADER] = options.nodePath.join(",")
+  }
+
+  if (options.block !== undefined) {
+    headers[BLOCK_HEADER] = String(options.block)
   }
 
   if (options.state && Object.keys(options.state).length > 0) {

--- a/javascript/packages/client/src/state/fragments.ts
+++ b/javascript/packages/client/src/state/fragments.ts
@@ -1,5 +1,5 @@
 import { scopeOf } from "./scopes"
-import { hostOf } from "../markup/anchors"
+import { connected, hostOf } from "../markup/anchors"
 
 import type { Slots } from "../slots/slots"
 import type { RefreshReport } from "./refresh"
@@ -22,7 +22,7 @@ export interface FragmentsDelegate {
   manifestFor(region: Region): StateManifest | null
   placedSlots(scope: StateScope, index: number): PlacedSlot[]
   writeInternal(name: string, scope: StateScope): void
-  requestRefetch(): void
+  requestBlock(region: Region, index: number): Promise<RefreshReport>
   resettle(slot: Slot): void
 }
 
@@ -32,6 +32,7 @@ export class Fragments {
   private readonly showing = new Map<Slot, FragmentPresentation>()
   private readonly armed = new Set<Slot>()
   private readonly observers = new Map<Slot, IntersectionObserver>()
+  private readonly polls = new Map<Slot, ReturnType<typeof setTimeout>>()
 
   constructor(slots: Slots, delegate: FragmentsDelegate) {
     this.slots = slots
@@ -120,6 +121,8 @@ export class Fragments {
   }
 
   hydrated(): void {
+    this.sweep()
+
     for (const region of this.slots.regions()) {
       const fragments = this.delegate.manifestFor(region)?.fragments
 
@@ -135,7 +138,7 @@ export class Fragments {
         }
 
         for (const placed of this.delegate.placedSlots(scope, Number(key))) {
-          this.arm(placed.slot, entry, placed.scope)
+          this.arm(placed.slot, Number(key), entry, placed.scope)
         }
       }
     }
@@ -160,6 +163,34 @@ export class Fragments {
 
     this.observers.clear()
     this.armed.clear()
+
+    for (const timer of this.polls.values()) {
+      clearTimeout(timer)
+    }
+
+    this.polls.clear()
+  }
+
+  private sweep(): void {
+    for (const [slot, timer] of this.polls) {
+      if (!connected(slot.anchor)) {
+        clearTimeout(timer)
+        this.polls.delete(slot)
+      }
+    }
+
+    for (const [slot, observer] of this.observers) {
+      if (!connected(slot.anchor)) {
+        observer.disconnect()
+        this.observers.delete(slot)
+      }
+    }
+
+    for (const slot of this.armed) {
+      if (!connected(slot.anchor)) {
+        this.armed.delete(slot)
+      }
+    }
   }
 
   private present(slot: Slot, fragment: FragmentEntry): void {
@@ -188,7 +219,7 @@ export class Fragments {
 
     const delay = fragment.delay ?? FRAGMENT_DELAY
 
-    if (delay <= 0) {
+    if (delay <= 0 || slot.branch === presentation.fallback) {
       this.swapToFallback(slot, presentation)
 
       return
@@ -204,12 +235,16 @@ export class Fragments {
   private swapToFallback(slot: Slot, presentation: FragmentPresentation): void {
     presentation.shownAt = Date.now()
 
+    if (presentation.deferred) {
+      this.slots.claim(slot)
+    }
+
     if (slot.branch !== presentation.fallback) {
       this.slots.switchBranch(slot, presentation.fallback)
     }
   }
 
-  private arm(slot: Slot, entry: FragmentEntry, scope: StateScope): void {
+  private arm(slot: Slot, index: number, entry: FragmentEntry, scope: StateScope): void {
     if (this.armed.has(slot)) {
       return
     }
@@ -217,15 +252,13 @@ export class Fragments {
     this.armed.add(slot)
 
     if (slot.branch !== entry.fallback) {
+      this.armPoll(slot, index, entry, scope)
+
       return
     }
 
-    const state = entry.state as string
-
     if (entry.mode === "async" || typeof IntersectionObserver === "undefined") {
-      this.present(slot, entry)
-      this.delegate.writeInternal(state, scope)
-      this.delegate.requestRefetch()
+      this.trigger(slot, index, entry, scope)
 
       return
     }
@@ -233,7 +266,7 @@ export class Fragments {
     const sentinel = this.sentinelFor(slot)
 
     if (!sentinel) {
-      this.delegate.writeInternal(state, scope)
+      this.trigger(slot, index, entry, scope)
 
       return
     }
@@ -245,13 +278,56 @@ export class Fragments {
 
       observer.disconnect()
       this.observers.delete(slot)
-      this.present(slot, entry)
-      this.delegate.writeInternal(state, scope)
-      this.delegate.requestRefetch()
+      this.trigger(slot, index, entry, scope)
     })
 
     observer.observe(sentinel)
     this.observers.set(slot, observer)
+  }
+
+  private trigger(slot: Slot, index: number, entry: FragmentEntry, scope: StateScope): void {
+    this.present(slot, entry)
+    this.delegate.writeInternal(entry.state as string, scope)
+
+    void this.delegate.requestBlock(scope.region, index).then((outcome) => {
+      this.settle(outcome)
+      this.armPoll(slot, index, entry, scope)
+    })
+  }
+
+  private armPoll(slot: Slot, index: number, entry: FragmentEntry, scope: StateScope): void {
+    const every = entry.poll ?? 0
+
+    if (every <= 0 || this.polls.has(slot)) {
+      return
+    }
+
+    const tick = (): void => {
+      this.polls.set(slot, setTimeout(() => {
+        if (!connected(slot.anchor)) {
+          this.polls.delete(slot)
+          this.armed.delete(slot)
+
+          return
+        }
+
+        if (document.hidden) {
+          tick()
+
+          return
+        }
+
+        void this.delegate.requestBlock(scope.region, index).then((outcome) => {
+          this.settle(outcome)
+
+          if (this.polls.has(slot)) {
+            tick()
+          }
+        })
+      }, every))
+    }
+
+    tick()
   }
 
   private sentinelFor(slot: Slot): Element | null {

--- a/javascript/packages/client/src/state/refresh.ts
+++ b/javascript/packages/client/src/state/refresh.ts
@@ -162,7 +162,7 @@ export class Refresh {
   }
 }
 
-function steeringNames(manifest: StateManifest): Set<string> {
+export function steeringNames(manifest: StateManifest): Set<string> {
   const names = new Set<string>()
 
   for (const conditional of Object.values(manifest.conditionals ?? {})) {

--- a/javascript/packages/client/src/state/state.ts
+++ b/javascript/packages/client/src/state/state.ts
@@ -14,6 +14,8 @@ import { printValue } from "./values"
 import { elementOf, hostOf } from "../markup/anchors"
 import { armMutationRefresh } from "../shared/mutation-refresh"
 import { armOf, evaluate, matches, mentions } from "./conditions"
+import { steeringNames } from "./refresh"
+import { slotsRequest } from "../shared/slots-request"
 import { collectionIn, scopeOf, scoped } from "./scopes"
 import { declarationSpot, declared, declaredValue } from "./declarations"
 
@@ -21,7 +23,7 @@ import type { Slots } from "../slots/slots"
 import type { Conditional } from "./types"
 import type { RefreshReport } from "./refresh"
 import type { StateKind, StateValue } from "./values"
-import type { Built, Item, Region, Slot } from "../types"
+import type { Built, Item, Payload, Region, Slot } from "../types"
 import type { CountOptions, DeclaredState, DependencyMap, PlacedSlot, ResolvedStateOptions, ScopeStore, ScopedSetOptions, SerializedState, StateChange, StateChangeDetail, StateListener, StateManifest, StateOptions, StateReport, StateScope, StateSlot, StateSnapshot, StateValues } from "./types"
 
 import type { SlotsDelegate } from "../types"
@@ -69,7 +71,7 @@ export class State implements ElementObserverDelegate, SlotsDelegate, SeedsDeleg
       manifestFor: (region) => this.manifestFor(region),
       placedSlots: (scope, index) => this.placedSlots(scope, index),
       writeInternal: (name, scope) => void this.setState({ [name]: true }, { scope }),
-      requestRefetch: () => void this.refetch.request(this.options.refetchDebounce).then((outcome) => this.fragments.settle(outcome)),
+      requestBlock: (region, index) => this.fetchBlock(region, index),
       resettle: (slot) => this.settleBranch(slot),
     })
     this.disarmMutationRefresh = armMutationRefresh(() => this.refreshAfterMutation())
@@ -554,6 +556,51 @@ export class State implements ElementObserverDelegate, SlotsDelegate, SeedsDeleg
     }
 
     return true
+  }
+
+  private async fetchBlock(region: Region, index: number): Promise<RefreshReport> {
+    const steering = this.blockSteering(region)
+    const address = { template: region.file, index }
+
+    let payload: Payload | null
+
+    try {
+      if (this.options.refetchTransport) {
+        payload = await this.options.refetchTransport(steering, new AbortController().signal, address)
+      } else {
+        payload = await slotsRequest(window.location.href, { format: this.options.format, state: steering, block: index })
+      }
+    } catch {
+      return { applied: 0, deferred: 0, stale: false, failed: true }
+    }
+
+    if (!payload) {
+      return { applied: 0, deferred: 0, stale: false, failed: true }
+    }
+
+    const report = this.slots.apply(payload)
+
+    return { applied: report.applied, deferred: report.deferred.length, stale: false, failed: false }
+  }
+
+  private blockSteering(region: Region): Record<string, Record<string, unknown>> {
+    const manifest = this.manifestFor(region)
+
+    if (!manifest) {
+      return {}
+    }
+
+    const values: Record<string, unknown> = {}
+
+    for (const name of steeringNames(manifest)) {
+      const value = this.valueAt(name, scopeOf(region))
+
+      if (value !== undefined) {
+        values[name] = value
+      }
+    }
+
+    return Object.keys(values).length > 0 ? { [region.file]: values } : {}
   }
 
   private requestReadRefetch(manifest: StateManifest, scope: StateScope, names: string[]): void {

--- a/javascript/packages/client/src/state/types.ts
+++ b/javascript/packages/client/src/state/types.ts
@@ -87,6 +87,7 @@ export interface FragmentEntry {
   reads?: number[]
   delay?: number
   hold?: number
+  poll?: number
   mode?: "lazy" | "async"
   state?: string
   on?: string[]
@@ -160,7 +161,12 @@ export interface StateOptions {
   refetchTransport?: RefreshTransport
 }
 
-export type RefreshTransport = (state: Record<string, Record<string, unknown>>, signal: AbortSignal) => Promise<Payload>
+export type RefreshTransport = (state: Record<string, Record<string, unknown>>, signal: AbortSignal, block?: BlockAddress) => Promise<Payload>
+
+export interface BlockAddress {
+  template: string
+  index: number
+}
 
 export interface StateReport extends ApplyReport {
   written: number

--- a/javascript/packages/client/test/deferred.test.ts
+++ b/javascript/packages/client/test/deferred.test.ts
@@ -76,7 +76,99 @@ describe("deferred blocks", () => {
 
     expect(transport).toHaveBeenCalledTimes(1)
     expect(calls[0][FILE]._herb_block_0).toBe(true)
+    expect(transport.mock.calls[0][2]).toEqual({ template: FILE, index: 0 })
     expect(document.body.innerHTML).not.toContain("loading stats")
+  })
+
+  test("two async blocks fan out in parallel over the scoped lane", async () => {
+    document.body.innerHTML =
+      `<!--herb-region:${FILE}:aaaaaaaa:0-->` +
+      `<div><!--herb-slot:0:conditional--><!--herb-branch:0:1--><p class="pulse">one loading</p><!--/herb-slot:0--></div>` +
+      `<div><!--herb-slot:2:conditional--><!--herb-branch:2:1--><p class="pulse">two loading</p><!--/herb-slot:2--></div>` +
+      `<!--/herb-region:${FILE}-->` +
+      `<template data-herb-dependencies>${JSON.stringify({
+        state: {},
+        states: {
+          [FILE]: {
+            version: "aaaaaaaa",
+            declarations: [
+              { name: "_herb_block_0", kind: "boolean", default: "false", value: false, scope: "region", internal: true },
+              { name: "_herb_block_1", kind: "boolean", default: "false", value: false, scope: "region", internal: true },
+            ],
+            reads: {},
+            conditionals: {
+              0: { arms: [{ branch: 0, condition: ["_herb_block_0", null] }], else: 1 },
+              2: { arms: [{ branch: 0, condition: ["_herb_block_1", null] }], else: 1 },
+            },
+            presence: {},
+            computed: {},
+            server: { branches: {}, reads: {} },
+            fragments: {
+              0: { mode: "async", state: "_herb_block_0", fallback: 1 },
+              2: { mode: "async", state: "_herb_block_1", fallback: 1 },
+            },
+          },
+        },
+      })}</template>`
+
+    const resolvers: Array<(payload: Payload) => void> = []
+    const transport = vi.fn((_state: Record<string, Record<string, unknown>>, _signal: AbortSignal, block?: { index: number }) =>
+      new Promise<Payload>((resolve) => {
+        resolvers.push((payload) => resolve(payload))
+
+        void block
+      }))
+
+    start({ state: { refetchTransport: transport, refetchDebounce: 0 } })
+
+    await vi.waitFor(() => {
+      if (transport.mock.calls.length < 2) {
+        throw new Error("still waiting")
+      }
+    })
+
+    expect(resolvers.length).toBe(2)
+
+    resolvers[1]({ template: FILE, version: "aaaaaaaa", occurrence: 0, slots: { 2: { branch: 0, statics: `<!--herb-branch:2:0--><p>two ready</p>`, slots: {} } } })
+    resolvers[0]({ template: FILE, version: "aaaaaaaa", occurrence: 0, slots: { 0: { branch: 0, statics: `<!--herb-branch:0:0--><p>one ready</p>`, slots: {} } } })
+
+    await vi.waitFor(() => {
+      if (!document.body.innerHTML.includes("one ready") || !document.body.innerHTML.includes("two ready")) {
+        throw new Error("still waiting")
+      }
+    })
+  })
+
+  test("a polled block refetches itself on its interval", async () => {
+    document.body.innerHTML = deferredPage("async").replace(
+      '"fragments":{"0":{"mode":"async","state":"_herb_block_0","fallback":1}}',
+      '"fragments":{"0":{"mode":"async","state":"_herb_block_0","fallback":1,"poll":40}}',
+    )
+
+    expect(document.body.innerHTML).toContain('"poll":40')
+
+    const transport = vi.fn(async () => PRIMARY)
+    const live = start({ state: { refetchTransport: transport, refetchDebounce: 0 } })
+
+    await vi.waitFor(() => {
+      if (!document.body.innerHTML.includes("42 things")) {
+        throw new Error("still waiting")
+      }
+    })
+
+    await vi.waitFor(() => {
+      if (transport.mock.calls.length < 3) {
+        throw new Error("still waiting")
+      }
+    })
+
+    live.stop()
+
+    const settled = transport.mock.calls.length
+
+    await new Promise((resolve) => setTimeout(resolve, 120))
+
+    expect(transport.mock.calls.length).toBe(settled)
   })
 
   test("a deferred block re-requests when its page comes back", async () => {
@@ -109,6 +201,33 @@ describe("deferred blocks", () => {
     })
 
     expect(transport).toHaveBeenCalledTimes(2)
+  })
+
+  test("a poll ends when its block leaves the page", async () => {
+    document.body.innerHTML = deferredPage("async").replace(
+      '"fragments":{"0":{"mode":"async","state":"_herb_block_0","fallback":1}}',
+      '"fragments":{"0":{"mode":"async","state":"_herb_block_0","fallback":1,"poll":40}}',
+    )
+
+    const transport = vi.fn(async () => PRIMARY)
+
+    start({ state: { refetchTransport: transport, refetchDebounce: 0 } })
+
+    await vi.waitFor(() => {
+      if (transport.mock.calls.length < 2) {
+        throw new Error("still waiting")
+      }
+    })
+
+    document.body.innerHTML = "<p>next page</p>"
+
+    await new Promise((resolve) => setTimeout(resolve, 60))
+
+    const settled = transport.mock.calls.length
+
+    await new Promise((resolve) => setTimeout(resolve, 150))
+
+    expect(transport.mock.calls.length).toBe(settled)
   })
 
   test("a lazy block waits for the viewport and then materializes", async () => {

--- a/lib/herb/engine/slots/components/base.rb
+++ b/lib/herb/engine/slots/components/base.rb
@@ -50,7 +50,7 @@ module Herb
             end
           end
 
-          TIMING_ATTRIBUTES = ["delay", "hold"].freeze #: Array[String]
+          TIMING_ATTRIBUTES = ["delay", "hold", "poll"].freeze #: Array[String]
 
           private
 

--- a/lib/herb/engine/slots/components/deferred.rb
+++ b/lib/herb/engine/slots/components/deferred.rb
@@ -14,7 +14,7 @@ module Herb
         # block nears the viewport.
         #
         class Deferred < Base
-          ATTRIBUTES = Fragment::ATTRIBUTES #: Array[String]
+          ATTRIBUTES = (Fragment::ATTRIBUTES + ["poll"]).freeze #: Array[String]
 
           #: () -> Array[String]
           def allowed_attributes
@@ -42,7 +42,7 @@ module Herb
 
             @visitor.record_deferred(if_node, mode: mode, state: state, timing: timing)
 
-            [@visitor.erb_code_node(@visitor.states.internal_assignment(state)), if_node]
+            [@visitor.record_assignment(@visitor.erb_code_node(@visitor.states.internal_assignment(state))), if_node]
           end
 
           private

--- a/lib/herb/engine/slots/dynamics_compiler.rb
+++ b/lib/herb/engine/slots/dynamics_compiler.rb
@@ -456,6 +456,65 @@ module Herb
             end
           end
         end
+
+        class Prune < Herb::Visitor
+          #: (Visitor, Integer) -> void
+          def initialize(slot_visitor, index)
+            super()
+
+            @slot_visitor = slot_visitor
+            @index = index
+          end
+
+          #: (untyped) -> void
+          def visit_document_node(node)
+            target = @slot_visitor.slot_nodes[@index]
+
+            return unless target
+
+            keep(node, target)
+          end
+
+          private
+
+          #: (untyped, untyped) -> void
+          def keep(node, target)
+            Visitor::BRANCH_BODY_PROPERTIES.each do |property|
+              next unless node.respond_to?(property)
+
+              value = node.send(property)
+
+              case value
+              when Array
+                if property == :conditions
+                  value.each { |arm| keep(arm, target) if contains?(arm, target) }
+                else
+                  value.replace(value.select { |child| child.equal?(target) || contains?(child, target) || @slot_visitor.assignment_node?(child) })
+                  value.each { |child| keep(child, target) if !child.equal?(target) && contains?(child, target) }
+                end
+              when Herb::AST::Node
+                keep(value, target) if contains?(value, target)
+              end
+            end
+
+            Visitor::BRANCH_CONTINUATION_PROPERTIES.each do |property|
+              next unless node.respond_to?(property)
+
+              continuation = node.send(property)
+
+              keep(continuation, target) if continuation && contains?(continuation, target)
+            end
+          end
+
+          #: (untyped, untyped) -> bool
+          def contains?(node, target)
+            return true if node.equal?(target)
+            return false unless node.is_a?(Herb::AST::Node)
+
+            node.compact_child_nodes.any? { |child| contains?(child, target) }
+          end
+        end
+
         attr_reader :slot_visitor #: Visitor
 
         #: (String, ?Hash[Symbol, untyped]) -> void
@@ -467,6 +526,7 @@ module Herb
           @slot_visitor = properties[:slot_visitor] || Visitor.new(mode: :server, mark: false)
           @slot_visitor.state_overrides!
           visitors = [*properties[:visitors], @slot_visitor]
+          visitors << Prune.new(@slot_visitor, properties[:block]) if properties[:block]
 
           super(
             input,

--- a/lib/herb/engine/slots/state_compiler.rb
+++ b/lib/herb/engine/slots/state_compiler.rb
@@ -617,7 +617,7 @@ module Herb
             assignments = "#{overrides_prelude}; #{assignments}" if @visitor.state_overrides?
             seeds = directive[:inline] || @visitor.degraded? ? nil : seeds_marker(bucket.values)
 
-            parent[position] = @visitor.erb_code_node(seeds ? "; #{assignments}; #{seeds}" : "; #{assignments}")
+            parent[position] = @visitor.record_assignment(@visitor.erb_code_node(seeds ? "; #{assignments}; #{seeds}" : "; #{assignments}"))
           end
 
           if @region_states.empty? && @item_states.empty? && @internal_states.empty?

--- a/lib/herb/engine/slots/visitor.rb
+++ b/lib/herb/engine/slots/visitor.rb
@@ -195,10 +195,12 @@ module Herb
           fragment_nodes = {} #: Hash[untyped, Hash[String, untyped]]
           fragment_fallbacks = {} #: Hash[untyped, Array[untyped]]
           deferred_nodes = {} #: Hash[untyped, Hash[Symbol, untyped]]
+          assignment_nodes = {} #: Hash[untyped, bool]
 
           @fragment_nodes = fragment_nodes.compare_by_identity
           @fragment_fallbacks = fragment_fallbacks.compare_by_identity
           @deferred_nodes = deferred_nodes.compare_by_identity
+          @assignment_nodes = assignment_nodes.compare_by_identity
         end
 
         #: () -> bool
@@ -270,6 +272,18 @@ module Herb
         #: (untyped, mode: String, state: String, timing: Hash[String, Integer]) -> void
         def record_deferred(node, mode:, state:, timing:)
           @deferred_nodes[node] = { mode: mode, state: state, timing: timing }
+        end
+
+        #: (untyped) -> untyped
+        def record_assignment(node)
+          @assignment_nodes[node] = true
+
+          node
+        end
+
+        #: (untyped) -> bool
+        def assignment_node?(node)
+          @assignment_nodes.key?(node)
         end
 
         #: () -> Hash[Integer, Hash[Symbol, untyped]]

--- a/sig/herb/engine/slots/dynamics_compiler.rbs
+++ b/sig/herb/engine/slots/dynamics_compiler.rbs
@@ -210,6 +210,22 @@ module Herb
           def iteration: (untyped, Symbol) -> void
         end
 
+        class Prune < Herb::Visitor
+          # : (Visitor, Integer) -> void
+          def initialize: (Visitor, Integer) -> void
+
+          # : (untyped) -> void
+          def visit_document_node: (untyped) -> void
+
+          private
+
+          # : (untyped, untyped) -> void
+          def keep: (untyped, untyped) -> void
+
+          # : (untyped, untyped) -> bool
+          def contains?: (untyped, untyped) -> bool
+        end
+
         attr_reader slot_visitor: Visitor
 
         # : (String, ?Hash[Symbol, untyped]) -> void

--- a/sig/herb/engine/slots/visitor.rbs
+++ b/sig/herb/engine/slots/visitor.rbs
@@ -169,6 +169,12 @@ module Herb
         # : (untyped, mode: String, state: String, timing: Hash[String, Integer]) -> void
         def record_deferred: (untyped, mode: String, state: String, timing: Hash[String, Integer]) -> void
 
+        # : (untyped) -> untyped
+        def record_assignment: (untyped) -> untyped
+
+        # : (untyped) -> bool
+        def assignment_node?: (untyped) -> bool
+
         # : () -> Hash[Integer, Hash[Symbol, untyped]]
         def deferred_entries: () -> Hash[Integer, Hash[Symbol, untyped]]
 

--- a/test/engine/slots/deferred_test.rb
+++ b/test/engine/slots/deferred_test.rb
@@ -145,7 +145,7 @@ module Engine
       test "an unknown attribute on a deferred block errors" do
         visitor, = compile(%(<%# herb:slots client %>\n<Async id="x"><p><%= @a %></p></Async>))
 
-        assert_equal ["`<Async>` only takes `delay` and `hold` and `on`."], visitor.diagnostics.map(&:message)
+        assert_equal ["`<Async>` only takes `delay` and `hold` and `on` and `poll`."], visitor.diagnostics.map(&:message)
       end
 
       test "timing attributes and state reads flow into a deferred entry" do
@@ -205,6 +205,92 @@ module Engine
         visitor, = compile(source)
 
         assert_empty visitor.diagnostics
+      end
+
+      test "a scoped compile runs only the addressed block" do
+        source = <<~ERB
+          <%# herb:slots client %>
+          <%# herb:state (label: "tiles") %>
+          <% Thread.current[:deferred_effects] << :top %>
+          <h1><%= label %></h1>
+          <Async>
+            <% Thread.current[:deferred_effects] << :first %>
+            <p><%= "first \#{label}" %></p>
+            <Fallback><p>one loading</p></Fallback>
+          </Async>
+          <Async>
+            <% Thread.current[:deferred_effects] << :second %>
+            <p><%= "second \#{label}" %></p>
+            <Fallback><p>two loading</p></Fallback>
+          </Async>
+        ERB
+
+        probe = Herb::Engine::Slots::Visitor.new(mode: :client, fatal: false)
+        Herb::Engine.new(source, visitors: [probe], filename: "app/views/test.html.erb")
+
+        second = probe.deferred_entries.keys.fetch(1)
+        compiler = Herb::Engine::Slots::DynamicsCompiler.new(source, filename: "app/views/test.html.erb", block: second)
+
+        Thread.current[:deferred_effects] = []
+        view = OverridableView.new({ "app/views/test.html.erb" => { "_herb_block_1" => true, "label" => "steered" } })
+        values = JSON.parse(JSON.generate(view.instance_eval(compiler.src)))
+
+        assert_equal [:second], Thread.current[:deferred_effects]
+        assert_equal [second.to_s], values["slots"].keys
+        assert_equal({ (second + 1).to_s => "second steered" }, values["slots"][second.to_s]["slots"])
+        assert_includes values["slots"][second.to_s]["statics"], "herb-branch:#{second}:0"
+      end
+
+      test "a scoped compile keeps the ancestors of a nested block" do
+        source = <<~ERB
+          <%# herb:slots client %>
+          <%# herb:state (peek: "") %>
+          <input value="<%= peek %>">
+          <% if peek.present? %>
+            <Lazy>
+              <p><%= "located \#{peek}" %></p>
+              <Fallback><p>looking</p></Fallback>
+            </Lazy>
+          <% end %>
+        ERB
+
+        probe = Herb::Engine::Slots::Visitor.new(mode: :client, fatal: false)
+        Herb::Engine.new(source, visitors: [probe], filename: "app/views/test.html.erb")
+
+        block = probe.deferred_entries.keys.fetch(0)
+        compiler = Herb::Engine::Slots::DynamicsCompiler.new(source, filename: "app/views/test.html.erb", block: block)
+
+        view = OverridableView.new({ "app/views/test.html.erb" => { "peek" => "basel", "_herb_block_0" => true } })
+        values = JSON.parse(JSON.generate(view.instance_eval(compiler.src)))
+        outer = values["slots"].values.fetch(0)
+
+        assert_equal 0, outer["branch"]
+        assert_equal "located basel", outer["slots"][block.to_s]["slots"].values.fetch(0)
+      end
+
+      test "poll flows into a deferred entry" do
+        source = ASYNC.sub("<Async>", %(<Async poll="5000">))
+
+        visitor, = compile(source)
+
+        assert_equal 5000, visitor.manifest["states"]["fragments"]["0"]["poll"]
+        assert_empty visitor.diagnostics
+      end
+
+      test "poll on a fragment errors" do
+        source = <<~ERB
+          <%# herb:slots client %>
+          <%# herb:state (peek: "") %>
+          <input value="<%= peek %>">
+          <Fragment poll="5000">
+            <p><%= Geo.locate(peek) %></p>
+            <Fallback><p>looking</p></Fallback>
+          </Fragment>
+        ERB
+
+        visitor, = compile(source)
+
+        assert_includes visitor.diagnostics.map(&:message).join, "only takes `delay` and `hold`"
       end
 
       test "the page and values compiles agree on indexes and state names" do


### PR DESCRIPTION
This pull request gives every deferred block its own request. 

A block trigger no longer rides the coalesced full-template pipeline. It fetches a values program scoped to that one block, in parallel with every other block, and a `poll` attribute re-issues the same scoped fetch on an interval.

```erb
<Async poll="2000">
  <p><%= Time.now.strftime("%H:%M:%S") %></p>

  <Fallback>
    <p class="skeleton"></p>
  </Fallback>
</Async>
```

Before this, a page with several `<Async>` tiles paid twice. The single-flight pipeline serialized the blocks, and every flight re-rendered every block already materialized, since their internal states stay steered. Ten dashboard tiles meant ten sequential flights of compounding cost. Now the ten tiles fan out as ten concurrent requests at mount.