### PR TITLE
Dev Tools: Key locationless diagnostics by message

### DIFF
--- a/javascript/packages/dev-tools/src/runtime/report.ts
+++ b/javascript/packages/dev-tools/src/runtime/report.ts
@@ -523,6 +523,7 @@ export function diagnosticKey(diagnostic: NormalizedDiagnostic): string {
   return JSON.stringify([
     diagnostic.template,
     diagnostic.location?.start.line ?? null,
-    diagnostic.code ?? diagnostic.message
+    diagnostic.code ?? null,
+    diagnostic.location && diagnostic.code ? null : diagnostic.message
   ]);
 }

--- a/javascript/packages/dev-tools/test/runtime-report.test.ts
+++ b/javascript/packages/dev-tools/test/runtime-report.test.ts
@@ -376,6 +376,20 @@ describe("diagnosticKey", () => {
   test("separates codeless entries by message", () => {
     expect(diagnosticKey(diagnostic({ message: "one" }))).not.toBe(diagnosticKey(diagnostic({ message: "two" })))
   })
+
+  test("separates locationless findings of one rule by message", () => {
+    const first = diagnostic({ code: "browser-scoped-style-no-unused-selector", message: "Selector `.detail` matches nothing" })
+    const second = diagnostic({ code: "browser-scoped-style-no-unused-selector", message: "Selector `.tracks` matches nothing" })
+
+    expect(diagnosticKey(first)).not.toBe(diagnosticKey(second))
+  })
+
+  test("collapses repeated locationless reports of the same message", () => {
+    const first = diagnostic({ code: "herb-unknown-state", message: "`$refresh` is not a state" })
+    const second = diagnostic({ code: "herb-unknown-state", message: "`$refresh` is not a state" })
+
+    expect(diagnosticKey(first)).toBe(diagnosticKey(second))
+  })
 })
 
 describe("readRuntimeReport", () => {


### PR DESCRIPTION
This pull request fixes the panel collapsing distinct findings into one card.

The panel folds repeated reports of the same diagnostic into a single entry with a counter, keyed by template, source line and rule code, so a warning that fires on every state write reads as one entry with `×N` instead of N duplicates. 

But a diagnostic without a source location, which is every finding the rendered-page linter produces, has no line to separate it from its neighbors. A locationless diagnostic now keeps its message in its key. Distinct findings of one rule on one template stay distinct, and repeated reports of the same message still collapse the way they should.
