### PR TITLE
Engine: Keep state reads live inside a `<Fallback>`

### DIFF
--- a/lib/herb/engine/slots/visitor.rb
+++ b/lib/herb/engine/slots/visitor.rb
@@ -269,6 +269,34 @@ module Herb
           @fragment_fallbacks[node] = fallback_children
         end
 
+        #: (Array[untyped]) -> void
+        def register_fallback_reads(children)
+          children.each do |child|
+            if child.is_a?(Herb::AST::ERBContentNode) && erb_outputs?(child) && fallback_state_read?(child)
+              record_slot(child, :child)
+
+              next
+            end
+
+            BRANCH_BODY_PROPERTIES.each do |property|
+              next unless child.respond_to?(property)
+
+              array = child.send(property)
+
+              register_fallback_reads(array) if array.is_a?(Array)
+            end
+          end
+        end
+
+        #: (untyped) -> bool
+        def fallback_state_read?(node)
+          name = expression_for(node).to_s.strip
+
+          return false unless name.match?(/\A[a-z_][a-zA-Z0-9_]*\z/)
+
+          state_declarations[:region].any? { |entry| entry[:name] == name && !entry[:derived] }
+        end
+
         #: (untyped, mode: String, state: String, timing: Hash[String, Integer]) -> void
         def record_deferred(node, mode:, state:, timing:)
           @deferred_nodes[node] = { mode: mode, state: state, timing: timing }
@@ -585,6 +613,8 @@ module Herb
           transform_components(node) if declares_slots?(node)
 
           visit_children_with_paths(node.children)
+
+          @fragment_fallbacks.each_value { |body| register_fallback_reads(body) }
 
           collapse_invariant_conditionals
           apply_names
@@ -1625,8 +1655,25 @@ module Herb
 
             next unless index
 
-            [@markers.statics_key(index, 1), [text_node(@markers.branch(index, 1)), *body]]
+            [@markers.statics_key(index, 1), [text_node(@markers.branch(index, 1)), *marked_fallback(body)]]
           }
+        end
+
+        #: (Array[untyped]) -> Array[untyped]
+        def marked_fallback(children)
+          children.flat_map do |child|
+            insert_markers(child)
+
+            slot_index = @standing[child]&.survivor&.index
+
+            next [child] unless slot_index
+
+            [
+              comment_node(@markers.slot_open(slot_index, @slots[slot_index].type)),
+              child,
+              comment_node(@markers.slot_close(slot_index))
+            ]
+          end
         end
 
         #: (String) -> String

--- a/sig/herb/engine/slots/visitor.rbs
+++ b/sig/herb/engine/slots/visitor.rbs
@@ -166,6 +166,12 @@ module Herb
         # : (untyped, Array[untyped], Hash[String, untyped]) -> void
         def record_fragment: (untyped, Array[untyped], Hash[String, untyped]) -> void
 
+        # : (Array[untyped]) -> void
+        def register_fallback_reads: (Array[untyped]) -> void
+
+        # : (untyped) -> bool
+        def fallback_state_read?: (untyped) -> bool
+
         # : (untyped, mode: String, state: String, timing: Hash[String, Integer]) -> void
         def record_deferred: (untyped, mode: String, state: String, timing: Hash[String, Integer]) -> void
 
@@ -489,6 +495,9 @@ module Herb
 
         # : () -> Array[[String, Array[untyped]]]
         def fallback_statics_entries: () -> Array[[ String, Array[untyped] ]]
+
+        # : (Array[untyped]) -> Array[untyped]
+        def marked_fallback: (Array[untyped]) -> Array[untyped]
 
         # : (String) -> String
         def covered_key: (String) -> String

--- a/test/engine/slots/components_test.rb
+++ b/test/engine/slots/components_test.rb
@@ -70,6 +70,45 @@ module Engine
         assert_equal plain.slots.map(&:type), seeded.slots.map(&:type)
       end
 
