### PR TITLE
Linter: Let the rendered-page linter see parked markup

### DIFF
--- a/javascript/packages/client/src/slots/slots.ts
+++ b/javascript/packages/client/src/slots/slots.ts
@@ -162,6 +162,30 @@ export class Slots implements ElementObserverDelegate, JournalDelegate, Collecti
     return this.index.files()
   }
 
+  parkedRoots(): DocumentFragment[] {
+    const roots = this.statics.all()
+
+    for (const region of this.regions()) {
+      for (const slot of region.slots.values()) {
+        this.capturedIn(slot, roots)
+      }
+    }
+
+    return roots
+  }
+
+  private capturedIn(slot: Slot, roots: DocumentFragment[]): void {
+    for (const fragment of slot.captured?.values() ?? []) {
+      roots.push(fragment)
+    }
+
+    for (const item of slot.items.values()) {
+      for (const inner of item.slots.values()) {
+        this.capturedIn(inner, roots)
+      }
+    }
+  }
+
   slotsFor(file: string, index: number): Slot[] {
     return this.index.slotsFor(file, index)
   }

--- a/javascript/packages/client/src/slots/statics.ts
+++ b/javascript/packages/client/src/slots/statics.ts
@@ -79,6 +79,10 @@ export class Statics {
     return this.held.get(file)?.fragments.get(key) ?? null
   }
 
+  all(): DocumentFragment[] {
+    return [...this.held.values()].flatMap((parked) => [...parked.fragments.values()])
+  }
+
   keys(file: string): string[] {
     return [...(this.held.get(file)?.fragments.keys() ?? [])]
   }

--- a/javascript/packages/client/test/refresh.test.ts
+++ b/javascript/packages/client/test/refresh.test.ts
@@ -101,6 +101,16 @@ describe("refetching server-derived slots", () => {
     expect(transport).not.toHaveBeenCalled()
   })
 
+  test("parked branches and captured material list as parked roots", async () => {
+    document.body.innerHTML = PAGE
+
+    const live = start({ state: { refetch: "off" } })
+    const roots = live.slots.parkedRoots()
+
+    expect(roots.length).toBeGreaterThan(0)
+    expect(roots.some((root) => root.querySelector("em") !== null)).toBe(true)
+  })
+
   test("writing a state its current value refetches nothing", async () => {
     document.body.innerHTML = PAGE
 

--- a/javascript/packages/linter/src/browser/rules/browser-scoped-style-no-unused-selector.ts
+++ b/javascript/packages/linter/src/browser/rules/browser-scoped-style-no-unused-selector.ts
@@ -90,13 +90,23 @@ function selectors(rules: ArrayLike<CSSRuleLike>): string[] {
   })
 }
 
