### PR TITLE
Client: Animate slot updates with `data-herb-transition`

### DIFF
--- a/javascript/packages/client/src/directives.ts
+++ b/javascript/packages/client/src/directives.ts
@@ -18,6 +18,7 @@ export { stateKindArticle } from "./state-kinds"
 export { isMarker, parseMarker } from "./markup/markers"
 export { clauses, names, balancedQuotes, splitOutsideQuotes, unquote } from "./grammar/parsing"
 export { eventSpecProblem } from "./actions/events"
+export { transitionIdentifier, TRANSITION_ATTRIBUTE } from "./shared/transitions"
 
 export type { Clause } from "./grammar/parsing"
 export type { StatePredicate } from "./state-predicates"

--- a/javascript/packages/client/src/outbox/outbox.ts
+++ b/javascript/packages/client/src/outbox/outbox.ts
@@ -3,6 +3,8 @@ import { HERB_ATTRIBUTES } from "../grammar/attributes"
 import { report } from "../shared/report"
 import { scopeOf } from "../state/scopes"
 import { slotsRequest } from "../shared/slots-request"
+import { transitionMutation } from "../shared/transitions"
+import { hostOf } from "../markup/anchors"
 
 import type { Slots } from "../slots/slots"
 import type { State } from "../state/state"
