### PR TITLE
Linter: Implement `herb-component-requires-slots` rule

### DIFF
--- a/javascript/packages/linter/docs/rules/README.md
+++ b/javascript/packages/linter/docs/rules/README.md
@@ -103,6 +103,7 @@ This page contains documentation for all Herb Linter rules.
 - [`herb-disable-comment-no-redundant-all`](./herb-disable-comment-no-redundant-all.md) - Disallow redundant use of `all` in `herb:disable` comments.
 - [`herb-disable-comment-unnecessary`](./herb-disable-comment-unnecessary.md) - Detect unnecessary `herb:disable` comments.
 - [`herb-disable-comment-valid-rule-name`](./herb-disable-comment-valid-rule-name.md) - Validate rule names in `herb:disable` comments.
+- [`herb-component-requires-slots`](./herb-component-requires-slots.md) - Require a `herb:slots` directive on templates using component tags.
 - [`herb-into-requires-collection`](./herb-into-requires-collection.md) - Require `data-herb-into` to name a keyed collection.
 - [`herb-scoped-style-no-unused-selector`](./herb-scoped-style-no-unused-selector.md) - No unused selector in a `<style scoped>` block.
 - [`herb-scoped-style-require-top-level`](./herb-scoped-style-require-top-level.md) - Require a `<style scoped>` block to be a top-level element.

--- a/javascript/packages/linter/docs/rules/herb-component-requires-slots.md
+++ b/javascript/packages/linter/docs/rules/herb-component-requires-slots.md
@@ -1,0 +1,43 @@
+# Linter Rule: Require a `herb:slots` directive on templates using component tags
+
+**Rule:** `herb-component-requires-slots`
+
+## Description
+
+Requires a template that uses component tags like `<Fragment>` or `<Fallback>` to opt into slots compilation with a `<%# herb:slots %>` directive.
+
+## Rationale
+
+Components only compile when the template declares slots. Without the directive the engine leaves the tags in place, the browser treats them as unknown elements, and a `<Fallback>` renders alongside the content it should replace, with no deferral and no swapping. Nothing else surfaces this, because `html-tag-name-lowercase` deliberately skips component-cased names.
+
+The rule flags any tag written in component case, an uppercase start on a name that is not a known HTML element, since nothing compiles those in a slots template either and the engine reports them there. Custom elements are unaffected, as their names are lowercase with a hyphen. XML templates are exempt, both by an `<?xml ?>` declaration and by an `.xml.erb` file name, since uppercase tags are ordinary there.
+
+## Examples
+
+### ✅ Good
+
+```erb
+<%# herb:slots client %>
+
+<Fragment>
+  <p><%= Geo.locate(city) %></p>
+  <Fallback><p class="pulse">Looking it up</p></Fallback>
+</Fragment>
+```
+
+```erb
+<div class="card"><my-widget></my-widget></div>
+```
+
+### 🚫 Bad
+
+```erb
+<Fragment>
+  <p><%= Geo.locate(city) %></p>
+  <Fallback><p class="pulse">Looking it up</p></Fallback>
+</Fragment>
+```
+
+## References
+
+- [`herb-state-requires-client-mode`](./herb-state-requires-client-mode.md)

--- a/javascript/packages/linter/src/rules.ts
+++ b/javascript/packages/linter/src/rules.ts
@@ -82,6 +82,7 @@ import { ERBRightTrimRule } from "./rules/erb-right-trim.js"
 import { ERBStrictLocalsCommentSyntaxRule } from "./rules/erb-strict-locals-comment-syntax.js"
 import { ERBStrictLocalsRequiredRule } from "./rules/erb-strict-locals-required.js"
 
+import { HerbComponentRequiresSlotsRule } from "./rules/herb-component-requires-slots.js"
 import { HerbConfigFrameworkOptionRule } from "./rules/herb-config-framework-option.js"
 import { HerbDisableCommentMalformedRule } from "./rules/herb-disable-comment-malformed.js"
 import { HerbDisableCommentMissingRulesRule } from "./rules/herb-disable-comment-missing-rules.js"