+const TRANSIENT_PSEUDO = /:(?:hover|focus-within|focus-visible|focus|active|visited|target)\b/g
+
+const PSEUDO_ELEMENT = /::[a-z-]+(?:\([^)]*\))?|:(?:before|after|first-line|first-letter)\b/g
+
 function matches(scope: QueryableLike, selector: string): boolean {
+  const resting = selector.replace(TRANSIENT_PSEUDO, "").replace(PSEUDO_ELEMENT, "")
+
+  if (resting.trim().length === 0) {
+    return true
+  }
+
   try {
-    if (scope.matches?.(selector)) {
+    if (scope.matches?.(resting)) {
       return true
     }
 
-    return scope.querySelectorAll(selector).length > 0
+    return scope.querySelectorAll(resting).length > 0
   } catch {
     return true
   }
@@ -104,6 +114,231 @@ function matches(scope: QueryableLike, selector: string): boolean {
 
 function isScoped(element: DOMElementLike): element is ScopedStyleElement {
   return isStyleElement(element) && hasAttribute(element, "scoped") || attributeValue(element, HERB_ATTRIBUTES.styleScoped) !== null
+}
+
+function splitOutsideBrackets(selector: string, separators: string): string[] {
+  const parts: string[] = []
+
+  let depth = 0
+  let quote: string | null = null
+  let current = ""
+
+  for (const character of selector) {
+    if (quote) {
+      if (character === quote) {
+        quote = null
+      }
+
+      current += character
+
+      continue
+    }
+
+    if (character === '"' || character === "'") {
+      quote = character
+      current += character
+
+      continue
+    }
+
+    if (character === "(" || character === "[") {
+      depth += 1
+    } else if (character === ")" || character === "]") {
+      depth -= 1
+    }
+
+    if (depth === 0 && separators.includes(character)) {
+      parts.push(current)
+      current = ""
+
+      continue
+    }
+
+    current += character
+  }
+
+  parts.push(current)
+
+  return parts
+}
+
+function lastCompound(selector: string): string | null {
+  const groups = splitOutsideBrackets(selector, ",")
+    .map((group) => {
+      const compounds = splitOutsideBrackets(group.trim(), " >+~")
+        .map((compound) => compound.trim())
+        .filter((compound) => compound.length > 0)
+
+      return compounds[compounds.length - 1] ?? ""
+    })
+    .filter((group) => group.length > 0)
+
+  if (groups.length === 0) {
+    return null
+  }
+
+  return groups.join(", ")
+}
+
+interface CompoundParts {
+  core: string
+  classes: string[]
+  valued: Array<{ name: string, test: string }>
+}
+
+interface DynamicElementLike {
+  getAttribute?(name: string): string | null
+  matches?(selectors: string): boolean
+}
+
+function simpleSelectors(compound: string): string[] {
+  const parts: string[] = []
+
+  let depth = 0
+  let quote: string | null = null
+  let current = ""
+
+  for (const character of compound) {
+    if (quote) {
+      if (character === quote) {
+        quote = null
+      }
+
+      current += character
+
+      continue
+    }
+
+    if (character === '"' || character === "'") {
+      quote = character
+      current += character
+
+      continue
+    }
+
+    if (character === "(" || character === "[") {
+      depth += 1
+    } else if (character === ")" || character === "]") {
+      depth -= 1
+    }
+
+    const opensBracket = character === "[" && depth === 1
+    const startsSimple = (character === "." || character === "#" || character === ":") && depth === 0 && !current.endsWith(":")
+
+    if ((opensBracket || startsSimple) && current.length > 0) {
+      parts.push(current)
+      current = ""
+    }
+
+    current += character
+  }
+
+  if (current.length > 0) {
+    parts.push(current)
+  }
+
+  return parts
+}
+
+const VALUED_ATTRIBUTE = /^\[([^\]~^$*|=]+)[~^$*|]?=/
+
+function compoundParts(compound: string): CompoundParts {
+  const kept: string[] = []
+  const classes: string[] = []
+  const valued: Array<{ name: string, test: string }> = []
+
+  for (const part of simpleSelectors(compound)) {
+    if (part.startsWith(".")) {
+      classes.push(part)
+
+      continue
+    }
+
+    const attribute = part.match(VALUED_ATTRIBUTE)
+
+    if (attribute) {
+      valued.push({ name: attribute[1].trim(), test: part })
+
+      continue
+    }
+
+    kept.push(part)
+  }
+
+  return { core: kept.join("") || "*", classes, valued }
+}
+
+function dynamicAttributeNames(element: DynamicElementLike): Set<string> {
+  const raw = element.getAttribute?.(HERB_ATTRIBUTES.slot) ?? ""
+  const names = new Set<string>()
+
+  for (const entry of raw.split(/\s+/).filter(Boolean)) {
+    const [, , ...name] = entry.split(":")
+
+    if (name.length > 0) {
+      names.add(name.join(":"))
+    }
+  }
+
+  return names
+}
+
+function satisfiedWithDynamics(root: QueryableLike, compound: string): boolean {
+  const { core, classes, valued } = compoundParts(compound)
+
+  if (classes.length === 0 && valued.length === 0) {
+    return false
+  }
+
+  let candidates: ArrayLike<unknown>
+
+  try {
+    candidates = root.querySelectorAll(core)
+  } catch {
+    return true
+  }
+
+  return Array.from(candidates).some((candidate) => {
+    const element = candidate as DynamicElementLike
+
+    if (typeof element.matches !== "function") {
+      return false
+    }
+
+    const dynamic = dynamicAttributeNames(element)
+
+    for (const test of classes) {
+      if (!element.matches(test) && !dynamic.has("class")) {
+        return false
+      }
+    }
+
+    for (const { name, test } of valued) {
+      if (!element.matches(test) && !dynamic.has(name)) {
+        return false
+      }
+    }
+
+    return true
+  })
+}
+
+function matchesParked(root: QueryableLike, selector: string): boolean {
+  if (matches(root, selector)) {
+    return true
+  }
+
+  const compound = lastCompound(selector)
+
+  if (compound === null) {
+    return false
+  }
+
+  if (compound !== selector && matches(root, compound)) {
+    return true
+  }
+
+  return satisfiedWithDynamics(root, compound.replace(TRANSIENT_PSEUDO, ""))
 }
 
 export class BrowserScopedStyleNoUnusedSelectorRule extends BrowserRule {
@@ -116,12 +351,16 @@ export class BrowserScopedStyleNoUnusedSelectorRule extends BrowserRule {
     }
   }
 
-  check(root: DOMNodeLike, _context?: Partial<LintContext>): UnboundLintOffense[] {
+  check(root: DOMNodeLike, context?: Partial<LintContext>): UnboundLintOffense[] {
     const scope = root as QueryableLike
 
     if (typeof scope.querySelectorAll !== "function") {
       return []
     }
+
+    const parked = Array.from(context?.parkedRoots?.() ?? []).filter(
+      (candidate): candidate is QueryableLike => typeof (candidate as QueryableLike).querySelectorAll === "function"
+    )
 
     const offenses: UnboundLintOffense[] = []
 
@@ -131,6 +370,10 @@ export class BrowserScopedStyleNoUnusedSelectorRule extends BrowserRule {
 
       for (const selector of selectors(element.sheet.cssRules)) {
         if (matches(scope, selector)) {
+          continue
+        }
+
+        if (parked.some((candidate) => matchesParked(candidate, selector))) {
           continue
         }
 

--- a/javascript/packages/linter/src/types.ts
+++ b/javascript/packages/linter/src/types.ts
@@ -281,6 +281,11 @@ export interface LintContext {
   partialCallers: RenderGraph | undefined
   projectPath: string | undefined
   herb: HerbBackend | undefined
+  parkedRoots: (() => ArrayLike<ParkedRoot>) | undefined
+}
+
+export interface ParkedRoot {
+  querySelectorAll(selectors: string): ArrayLike<unknown>
 }
 
 /**
@@ -298,7 +303,8 @@ export const DEFAULT_LINT_CONTEXT: LintContext = {
   partials: undefined,
   partialCallers: undefined,
   projectPath: undefined,
-  herb: undefined
+  herb: undefined,
+  parkedRoots: undefined
 } as const
 
 export abstract class SourceRule<TAutofixContext extends BaseAutofixContext = BaseAutofixContext> {

--- a/javascript/packages/linter/test/browser/browser-rule.test.ts
+++ b/javascript/packages/linter/test/browser/browser-rule.test.ts
@@ -51,6 +51,50 @@ describe("browser-scoped-style-no-unused-selector", () => {
     `)
   })
 
+  test("says nothing about a selector gated on interaction state", () => {
+    expectNoOffenses(`
+      <style scoped>
+        .card:hover img { opacity: 0.8 }
+        .row:focus-within .play { display: inline }
+        .link:active { color: red }
+      </style>
+      <div class="card"><img src="x.png"></div>
+      <div class="row"><span class="play"></span></div>
+      <a class="link">go</a>
+    `)
+  })
+
+  test("still reports a hover selector whose markup is gone", () => {
+    expectInfo(unused(".vanished:hover img"))
+
+    assertOffenses(`
+      <style scoped>.vanished:hover img { opacity: 0.8 }</style>
+      <div class="card">used</div>
+    `)
+  })
+
+  test("checks a pseudo-element selector on its originating element", () => {
+    expectNoOffenses(`
+      <style scoped>
+        .sheet::before { content: "" }
+        .field::placeholder { color: gray }
+        .row:after { clear: both }
+      </style>
+      <div class="sheet"></div>
+      <input class="field">
+      <div class="row"></div>
+    `)
+  })
+
+  test("still reports a pseudo-element whose originating element is gone", () => {
+    expectInfo(unused(".vanished::before"))
+
+    assertOffenses(`
+      <style scoped>.vanished::before { content: "" }</style>
+      <div class="sheet"></div>
+    `)
+  })
+
   test("says nothing about a selector that matches the element it is scoped to", () => {
     expectNoOffenses(`
       <div class="card">
@@ -97,6 +141,76 @@ describe("browser-scoped-style-no-unused-selector", () => {
       <style scoped>DIV.Card { color: red }</style>
       <div class="Card"></div>
     `)
+  })
+})
+
+describe("matching against parked markup", () => {
+  const check = (markup: string, parked: string[]) => {
+    const roots = parked.map((fragment) => {
+      const template = document.createElement("template")
+
+      template.innerHTML = fragment
+
+      return template.content
+    })
+
+    return new BrowserScopedStyleNoUnusedSelectorRule().check(dom(markup) as any, { parkedRoots: () => roots })
+  }
+
+  test("says nothing about a selector whose markup is parked for later", () => {
+    const offenses = check(
+      `<style scoped>.detail .cover { width: 4rem }</style>`,
+      [`<section class="detail"><img class="cover"></section>`]
+    )
+
+    expect(offenses).toHaveLength(0)
+  })
+
+  test("accepts a parked match through the selector's innermost compound alone", () => {
+    const offenses = check(
+      `<style scoped>.player .tracks li:hover .play { display: inline }</style>`,
+      [`<span class="play"></span>`]
+    )
+
+    expect(offenses).toHaveLength(0)
+  })
+
+  test("honors a parked element whose class is a blanked slot", () => {
+    const offenses = check(
+      `<style scoped>.wave.is-on { display: flex }</style>`,
+      [`<span class="wave " data-herb-slot="16:attribute_interpolation:class"></span>`]
+    )
+
+    expect(offenses).toHaveLength(0)
+  })
+
+  test("honors a parked element whose tested attribute is a slot", () => {
+    const offenses = check(
+      `<style scoped>.playhead[data-playing="false"] { animation-play-state: paused }</style>`,
+      [`<div class="playhead" data-playing="" data-herb-slot="9:attribute:data-playing"></div>`]
+    )
+
+    expect(offenses).toHaveLength(0)
+  })
+
+  test("still reports a class no parked element could ever carry", () => {
+    const offenses = check(
+      `<style scoped>.wave.is-on { display: flex }</style>`,
+      [`<span class="wave"></span>`]
+    )
+
+    expect(offenses).toHaveLength(1)
+    expect(offenses[0].message).toBe(unused(".wave.is-on"))
+  })
+
+  test("still reports a selector no parked markup answers for", () => {
+    const offenses = check(
+      `<style scoped>.vanished { color: red }</style>`,
+      [`<section class="detail"><img class="cover"></section>`]
+    )
+
+    expect(offenses).toHaveLength(1)
+    expect(offenses[0].message).toBe(unused(".vanished"))
   })
 })
 


### PR DESCRIPTION
This pull request teaches `browser-scoped-style-no-unused-selector` about markup the page holds ready without rendering it, and stops it reporting selectors gated on interaction state.

The rule matches each scoped-style selector against the live DOM, which is the right default and the wrong whole story on a slots page. A client-mode template parks the branches its conditionals did not take, so with nothing selected, every selector written for a detail panel, an empty-state branch or a skeleton fallback matches nothing and reported as unused. 
