### PR TITLE
Client: Keep deferred and steered content honest while the server answers

### DIFF
--- a/javascript/packages/client/src/slots/apply.ts
+++ b/javascript/packages/client/src/slots/apply.ts
@@ -1,4 +1,5 @@
 import { attributeValue } from "../markup/fragments"
+import { itemStaticsKey } from "../markup/markers"
 import { report as reportDiagnostic } from "../shared/report"
 
 import type { Slots } from "./slots"
@@ -85,6 +86,10 @@ function applySlots(slots: Slots, payload: Payload, container: SlotMap, values: 
         ) {
           const parked = parkBranchStatics(slots, payload, slot, value as Branched)
 
+          if (parked) {
+            slots.announceBranchMaterial(slot)
+          }
+
           if (value.branch === slot.branch) {
             applySlots(slots, payload, owner(slot), value.slots, report, mode)
           } else if (value.branch !== null) {
@@ -92,10 +97,6 @@ function applySlots(slots: Slots, payload: Payload, container: SlotMap, values: 
 
             shown.set(value.branch, { ...(shown.get(value.branch) ?? {}), ...leaves(value.slots) })
             slot.shown = shown
-          }
-
-          if (parked) {
-            slots.announceBranchMaterial(slot)
           }
         }
 
@@ -234,7 +235,20 @@ function applyBranch(slots: Slots, payload: Payload, slot: Slot, value: Branched
     }
   }
 