@@ -30,21 +32,29 @@ export class Outbox {
   submit(options: SubmitOptions): Promise<MutationResult> {
     const key = options.key ?? `herb-pending-${(this.minted += 1)}`
     const slot = this.collection(options.into)
-
-    let item: Item | null = null
-
-    if (slot) {
-      item = this.slots.addItem(slot, key, { values: options.values, text: true })
-    }
-
     const record: Sending = { options, key, slot: null }
 
-    if (slot && item) {
-      this.setStates(slot, item, { pending: true, failed: false })
+    let inserted = false
 
-      record.slot = slot
+    const insert = () => {
+      inserted = true
+
+      if (!slot) {
+        return
+      }
+
+      const item = this.slots.addItem(slot, key, { values: options.values, text: true })
+
+      if (item) {
+        this.setStates(slot, item, { pending: true, failed: false })
+
+        record.slot = slot
+      }
     }
 
+    const pending = transitionMutation(insert, (slot && hostOf(slot.anchor)) || document)
+
+    record.inserted = inserted ? undefined : pending
     this.records.set(key, record)
 
     return this.enqueue(record)
@@ -210,6 +220,10 @@ export class Outbox {
   }
 
   private async send(record: Sending): Promise<MutationResult> {
+    if (record.inserted) {
+      await record.inserted
+    }
+
     const { options, key } = record
     let payload: Payload | null = null
 
@@ -221,10 +235,10 @@ export class Outbox {
       return { status: statusOf(record.slot, "failed"), key, error: error as Error }
     }
 
-    return this.confirm(record, payload)
+    return await this.confirm(record, payload)
   }
 
-  private confirm(record: Sending, payload: Payload | null): MutationResult {
+  private async confirm(record: Sending, payload: Payload | null): Promise<MutationResult> {
     const { options, key } = record
     const slot = record.slot
 
@@ -254,7 +268,11 @@ export class Outbox {
       narrowed = this.narrow(payload, slot)
     }
 
-    const report = this.slots.apply(narrowed, { items: "merge" })
+    let report!: ReturnType<Slots["apply"]>
+
+    await transitionMutation(() => {
+      report = this.slots.apply(narrowed, { items: "merge" })
+    }, (record.slot && hostOf(record.slot.anchor)) || document)
 
     if (report.applied === 0 && report.deferred.some((deferred) => deferred.reason === "stale-version")) {
       this.settle(record, confirmed)

--- a/javascript/packages/client/src/outbox/types.ts
+++ b/javascript/packages/client/src/outbox/types.ts
@@ -49,4 +49,5 @@ export interface Sending {
   options: SubmitOptions
   key: string
   slot: Slot | null
+  inserted?: Promise<void>
 }

--- a/javascript/packages/client/src/shared/transitions.ts
+++ b/javascript/packages/client/src/shared/transitions.ts
@@ -1,0 +1,294 @@
+export interface TransitionOptions {
+  force?: boolean
+  type?: string
+}
+
+interface Job {
+  callback: () => void
+  root: ParentNode
+  type: string | undefined
+  done: () => void
+}
+
+interface ViewTransitionLike {
+  ready?: Promise<void>
+  finished: Promise<void>
+  updateCallbackDone: Promise<void>
+  skipTransition(): void
+}
+
+type StartViewTransition = (update: (() => void) | { update: () => void; types: string[] }) => ViewTransitionLike
+
+type WithViewTransitions = Document & { startViewTransition?: StartViewTransition }
+
+export const TRANSITION_SELECTOR = "[data-herb-transition]"
+export const TRANSITION_ATTRIBUTE = "data-herb-transition"
+
+const DEFAULT_NAME = "match-element"
+
+let animating = false
+const pending: Job[] = []
+
+export function transitionMutation(callback: () => void, root: ParentNode = document, options: TransitionOptions | boolean = {}): Promise<void> {
+  const { force = false, type } = typeof options === "boolean" ? { force: options } : options
+
+  if (!eligible(root, force)) {
+    callback()
+
+    return Promise.resolve()
+  }
+
+  return new Promise((resolve) => {
+    pending.push({ callback, root, type, done: resolve })
+
+    if (!animating) {
+      flush()
+    }
+  })
+}
+
+function eligible(root: ParentNode, force: boolean): boolean {
+  if (typeof document === "undefined") {
+    return false
+  }
+
+  const markedRoot = root instanceof Element && root.matches(TRANSITION_SELECTOR)
+
+  if (!force && !markedRoot && !root.querySelector(TRANSITION_SELECTOR)) {
+    return false
+  }
+
+  if (typeof (document as WithViewTransitions).startViewTransition !== "function") {
+    return false
+  }
+
+  if (document.visibilityState === "hidden") {
+    return false
+  }
+
+  if (document.querySelector("dialog:modal")) {
+    return false
+  }
+
+  for (const popover of document.querySelectorAll(":popover-open")) {
+    for (const child of popover.querySelectorAll("*")) {
+      if ((child as Element & { checkVisibility?: () => boolean }).checkVisibility?.()) {
+        return false
+      }
+    }
+  }
+
+  return true
+}
+
+function flush(): void {
+  const batch = pending.splice(0)
+
+  if (batch.length === 0) {
+    animating = false
+
+    return
+  }
+
+  animating = true
+
+  const roots = batch.map((job) => job.root)
+  const types = [...new Set(batch.map((job) => job.type).filter((type): type is string => type !== undefined))]
+  const start = (document as WithViewTransitions).startViewTransition as StartViewTransition
+
+  setNames(roots, types.length > 0)
+
+  if (!anyEffectiveName(roots)) {
+    clearNames()
+
+    for (const job of batch) {
+      job.callback()
+      job.done()
+    }
+
+    flush()
+
+    return
+  }
+
+  const style = document.createElement("style")
+
+  style.textContent = `
+    @layer herb-transitions {
+      ::view-transition-group(*),
+      ::view-transition-old(*),
+      ::view-transition-new(*) {
+        animation-duration: 150ms;
+      }
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+      ::view-transition-group(*), ::view-transition-old(*), ::view-transition-new(*) {
+        animation: none !important;
+      }
+    }
+
+    ::view-transition-old(root) {
+      animation: none !important;
+      opacity: 0 !important;
+    }
+
+    ::view-transition-new(root) {
+      animation: none !important;
+      opacity: 1 !important;
+    }
+  `
+
+  const nonce = document.querySelector<HTMLMetaElement>('meta[name="csp-nonce"]')?.content
+
+  if (nonce) {
+    style.nonce = nonce
+  }
+
+  document.head.appendChild(style)
+
+  const update = () => {
+    for (const job of batch) {
+      job.callback()
+      job.done()
+    }
+
+    setNames(roots, types.length > 0)
+  }
+
+  let transition: ViewTransitionLike
+
+  try {
+    transition = startWithTypes(start, update, types)
+  } catch {
+    style.remove()
+    clearNames()
+
+    for (const job of batch) {
+      job.callback()
+      job.done()
+    }
+
+    flush()
+
+    return
+  }
+
+  transition.ready?.catch(() => {})
+  skipUnderTopLayer(transition)
+  skipWhenHidden(transition)
+
+  transition.finished.finally(() => {
+    style.remove()
+    clearNames()
+    flush()
+  }).catch(() => {})
+}
+
+function startWithTypes(start: StartViewTransition, update: () => void, types: string[]): ViewTransitionLike {
+  if (types.length === 0) {
+    return start.call(document, update)
+  }
+
+  try {
+    return start.call(document, { update, types })
+  } catch {
+    return start.call(document, update)
+  }
+}
+
+function markedIn(roots: ParentNode[]): HTMLElement[] {
+  const found: HTMLElement[] = []
+
+  for (const root of roots) {
+    if (root instanceof HTMLElement && root.matches(TRANSITION_SELECTOR)) {
+      found.push(root)
+    }
+
+    found.push(...root.querySelectorAll<HTMLElement>(TRANSITION_SELECTOR))
+  }
+
+  return found
+}
+
+function anyEffectiveName(roots: ParentNode[]): boolean {
+  return markedIn(roots).some((element) => getComputedStyle(element).viewTransitionName !== "none")
+}
+
+function setNames(roots: ParentNode[], typed = false): void {
+  for (const root of roots) {
+    const marked = [...root.querySelectorAll<HTMLElement>(TRANSITION_SELECTOR)]
+
+    if (root instanceof HTMLElement && root.matches(TRANSITION_SELECTOR)) {
+      marked.unshift(root)
+    }
+
+    for (const element of marked) {
+      if (element.style.viewTransitionName) {
+        continue
+      }
+
+      const name = element.getAttribute(TRANSITION_ATTRIBUTE)
+
+      if (!name && typed) {
+        continue
+      }
+
+      element.style.viewTransitionName = name ? identifier(name) : DEFAULT_NAME
+    }
+  }
+}
+
+function clearNames(): void {
+  for (const element of document.querySelectorAll<HTMLElement>(TRANSITION_SELECTOR)) {
+    element.style.viewTransitionName = ""
+  }
+}
+
+export function transitionIdentifier(name: string): string {
+  return identifier(name)
+}
+
+function identifier(name: string): string {
+  return name.replace(/[^a-zA-Z0-9_-]/g, "-")
+}
+
+function skipWhenHidden(transition: ViewTransitionLike): void {
+  const onHidden = () => {
+    if (document.visibilityState === "hidden") {
+      transition.skipTransition()
+    }
+  }
+
+  document.addEventListener("visibilitychange", onHidden)
+
+  transition.finished.finally(() => {
+    document.removeEventListener("visibilitychange", onHidden)
+  }).catch(() => {})
+}
+
+function skipUnderTopLayer(transition: ViewTransitionLike): void {
+  const onBeforeToggle = (event: Event) => {
+    const toggle = event as Event & { newState?: string }
+
+    if (toggle.newState === "open" && (event.target as Element | null)?.matches?.("dialog, [popover]")) {
+      transition.skipTransition()
+    }
+  }
+
+  document.addEventListener("beforetoggle", onBeforeToggle, true)
+
+  const observer = new MutationObserver(() => {
+    if (document.querySelector("dialog:modal")) {
+      transition.skipTransition()
+      observer.disconnect()
+    }
+  })
+
+  observer.observe(document.documentElement, { attributes: true, attributeFilter: ["open"], subtree: true })
+
+  transition.finished.finally(() => {
+    observer.disconnect()
+    document.removeEventListener("beforetoggle", onBeforeToggle, true)
+  }).catch(() => {})
+}

--- a/javascript/packages/client/src/state/fragments.ts
+++ b/javascript/packages/client/src/state/fragments.ts
@@ -1,5 +1,6 @@
 import { scopeOf } from "./scopes"
 import { connected, hostOf } from "../markup/anchors"
+import { transitionMutation } from "../shared/transitions"
 
 import type { Slots } from "../slots/slots"
 import type { RefreshReport } from "./refresh"
@@ -90,7 +91,8 @@ export class Fragments {
 
         presentation.restoreTimer = setTimeout(() => {
           this.showing.delete(slot)
-          this.delegate.resettle(slot)
+
+          void transitionMutation(() => this.delegate.resettle(slot), hostOf(slot.anchor) ?? document)
         }, Math.max(remaining, 0))
 
         continue
@@ -108,11 +110,13 @@ export class Fragments {
         this.showing.delete(slot)
 
         if (slot.branch === presentation.fallback) {
-          this.slots.switchBranch(slot, restored)
+          void transitionMutation(() => void this.slots.switchBranch(slot, restored), hostOf(slot.anchor) ?? document)
         }
       }, remaining)
 
-      this.slots.switchBranch(slot, presentation.fallback)
+      if (this.slots.switchBranch(slot, presentation.fallback)) {
+        this.delegate.resettle(slot)
+      }
     }
   }
 
@@ -239,8 +243,8 @@ export class Fragments {
       this.slots.claim(slot)
     }
 
-    if (slot.branch !== presentation.fallback) {
-      this.slots.switchBranch(slot, presentation.fallback)
+    if (slot.branch !== presentation.fallback && this.slots.switchBranch(slot, presentation.fallback)) {
+      this.delegate.resettle(slot)
     }
   }
 

--- a/javascript/packages/client/src/state/refresh.ts
+++ b/javascript/packages/client/src/state/refresh.ts
@@ -1,5 +1,6 @@
 import { armOf } from "./conditions"
 import { slotsRequest } from "../shared/slots-request"
+import { transitionMutation } from "../shared/transitions"
 
 import type { Slots } from "../slots/slots"
 import type { Payload, Region } from "../types"
@@ -101,7 +102,11 @@ export class Refresh {
       return
     }
 
-    const report = this.slots.apply(payload)
+    let report!: ReturnType<Slots["apply"]>
+
+    await transitionMutation(() => {
+      report = this.slots.apply(payload)
+    })
 
     this.settle({ applied: report.applied, deferred: report.deferred.length, stale: false, failed: false })
   }

--- a/javascript/packages/client/src/state/server.ts
+++ b/javascript/packages/client/src/state/server.ts
@@ -1,5 +1,6 @@
 import { elementOf } from "../markup/anchors"
 import { slotsRequest } from "../shared/slots-request"
+import { transitionMutation } from "../shared/transitions"
 
 import type { Slots } from "../slots/slots"
 import type { ApplyReport, Payload, Slot } from "../types"
@@ -150,7 +151,11 @@ export class ServerState {
     let report: ApplyReport = { applied: 0, deferred: [] }
 
     if (payload) {
-      report = this.slots.apply(payload)
+      const applied = payload
+
+      await transitionMutation(() => {
+        report = this.slots.apply(applied)
+      })
     }
 
     return this.settle({ ...report, written: restores.length, restored: 0, stale: false, failed: false })

--- a/javascript/packages/client/src/state/state.ts
+++ b/javascript/packages/client/src/state/state.ts
@@ -16,6 +16,7 @@ import { armMutationRefresh } from "../shared/mutation-refresh"
 import { armOf, evaluate, matches, mentions } from "./conditions"
 import { steeringNames } from "./refresh"
 import { slotsRequest } from "../shared/slots-request"
+import { TRANSITION_SELECTOR, transitionMutation } from "../shared/transitions"
 import { collectionIn, scopeOf, scoped } from "./scopes"
 import { declarationSpot, declared, declaredValue } from "./declarations"
 
@@ -578,7 +579,14 @@ export class State implements ElementObserverDelegate, SlotsDelegate, SeedsDeleg
       return { applied: 0, deferred: 0, stale: false, failed: true }
     }
 
-    const report = this.slots.apply(payload)
+    let report!: ReturnType<Slots["apply"]>
+
+    const slot = region.slots.get(index)
+    const root = (slot && hostOf(slot.anchor)) || document
+
+    await transitionMutation(() => {
+      report = this.slots.apply(payload)
+    }, root)
 
     return { applied: report.applied, deferred: report.deferred.length, stale: false, failed: false }
   }
@@ -610,6 +618,26 @@ export class State implements ElementObserverDelegate, SlotsDelegate, SeedsDeleg
 
     const reads = manifest.server?.reads ?? {}
     const stale = new Set(names.flatMap((name) => (reads[name] ?? []).map((read) => read.index)))
+
+    const branches = manifest.server?.branches ?? {}
+
+    for (const [conditionalKey, entries] of Object.entries(branches)) {
+      const conditional = manifest.conditionals[conditionalKey]
+
+      if (!conditional) {
+        continue
+      }
+
+      const placements = this.placedSlots(scope, Number(conditionalKey))
+
+      if (placements.length === 0 || placements.some((placed) => this.targetBranch(conditional, placed.scope) === 0)) {
+        continue
+      }
+
+      for (const entry of entries) {
+        stale.delete(entry.index)
+      }
+    }
 
     if (stale.size === 0) {
       return
@@ -879,6 +907,26 @@ export class State implements ElementObserverDelegate, SlotsDelegate, SeedsDeleg
     scoped(this.scoped, scope).set(name, value)
   }
 
+  private departing(placed: PlacedSlot, manifest: StateManifest): boolean {
+    for (let ancestor = placed.slot.parent; ancestor; ancestor = ancestor.parent) {
+      const conditional = manifest.conditionals[String(ancestor.index)]
+
+      if (!conditional || ancestor.branch === null) {
+        continue
+      }
+
+      if (this.targetBranch(conditional, placed.scope) !== ancestor.branch) {
+        if (this.fragments.holding(ancestor)) {
+          continue
+        }
+
+        return true
+      }
+    }
+
+    return false
+  }
+
   private writeValueSlots(manifest: StateManifest, scope: StateScope, name: string, value: StateValue): void {
     const computed = manifest.computed ?? {}
 
@@ -889,6 +937,10 @@ export class State implements ElementObserverDelegate, SlotsDelegate, SeedsDeleg
 
       for (const placed of this.placedSlots(scope, index)) {
         if (placed.slot.type === "boolean_attribute") {
+          continue
+        }
+
+        if (this.departing(placed, manifest)) {
           continue
         }
 
@@ -907,6 +959,10 @@ export class State implements ElementObserverDelegate, SlotsDelegate, SeedsDeleg
       }
 
       for (const placed of this.placedSlots(scope, Number(indexKey))) {
+        if (this.departing(placed, manifest)) {
+          continue
+        }
+
         const present = matches(entry, (name) => this.valueAt(name, placed.scope))
 
         this.slots.setBooleanAttribute(placed.slot, present)
@@ -922,6 +978,10 @@ export class State implements ElementObserverDelegate, SlotsDelegate, SeedsDeleg
       }
 
       for (const placed of this.placedSlots(scope, Number(indexKey))) {
+        if (this.departing(placed, manifest)) {
+          continue
+        }
+
         this.write(placed.slot, printValue(evaluate(entry, (name) => this.valueAt(name, placed.scope))))
         this.slots.claim(placed.slot)
       }
@@ -944,6 +1004,19 @@ export class State implements ElementObserverDelegate, SlotsDelegate, SeedsDeleg
         const target = this.targetBranch(conditional, placed.scope)
 
         this.slots.claim(slot)
+
+        const host = hostOf(slot.anchor)
+        const leaving = slot.branch !== target && Boolean(host?.querySelector(TRANSITION_SELECTOR))
+
+        if (leaving) {
+          void transitionMutation(() => {
+            if (!this.slots.switchBranch(slot, target) && slot.branch !== target && this.options.refetch !== "off") {
+              void this.refetch.request(this.options.refetchDebounce).then((outcome) => this.fragments.settle(outcome))
+            }
+          }, host ?? document)
+
+          continue
+        }
 
         if (!this.slots.switchBranch(slot, target) && slot.branch !== target) {
           if (this.options.refetch !== "off") {

--- a/javascript/packages/client/test/fragment-fallback-seeding.test.ts
+++ b/javascript/packages/client/test/fragment-fallback-seeding.test.ts
@@ -1,0 +1,54 @@
+import { test, expect, afterEach, vi } from "vitest"
+
+import { Runtime } from "../src/runtime"
+
+const FILE = "app/views/test.html.erb"
+
+const PAGE =
+  `<!--herb-region:${FILE}:11aa22bb:0-->` +
+  `<!--herb-slot:0:conditional--><!--herb-branch:0:0--><p id="loaded">tracks <!--herb-slot:2-->one two<!--/herb-slot:2--></p><!--/herb-slot:0-->` +
+  `<!--/herb-region:${FILE}-->` +
+  `<template data-herb-region="${FILE}:11aa22bb"><!--herb-branch:0:0--><p id="loaded">tracks <!--herb-slot:2--><!--/herb-slot:2--></p><!--herb-branch:0:1--><p id="waiting">by <!--herb-slot:1--><!--/herb-slot:1--></p></template>` +
+  `<template data-herb-dependencies>${JSON.stringify({
+    state: {},
+    states: {
+      [FILE]: {
+        version: "11aa22bb",
+        declarations: [
+          { name: "album", kind: "string", default: '""', scope: "region", value: "a" },
+          { name: "artist", kind: "string", default: '""', scope: "region", value: "" },
+        ],
+        reads: { artist: [1] },
+        conditionals: { 0: { arms: [{ branch: 0, condition: ["album", null, "present"] }], else: 1 } },
+        server: { branches: { 0: [{ index: 2, node_path: [0] }] }, reads: { album: [{ index: 2, node_path: [0] }] } },
+        fragments: { 0: { fallback: 1, reads: [2], on: ["album"], delay: 0, hold: 50 } },
+      },
+    },
+  })}</template>`
+
+let runtime: Runtime | null = null
+
+afterEach(() => {
+  runtime?.stop()
+  runtime = null
+  document.body.innerHTML = ""
+})
+
+test("a presented fallback seeds the state reads it contains", async () => {
+  document.body.innerHTML = PAGE
+
+  const transport = vi.fn(() => new Promise<never>(() => {}))
+
+  runtime = Runtime.start({ state: { refetchTransport: transport as never, refetchDebounce: 0 } })
+
+  runtime.state.setState({ artist: "Modular Grid" })
+  runtime.state.setState({ album: "b" })
+
+  await vi.waitFor(() => {
+    if (!document.getElementById("waiting")) {
+      throw new Error("fallback not presented yet")
+    }
+  })
+
+  expect(document.getElementById("waiting")!.textContent).toBe("by Modular Grid")
+})

--- a/javascript/packages/client/test/outbox.test.ts
+++ b/javascript/packages/client/test/outbox.test.ts
@@ -506,3 +506,53 @@ describe("a template that declares no mutation states", () => {
     delete (window as unknown as { HerbDevTools?: unknown }).HerbDevTools
   })
 })
+
+  test("an optimistic insert into a marked collection runs a view transition", async () => {
+    document.body.innerHTML = PAGE.replace(/<li /g, "<li data-herb-transition ")
+
+    slots = new Slots()
+    slots.scan(document.body)
+    state = new State(slots)
+    state.adopt()
+
+    const doc = document as unknown as { startViewTransition?: (update: () => void) => unknown }
+    const native = doc.startViewTransition
+    let started = 0
+
+    doc.startViewTransition = (update: () => void) => {
+      started += 1
+      update()
+
+      return { ready: Promise.resolve(), finished: Promise.resolve(), updateCallbackDone: Promise.resolve(), skipTransition: () => {} }
+    }
+
+    try {
+      let release!: (payload: Payload) => void
+      const outbox = build(() => new Promise((resolve) => (release = resolve)))
+
+      const result = outbox.submit({
+        url: "/messages",
+        body: { body: "typed" },
+        into: { file: FILE, name: "messages" },
+        values: { body: "typed" },
+      })
+
+      for (let i = 0; i < 50 && document.querySelectorAll("li").length < 2; i++) {
+        await new Promise((resolve) => setTimeout(resolve, 10))
+      }
+
+      expect(document.querySelectorAll("li").length).toBe(2)
+
+      expect(started).toBeGreaterThanOrEqual(1)
+
+      await new Promise((resolve) => setTimeout(resolve, 10))
+
+      release(confirmPayload("message_42", "stored"))
+
+      const outcome = await result
+
+      expect(outcome.status).toBe("confirmed")
+    } finally {
+      doc.startViewTransition = native
+    }
+  })

--- a/javascript/packages/client/test/refresh.test.ts
+++ b/javascript/packages/client/test/refresh.test.ts
@@ -101,6 +101,46 @@ describe("refetching server-derived slots", () => {
     expect(transport).not.toHaveBeenCalled()
   })
 
+  test("closing a branch over its own reads refetches nothing", async () => {
+    document.body.innerHTML =
+      `<!--herb-region:${FILE}:aaaaaaaa:0-->` +
+      `<div><!--herb-slot:0:conditional--><!--herb-branch:0:1--><!--/herb-slot:0--></div>` +
+      `<template data-herb-region="${FILE}:aaaaaaaa">` +
+      `<!--herb-branch:0:0--><p><!--herb-slot:2--><!--/herb-slot:2--></p>` +
+      `<!--herb-branch:0:1-->` +
+      `</template>` +
+      `<!--/herb-region:${FILE}-->` +
+      dependencies({
+        version: "aaaaaaaa",
+        declarations: [{ name: "album", kind: "string", default: '""', value: "", scope: "region" }],
+        reads: {},
+        conditionals: { 0: { arms: [{ branch: 0, condition: ["album", null, "present"] }], else: 1 } },
+        presence: {},
+        computed: {},
+        server: { reads: { album: [{ index: 2, node_path: [1, 0] }] }, branches: { 0: [{ index: 2, node_path: [1, 0] }] } },
+      })
+
+    const transport = vi.fn(async () => payloadFor({ 0: { branch: 0, slots: { 2: "opened" } } }))
+    const live = start({ state: { refetchTransport: transport, refetchDebounce: 0 } })
+
+    live.state.setState({ album: "acid-archive" })
+
+    await vi.waitFor(() => {
+      if (!document.body.innerHTML.includes("opened")) {
+        throw new Error("still waiting")
+      }
+    })
+
+    const settled = transport.mock.calls.length
+
+    live.state.setState({ album: "" })
+
+    await new Promise((resolve) => setTimeout(resolve, 40))
+
+    expect(document.body.innerHTML).not.toContain("opened")
+    expect(transport.mock.calls.length).toBe(settled)
+  })
+
   test("parked branches and captured material list as parked roots", async () => {
     document.body.innerHTML = PAGE
 

--- a/javascript/packages/client/test/transitions.test.ts
+++ b/javascript/packages/client/test/transitions.test.ts
@@ -1,0 +1,516 @@
+import { describe, test, expect, afterEach, vi } from "vitest"
+
+import { Runtime } from "../src/runtime"
+import { transitionMutation } from "../src/shared/transitions"
+
+type StartViewTransition = ((update: () => void) => unknown) | undefined
+
+const documentWithVT = document as unknown as { startViewTransition?: StartViewTransition }
+const native = documentWithVT.startViewTransition
+
+interface FakeTransition {
+  ready: Promise<void>
+  finished: Promise<void>
+  updateCallbackDone: Promise<void>
+  skipTransition(): void
+}
+
+function stub(): { calls: number; names: string[][] } {
+  const seen = { calls: 0, names: [] as string[][] }
+
+  documentWithVT.startViewTransition = (update: () => void): FakeTransition => {
+    seen.calls += 1
+    update()
+    seen.names.push([...document.querySelectorAll<HTMLElement>("[data-herb-transition]")].map((el) => el.style.viewTransitionName))
+
+    return {
+      ready: Promise.resolve(),
+      finished: Promise.resolve(),
+      updateCallbackDone: Promise.resolve(),
+      skipTransition: () => {},
+    }
+  }
+
+  return seen
+}
+
+afterEach(() => {
+  documentWithVT.startViewTransition = native
+  document.body.innerHTML = ""
+})
+
+describe("content security policy", () => {
+  test("the injected style element carries the page's csp nonce", async () => {
+    document.head.innerHTML = `<meta name="csp-nonce" content="abc123">`
+    document.body.innerHTML = `<div data-herb-transition><p id="content">before</p></div>`
+
+    let nonce: string | null = null
+
+    documentWithVT.startViewTransition = ((update: () => void) => {
+      nonce = document.querySelector("style")?.nonce ?? null
+      update()
+
+      return { ready: Promise.resolve(), finished: Promise.resolve(), updateCallbackDone: Promise.resolve(), skipTransition() {} }
+    }) as StartViewTransition
+
+    await transitionMutation(() => {
+      document.getElementById("content")!.textContent = "after"
+    })
+
+    document.head.innerHTML = ""
+
+    expect(nonce).toBe("abc123")
+  })
+})
+
+describe("a start that throws", () => {
+  test("still runs the mutation, removes the style, and stays unwedged", async () => {
+    document.body.innerHTML = `<div data-herb-transition><p id="content">before</p></div>`
+
+    documentWithVT.startViewTransition = (() => {
+      throw new TypeError("boom")
+    }) as StartViewTransition
+
+    await transitionMutation(() => {
+      document.getElementById("content")!.textContent = "after"
+    })
+
+    expect(document.getElementById("content")!.textContent).toBe("after")
+    expect(document.querySelector("style")).toBeNull()
+
+    documentWithVT.startViewTransition = ((update: () => void) => {
+      update()
+
+      return { ready: Promise.resolve(), finished: Promise.resolve(), updateCallbackDone: Promise.resolve(), skipTransition() {} }
+    }) as StartViewTransition
+
+    await transitionMutation(() => {
+      document.getElementById("content")!.textContent = "again"
+    })
+
+    expect(document.getElementById("content")!.textContent).toBe("again")
+  })
+})
+
+describe("typed transitions", () => {
+  test("passes types through the config form of startViewTransition", async () => {
+    document.body.innerHTML = `<div data-herb-transition="panel"><p id="content">before</p></div>`
+
+    let received: string[] | null = null
+
+    documentWithVT.startViewTransition = ((config: { update: () => void; types: string[] } | (() => void)) => {
+      if (typeof config === "function") {
+        config()
+      } else {
+        received = config.types
+        config.update()
+      }
+
+      return { ready: Promise.resolve(), finished: Promise.resolve(), updateCallbackDone: Promise.resolve(), skipTransition() {} }
+    }) as StartViewTransition
+
+    await transitionMutation(() => {
+      document.getElementById("content")!.textContent = "after"
+    }, document, { type: "forward" })
+
+    expect(received).toEqual(["forward"])
+    expect(document.getElementById("content")!.textContent).toBe("after")
+  })
+
+  test("falls back to the callback form when the config form throws", async () => {
+    document.body.innerHTML = `<div data-herb-transition="panel"><p id="content">before</p></div>`
+
+    let calls = 0
+
+    documentWithVT.startViewTransition = ((config: { update: () => void } | (() => void)) => {
+      calls += 1
+
+      if (typeof config !== "function") {
+        throw new TypeError("callback expected")
+      }
+
+      config()
+
+      return { ready: Promise.resolve(), finished: Promise.resolve(), updateCallbackDone: Promise.resolve(), skipTransition() {} }
+    }) as StartViewTransition
+
+    await transitionMutation(() => {
+      document.getElementById("content")!.textContent = "after"
+    }, document, { type: "forward" })
+
+    expect(calls).toBe(2)
+    expect(document.getElementById("content")!.textContent).toBe("after")
+  })
+
+  test("a typed swap leaves unnamed marks unnamed, so they ride the parent snapshot", async () => {
+    document.body.innerHTML = `<div data-herb-transition="panel"><p data-herb-transition id="plain">before</p></div>`
+
+    let named: string | null = null
+    let unnamed: string | null = null
+
+    documentWithVT.startViewTransition = ((config: { update: () => void; types: string[] } | (() => void)) => {
+      const update = typeof config === "function" ? config : config.update
+
+      update()
+
+      named = document.querySelector<HTMLElement>("[data-herb-transition=panel]")!.style.viewTransitionName || null
+      unnamed = document.getElementById("plain")!.style.viewTransitionName || null
+
+      return { ready: Promise.resolve(), finished: Promise.resolve(), updateCallbackDone: Promise.resolve(), skipTransition() {} }
+    }) as StartViewTransition
+
+    await transitionMutation(() => {
+      document.getElementById("plain")!.textContent = "after"
+    }, document, { type: "backward" })
+
+    expect(named).toBe("panel")
+    expect(unnamed).toBeNull()
+  })
+})
+
+describe("transitionMutation", () => {
+  test("a marked element runs the mutation inside a view transition and names itself", async () => {
+    document.body.innerHTML = `<div data-herb-transition><p id="content">before</p></div>`
+
+    const seen = stub()
+    const mutate = vi.fn(() => {
+      document.getElementById("content")!.textContent = "after"
+    })
+
+    await transitionMutation(mutate)
+
+    expect(seen.calls).toBe(1)
+    expect(mutate).toHaveBeenCalledTimes(1)
+    expect(document.body.innerHTML).toContain("after")
+    expect(seen.names[0]).toEqual(["match-element"])
+
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(document.querySelector<HTMLElement>("[data-herb-transition]")!.style.viewTransitionName).toBe("")
+  })
+
+  test("a valued attribute names the transition for user CSS", async () => {
+    document.body.innerHTML = `<div data-herb-transition="side panel"></div>`
+
+    const seen = stub()
+
+    await transitionMutation(() => {})
+
+    expect(seen.names[0]).toEqual(["side-panel"])
+  })
+
+  test("CSS turning every marked element off skips the transition", async () => {
+    document.body.innerHTML = `<style>#off { view-transition-name: none !important }</style><div id="off" data-herb-transition><p id="content">before</p></div>`
+
+    const seen = stub()
+
+    await transitionMutation(() => {
+      document.getElementById("content")!.textContent = "after"
+    })
+
+    expect(document.getElementById("content")!.textContent).toBe("after")
+    expect(seen.calls).toBe(0)
+    expect(document.getElementById("off")!.style.viewTransitionName).toBe("")
+  })
+
+  test("one live marked element keeps the transition despite a vetoed sibling", async () => {
+    document.body.innerHTML = `<style>#off { view-transition-name: none !important }</style><div id="off" data-herb-transition></div><div data-herb-transition></div>`
+
+    const seen = stub()
+
+    await transitionMutation(() => {})
+
+    expect(seen.calls).toBe(1)
+  })
+
+  test("a hidden document mutates without a transition", async () => {
+    document.body.innerHTML = `<div data-herb-transition><p id="content">before</p></div>`
+
+    const seen = stub()
+
+    Object.defineProperty(document, "visibilityState", { value: "hidden", configurable: true })
+
+    try {
+      await transitionMutation(() => {
+        document.getElementById("content")!.textContent = "after"
+      })
+    } finally {
+      Object.defineProperty(document, "visibilityState", { value: "visible", configurable: true })
+    }
+
+    expect(document.getElementById("content")!.textContent).toBe("after")
+    expect(seen.calls).toBe(0)
+  })
+
+  test("a page without marked elements mutates without a transition", async () => {
+    document.body.innerHTML = `<div><p id="content">before</p></div>`
+
+    const seen = stub()
+
+    await transitionMutation(() => {
+      document.getElementById("content")!.textContent = "after"
+    })
+
+    expect(seen.calls).toBe(0)
+    expect(document.body.innerHTML).toContain("after")
+  })
+
+  test("an open modal dialog skips the transition and keeps the mutation", async () => {
+    document.body.innerHTML = `<div data-herb-transition></div><dialog id="modal"><p>open</p></dialog>`
+    document.querySelector<HTMLDialogElement>("#modal")!.showModal()
+
+    const seen = stub()
+    const mutate = vi.fn()
+
+    await transitionMutation(mutate)
+
+    document.querySelector<HTMLDialogElement>("#modal")!.close()
+
+    expect(seen.calls).toBe(0)
+    expect(mutate).toHaveBeenCalledTimes(1)
+  })
+
+  test("a browser without the API mutates without a transition", async () => {
+    document.body.innerHTML = `<div data-herb-transition><p id="content">before</p></div>`
+
+    documentWithVT.startViewTransition = undefined
+
+    await transitionMutation(() => {
+      document.getElementById("content")!.textContent = "after"
+    })
+
+    expect(document.body.innerHTML).toContain("after")
+  })
+
+  test("concurrent mutations batch into one following transition", async () => {
+    document.body.innerHTML = `<div data-herb-transition></div>`
+
+    const seen = stub()
+    const order: number[] = []
+
+    await Promise.all([
+      transitionMutation(() => order.push(1)),
+      transitionMutation(() => order.push(2)),
+      transitionMutation(() => order.push(3)),
+    ])
+
+    expect(order).toEqual([1, 2, 3])
+    expect(seen.calls).toBeLessThanOrEqual(2)
+  })
+
+  test("naming stays scoped to the mutation's own subtree", async () => {
+    document.body.innerHTML = `<div id="mine" data-herb-transition="mine"></div><div data-herb-transition="other"></div>`
+
+    const seen = stub()
+
+    await transitionMutation(() => {}, document.getElementById("mine")!)
+
+    expect(seen.names[0]).toEqual(["mine", ""])
+  })
+
+  test("elements added by the mutation get named before the new capture", async () => {
+    document.body.innerHTML = `<div id="host" data-herb-transition></div>`
+
+    const seen = stub()
+
+    await transitionMutation(() => {
+      document.getElementById("host")!.insertAdjacentHTML("afterend", `<div data-herb-transition="fresh"></div>`)
+    })
+
+    expect(seen.names[0]).toEqual(["match-element", "fresh"])
+  })
+})
+
+const FILE = "app/views/chat/panel.html.erb"
+
+function panelPage(marked: boolean): string {
+  return (
+    `<!--herb-region:${FILE}:aaaaaaaa:0-->` +
+    `<!--herb-slot:0:conditional--><!--herb-branch:0:1--><!--/herb-slot:0-->` +
+    `<template data-herb-region="${FILE}:aaaaaaaa">` +
+    `<!--herb-branch:0:0--><div id="panel"${marked ? ' data-herb-transition="panel"' : ""}>opened</div>` +
+    `<!--herb-branch:0:1-->` +
+    `</template>` +
+    `<!--/herb-region:${FILE}-->` +
+    `<template data-herb-dependencies>${JSON.stringify({
+      state: {},
+      states: {
+        [FILE]: {
+          version: "aaaaaaaa",
+          declarations: [{ name: "open", kind: "boolean", default: "false", value: false, scope: "region" }],
+          reads: {},
+          conditionals: { 0: { arms: [{ branch: 0, condition: ["open", null] }], else: 1 } },
+          presence: {},
+          computed: {},
+          server: { branches: {}, reads: {} },
+        },
+      },
+    })}</template>`
+  )
+}
+
+describe("marked branch flips", () => {
+  let runtime: Runtime | null = null
+
+  afterEach(() => {
+    runtime?.stop()
+    runtime = null
+    document.body.innerHTML = ""
+  })
+
+  test("mounting into unmarked surroundings stays synchronous", () => {
+    document.body.innerHTML = panelPage(true)
+
+    const seen = stub()
+
+    runtime = Runtime.start({ state: { refetch: "off" } })
+    runtime.state.setState({ open: true })
+
+    expect(document.body.innerHTML).toContain("opened")
+    expect(seen.calls).toBe(0)
+  })
+
+  test("flipping away from visible marked content runs a view transition", async () => {
+    document.body.innerHTML = panelPage(true)
+
+    const seen = stub()
+
+    runtime = Runtime.start({ state: { refetch: "off" } })
+    runtime.state.setState({ open: true })
+
+    expect(document.body.innerHTML).toContain("opened")
+
+    runtime.state.setState({ open: false })
+
+    await vi.waitFor(() => {
+      if (document.body.innerHTML.includes("opened")) {
+        throw new Error("still waiting")
+      }
+    })
+
+    expect(seen.calls).toBe(1)
+  })
+
+  test("an unmarked branch flips synchronously", () => {
+    document.body.innerHTML = panelPage(false)
+
+    const seen = stub()
+
+    runtime = Runtime.start({ state: { refetch: "off" } })
+    runtime.state.setState({ open: true })
+
+    expect(document.body.innerHTML).toContain("opened")
+    expect(seen.calls).toBe(0)
+  })
+})
+
+const READ_FILE = "app/views/chat/detail.html.erb"
+
+function detailPage(): string {
+  return (
+    `<!--herb-region:${READ_FILE}:aaaaaaaa:0-->` +
+    `<!--herb-slot:0:conditional--><!--herb-branch:0:1--><!--/herb-slot:0-->` +
+    `<template data-herb-region="${READ_FILE}:aaaaaaaa">` +
+    `<!--herb-branch:0:0--><div data-herb-transition="detail"><span id="value"><!--herb-slot:1--><!--/herb-slot:1--></span></div>` +
+    `<!--herb-branch:0:1-->` +
+    `</template>` +
+    `<!--/herb-region:${READ_FILE}-->` +
+    `<template data-herb-dependencies>${JSON.stringify({
+      state: {},
+      states: {
+        [READ_FILE]: {
+          version: "aaaaaaaa",
+          declarations: [{ name: "album", kind: "string", default: '""', value: "", scope: "region" }],
+          reads: { album: [1] },
+          conditionals: { 0: { arms: [{ branch: 0, condition: ["album", null, "present"] }], else: 1 } },
+          presence: {},
+          computed: {},
+          server: { branches: {}, reads: {} },
+        },
+      },
+    })}</template>`
+  )
+}
+
+describe("reads in a leaving branch", () => {
+  let runtime: Runtime | null = null
+
+  afterEach(() => {
+    runtime?.stop()
+    runtime = null
+    document.body.innerHTML = ""
+  })
+
+  test("a read inside a leaving branch keeps what it showed", async () => {
+    document.body.innerHTML = detailPage()
+
+    let shownAtCapture: string | null = null
+
+    documentWithVT.startViewTransition = (update: () => void): FakeTransition => {
+      shownAtCapture = document.getElementById("value")?.textContent ?? null
+
+      update()
+
+      return {
+        ready: Promise.resolve(),
+        finished: Promise.resolve(),
+        updateCallbackDone: Promise.resolve(),
+        skipTransition: () => {},
+      }
+    }
+
+    runtime = Runtime.start({ state: { refetch: "off" } })
+    runtime.state.setState({ album: "basel" })
+
+    expect(document.getElementById("value")?.textContent).toBe("basel")
+
+    runtime.state.setState({ album: "" })
+
+    await vi.waitFor(() => {
+      if (document.getElementById("value")) {
+        throw new Error("still waiting")
+      }
+    })
+
+    expect(shownAtCapture).toBe("basel")
+  })
+})
+
+describe("collection appends", () => {
+  let runtime: Runtime | null = null
+
+  afterEach(() => {
+    runtime?.stop()
+    runtime = null
+    document.body.innerHTML = ""
+  })
+
+  test("an appended item lands inside a view transition when rows are marked", async () => {
+    const LIST = "app/views/chat/list.html.erb"
+
+    document.body.innerHTML =
+      `<!--herb-region:${LIST}:bbbbbbbb:0--><ul>` +
+      `<!--herb-slot:0:collection-->` +
+      `<!--herb-item:0:1--><li data-herb-transition data-herb-slot="1:child">one</li><!--/herb-item:0-->` +
+      `<!--/herb-slot:0--></ul>` +
+      `<template data-herb-region="${LIST}:bbbbbbbb"><!--herb-branch:0:item-->` +
+      `<!--herb-item:0:--><li data-herb-transition data-herb-slot="1:child"></li><!--/herb-item:0--></template>` +
+      `<!--/herb-region:${LIST}-->`
+
+    const seen = stub()
+    const transport = vi.fn(async () => ({
+      template: LIST,
+      version: "bbbbbbbb",
+      occurrence: 0,
+      slots: { 0: { items: { 1: { 1: "one" }, 2: { 1: "two" } }, order: ["1", "2"] } },
+    }))
+
+    runtime = Runtime.start({ state: { refetchTransport: transport } })
+
+    await runtime.refresh()
+
+    expect(document.body.innerHTML).toContain("two")
+    expect(seen.calls).toBe(1)
+    expect(document.querySelectorAll("li").length).toBe(2)
+  })
+})

--- a/lib/herb/engine/slots/state_compiler.rb
+++ b/lib/herb/engine/slots/state_compiler.rb
@@ -401,7 +401,8 @@ module Herb
 
               slot = @visitor.slots[inside]
 
-              next unless slot&.valued?
+              next unless slot
+              next unless slot.valued? || refetchable.include?(inside)
               next if covered.include?(inside)
               next if @near_missed.include?(inside)
 

--- a/test/engine/slots/states_test.rb
+++ b/test/engine/slots/states_test.rb
@@ -1462,6 +1462,30 @@ module Engine
         assert_includes error.message, "Integer literal"
       end
 
+      test "a collection reading a state joins its branch's members" do
+        source = <<~ERB
+          <%# herb:slots client %>
+          <%# herb:state (album: "") %>
+          <input value="<%= album %>">
+          <% if album.present? %>
+            <ul>
+              <% Catalog.tracks(album).each do |entry| %>
+                <%# herb:key entry %>
+                <li><%= entry %></li>
+              <% end %>
+            </ul>
+          <% end %>
+        ERB
+
+        visitor = Herb::Engine::Slots::Visitor.new(mode: :client, fatal: false)
+        Herb::Engine.new(source, visitors: [visitor], filename: "app/views/test.html.erb")
+
+        branches = visitor.manifest["states"]["server"]["branches"]
+        refetchable = visitor.manifest["states"]["server"]["reads"]["album"].map { |read| read["index"] }
+
+        assert_equal [], refetchable - branches.values.flatten.map { |entry| entry["index"] }
+      end
+
       test "a block argument shadows a state inside its body" do
         source = <<~ERB
           <%# herb:slots client %>


### PR DESCRIPTION
This pull request lets a template animate what the slots system changes. An element carrying `data-herb-transition` animates through the browser's View Transitions API whenever a payload application or a deferred block's lifecycle mutates the page around it.

```erb
<Async>
  <p data-herb-transition="stat">42</p>

  <Fallback>
    <p data-herb-transition="stat" class="skeleton"></p>
  </Fallback>
</Async>
```

A bare attribute uses the `match-element` keyword, which auto-names each element for the browser's default crossfade. A value names the transition instead, so the page's own CSS owns the animation through `::view-transition-old(name)` and `::view-transition-new(name)`, and two different elements sharing a name, like a skeleton and the content replacing it, pair into one old-to-new animation.