### PR TITLE
Engine: Compile standalone `herb-key` element to a keyed collection

### DIFF
--- a/lib/herb/engine/slots/visitor.rb
+++ b/lib/herb/engine/slots/visitor.rb
@@ -65,6 +65,7 @@ module Herb
         OCCURRENCES = "@_herb_region_occurrences" #: String
         OCCURRENCE = "_herb_occurrence" #: String
         NAME_ATTRIBUTE = "data-herb-name" #: String
+        KEY_ATTRIBUTE = "herb-key" #: String
 
         CAPTURING = /\b(?:content_for|provide|capture)\b/ #: Regexp
         LISTENER_ATTRIBUTES = ["data-herb-set", "data-herb-toggle", "data-herb-increment", "data-herb-decrement", "data-herb-reset"].freeze #: Array[String]
@@ -610,7 +611,10 @@ module Herb
         def visit_document_node(node)
           @document = node
 
-          transform_components(node) if declares_slots?(node)
+          if declares_slots?(node)
+            transform_components(node)
+            wrap_keyed_elements(node)
+          end
 
           visit_children_with_paths(node.children)
 
@@ -1388,6 +1392,61 @@ module Herb
           }
         end
 
+        #: (untyped) -> void
+        def wrap_keyed_elements(node)
+          iteration = node.is_a?(Herb::AST::ERBIterationBlockNode) || node.is_a?(Herb::AST::ERBForNode) || node.is_a?(Herb::AST::ERBWhileNode) || node.is_a?(Herb::AST::ERBUntilNode)
+
+          BRANCH_BODY_PROPERTIES.each do |property|
+            next unless node.respond_to?(property)
+
+            array = node.send(property)
+
+            next unless array.is_a?(Array)
+
+            sole_element = iteration && array.grep(Herb::AST::HTMLElementNode).one?
+
+            array.each_with_index do |child, at|
+              wrap_keyed_elements(child)
+
+              next unless child.is_a?(Herb::AST::HTMLElementNode)
+              next if sole_element
+
+              expression = keyed_element_expression(child)
+
+              array[at] = synthesized_collection(child, expression) if expression
+            end
+          end
+        end
+
+        #: (untyped) -> String?
+        def keyed_element_expression(element)
+          attribute = attributes_for(element).find { |candidate| attribute_name_for(candidate)&.downcase == KEY_ATTRIBUTE }
+
+          return nil unless attribute
+
+          key_expression_for(attribute)
+        end
+
+        #: (untyped, String) -> untyped
+        def synthesized_collection(element, expression)
+          remove_herb_key_attribute(element)
+
+          parsed = Herb.parse("<% [#{expression}].each do %><%# herb:key #{expression} %><% end %>", iteration_nodes: true, herb_directives: true, track_locations: false).value.children.first #: untyped
+
+          parsed.body << element
+
+          parsed
+        end
+
+        #: (untyped) -> void
+        def remove_herb_key_attribute(element)
+          open_tag = element.open_tag
+
+          return unless OPEN_TAG_TYPES.any? { |type| open_tag.is_a?(type) }
+
+          open_tag.children.reject! { |child| attribute_name_for(child)&.downcase == KEY_ATTRIBUTE }
+        end
+
         #: (untyped) -> [Symbol, String?]
         def key_for(node)
           body = collection_body(node)
@@ -1400,14 +1459,14 @@ module Herb
 
           attributes = attributes_for(elements.first)
 
-          ["herb-key", "id"].each do |name|
+          [KEY_ATTRIBUTE, "id"].each do |name|
             attribute = attributes.find { |candidate| attribute_name_for(candidate)&.downcase == name }
             next unless attribute
 
             expression = key_expression_for(attribute)
             next unless expression
 
-            return [name == "herb-key" ? :herb_key : :id, expression]
+            return [name == KEY_ATTRIBUTE ? :herb_key : :id, expression]
           end
 
           [:index, nil]

--- a/sig/herb/engine/slots/visitor.rbs
+++ b/sig/herb/engine/slots/visitor.rbs
@@ -59,6 +59,8 @@ module Herb
 
         NAME_ATTRIBUTE: String
 
+        KEY_ATTRIBUTE: String
+
         CAPTURING: Regexp
 
         LISTENER_ATTRIBUTES: Array[String]
@@ -443,6 +445,18 @@ module Herb
 
         # : (String, Annotation, untyped) -> bool
         def attribute_conflict?: (String, Annotation, untyped) -> bool
+
+        # : (untyped) -> void
+        def wrap_keyed_elements: (untyped) -> void
+
+        # : (untyped) -> String?
+        def keyed_element_expression: (untyped) -> String?
+
+        # : (untyped, String) -> untyped
+        def synthesized_collection: (untyped, String) -> untyped
+
+        # : (untyped) -> void
+        def remove_herb_key_attribute: (untyped) -> void
 
         # : (untyped) -> [Symbol, String?]
         def key_for: (untyped) -> [ Symbol, String? ]

