### PR TITLE
Core: Type `size_t` error fields as `number`

### DIFF
--- a/templates/javascript/packages/core/src/errors.ts.erb
+++ b/templates/javascript/packages/core/src/errors.ts.erb
@@ -67,8 +67,10 @@ export interface Serialized<%= error.name %> {
   <%= field.name %>: string | null;
   <%- when Herb::Template::PositionField -%>
   <%= field.name %>: SerializedPosition;
+  <%- when Herb::Template::SizeTField -%>
+  <%= field.name %>: number;
   <%- else -%>
-  <%= field.name %>: any; // <%= field.inspect %>
+  <% raise "Unexpected type: #{field.class}" %>
   <%- end -%>
   <%- end -%>
 }
@@ -87,8 +89,10 @@ export interface <%= error.name %>Props {
   <%= field.name %>: string | null;
   <%- when Herb::Template::PositionField -%>
   <%= field.name %>: Position;
+  <%- when Herb::Template::SizeTField -%>
+  <%= field.name %>: number;
   <%- else -%>
-  <%= field.name %>: any; // <%= field.inspect %>
+  <% raise "Unexpected type: #{field.class}" %>
   <%- end -%>
   <%- end -%>
 }
@@ -104,8 +108,10 @@ export class <%= error.name %> extends HerbError {
   readonly <%= field.name %>: string | null;
   <%- when Herb::Template::PositionField -%>
   readonly <%= field.name %>: Position;
+  <%- when Herb::Template::SizeTField -%>
+  readonly <%= field.name %>: number;
   <%- else -%>
-  readonly <%= field.name %>: any;
+  <% raise "Unexpected type: #{field.class}" %>
   <%- end -%>
   <%- end -%>
 


### PR DESCRIPTION
This pull request fixes `templates/javascript/packages/core/src/errors.ts.erb` so that `size_t` error fields get a real TypeScript type, and so that rendering the template twice produces the same file.

The template has five `case field` blocks. Three of them, the ones generating `from`, `toJSON` and `treeInspect`, already handled `Herb::Template::SizeTField` and raised on anything they didn't recognize. The three blocks generating the type declarations, `Serialized<Name>`, `<Name>Props` and the class body, never listed `SizeTField`, so those fields fell through to an `else` branch that emitted `any` along with `<%= field.inspect %>`.

That fallback interpolates the Ruby field object itself, so the generated TypeScript ended up carrying a Ruby object's memory address:

```ts
  line: any; // #<Herb::Template::SizeTField:0x0000000123cf3888 @name="line", @options={kind: nil}>
```

The address changes on every process, so `bundle exec rake templates` rewrote `javascript/packages/core/src/errors.ts` on every single run instead of reporting `[unchanged]`. Since that file is gitignored, this never showed up as a dirty tree, only as churn and as `any` types in the published `@herb-tools/core` error definitions.