+function parkItemStatics(slots: Slots, payload: Payload, slot: Slot, value: Collected): void {
+    if (!value.statics) {
+      return
+    }
+
+    slots.holdStatics(
+      { file: payload.template, version: payload.version },
+      { [itemStaticsKey(slot.index)]: value.statics },
+    )
+  }
+
 function applyItems(slots: Slots, payload: Payload, slot: Slot, value: Collected, report: ApplyReport, mode: ApplyMode): void {
+    parkItemStatics(slots, payload, slot, value)
+
     const wanted = value.order ?? Object.keys(value.items)
     const unbuilt = slots.reconcileItems(slot, wanted, mode)
 

--- a/javascript/packages/client/src/slots/slots.ts
+++ b/javascript/packages/client/src/slots/slots.ts
@@ -30,9 +30,9 @@ import { ElementObserver } from "../shared/element-observer"
 import { applyPayload } from "./apply"
 
 import { ancestorsOf, descendantsOf } from "./tree"
-import { ITEM_STATICS, branchKey, branchOf, itemStaticsKey, keyedSlotMarker } from "../markup/markers"
+import { ITEM_STATICS, branchKey, branchOf, itemStaticsKey, keyedSlotMarker, slotOpenIndex } from "../markup/markers"
 import { blankSeeds, blankSlots, interpolateParts, valuesIn, withoutMarkers, fillSlots } from "../markup/fragments"
-import { currentHTML, currentText, elementOf, htmlOf, innerRange, rangeOf as rangeOfAnchor } from "../markup/anchors"
+import { anchoredSlots, currentHTML, currentText, elementOf, htmlOf, innerRange, rangeOf as rangeOfAnchor, slotOpeners } from "../markup/anchors"
 
 import type { StateManifest } from "../state/types"
 import type { TemplateManifest } from "./manifests"
@@ -41,7 +41,7 @@ import type { CollectionsDelegate } from "./collections"
 import type { RegionIndexDelegate } from "./region-index"
 import type { JournalDelegate } from "./journal"
 
-import type { AddItemOptions, AttributeParts, ApplyMode, BuildCause, Built, SlotsDelegate, ApplyOptions, ApplyReport, Item, ItemMap, ItemPlan, ItemStep, Payload, Placement, Region, ScanContext, RenderMode, RevertToken, ScanResult, Slot, SlotAddress, SlotEventDetail, SlotOperation, SlotValue, SlotValues, StaticsIdentity, TransactionResult } from "../types"
+import type { AddItemOptions, AttributeParts, ApplyMode, BuildCause, Built, SlotsDelegate, ApplyOptions, ApplyReport, Item, ItemMap, ItemPlan, ItemStep, Payload, Placement, Region, ScanContext, RenderMode, RevertToken, ScanResult, Slot, SlotAddress, SlotEventDetail, SlotMap, SlotOperation, SlotValue, SlotValues, StaticsIdentity, TransactionResult } from "../types"
 
 export class Slots implements ElementObserverDelegate, JournalDelegate, CollectionsDelegate, RegionIndexDelegate {
   private journal = new Journal(this)
@@ -831,6 +831,68 @@ export class Slots implements ElementObserverDelegate, JournalDelegate, Collecti
     fillSlots(fragment, dynamics, false, (index) => this.manifests.partsForFile(slot.region.file, index))
 
     return fragment
+  }
+
+  invalidateStale(region: Region, stale: Set<number>): void {
+    const walk = (slots: SlotMap): void => {
+      for (const slot of slots.values()) {
+        if (slot.shown) {
+          for (const values of slot.shown.values()) {
+            for (const index of Object.keys(values)) {
+              if (stale.has(Number(index)) || this.embedsStale(values[Number(index)], stale)) {
+                delete values[Number(index)]
+              }
+            }
+          }
+        }
+
+        if (slot.captured) {
+          for (const [branch, fragment] of [...slot.captured]) {
+            if (this.holdsAny(fragment, stale)) {
+              slot.captured.delete(branch)
+            }
+          }
+        }
+
+        for (const item of slot.items.values()) {
+          walk(item.slots)
+        }
+      }
+    }
+
+    walk(region.slots)
+  }
+
+  private embedsStale(value: SlotValue, stale: Set<number>): boolean {
+    if (typeof value !== "string") {
+      return false
+    }
+
+    for (const match of value.matchAll(/<!--\s*herb-slot:(\d+)/g)) {
+      if (stale.has(Number(match[1]))) {
+        return true
+      }
+    }
+
+    return false
+  }
+
+  private holdsAny(fragment: DocumentFragment, stale: Set<number>): boolean {
+    for (const open of slotOpeners(fragment)) {
+      const index = slotOpenIndex(open.data.trim())
+
+      if (index !== null && stale.has(index)) {
+        return true
+      }
+    }
+
+    for (const [, entry] of anchoredSlots(fragment)) {
+      if (stale.has(entry.index)) {
+        return true
+      }
+    }
+
+    return false
   }
 
   recordBuilt(slot: Slot, item: Item): void {

--- a/javascript/packages/client/src/state/state.ts
+++ b/javascript/packages/client/src/state/state.ts
@@ -508,6 +508,7 @@ export class State implements ElementObserverDelegate, SlotsDelegate, SeedsDeleg
 
       const changed = [...grouped, ...recomputed]
 
+      this.invalidateStaleReads(manifest, scope, changed)
       this.writeConditionals(manifest, scope, changed)
       this.writePresence(manifest, scope, changed)
       this.writeComputed(manifest, scope, changed)
@@ -527,6 +528,7 @@ export class State implements ElementObserverDelegate, SlotsDelegate, SeedsDeleg
     }
 
     if (recounted.length > 0) {
+      this.invalidateStaleReads(manifest, regionScope, recounted)
       this.writeConditionals(manifest, regionScope, recounted)
       this.writePresence(manifest, regionScope, recounted)
       this.writeComputed(manifest, regionScope, recounted)
@@ -617,6 +619,15 @@ export class State implements ElementObserverDelegate, SlotsDelegate, SeedsDeleg
     }
 
     return Object.keys(values).length > 0 ? { [region.file]: values } : {}
+  }
+
+  private invalidateStaleReads(manifest: StateManifest, scope: StateScope, names: string[]): void {
+    const reads = manifest.server?.reads ?? {}
+    const stale = new Set(names.flatMap((name) => (reads[name] ?? []).map((read) => read.index)))
+
+    if (stale.size > 0) {
+      this.slots.invalidateStale(scope.region, stale)
+    }
   }
 
   private requestReadRefetch(manifest: StateManifest, scope: StateScope, names: string[]): void {

--- a/javascript/packages/client/src/types.ts
+++ b/javascript/packages/client/src/types.ts
@@ -228,6 +228,7 @@ export interface Branched {
 export interface Collected {
   items: PayloadItems
   order?: string[]
+  statics?: string
 }
 
 export interface KeyedValue {

--- a/javascript/packages/client/test/collection-statics.test.ts
+++ b/javascript/packages/client/test/collection-statics.test.ts
@@ -1,0 +1,135 @@
+import { describe, test, expect, beforeEach } from "vitest"
+
+import { Slots } from "../src/slots/slots"
+import { State } from "../src/state/state"
+
+const FILE = "app/views/dashboard/show.html.erb"
+const VERSION = "9d8c7b6a"
+
+const PAGE =
+  `<!--herb-region:${FILE}:${VERSION}:0-->` +
+  `<section><!--herb-slot:0:conditional--><!--/herb-slot:0--></section>` +
+  `<!--/herb-region:${FILE}-->`
+
+const BRANCH_STATICS =
+  `<!--herb-branch:0:0--><ul><!--herb-slot:1:collection--><!--/herb-slot:1--></ul>`
+
+const ITEM_STATICS =
+  `<!--herb-branch:1:item--><!--herb-item:1:--><li herb-key="" data-herb-slot="2:attribute:herb-key"><span data-herb-slot="3:child"></span></li><!--/herb-item:1-->`
+
+let slots: Slots
+
+beforeEach(() => {
+  document.body.innerHTML = PAGE
+
+  slots = new Slots()
+  slots.scan(document.body)
+})
+
+describe("a payload carrying a collection's item statics", () => {
+  test("builds the items without any parked material", () => {
+    const report = slots.apply({
+      template: FILE,
+      version: VERSION,
+      occurrence: 0,
+      slots: {
+        0: {
+          branch: 0,
+          statics: BRANCH_STATICS,
+          slots: {
+            1: {
+              items: {
+                Europe: { 2: "Europe", 3: "Europe" },
+                Asia: { 2: "Asia", 3: "Asia" },
+              },
+              order: ["Europe", "Asia"],
+              statics: ITEM_STATICS,
+            },
+          },
+        },
+      },
+    })
+
+    expect(report.deferred).toEqual([])
+    expect(document.querySelectorAll("li").length).toBe(2)
+    expect(document.body.textContent).toContain("Europe")
+    expect(document.body.textContent).toContain("Asia")
+  })
+})
+
+const DEFERRED_FILE = "app/views/deferred/show.html.erb"
+const DEFERRED_VERSION = "8e7f6a5b"
+
+const DEFERRED_MANIFEST = {
+  state: {},
+  states: {
+    [DEFERRED_FILE]: {
+      version: DEFERRED_VERSION,
+      declarations: [
+        { name: "_herb_block_0", kind: "boolean", default: "false", derived: null, scope: "region", value: false, internal: true },
+      ],
+      reads: {},
+      conditionals: {
+        0: { arms: [{ branch: 0, condition: ["_herb_block_0", null] }], else: 1 },
+      },
+      presence: {},
+      computed: {},
+    },
+  },
+}
+
+const DEFERRED_PAGE =
+  `<!--herb-region:${DEFERRED_FILE}:${DEFERRED_VERSION}:0-->` +
+  `<section><!--herb-slot:0:conditional--><!--herb-branch:0:1--><p id="waiting">loading</p><!--/herb-slot:0--></section>` +
+  `<!--/herb-region:${DEFERRED_FILE}-->` +
+  `<template data-herb-region="${DEFERRED_FILE}:${DEFERRED_VERSION}"><!--herb-branch:0:1--><p id="waiting">loading</p></template>` +
+  `<template data-herb-dependencies>${JSON.stringify(DEFERRED_MANIFEST)}</template>`
+
+describe("a deferred block's payload holding a collection", () => {
+  let state: State
+
+  beforeEach(() => {
+    document.body.innerHTML = DEFERRED_PAGE
+
+    slots = new Slots()
+    slots.scan(document.body)
+
+    state = new State(slots, {})
+    state.adopt()
+  })
+
+  test("builds the items when the payload's material lets the state switch over", () => {
+    expect(slots.slot(DEFERRED_FILE, 0)?.branch).toBe(1)
+
+    state.setState({ _herb_block_0: true })
+
+    expect(slots.slot(DEFERRED_FILE, 0)?.claimed).toBe(true)
+
+    const report = slots.apply({
+      template: DEFERRED_FILE,
+      version: DEFERRED_VERSION,
+      occurrence: 0,
+      slots: {
+        0: {
+          branch: 0,
+          statics: `<!--herb-branch:0:0--><ul><!--herb-slot:1:collection--><!--/herb-slot:1--></ul>`,
+          slots: {
+            1: {
+              items: {
+                Europe: { 2: "Europe", 3: "Europe" },
+                Asia: { 2: "Asia", 3: "Asia" },
+              },
+              order: ["Europe", "Asia"],
+              statics: `<!--herb-branch:1:item--><!--herb-item:1:--><li herb-key="" data-herb-slot="2:attribute:herb-key"><span data-herb-slot="3:child"></span></li><!--/herb-item:1-->`,
+            },
+          },
+        },
+      },
+    })
+
+    expect(report.deferred).toEqual([])
+    expect(slots.slot(DEFERRED_FILE, 0)?.branch).toBe(0)
+    expect(document.querySelectorAll("li").length).toBe(2)
+    expect(document.body.textContent).toContain("Asia")
+  })
+})

--- a/javascript/packages/client/test/stale-server-read.test.ts
+++ b/javascript/packages/client/test/stale-server-read.test.ts
@@ -1,0 +1,186 @@
+import { describe, test, expect, beforeEach } from "vitest"
+
+import { Slots } from "../src/slots/slots"
+import { State } from "../src/state/state"
+
+const FILE = "app/views/cascade/show.html.erb"
+const VERSION = "1f2e3d4c"
+
+const MANIFEST = {
+  state: {},
+  states: {
+    [FILE]: {
+      version: VERSION,
+      declarations: [
+        { name: "country", kind: "string", default: '""', derived: null, scope: "region", value: "CH" },
+        { name: "state", kind: "string", default: '""', derived: null, scope: "region", value: "" },
+      ],
+      reads: {},
+      conditionals: {
+        0: { arms: [{ branch: 0, condition: ["state", null, "present"] }], else: 1 },
+      },
+      presence: {},
+      computed: {},
+      server: {
+        reads: {
+          country: [{ index: 1, node_path: [0] }],
+          state: [{ index: 1, node_path: [0] }],
+        },
+        branches: {
+          0: [{ index: 1, node_path: [0] }],
+        },
+      },
+    },
+  },
+}
+
+const PAGE =
+  `<!--herb-region:${FILE}:${VERSION}:0-->` +
+  `<div><!--herb-slot:0:conditional--><!--/herb-slot:0--></div>` +
+  `<!--/herb-region:${FILE}-->` +
+  `<template data-herb-region="${FILE}:${VERSION}">` +
+  `<!--herb-branch:0:0--><p id="cities"><!--herb-slot:1--><!--/herb-slot:1--></p>` +
+  `<!--herb-branch:0:1--><p id="waiting">loading</p>` +
+  `</template>` +
+  `<template data-herb-dependencies>${JSON.stringify(MANIFEST)}</template>`
+
+let slots: Slots
+let state: State
+
+function shown(): string {
+  const slot = slots.slot(FILE, 1)
+
+  return slot ? slots.rangeOf(slot).toString() : "<not placed>"
+}
+
+beforeEach(() => {
+  document.body.innerHTML = PAGE
+
+  slots = new Slots()
+  slots.scan(document.body)
+
+  state = new State(slots, {})
+  state.adopt()
+})
+
+describe("a server-read slot inside a conditional the same state drives", () => {
+  test("does not resurrect a captured value after the read's state changed", () => {
+    state.setState({ state: "BS" })
+
+    expect(slots.slot(FILE, 0)?.branch).toBe(0)
+
+    slots.apply({ template: FILE, version: VERSION, occurrence: 0, slots: { 0: { branch: 0, slots: { 1: "Basel and Riehen" } } } })
+
+    expect(shown()).toBe("Basel and Riehen")
+
+    state.setState({ state: "" })
+
+    expect(slots.slot(FILE, 0)?.branch).toBe(1)
+
+    state.setState({ state: "GE" })
+
+    expect(slots.slot(FILE, 0)?.branch).toBe(0)
+    expect(shown()).toBe("")
+  })
+
+  test("does not resurrect a captured value after another read changed while hidden", () => {
+    state.setState({ state: "BS" })
+    slots.apply({ template: FILE, version: VERSION, occurrence: 0, slots: { 0: { branch: 0, slots: { 1: "Basel and Riehen" } } } })
+
+    state.setState({ country: "DE", state: "" })
+
+    expect(slots.slot(FILE, 0)?.branch).toBe(1)
+
+    state.setState({ state: "BY" })
+
+    expect(slots.slot(FILE, 0)?.branch).toBe(0)
+    expect(shown()).toBe("")
+  })
+})
+
+const NESTED_FILE = "app/views/nested/show.html.erb"
+const NESTED_VERSION = "5a6b7c8d"
+
+const NESTED_MANIFEST = {
+  state: {},
+  states: {
+    [NESTED_FILE]: {
+      version: NESTED_VERSION,
+      declarations: [
+        { name: "country", kind: "string", default: '""', derived: null, scope: "region", value: "CH" },
+        { name: "state", kind: "string", default: '""', derived: null, scope: "region", value: "" },
+      ],
+      reads: {},
+      conditionals: {
+        0: { arms: [{ branch: 0, condition: ["state", null, "present"] }], else: null },
+      },
+      presence: {},
+      computed: {},
+      server: {
+        reads: {
+          country: [{ index: 1, node_path: [0] }],
+          state: [{ index: 1, node_path: [0] }],
+        },
+        branches: {
+          0: [{ index: 1, node_path: [0] }],
+        },
+      },
+      fragments: {
+        2: { fallback: 1, reads: [1] },
+      },
+    },
+  },
+}
+
+const NESTED_PAGE =
+  `<!--herb-region:${NESTED_FILE}:${NESTED_VERSION}:0-->` +
+  `<div><!--herb-slot:0:conditional--><!--/herb-slot:0--></div>` +
+  `<!--/herb-region:${NESTED_FILE}-->` +
+  `<template data-herb-region="${NESTED_FILE}:${NESTED_VERSION}">` +
+  `<!--herb-branch:0:0--><section><!--herb-slot:2:conditional--><!--/herb-slot:2--></section>` +
+  `<!--herb-branch:2:0--><p id="cities"><!--herb-slot:1--><!--/herb-slot:1--></p>` +
+  `<!--herb-branch:2:1--><p id="waiting">loading</p>` +
+  `</template>` +
+  `<template data-herb-dependencies>${JSON.stringify(NESTED_MANIFEST)}</template>`
+
+describe("a server-read slot nested in a fragment conditional inside the driven branch", () => {
+  beforeEach(() => {
+    document.body.innerHTML = NESTED_PAGE
+
+    slots = new Slots()
+    slots.scan(document.body)
+
+    state = new State(slots, {})
+    state.adopt()
+  })
+
+  function nestedShown(): string {
+    const slot = slots.slot(NESTED_FILE, 1)
+
+    return slot ? slots.rangeOf(slot).toString() : "<not placed>"
+  }
+
+  test("does not resurrect the nested value through the outer branch's stash", () => {
+    state.setState({ state: "BS" })
+
+    expect(slots.slot(NESTED_FILE, 0)?.branch).toBe(0)
+
+    slots.apply({
+      template: NESTED_FILE,
+      version: NESTED_VERSION,
+      occurrence: 0,
+      slots: { 2: { branch: 0, slots: { 1: "Basel and Riehen" } } },
+    })
+
+    expect(nestedShown()).toBe("Basel and Riehen")
+
+    state.setState({ state: "" })
+
+    expect(slots.slot(NESTED_FILE, 0)?.branch).toBeNull()
+
+    state.setState({ state: "GE" })
+
+    expect(slots.slot(NESTED_FILE, 0)?.branch).toBe(0)
+    expect(nestedShown()).not.toContain("Basel")
+  })
+})

--- a/lib/herb/engine/slots/dynamics_compiler.rb
+++ b/lib/herb/engine/slots/dynamics_compiler.rb
@@ -532,6 +532,7 @@ module Herb
         def initialize(input, properties = {})
           @block_depth = 0
           @scopes = [] #: Array[Integer]
+          @withheld = {} #: Hash[Integer, bool]
           @input = input
           @filename = properties[:filename]
           @slot_visitor = properties[:slot_visitor] || Visitor.new(mode: :server, mark: false)
@@ -670,6 +671,8 @@ module Herb
         def scope_branch(index, branch)
           leave_scope(index)
 
+          @withheld[index] = withheld?(index, branch)
+
           statics = payload_statics(index, branch)
           parked = statics ? " statics: #{statics.inspect}," : ""
 
@@ -680,12 +683,26 @@ module Herb
 
         #: (Integer, Integer) -> String?
         def payload_statics(index, branch)
-          server = @input.is_a?(String) && Visitor.directive_mode(@input) == :server
-          withheld = branch.zero? && @slot_visitor.deferred_entries.key?(index)
-
-          return nil unless server || withheld
+          return nil unless server_mode? || withheld?(index, branch)
 
           branch_statics["#{index}:#{branch}"]
+        end
+
+        #: () -> bool
+        def server_mode?
+          @input.is_a?(String) && Visitor.directive_mode(@input) == :server
+        end
+
+        #: (Integer, Integer) -> bool
+        def withheld?(index, branch)
+          branch.zero? && @slot_visitor.deferred_entries.key?(index)
+        end
+
+        #: (Integer) -> String?
+        def item_statics(index)
+          return nil unless server_mode? || @scopes.any? { |scope| @withheld[scope] }
+
+          branch_statics["#{index}:#{Markers::ITEM_STATICS}"]
         end
 
         #: () -> Hash[String, String]
@@ -702,6 +719,8 @@ module Herb
         #: (Integer) -> void
         def scope_close_conditional(index)
           leave_scope(index)
+
+          @withheld.delete(index)
 
           @src << "; #{current_scope}[#{index}] = (#{SLOT_BUFFER}#{index} || { branch: nil });"
         end
@@ -747,7 +766,10 @@ module Herb
 
         #: (Integer) -> void
         def scope_close_collection(index)
-          @src << "; #{current_scope}[#{index}] = { items: #{ITEMS_BUFFER}#{index}, order: #{ITEMS_BUFFER}#{index}.keys };"
+          statics = item_statics(index)
+          parked = statics ? ", statics: #{statics.inspect}" : ""
+
+          @src << "; #{current_scope}[#{index}] = { items: #{ITEMS_BUFFER}#{index}, order: #{ITEMS_BUFFER}#{index}.keys#{parked} };"
         end
 
         #: (Integer, String) -> void

--- a/sig/herb/engine/slots/dynamics_compiler.rbs
+++ b/sig/herb/engine/slots/dynamics_compiler.rbs
@@ -278,6 +278,15 @@ module Herb
         # : (Integer, Integer) -> String?
         def payload_statics: (Integer, Integer) -> String?
 
+        # : () -> bool
+        def server_mode?: () -> bool
+
+        # : (Integer, Integer) -> bool
+        def withheld?: (Integer, Integer) -> bool
+
+        # : (Integer) -> String?
+        def item_statics: (Integer) -> String?
+
         # : () -> Hash[String, String]
         def branch_statics: () -> Hash[String, String]
 

--- a/test/engine/slots/deferred_test.rb
+++ b/test/engine/slots/deferred_test.rb
@@ -299,6 +299,38 @@ module Engine
 
         assert_equal page_visitor.deferred_entries, compiler.slot_visitor.deferred_entries
       end
+
+      ASYNC_COLLECTION = <<~ERB
+        <%# herb:slots client %>
+        <Async>
+          <ul>
+            <% @rows.each do |row| %>
+              <li herb-key="<%= row %>"><%= row %></li>
+            <% end %>
+          </ul>
+          <Fallback><p class="pulse">rows loading</p></Fallback>
+        </Async>
+      ERB
+
+      test "steering a deferred block ships a collection's item statics along" do
+        compiler = Herb::Engine::Slots::DynamicsCompiler.new(ASYNC_COLLECTION, filename: "app/views/test.html.erb")
+
+        view = OverridableView.new({ "app/views/test.html.erb" => { "_herb_block_0" => true } })
+        view.instance_variable_set(:@rows, ["Europe", "Asia"])
+        values = JSON.parse(JSON.generate(view.instance_eval(compiler.src)))
+
+        assert_snapshot_matches(JSON.pretty_generate(values), ASYNC_COLLECTION, { probe: "steered collection values" })
+      end
+
+      test "an unsteered deferred block ships no item statics" do
+        compiler = Herb::Engine::Slots::DynamicsCompiler.new(ASYNC_COLLECTION, filename: "app/views/test.html.erb")
+
+        view = OverridableView.new(nil)
+        view.instance_variable_set(:@rows, ["Europe", "Asia"])
+        values = JSON.parse(JSON.generate(view.instance_eval(compiler.src)))
+
+        refute values["slots"]["0"].key?("statics")
+      end
     end
   end
 end

--- a/test/snapshots/engine/slots/deferred_test/test_0020_steering_a_deferred_block_ships_a_collection's_item_statics_along_fd9da643123e50c79f4cc241a3f5f4ba-d84c17dcc5ef0df5aed1d7ce68f9ed2c.txt
+++ b/test/snapshots/engine/slots/deferred_test/test_0020_steering_a_deferred_block_ships_a_collection's_item_statics_along_fd9da643123e50c79f4cc241a3f5f4ba-d84c17dcc5ef0df5aed1d7ce68f9ed2c.txt
@@ -1,0 +1,44 @@
+---
+source: "Engine::Slots::DeferredTest#test_0020_steering a deferred block ships a collection's item statics along"
+input: |2-
+<%# herb:slots client %>
+<Async>
+  <ul>
+    <% @rows.each do |row| %>
+      <li herb-key="<%= row %>"><%= row %></li>
+    <% end %>
+  </ul>
+  <Fallback><p class="pulse">rows loading</p></Fallback>
+</Async>
+options: {probe: "steered collection values"}
+---
+{
+  "template": "app/views/test.html.erb",
+  "version": "a8478f9f",
+  "occurrence": 0,
+  "slots": {
+    "0": {
+      "branch": 0,
+      "statics": "<!--herb-branch:0:0-->\n  <ul>\n    <!--herb-slot:1:collection--><!--/herb-slot:1-->\n  </ul>\n  \n",
+      "slots": {
+        "1": {
+          "items": {
+            "Europe": {
+              "2": "Europe",
+              "3": "Europe"
+            },
+            "Asia": {
+              "2": "Asia",
+              "3": "Asia"
+            }
+          },
+          "order": [
+            "Europe",
+            "Asia"
+          ],
+          "statics": "<!--herb-branch:1:item--><!--herb-item:1:-->\n      <li herb-key=\"\" data-herb-slot=\"2:attribute:herb-key 3:child\"></li>\n    <!--/herb-item:1-->"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This pull request fixes two ways a steered page could show the wrong thing between a state change and the refetch that answers it. Both came out of the demo app, one from the cascade selects and one from the dashboard tiles.

The first is a resurrected old value. The stashes that make branch switches instant, the captured fragment and the remembered slot values, would bring back a server read's previous answer when the state it depends on had changed while the branch was hidden. In the cascade demo, drilling down to a state, switching the country, and picking a state again flashed the old country's cities before the refetch answered. The write pipeline now drops every stash holding a stale server read before conditionals are written. That includes a remembered value that embeds the stale slot's markers inside a nested conditional's serialized content, which was the vector in the cascade, the fragment conditional's whole branch rode along as one remembered string on its parent.

The second is a collection that never appears. A collection inside an `<Async>` or `<Lazy>` block renders no items on the first response, so the client had no row template to build the payload's items from and the block sat empty until something else happened to deliver the parked statics. The values compile now ships the collection's item statics along with the items, the way a withheld branch already ships its branch statics, and the client parks them before it builds the rows. The claimed conditional path also announces freshly parked material before applying nested values, so the state layer switches the branch first and the collection lands in a materialized branch instead of being dropped by the leaves-only stash.
