### PR TITLE
Client: Show a fragment's fallback immediately while it holds no content

### DIFF
--- a/javascript/packages/client/src/state/fragments.ts
+++ b/javascript/packages/client/src/state/fragments.ts
@@ -223,7 +223,7 @@ export class Fragments {
 
     const delay = fragment.delay ?? FRAGMENT_DELAY
 
-    if (delay <= 0 || slot.branch === presentation.fallback) {
+    if (delay <= 0 || slot.branch === null || slot.branch === presentation.fallback || this.blank(slot, fragment)) {
       this.swapToFallback(slot, presentation)
 
       return
@@ -234,6 +234,22 @@ export class Fragments {
 
       this.swapToFallback(slot, presentation)
     }, delay)
+  }
+
+  private blank(slot: Slot, fragment: FragmentEntry): boolean {
+    const reads = fragment.reads ?? []
+
+    if (reads.length === 0) {
+      return false
+    }
+
+    const descendants = this.slots.descendantsOf(slot)
+
+    return !reads.some((index) => {
+      const read = descendants.find((child) => child.index === index)
+
+      return read ? this.slots.currentText(read).trim() !== "" : false
+    })
   }
 
   private swapToFallback(slot: Slot, presentation: FragmentPresentation): void {

--- a/javascript/packages/client/test/fragment-empty-delay.test.ts
+++ b/javascript/packages/client/test/fragment-empty-delay.test.ts
@@ -1,0 +1,51 @@
+import { test, expect, afterEach, vi } from "vitest"
+
+import { Runtime } from "../src/runtime"
+
+const FILE = "app/views/test.html.erb"
+
+const PAGE =
+  `<!--herb-region:${FILE}:11aa22bb:0-->` +
+  `<input value="" data-herb-slot="0:attribute:value">` +
+  `<!--herb-slot:1:conditional--><!--/herb-slot:1-->` +
+  `<!--/herb-region:${FILE}-->` +
+  `<template data-herb-region="${FILE}:11aa22bb"><!--herb-branch:1:0--><p id="loaded"><!--herb-slot:2--><!--/herb-slot:2--></p><!--herb-branch:1:1--><p id="waiting">loading</p></template>` +
+  `<template data-herb-dependencies>${JSON.stringify({
+    state: {},
+    states: {
+      [FILE]: {
+        version: "11aa22bb",
+        declarations: [{ name: "album", kind: "string", default: '""', scope: "region", value: "" }],
+        reads: { album: [0] },
+        conditionals: { 1: { arms: [{ branch: 0, condition: ["album", null, "present"] }], else: 1 } },
+        server: { branches: { 1: [{ index: 2, node_path: [0] }] }, reads: { album: [{ index: 2, node_path: [0] }] } },
+        fragments: { 1: { fallback: 1, reads: [2], on: ["album"], delay: 400, hold: 40 } },
+      },
+    },
+  })}</template>`
+
+let runtime: Runtime | null = null
+
+afterEach(() => {
+  runtime?.stop()
+  runtime = null
+  document.body.innerHTML = ""
+})
+
+test("an empty fragment shows its fallback immediately even with a delay", async () => {
+  document.body.innerHTML = PAGE
+
+  const transport = vi.fn(() => new Promise<never>(() => {}))
+
+  runtime = Runtime.start({ state: { refetchTransport: transport as never, refetchDebounce: 0 } })
+
+  runtime.state.setState({ album: "b" })
+
+  await vi.waitFor(() => {
+    if (!document.getElementById("waiting")) {
+      throw new Error("fallback not shown yet")
+    }
+  }, { timeout: 200 })
+
+  expect(document.getElementById("waiting")!.textContent).toBe("loading")
+})


### PR DESCRIPTION
This pull request makes a `<Fragment>`'s `delay` guard only the replacement of content that is actually on screen. 

The delay exists so a fast answer never flashes a skeleton over values the user is already reading. When the fragment holds nothing yet, deferring the fallback protects nothing, it leaves a void where the skeleton should be.

The gap showed in the music demo. Tuning the fragment to `delay="300"` so album switches keep the old values made the first open worse, the freshly materialized fragment area sat empty for the grace period because its state-owned conditional had already switched to a primary branch with no values in it.

`present` now swaps to the fallback immediately when the slot renders no branch, when it already shows the fallback, or when none of the fragment's server-read slots hold any text. A fragment with content keeps the full grace period, so the two behaviors an author wants come from one `delay`: instant skeleton on first appearance, held values on a change.