@@ -252,6 +253,7 @@ export const rules: RuleClass[] = [
   ERBStrictLocalsCommentSyntaxRule,
   ERBStrictLocalsRequiredRule,
 
+  HerbComponentRequiresSlotsRule,
   HerbConfigFrameworkOptionRule,
   HerbDisableCommentMalformedRule,
   HerbDisableCommentMissingRulesRule,

--- a/javascript/packages/linter/src/rules/herb-component-requires-slots.ts
+++ b/javascript/packages/linter/src/rules/herb-component-requires-slots.ts
@@ -1,0 +1,67 @@
+import { BaseRuleVisitor } from "../utils/rule-utils.js"
+import { ParserRule } from "../types.js"
+import { slotsDirectiveMode } from "../utils/state-directives-utils.js"
+import { getTagName, isKnownHTMLElement } from "@herb-tools/core"
+
+import type { UnboundLintOffense, LintContext, FullRuleConfig } from "../types.js"
+import type { ParseResult, ERBContentNode, HTMLOpenTagNode, XMLDeclarationNode } from "@herb-tools/core"
+
+class ComponentRequiresSlotsVisitor extends BaseRuleVisitor {
+  public declaresSlots = false
+  public xml = false
+  public components: HTMLOpenTagNode[] = []
+
+  visitXMLDeclarationNode(_node: XMLDeclarationNode): void {
+    this.xml = true
+  }
+
+  visitERBContentNode(node: ERBContentNode): void {
+    if (slotsDirectiveMode(node) !== null) {
+      this.declaresSlots = true
+    }
+  }
+
+  visitHTMLOpenTagNode(node: HTMLOpenTagNode): void {
+    const name = getTagName(node)
+
+    if (name && /^[A-Z]/.test(name) && !isKnownHTMLElement(name.toLowerCase())) {
+      this.components.push(node)
+    }
+
+    super.visitHTMLOpenTagNode(node)
+  }
+
+  reportOutsideSlots(): void {
+    if (this.declaresSlots || this.xml) return
+
+    for (const component of this.components) {
+      this.addOffense(
+        `\`<${getTagName(component)}>\` is written like a component, but this template never opts into slots, so the browser renders it as a literal unknown element. Add \`<%# herb:slots client %>\` to compile it, or lowercase the tag if it is meant as plain HTML.`,
+        component.location,
+      )
+    }
+  }
+}
+
+export class HerbComponentRequiresSlotsRule extends ParserRule {
+  static ruleName = "herb-component-requires-slots"
+  static introducedIn = this.version("unreleased")
+
+  get defaultConfig(): FullRuleConfig {
+    return {
+      enabled: true,
+      severity: "error"
+    }
+  }
+
+  check(result: ParseResult, context?: Partial<LintContext>): UnboundLintOffense[] {
+    if (context?.fileName?.endsWith(".xml.erb")) return []
+
+    const visitor = new ComponentRequiresSlotsVisitor(this.ruleName, context)
+
+    visitor.visit(result.value)
+    visitor.reportOutsideSlots()
+
+    return visitor.offenses
+  }
+}

--- a/javascript/packages/linter/src/rules/index.ts
+++ b/javascript/packages/linter/src/rules/index.ts
@@ -83,6 +83,7 @@ export * from "./erb-right-trim.js"
 export * from "./erb-strict-locals-comment-syntax.js"
 export * from "./erb-strict-locals-required.js"
 
+export * from "./herb-component-requires-slots.js"
 export * from "./herb-config-framework-option.js"
 export * from "./herb-disable-comment-malformed.js"
 export * from "./herb-disable-comment-missing-rules.js"

--- a/javascript/packages/linter/test/__snapshots__/cli.test.ts.snap
+++ b/javascript/packages/linter/test/__snapshots__/cli.test.ts.snap
@@ -19,7 +19,7 @@ test-file-with-errors.html.erb:
   Failing      2 errors (2 offenses across 1 file)
   Not failing  1 warning (1 offense across 1 file, below --fail-level=error)
   Fixable      3 offenses | 2 autocorrectable using \`--fix\`
-  Rules        159 enabled | all rules via --all-rules"
+  Rules        160 enabled | all rules via --all-rules"
 `;
 
 exports[`CLI Output Formatting > \`all\` pseudo rule in .herb.yml > \`Rules\` summary line > \`--only\` replaces the counts from a disabled \`all\` 1`] = `
@@ -50,7 +50,7 @@ exports[`CLI Output Formatting > \`all\` pseudo rule in .herb.yml > \`Rules\` su
   Checked      1 file
   Offenses     0 offenses
   Fixable      0 offenses
-  Rules        0 enabled | 159 not enabled
+  Rules        0 enabled | 160 not enabled
 
  No rules enabled:
   Every linter rule is turned off, so no offenses can be reported.
@@ -71,7 +71,7 @@ exports[`CLI Output Formatting > \`all\` pseudo rule in .herb.yml > \`Rules\` su
   Checked      1 file
   Offenses     0 offenses
   Fixable      0 offenses
-  Rules        0 enabled | 159 not enabled
+  Rules        0 enabled | 160 not enabled
 
  No rules enabled:
   Every linter rule is turned off, so no offenses can be reported.
@@ -102,7 +102,7 @@ test-file-with-errors.html.erb:
   Failing      2 errors (2 offenses across 1 file)
   Not failing  1 warning (1 offense across 1 file, below --fail-level=error)
   Fixable      3 offenses | 2 autocorrectable using \`--fix\`
-  Rules        159 enabled"
+  Rules        160 enabled"
 `;
 
 exports[`CLI Output Formatting > \`all\` pseudo rule in .herb.yml > \`Rules\` summary line > \`all: enabled: true\` reports no version-skipped rules 1`] = `
@@ -124,7 +124,7 @@ test-file-with-errors.html.erb:
   Failing      2 errors (2 offenses across 1 file)
   Not failing  1 warning (1 offense across 1 file, below --fail-level=error)
   Fixable      3 offenses | 2 autocorrectable using \`--fix\`
-  Rules        159 enabled"
+  Rules        160 enabled"
 `;
 
 exports[`CLI Output Formatting > \`all\` pseudo rule in .herb.yml > \`Rules\` summary line > reports enabled and not-enabled rules when no \`all\` is configured 1`] = `
@@ -146,7 +146,7 @@ test/fixtures/test-file-with-errors.html.erb:
   Failing      2 errors (2 offenses across 1 file)
   Not failing  1 warning (1 offense across 1 file, below --fail-level=error)
   Fixable      3 offenses | 2 autocorrectable using \`--fix\`
-  Rules        138 enabled | 21 not enabled"
+  Rules        139 enabled | 21 not enabled"
 `;
 
 exports[`CLI Output Formatting > \`all\` pseudo rule in .herb.yml > \`Rules\` summary line > rules opted back in on top of \`all: enabled: false\` count as enabled 1`] = `
@@ -165,7 +165,7 @@ test-file-with-errors.html.erb:
   Failing      0 offenses
   Not failing  1 warning (1 offense across 1 file, below --fail-level=error)
   Fixable      0 offenses
-  Rules        1 enabled | 158 not enabled"
+  Rules        1 enabled | 159 not enabled"
 `;
 
 exports[`CLI Output Formatting > \`all\` pseudo rule in .herb.yml > \`Rules\` summary line > rules opted out on top of \`all: enabled: true\` count as disabled 1`] = `
@@ -184,7 +184,7 @@ test-file-with-errors.html.erb:
   Checked      1 file
   Offenses     2 errors (2 offenses across 1 file)
   Fixable      2 offenses | 2 autocorrectable using \`--fix\`
-  Rules        158 enabled | 1 disabled"
+  Rules        159 enabled | 1 disabled"
 `;
 
 exports[`CLI Output Formatting > --all-rules > reports every offense for the fixture with --all-rules 1`] = `
@@ -214,7 +214,7 @@ test/fixtures/all-rules.html.erb:
   Failing      0 offenses
   Not failing  6 warnings (6 offenses across 1 file, below --fail-level=error)
   Fixable      0 offenses
-  Rules        159 enabled | all rules via --all-rules"
+  Rules        160 enabled | all rules via --all-rules"
 `;
 
 exports[`CLI Output Formatting > --all-rules > reports nothing for the fixture with the default rule set 1`] = `
@@ -226,7 +226,7 @@ exports[`CLI Output Formatting > --all-rules > reports nothing for the fixture w
   Checked      1 file
   Offenses     0 offenses
   Fixable      0 offenses
-  Rules        138 enabled | 21 not enabled"
+  Rules        139 enabled | 21 not enabled"
 `;
 
 exports[`CLI Output Formatting > --ignore-disable-comments 1`] = `
@@ -377,7 +377,7 @@ test/fixtures/ignored.html.erb:8:8
   Not failing  2 warnings (2 offenses across 1 file, below --fail-level=error)
   Note         3 additional offenses reported (would have been ignored)
   Fixable      7 offenses | 4 autocorrectable using \`--fix\`
-  Rules        138 enabled | 21 not enabled"
+  Rules        139 enabled | 21 not enabled"
 `;
 
 exports[`CLI Output Formatting > --log-level > counts the hidden offenses and suggests the level that reveals them 1`] = `
@@ -395,7 +395,7 @@ exports[`CLI Output Formatting > --log-level > counts the hidden offenses and su
   Not failing  2 info | 1 hint (3 offenses across 1 file, below --fail-level=error)
   Not shown    3 offenses hidden, show them with --log-level=hint
   Fixable      3 offenses | 2 autocorrectable using \`--fix\`
-  Rules        138 enabled | 21 not enabled"
+  Rules        139 enabled | 21 not enabled"
 `;
 
 exports[`CLI Output Formatting > --log-level > doesn't report offenses below the given level 1`] = `
@@ -412,7 +412,7 @@ exports[`CLI Output Formatting > --log-level > doesn't report offenses below the
   Not failing  1 hint (1 offense across 1 file, below --fail-level=error)
   Not shown    1 offense hidden, show it with --log-level=hint
   Fixable      0 offenses
-  Rules        137 enabled | 21 not enabled | 1 disabled"
+  Rules        138 enabled | 21 not enabled | 1 disabled"
 `;
 
 exports[`CLI Output Formatting > --log-level > prefers the CLI flag over the config file 1`] = `
@@ -431,7 +431,7 @@ test-file-with-errors.html.erb:
   Failing      0 offenses
   Not failing  1 hint (1 offense across 1 file, below --fail-level=error)
   Fixable      0 offenses
-  Rules        137 enabled | 21 not enabled | 1 disabled"
+  Rules        138 enabled | 21 not enabled | 1 disabled"
 `;
 
 exports[`CLI Output Formatting > --log-level > reads logLevel from the config file 1`] = `
@@ -448,7 +448,7 @@ exports[`CLI Output Formatting > --log-level > reads logLevel from the config fi
   Not failing  1 hint (1 offense across 1 file, below --fail-level=error)
   Not shown    1 offense hidden, show it with --log-level=hint
   Fixable      0 offenses
-  Rules        137 enabled | 21 not enabled | 1 disabled"
+  Rules        138 enabled | 21 not enabled | 1 disabled"
 `;
 
 exports[`CLI Output Formatting > --log-level > still counts hidden offenses towards the exit code 1`] = `
@@ -464,7 +464,7 @@ exports[`CLI Output Formatting > --log-level > still counts hidden offenses towa
   Offenses     1 hint (1 offense across 1 file)
   Not shown    1 offense hidden, show it with --log-level=hint
   Fixable      0 offenses
-  Rules        137 enabled | 21 not enabled | 1 disabled"
+  Rules        138 enabled | 21 not enabled | 1 disabled"
 `;
 
 exports[`CLI Output Formatting > --log-level > still reports offenses at or above the given level 1`] = `
@@ -483,7 +483,7 @@ test-file-with-errors.html.erb:
   Failing      0 offenses
   Not failing  1 hint (1 offense across 1 file, below --fail-level=error)
   Fixable      0 offenses
-  Rules        137 enabled | 21 not enabled | 1 disabled"
+  Rules        138 enabled | 21 not enabled | 1 disabled"
 `;
 
 exports[`CLI Output Formatting > --log-level > with --all-rules > keeps the log level when it is passed explicitly 1`] = `
@@ -505,7 +505,7 @@ test-file-with-errors.html.erb:
   Not failing  1 hint (1 offense across 1 file, below --fail-level=error)
   Not shown    1 offense hidden, show it with --log-level=hint
   Fixable      3 offenses | 2 autocorrectable using \`--fix\`
-  Rules        159 enabled | all rules via --all-rules"
+  Rules        160 enabled | all rules via --all-rules"
 `;
 
 exports[`CLI Output Formatting > --log-level > with --all-rules > lowers the log level to report the rules it was asked for 1`] = `
@@ -528,7 +528,7 @@ test-file-with-errors.html.erb:
   Not failing  1 hint (1 offense across 1 file, below --fail-level=error)
   Log level    hint | lowered from warning by --all-rules
   Fixable      3 offenses | 2 autocorrectable using \`--fix\`
-  Rules        159 enabled | all rules via --all-rules"
+  Rules        160 enabled | all rules via --all-rules"
 `;
 
 exports[`CLI Output Formatting > --log-level > with --only > keeps the log level when it is passed explicitly 1`] = `
@@ -689,7 +689,7 @@ test/fixtures/test-file-with-errors.html.erb:2:22
   Failing      2 errors (2 offenses across 1 file)
   Not failing  1 warning (1 offense across 1 file, below --fail-level=error)
   Fixable      3 offenses | 2 autocorrectable using \`--fix\`
-  Rules        138 enabled | 21 not enabled"
+  Rules        139 enabled | 21 not enabled"
 `;
 
 exports[`CLI Output Formatting > GitHub Actions format includes rule codes 1`] = `
@@ -721,7 +721,7 @@ test/fixtures/no-trailing-newline.html.erb:1:29
   Checked      1 file
   Offenses     1 error (1 offense across 1 file)
   Fixable      1 offense | 1 autocorrectable using \`--fix\`
-  Rules        138 enabled | 21 not enabled"
+  Rules        139 enabled | 21 not enabled"
 `;
 
 exports[`CLI Output Formatting > GitHub Actions format includes rule codes 2`] = `
@@ -810,7 +810,7 @@ test/fixtures/erb-no-extra-whitespace-inside-tags.html.erb:1:4
   Checked      1 file
   Offenses     4 errors (4 offenses across 1 file)
   Fixable      4 offenses | 3 autocorrectable using \`--fix\`
-  Rules        138 enabled | 21 not enabled"
+  Rules        139 enabled | 21 not enabled"
 `;
 
 exports[`CLI Output Formatting > Ignores disabled rules 1`] = `
@@ -870,7 +870,7 @@ test/fixtures/ignored.html.erb:6:14
   Offenses     2 errors (2 offenses across 1 file)
   Ignored      3 offenses suppressed with herb:disable
   Fixable      2 offenses | 2 autocorrectable using \`--fix\`
-  Rules        138 enabled | 21 not enabled"
+  Rules        139 enabled | 21 not enabled"
 `;
 
 exports[`CLI Output Formatting > New rules available hint > keeps the space before the version label inside the gray sequence 1`] = `"  ]8;;https://herb-tools.dev/linter/rules/svg-tag-name-capitalization\\[37msvg-tag-name-capitalization[0m]8;;\\[90m (introduced in 0.4.2)[0m"`;
@@ -932,7 +932,7 @@ test/fixtures/tag-attributes.html.erb:5:0
   Failing      0 offenses
   Not failing  2 warnings (2 offenses across 1 file, below --fail-level=error)
   Fixable      2 offenses | 2 autocorrectable using \`--fix\`
-  Rules        138 enabled | 21 not enabled"
+  Rules        139 enabled | 21 not enabled"
 `;
 
 exports[`CLI Output Formatting > diplays only parsers errors if one is present 1`] = `
@@ -958,7 +958,7 @@ test/fixtures/parser-errors.html.erb:2:16
   Checked      1 file
   Offenses     1 error (1 offense across 1 file)
   Fixable      0 offenses
-  Rules        138 enabled | 21 not enabled"
+  Rules        139 enabled | 21 not enabled"
 `;
 
 exports[`CLI Output Formatting > displays most violated rules with multiple offenses 1`] = `
@@ -1210,7 +1210,7 @@ test/fixtures/multiple-rule-offenses.html.erb:4:7
   Failing      8 errors (8 offenses across 1 file)
   Not failing  6 warnings (6 offenses across 1 file, below --fail-level=error)
   Fixable      14 offenses | 4 autocorrectable using \`--fix\`
-  Rules        138 enabled | 21 not enabled"
+  Rules        139 enabled | 21 not enabled"
 `;
 
 exports[`CLI Output Formatting > displays rule offenses when showing all rules 1`] = `
@@ -1335,7 +1335,7 @@ test/fixtures/few-rule-offenses.html.erb:6:0
   Failing      4 errors (4 offenses across 1 file)
   Not failing  2 warnings (2 offenses across 1 file, below --fail-level=error)
   Fixable      6 offenses | 3 autocorrectable using \`--fix\`
-  Rules        138 enabled | 21 not enabled"
+  Rules        139 enabled | 21 not enabled"
 `;
 
 exports[`CLI Output Formatting > formats GitHub Actions output correctly for bad file 1`] = `
@@ -1390,7 +1390,7 @@ test/fixtures/bad-file.html.erb:1:16
   Checked      1 file
   Offenses     2 errors (2 offenses across 1 file)
   Fixable      2 offenses | 2 autocorrectable using \`--fix\`
-  Rules        138 enabled | 21 not enabled"
+  Rules        139 enabled | 21 not enabled"
 `;
 
 exports[`CLI Output Formatting > formats GitHub Actions output correctly for clean file 1`] = `
@@ -1402,7 +1402,7 @@ exports[`CLI Output Formatting > formats GitHub Actions output correctly for cle
   Checked      1 file
   Offenses     0 offenses
   Fixable      0 offenses
-  Rules        138 enabled | 21 not enabled"
+  Rules        139 enabled | 21 not enabled"
 `;
 
 exports[`CLI Output Formatting > formats GitHub Actions output correctly for file with errors 1`] = `
@@ -1481,7 +1481,7 @@ test/fixtures/test-file-with-errors.html.erb:2:22
   Failing      2 errors (2 offenses across 1 file)
   Not failing  1 warning (1 offense across 1 file, below --fail-level=error)
   Fixable      3 offenses | 2 autocorrectable using \`--fix\`
-  Rules        138 enabled | 21 not enabled"
+  Rules        139 enabled | 21 not enabled"
 `;
 
 exports[`CLI Output Formatting > formats GitHub Actions output with --format=github option 1`] = `
@@ -1538,7 +1538,7 @@ test/fixtures/test-file-simple.html.erb:2:22
   Checked      1 file
   Offenses     2 errors (2 offenses across 1 file)
   Fixable      2 offenses | 2 autocorrectable using \`--fix\`
-  Rules        138 enabled | 21 not enabled"
+  Rules        139 enabled | 21 not enabled"
 `;
 
 exports[`CLI Output Formatting > formats JSON output correctly for bad file 1`] = `
@@ -1585,7 +1585,7 @@ exports[`CLI Output Formatting > formats JSON output correctly for bad file 1`] 
   "summary": {
     "filesChecked": 1,
     "filesWithOffenses": 1,
-    "ruleCount": 138,
+    "ruleCount": 139,
     "totalErrors": 2,
     "totalHints": 0,
     "totalIgnored": 0,
@@ -1607,7 +1607,7 @@ exports[`CLI Output Formatting > formats JSON output correctly for clean file 1`
   "summary": {
     "filesChecked": 1,
     "filesWithOffenses": 0,
-    "ruleCount": 138,
+    "ruleCount": 139,
     "totalErrors": 0,
     "totalHints": 0,
     "totalIgnored": 0,
@@ -1681,7 +1681,7 @@ exports[`CLI Output Formatting > formats JSON output correctly for file with err
   "summary": {
     "filesChecked": 1,
     "filesWithOffenses": 1,
-    "ruleCount": 138,
+    "ruleCount": 139,
     "totalErrors": 2,
     "totalHints": 0,
     "totalIgnored": 0,
@@ -1764,7 +1764,7 @@ test/fixtures/test-file-with-errors.html.erb:2:22
   Failing      2 errors (2 offenses across 1 file)
   Not failing  1 warning (1 offense across 1 file, below --fail-level=error)
   Fixable      3 offenses | 2 autocorrectable using \`--fix\`
-  Rules        138 enabled | 21 not enabled"
+  Rules        139 enabled | 21 not enabled"
 `;
 
 exports[`CLI Output Formatting > formats simple output correctly 1`] = `
@@ -1783,7 +1783,7 @@ test/fixtures/test-file-simple.html.erb:
   Checked      1 file
   Offenses     2 errors (2 offenses across 1 file)
   Fixable      2 offenses | 2 autocorrectable using \`--fix\`
-  Rules        138 enabled | 21 not enabled"
+  Rules        139 enabled | 21 not enabled"
 `;
 
 exports[`CLI Output Formatting > formats simple output for bad-file correctly 1`] = `
@@ -1802,7 +1802,7 @@ test/fixtures/bad-file.html.erb:
   Checked      1 file
   Offenses     2 errors (2 offenses across 1 file)
   Fixable      2 offenses | 2 autocorrectable using \`--fix\`
-  Rules        138 enabled | 21 not enabled"
+  Rules        139 enabled | 21 not enabled"
 `;
 
 exports[`CLI Output Formatting > formats success output correctly 1`] = `
@@ -1814,7 +1814,7 @@ exports[`CLI Output Formatting > formats success output correctly 1`] = `
   Checked      1 file
   Offenses     0 offenses
   Fixable      0 offenses
-  Rules        138 enabled | 21 not enabled"
+  Rules        139 enabled | 21 not enabled"
 `;
 
 exports[`CLI Output Formatting > handles boolean attributes 1`] = `
@@ -1826,7 +1826,7 @@ exports[`CLI Output Formatting > handles boolean attributes 1`] = `
   Checked      1 file
   Offenses     0 offenses
   Fixable      0 offenses
-  Rules        138 enabled | 21 not enabled"
+  Rules        139 enabled | 21 not enabled"
 `;
 
 exports[`CLI Output Formatting > handles multiple errors correctly 1`] = `
@@ -1877,7 +1877,7 @@ test/fixtures/bad-file.html.erb:1:16
   Checked      1 file
   Offenses     2 errors (2 offenses across 1 file)
   Fixable      2 offenses | 2 autocorrectable using \`--fix\`
-  Rules        138 enabled | 21 not enabled"
+  Rules        139 enabled | 21 not enabled"
 `;
 
 exports[`CLI Output Formatting > herb:disable rules 1`] = `
@@ -2020,7 +2020,7 @@ test/fixtures/disabled-1.html.erb:14:19
   Not failing  6 warnings (6 offenses across 1 file, below --fail-level=error)
   Ignored      8 offenses suppressed with herb:disable
   Fixable      8 offenses | 1 autocorrectable using \`--fix\`
-  Rules        138 enabled | 21 not enabled"
+  Rules        139 enabled | 21 not enabled"
 `;
 
 exports[`CLI Output Formatting > herb:disable rules 2`] = `
@@ -2279,7 +2279,7 @@ test/fixtures/disabled-2.html.erb:2:44
   Not failing  7 warnings (7 offenses across 1 file, below --fail-level=error)
   Ignored      5 offenses suppressed with herb:disable
   Fixable      13 offenses | 6 autocorrectable using \`--fix\`
-  Rules        138 enabled | 21 not enabled"
+  Rules        139 enabled | 21 not enabled"
 `;
 
 exports[`CLI Output Formatting > missing \`framework\` option > reports the missing option per template 1`] = `
@@ -2298,7 +2298,7 @@ clean-file.html.erb:
   Failing      0 offenses
   Not failing  1 info (1 offense across 1 file, below --fail-level=error)
   Fixable      0 offenses
-  Rules        1 enabled | 158 not enabled"
+  Rules        1 enabled | 159 not enabled"
 `;
 
 exports[`CLI Output Formatting > non-failing offenses tip > points at --log-level when many offenses don't fail the build 1`] = `
@@ -2336,7 +2336,7 @@ multiple-rule-offenses.html.erb:
   Failing      3 errors (3 offenses across 1 file)
   Not failing  1 info | 10 hints (11 offenses across 1 file, below --fail-level=error)
   Fixable      14 offenses | 4 autocorrectable using \`--fix\`
-  Rules        138 enabled | 21 not enabled
+  Rules        139 enabled | 21 not enabled
 
  TIP: 11 of the logged offenses don't fail the build.
       Run herb-lint --log-level=error to stop logging them, or set linter.logLevel in your .herb.yml.
@@ -2368,7 +2368,7 @@ multiple-rule-offenses.html.erb:
   Not failing  1 info | 10 hints (11 offenses across 1 file, below --fail-level=error)
   Not shown    11 offenses hidden, show them with --log-level=hint
   Fixable      14 offenses | 4 autocorrectable using \`--fix\`
-  Rules        138 enabled | 21 not enabled"
+  Rules        139 enabled | 21 not enabled"
 `;
 
 exports[`CLI Output Formatting > non-failing offenses tip > stays quiet when --log-level is passed explicitly, even when it hides nothing 1`] = `
@@ -2406,7 +2406,7 @@ multiple-rule-offenses.html.erb:
   Failing      3 errors (3 offenses across 1 file)
   Not failing  1 info | 10 hints (11 offenses across 1 file, below --fail-level=error)
   Fixable      14 offenses | 4 autocorrectable using \`--fix\`
-  Rules        138 enabled | 21 not enabled"
+  Rules        139 enabled | 21 not enabled"
 `;
 
 exports[`CLI Output Formatting > non-failing offenses tip > stays quiet when logLevel is set in the config file 1`] = `
@@ -2444,7 +2444,7 @@ multiple-rule-offenses.html.erb:
   Failing      3 errors (3 offenses across 1 file)
   Not failing  1 info | 10 hints (11 offenses across 1 file, below --fail-level=error)
   Fixable      14 offenses | 4 autocorrectable using \`--fix\`
-  Rules        138 enabled | 21 not enabled"
+  Rules        139 enabled | 21 not enabled"
 `;
 
 exports[`CLI Output Formatting > non-failing offenses tip > stays quiet when only a handful of offenses don't fail the build 1`] = `
@@ -2482,7 +2482,7 @@ multiple-rule-offenses.html.erb:
   Failing      8 errors (8 offenses across 1 file)
   Not failing  6 warnings (6 offenses across 1 file, below --fail-level=error)
   Fixable      14 offenses | 4 autocorrectable using \`--fix\`
-  Rules        138 enabled | 21 not enabled"
+  Rules        139 enabled | 21 not enabled"
 `;
 
 exports[`CLI Output Formatting > points at the flag instead of previewing once there are too many corrections 1`] = `
@@ -2578,7 +2578,7 @@ test/fixtures/test-file-simple.html.erb:2:22
   Checked      1 file
   Offenses     2 errors (2 offenses across 1 file)
   Fixable      2 offenses | 2 autocorrectable using \`--fix\`
-  Rules        138 enabled | 21 not enabled"
+  Rules        139 enabled | 21 not enabled"
 `;
 
 exports[`CLI Output Formatting > previews the correction under each correctable offense 1`] = `
@@ -2635,7 +2635,7 @@ test/fixtures/test-file-simple.html.erb:2:22
   Checked      1 file
   Offenses     2 errors (2 offenses across 1 file)
   Fixable      2 offenses | 2 autocorrectable using \`--fix\`
-  Rules        138 enabled | 21 not enabled"
+  Rules        139 enabled | 21 not enabled"
 `;
 
 exports[`CLI Output Formatting > summary offense buckets > groups every severity into one line when --fail-level is hint 1`] = `
@@ -2672,7 +2672,7 @@ test/fixtures/multiple-rule-offenses.html.erb:
   Checked      1 file
   Offenses     8 errors | 6 warnings (14 offenses across 1 file)
   Fixable      14 offenses | 4 autocorrectable using \`--fix\`
-  Rules        138 enabled | 21 not enabled"
+  Rules        139 enabled | 21 not enabled"
 `;
 
 exports[`CLI Output Formatting > summary offense buckets > groups every severity into one line when --fail-level is info 1`] = `
@@ -2709,7 +2709,7 @@ test/fixtures/multiple-rule-offenses.html.erb:
   Checked      1 file
   Offenses     8 errors | 6 warnings (14 offenses across 1 file)
   Fixable      14 offenses | 4 autocorrectable using \`--fix\`
-  Rules        138 enabled | 21 not enabled"
+  Rules        139 enabled | 21 not enabled"
 `;
 
 exports[`CLI Output Formatting > summary offense buckets > groups every severity into one line when --fail-level is warning 1`] = `
@@ -2746,7 +2746,7 @@ test/fixtures/multiple-rule-offenses.html.erb:
   Checked      1 file
   Offenses     8 errors | 6 warnings (14 offenses across 1 file)
   Fixable      14 offenses | 4 autocorrectable using \`--fix\`
-  Rules        138 enabled | 21 not enabled"
+  Rules        139 enabled | 21 not enabled"
 `;
 
 exports[`CLI Output Formatting > summary offense buckets > moves a severity between buckets as --fail-level is lowered 1`] = `
@@ -2784,7 +2784,7 @@ multiple-rule-offenses.html.erb:
   Failing      8 errors | 4 warnings | 1 info (13 offenses across 1 file)
   Not failing  1 hint (1 offense across 1 file, below --fail-level=info)
   Fixable      14 offenses | 4 autocorrectable using \`--fix\`
-  Rules        138 enabled | 21 not enabled"
+  Rules        139 enabled | 21 not enabled"
 `;
 
 exports[`CLI Output Formatting > summary offense buckets > splits the buckets when only some severities fail the build 1`] = `
@@ -2822,7 +2822,7 @@ multiple-rule-offenses.html.erb:
   Failing      8 errors | 4 warnings (12 offenses across 1 file)
   Not failing  1 info | 1 hint (2 offenses across 1 file, below --fail-level=warning)
   Fixable      14 offenses | 4 autocorrectable using \`--fix\`
-  Rules        138 enabled | 21 not enabled"
+  Rules        139 enabled | 21 not enabled"
 `;
 
 exports[`CLI Output Formatting > unsafe autocorrectable offenses > counts and tags them separately from offenses --fix can correct 1`] = `
@@ -2942,5 +2942,5 @@ test/fixtures/test-file-with-errors.html.erb:2:22
   Failing      2 errors (2 offenses across 1 file)
   Not failing  1 warning (1 offense across 1 file, below --fail-level=error)
   Fixable      3 offenses | 2 autocorrectable using \`--fix\`
-  Rules        138 enabled | 21 not enabled"
+  Rules        139 enabled | 21 not enabled"
 `;

--- a/javascript/packages/linter/test/rules/herb-component-requires-slots.test.ts
+++ b/javascript/packages/linter/test/rules/herb-component-requires-slots.test.ts
@@ -1,0 +1,65 @@
+import dedent from "dedent"
+import { describe, test } from "vitest"
+import { HerbComponentRequiresSlotsRule } from "../../src/rules/herb-component-requires-slots.js"
+import { createLinterTest } from "../helpers/linter-test-helper.js"
+
+const { expectNoOffenses, expectError, assertOffenses } = createLinterTest(HerbComponentRequiresSlotsRule)
+
+const message = (name: string) => `\`<${name}>\` is written like a component, but this template never opts into slots, so the browser renders it as a literal unknown element. Add \`<%# herb:slots client %>\` to compile it, or lowercase the tag if it is meant as plain HTML.`
+
+describe("herb-component-requires-slots", () => {
+  test("passes for components in a client slots template", () => {
+    expectNoOffenses(dedent`
+      <%# herb:slots client %>
+      <Fragment>
+        <p><%= @value %></p>
+        <Fallback><p>waiting</p></Fallback>
+      </Fragment>
+    `)
+  })
+
+  test("passes for components in a server slots template", () => {
+    expectNoOffenses(dedent`
+      <%# herb:slots server %>
+      <Fragment>
+        <p><%= @value %></p>
+        <Fallback><p>waiting</p></Fallback>
+      </Fragment>
+    `)
+  })
+
+  test("passes for plain HTML and custom elements without the directive", () => {
+    expectNoOffenses(dedent`
+      <div class="card"><my-widget></my-widget></div>
+    `)
+  })
+
+  test("passes for an XML document, where uppercase tags are ordinary", () => {
+    expectNoOffenses(dedent`
+      <?xml version="1.0" encoding="UTF-8"?>
+      <OpenSearchDescription>
+        <ShortName><%= @name %></ShortName>
+      </OpenSearchDescription>
+    `)
+  })
+
+  test("flags each component tag in a template without the directive", () => {
+    expectError(message("Fragment"))
+    expectError(message("Fallback"))
+
+    assertOffenses(dedent`
+      <Fragment>
+        <p><%= @value %></p>
+        <Fallback><p>waiting</p></Fallback>
+      </Fragment>
+    `)
+  })
+
+  test("flags a component name Herb does not know, since nothing compiles it either", () => {
+    expectError(message("MyWidget"))
+
+    assertOffenses(dedent`
+      <MyWidget></MyWidget>
+    `)
+  })
+})


### PR DESCRIPTION
This pull request implements the `herb-component-requires-slots` rule, which requires a template that uses component tags like `<Fragment>` or `<Fallback>` to opt into slots compilation with a `<%# herb:slots %>` directive.

Components only compile when the template declares slots. Without the directive the engine leaves the tags in place, the browser treats them as unknown elements, and a `<Fallback>` renders alongside the content it should replace, with no deferral and no swapping. Nothing else surfaces this, because `html-tag-name-lowercase` deliberately skips component-cased names, so a `<Fragment>` in a plain template fails completely silently.