--- a/test/engine/slots/markers_test.rb
+++ b/test/engine/slots/markers_test.rb
@@ -540,6 +540,14 @@ module Engine
 
         assert_equal [], recognized
       end
+
+      test "delimits a standalone keyed element as a one-item collection" do
+        assert_evaluated_snapshot(
+          %(<%# herb:slots %>\n<div herb-key="<%= @id %>"><%= @name %></div>),
+          { "@id" => 7, "@name" => "Marco" },
+          options
+        )
+      end
     end
   end
 end

--- a/test/engine/slots/states_test.rb
+++ b/test/engine/slots/states_test.rb
@@ -1486,6 +1486,26 @@ module Engine
         assert_equal [], refetchable - branches.values.flatten.map { |entry| entry["index"] }
       end
 
+      test "a standalone keyed element reading a state registers a refetch read" do
+        source = <<~ERB
+          <%# herb:slots client %>
+          <%# herb:state (track: "", number: 0) %>
+          <input value="<%= track %>">
+          <div herb-key="<%= track %>:<%= number %>" class="playhead">x</div>
+        ERB
+
+        visitor = Herb::Engine::Slots::Visitor.new(mode: :client, fatal: false)
+        Herb::Engine.new(source, visitors: [visitor], filename: "app/views/test.html.erb")
+
+        collection = visitor.slots.find { |slot| slot.type == :collection }
+        reads = visitor.manifest["states"]["server"]["reads"]
+
+        refute_nil collection
+        assert_equal :directive, collection.key_source
+        assert_equal([collection.index], reads.fetch("track").map { |read| read["index"] })
+        assert_equal([collection.index], reads.fetch("number").map { |read| read["index"] })
+      end
+
       test "a block argument shadows a state inside its body" do
         source = <<~ERB
           <%# herb:slots client %>

--- a/test/engine/slots/visitor_test.rb
+++ b/test/engine/slots/visitor_test.rb
@@ -494,6 +494,22 @@ module Engine
       test "records what a block whose value is not output contains" do
         assert_slots_snapshot("<div><% @user.tap do |u| %><b><%= u.name %></b><% end %></div>")
       end
+
+      test "wraps a standalone element carrying a dynamic herb-key in a one-item collection" do
+        assert_slots_snapshot(%(<%# herb:slots %>\n<div herb-key="<%= @track %>">x</div>))
+      end
+
+      test "builds an interpolated key for a standalone herb-key holding several expressions" do
+        assert_slots_snapshot(%(<%# herb:slots %>\n<div herb-key="<%= @track %>:<%= @number %>">x</div>))
+      end
+
+      test "leaves a static herb-key alone" do
+        assert_slots_snapshot(%(<%# herb:slots %>\n<div herb-key="fixed">x</div>))
+      end
+
+      test "leaves a herb-key inside a collection body to the collection" do
+        assert_slots_snapshot(%(<%# herb:slots %>\n<% @u.each do |u| %><li herb-key="<%= u.id %>">x</li><% end %>))
+      end
     end
   end
 end

--- a/test/snapshots/engine/slots/markers_test/test_0068_delimits_a_standalone_keyed_element_as_a_one-item_collection_3afef27459b188867dcc945d4f8b00e2.txt
+++ b/test/snapshots/engine/slots/markers_test/test_0068_delimits_a_standalone_keyed_element_as_a_one-item_collection_3afef27459b188867dcc945d4f8b00e2.txt
@@ -1,0 +1,6 @@
+---
+source: "Engine::Slots::MarkersTest#test_0068_delimits a standalone keyed element as a one-item collection"
+input: "{source: \"<%# herb:slots %>\\n<div herb-key=\\\"<%= @id %>\\\"><%= @name %></div>\", locals: {\"@id\" => 7, \"@name\" => \"Marco\"}, options: {visitors: [#<Herb::Engine::Slots::Visitor server>], filename: \"app/views/test.html.erb\"}}"
+---
+<!--herb-region:app/views/test.html.erb:cf790895:0-->
+<!--herb-slot:0:collection--><!--herb-item:0:7--><div data-herb-slot="1:child">Marco</div><!--/herb-item:0--><!--/herb-slot:0--><!--/herb-region:app/views/test.html.erb-->

--- a/test/snapshots/engine/slots/visitor_test/test_0075_wraps_a_standalone_element_carrying_a_dynamic_herb-key_in_a_one-item_collection_80c3fcc99892d4f82e9050f63ff1cbe5-4c591885d0bd22e1b3fcfc215038ec41.txt
+++ b/test/snapshots/engine/slots/visitor_test/test_0075_wraps_a_standalone_element_carrying_a_dynamic_herb-key_in_a_one-item_collection_80c3fcc99892d4f82e9050f63ff1cbe5-4c591885d0bd22e1b3fcfc215038ec41.txt
@@ -1,0 +1,12 @@
+---
+source: "Engine::Slots::VisitorTest#test_0075_wraps a standalone element carrying a dynamic herb-key in a one-item collection"
+input: |2-
+<%# herb:slots %>
+<div herb-key="<%= @track %>">x</div>
+options: {filename: "app/views/test.html.erb"}
+---
+file: app/views/test.html.erb
+version: 4d6d3b5f
+
+slots:
+  index=0  type=collection  node_path=[2]  expression="[@track].each do"  key_source=directive  key_expression="@track"

--- a/test/snapshots/engine/slots/visitor_test/test_0076_builds_an_interpolated_key_for_a_standalone_herb-key_holding_several_expressions_58b1a46a35d4dcd221c99bd0a62f8023-4c591885d0bd22e1b3fcfc215038ec41.txt
+++ b/test/snapshots/engine/slots/visitor_test/test_0076_builds_an_interpolated_key_for_a_standalone_herb-key_holding_several_expressions_58b1a46a35d4dcd221c99bd0a62f8023-4c591885d0bd22e1b3fcfc215038ec41.txt
@@ -1,0 +1,12 @@
+---
+source: "Engine::Slots::VisitorTest#test_0076_builds an interpolated key for a standalone herb-key holding several expressions"
+input: |2-
+<%# herb:slots %>
+<div herb-key="<%= @track %>:<%= @number %>">x</div>
+options: {filename: "app/views/test.html.erb"}
+---
+file: app/views/test.html.erb
+version: 4d6d3b5f
+
+slots:
+  index=0  type=collection  node_path=[2]  expression="[\"\#{@track}:\#{@number}\"].each do"  key_source=directive  key_expression="\"\#{@track}:\#{@number}\""

--- a/test/snapshots/engine/slots/visitor_test/test_0077_leaves_a_static_herb-key_alone_0b3ef5690894d2e57105597099539270-4c591885d0bd22e1b3fcfc215038ec41.txt
+++ b/test/snapshots/engine/slots/visitor_test/test_0077_leaves_a_static_herb-key_alone_0b3ef5690894d2e57105597099539270-4c591885d0bd22e1b3fcfc215038ec41.txt
@@ -1,0 +1,11 @@
+---
+source: "Engine::Slots::VisitorTest#test_0077_leaves a static herb-key alone"
+input: |2-
+<%# herb:slots %>
+<div herb-key="fixed">x</div>
+options: {filename: "app/views/test.html.erb"}
+---
+file: app/views/test.html.erb
+version: e3b0c442
+
+slots: (none)

--- a/test/snapshots/engine/slots/visitor_test/test_0078_leaves_a_herb-key_inside_a_collection_body_to_the_collection_a55a1e3e6f9e9f94a2a961e93e3683ee-4c591885d0bd22e1b3fcfc215038ec41.txt
+++ b/test/snapshots/engine/slots/visitor_test/test_0078_leaves_a_herb-key_inside_a_collection_body_to_the_collection_a55a1e3e6f9e9f94a2a961e93e3683ee-4c591885d0bd22e1b3fcfc215038ec41.txt
@@ -1,0 +1,13 @@
+---
+source: "Engine::Slots::VisitorTest#test_0078_leaves a herb-key inside a collection body to the collection"
+input: |2-
+<%# herb:slots %>
+<% @u.each do |u| %><li herb-key="<%= u.id %>">x</li><% end %>
+options: {filename: "app/views/test.html.erb"}
+---
+file: app/views/test.html.erb
+version: 6cf60e19
+
+slots:
+  index=0  type=collection  node_path=[2]  expression="@u.each do |u|"  key_source=herb_key  key_expression="u.id"
+  index=1  type=attribute  node_path=[2, 0]  expression="u.id"  attribute="herb-key"


### PR DESCRIPTION
This pull request lets an element outside any collection carry a `herb-key` attribute and get keyed identity from it. 

```erb
<div class="playhead" herb-key="<%= track %>:<%= number %>">
  <div class="playhead-fill" style="animation-duration: <%= Music.seconds(track, number) %>s"></div>
</div>
```

The visitor now runs a pre-pass over the document when it declares slots. An element whose `herb-key` holds at least one expression is wrapped in a synthesized one-item collection, `<% [key].each do %>` with a `herb:key` directive carrying the same expression, and the attribute is removed from the element. The element compiles exactly like the hand-written idiom, one collection slot delimited by item markers whose key is the evaluated expression. A key change replaces the element, which restarts creation-scoped CSS animations, and a key expression mentioning a state registers as a server read, so a refetch delivers the fresh server-computed values inside.

The attribute is consumed at compile time the way component tags are. It never reaches the rendered page, which keeps the parked copy from carrying a stale key, since runtime identity lives entirely in the item markers. A composite key like `herb-key="<%= track %>:<%= number %>"` builds the same interpolated key string the collection key reader already produces, a static `herb-key="fixed"` compiles to nothing since a key that cannot change buys nothing, and a `herb-key` on the sole element of a real collection body keeps its existing meaning, it keys that collection and stays a live attribute slot.