+      test "a state read in a fallback stays a live slot" do
+        source = <<~ERB
+          <%# herb:slots client %>
+          <%# herb:state (album: "a", artist: "") %>
+          <input value="<%= album %>">
+          <Fragment on="album">
+            <p><%= Geo.locate(album) %></p>
+            <Fallback><p>by <%= artist %></p></Fallback>
+          </Fragment>
+        ERB
+
+        visitor, engine = compile(source)
+
+        assert_empty visitor.diagnostics
+        assert_equal [3], visitor.manifest["states"]["reads"]["artist"]
+        assert_equal [:attribute, :conditional, :child, :child], visitor.slots.map(&:type)
+
+        page = Object.new.instance_eval(engine.src.gsub("Geo.locate(album)", "'located'"))
+
+        assert_snapshot_matches(page, source, { probe: "fallback state read" })
+      end
+
+      test "a derived state read in a fallback renders once and holds no slot" do
+        source = <<~ERB
+          <%# herb:slots client %>
+          <%# herb:state (album: "a", artist: "", credit: artist) %>
+          <input value="<%= album %>">
+          <Fragment on="album">
+            <p><%= Geo.locate(album) %></p>
+            <Fallback><p>by <%= credit %></p></Fallback>
+          </Fragment>
+        ERB
+
+        visitor, = compile(source)
+
+        assert_nil visitor.manifest["states"]["reads"]["credit"]
+        assert_equal [:attribute, :conditional, :child], visitor.slots.map(&:type)
+      end
+
       test "the manifest maps the fragment to the reads inside it" do
         visitor, = compile(FRAGMENT)
 

--- a/test/snapshots/engine/slots/components_test/test_0005_a_state_read_in_a_fallback_stays_a_live_slot_3e25227a6cd354567d4e32427ced3b53-94d8e56a7b2a3db7f06fdc2def091bd5.txt
+++ b/test/snapshots/engine/slots/components_test/test_0005_a_state_read_in_a_fallback_stays_a_live_slot_3e25227a6cd354567d4e32427ced3b53-94d8e56a7b2a3db7f06fdc2def091bd5.txt
@@ -1,0 +1,22 @@
+---
+source: "Engine::Slots::ComponentsTest#test_0005_a state read in a fallback stays a live slot"
+input: |2-
+<%# herb:slots client %>
+<%# herb:state (album: "a", artist: "") %>
+<input value="<%= album %>">
+<Fragment on="album">
+  <p><%= Geo.locate(album) %></p>
+  <Fallback><p>by <%= artist %></p></Fallback>
+</Fragment>
+options: {probe: "fallback state read"}
+---
+<!--herb-region:app/views/test.html.erb:044297f3:0-->
+<input value="a" data-herb-slot="0:attribute:value">
+<!--herb-slot:1:conditional--><!--herb-branch:1:0-->
+  <p data-herb-slot="2:child">located</p>
+  
+<!--/herb-slot:1-->
+<!--/herb-region:app/views/test.html.erb--><template data-herb-region="app/views/test.html.erb:044297f3"><!--herb-branch:1:0-->
+  <p data-herb-slot="2:child"></p>
+  
+<!--herb-branch:1:1--><p>by <!--herb-slot:3--><!--/herb-slot:3--></p></template>


### PR DESCRIPTION
This pull request lets a `<Fragment>`'s `<Fallback>` read client states. 

A fallback compiles render-once by design, since it has to stand in server-side, so until now every ERB inside it rendered at page render and went static, and a fallback saying `by <%= artist %>` stayed frozen at the initial value no matter what the client knew. 

The visitor now walks each recorded fallback body after the directives are parsed, and an output tag whose expression is exactly a declared, underived region state becomes an ordinary slot, registered through the same annotation machinery as page slots, numbered with them, and listed in the manifest's read map. 

The statics emission wraps those nodes in slot markers, reusing the marker-insertion pass for nested positions, so the parked fallback carries live slots holding the server-rendered initial value. Everything else in a fallback keeps rendering once, a helper call, an instance variable, or a derived state stays static, and `<Async>`/`<Lazy>` fallbacks are untouched since they compile as real branches and were always live.

The client side needs nothing new. The fallback presentation resettles the branch it shows and the departing-reads guard exempts a presentation-held slot, both shipped in #2575, so a presented fallback's slots fill from current state and follow later writes.

```erb
<%# herb:state (album: "", album_artist: "") %>

<Fragment on="album">
  <ul class="tracks"><%# server-derived rows %></ul>

  <Fallback>
    <p class="detail-meta"><%= album_artist %> &middot; <span class="skeleton">&nbsp;</span></p>
  </Fallback>
</Fragment>
```
