### PR TITLE
Engine: Keep slot markers when later visitor rewrites the tags 

### DIFF
--- a/lib/herb/engine/slots/visitor.rb
+++ b/lib/herb/engine/slots/visitor.rb
@@ -640,6 +640,7 @@ module Herb
 
           return wrap_region(node) if @degraded
 
+          follow_replacements
           insert_markers(node)
           wrap_displaced
 
@@ -648,6 +649,21 @@ module Herb
           wrap_region(node)
           append_statics(node)
           deliver_manifest(node)
+        end
+
+        #: () -> void
+        def follow_replacements
+          replacements = context.replacements
+
+          return unless replacements.any?
+
+          replacements.each do |replacement, original|
+            annotations = @standing[original]
+            @standing[replacement] = annotations if annotations
+
+            index = @indices[original]
+            @indices[replacement] = index if index
+          end
         end
 
         #: (untyped) -> void

--- a/lib/herb/engine/visitors/instrumentation_visitor.rb
+++ b/lib/herb/engine/visitors/instrumentation_visitor.rb
@@ -143,12 +143,19 @@ module Herb
         if framed?(node)
           [enter_node(node), node, leave_node(node)]
         elsif erb_outputs?(node)
-          [wrapped_output(node)]
+          [replacing(node, wrapped_output(node))]
         elsif erb_statement?(node)
-          [wrapped_statement(node)]
+          [replacing(node, wrapped_statement(node))]
         else
           [node]
         end
+      end
+
+      #: (Herb::AST::Node, Herb::AST::Node) -> Herb::AST::Node
+      def replacing(node, replacement)
+        context.replacements.record(node, replacement)
+
+        replacement
       end
 
       def framed?(node)

--- a/lib/herb/visitor/context.rb
+++ b/lib/herb/visitor/context.rb
@@ -4,6 +4,7 @@
 require "pathname"
 
 require_relative "context/origin"
+require_relative "context/replacements"
 
 module Herb
   class Visitor
@@ -40,9 +41,17 @@ module Herb
         @project_path_cache << self.class.coerce_project_path(project_path) if project_path
         @relative_file_path_cache = [] #: Array[String]
         @options = options.dup.freeze
-        @data = data.tap { |values| values[:origin] ||= Origin.new }.freeze
+        @data = self.class.with_records(data).freeze
 
         freeze
+      end
+
+      #: (Hash[Symbol, untyped]) -> Hash[Symbol, untyped]
+      def self.with_records(data)
+        data[:origin] ||= Origin.new
+        data[:replacements] ||= Replacements.new
+
+        data
       end
 
       #: () -> Pathname
@@ -58,6 +67,11 @@ module Herb
       #: () -> Herb::Visitor::Context::Origin
       def origin
         data[:origin]
+      end
+
+      #: () -> Herb::Visitor::Context::Replacements
+      def replacements
+        data[:replacements]
       end
 
       #: (Symbol) -> untyped

--- a/lib/herb/visitor/context/replacements.rb
+++ b/lib/herb/visitor/context/replacements.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+# typed: false
+
+module Herb
+  class Visitor
+    class Context
+      # Which nodes stand in the tree where another node stood when the compile began.
+      #
+      # A visitor that rewrites an ERB tag builds a fresh node for it and puts that where the old
+      # one was. Any other visitor that recorded something about the old node by identity is then
+      # holding a key nothing in the tree matches, and its `finish` walks a tree it no longer
+      # recognizes. The rewriter knows what it swapped and the recorder knows what it recorded, so
+      # the answer has to live on the compile, where both can reach it.
+      #
+      #     replacements.record(tag, wrapped)
+      #
+      #     replacements.original_of(wrapped) #=> tag
+      #
+      # A chain collapses as it is recorded, so a node replaced twice still answers with the node
+      # the compile started from. Only replaced nodes are recorded, so an untouched tree costs
+      # nothing.
+      #
+      class Replacements
+        #: () -> void
+        def initialize
+          originals = {} #: Hash[Herb::AST::Node, Herb::AST::Node]
+
+          @originals = originals.compare_by_identity
+        end
+
+        #: (Herb::AST::Node, Herb::AST::Node) -> void
+        def record(original, replacement)
+          return if original.equal?(replacement)
+
+          @originals[replacement] = original_of(original)
+
+          nil
+        end
+
+        #: (Herb::AST::Node) -> Herb::AST::Node
+        def original_of(node)
+          @originals[node] || node
+        end
+
+        #: () -> bool
+        def any?
+          !@originals.empty?
+        end
+
+        #: () { (Herb::AST::Node, Herb::AST::Node) -> void } -> void
+        def each(&)
+          @originals.each(&)
+
+          nil
+        end
+      end
+    end
+  end
+end

--- a/sig/herb/engine/slots/visitor.rbs
+++ b/sig/herb/engine/slots/visitor.rbs
@@ -302,6 +302,9 @@ module Herb
         # : (untyped) -> void
         def finish: (untyped) -> void
 
+        # : () -> void
+        def follow_replacements: () -> void
+
         # : (untyped) -> void
         def deliver_manifest: (untyped) -> void
 

--- a/sig/herb/engine/visitors/instrumentation_visitor.rbs
+++ b/sig/herb/engine/visitors/instrumentation_visitor.rbs
@@ -69,6 +69,9 @@ module Herb
       # : (Herb::AST::Node) -> Array[Herb::AST::Node]
       def rewrite_node: (Herb::AST::Node) -> Array[Herb::AST::Node]
 
+      # : (Herb::AST::Node, Herb::AST::Node) -> Herb::AST::Node
+      def replacing: (Herb::AST::Node, Herb::AST::Node) -> Herb::AST::Node
+
       def framed?: (untyped node) -> untyped
 
       def assignment?: (untyped node) -> untyped

--- a/sig/herb/visitor/context.rbs
+++ b/sig/herb/visitor/context.rbs
@@ -32,6 +32,9 @@ module Herb
       # : (?file_path: (String | Pathname)?, ?project_path: (String | Pathname)?, ?options: Hash[Symbol, untyped], **untyped) -> void
       def initialize: (?file_path: (String | Pathname)?, ?project_path: (String | Pathname)?, ?options: Hash[Symbol, untyped], **untyped) -> void
 
+      # : (Hash[Symbol, untyped]) -> Hash[Symbol, untyped]
+      def self.with_records: (Hash[Symbol, untyped]) -> Hash[Symbol, untyped]
+
       # : () -> Pathname
       def project_path: () -> Pathname
 
@@ -40,6 +43,9 @@ module Herb
 
       # : () -> Herb::Visitor::Context::Origin
       def origin: () -> Herb::Visitor::Context::Origin
+
+      # : () -> Herb::Visitor::Context::Replacements
+      def replacements: () -> Herb::Visitor::Context::Replacements
 
       # : (Symbol) -> untyped
       def []: (Symbol) -> untyped

--- a/sig/herb/visitor/context/replacements.rbs
+++ b/sig/herb/visitor/context/replacements.rbs
@@ -1,0 +1,39 @@
+# Generated from lib/herb/visitor/context/replacements.rb with RBS::Inline
+
+module Herb
+  class Visitor
+    class Context
+      # Which nodes stand in the tree where another node stood when the compile began.
+      #
+      # A visitor that rewrites an ERB tag builds a fresh node for it and puts that where the old
+      # one was. Any other visitor that recorded something about the old node by identity is then
+      # holding a key nothing in the tree matches, and its `finish` walks a tree it no longer
+      # recognizes. The rewriter knows what it swapped and the recorder knows what it recorded, so
+      # the answer has to live on the compile, where both can reach it.
+      #
+      #     replacements.record(tag, wrapped)
+      #
+      #     replacements.original_of(wrapped) #=> tag
+      #
+      # A chain collapses as it is recorded, so a node replaced twice still answers with the node
+      # the compile started from. Only replaced nodes are recorded, so an untouched tree costs
+      # nothing.
+      class Replacements
+        # : () -> void
+        def initialize: () -> void
+
+        # : (Herb::AST::Node, Herb::AST::Node) -> void
+        def record: (Herb::AST::Node, Herb::AST::Node) -> void
+
+        # : (Herb::AST::Node) -> Herb::AST::Node
+        def original_of: (Herb::AST::Node) -> Herb::AST::Node
+
+        # : () -> bool
+        def any?: () -> bool
+
+        # : () { (Herb::AST::Node, Herb::AST::Node) -> void } -> void
+        def each: () { (Herb::AST::Node, Herb::AST::Node) -> void } -> void
+      end
+    end
+  end
+end

--- a/test/engine/slots/instrumentation_test.rb
+++ b/test/engine/slots/instrumentation_test.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require_relative "../../test_helper"
+require_relative "../../snapshot_utils"
+require_relative "../../../lib/herb/engine"
+require_relative "../../../lib/herb/engine/slots/visitor"
+require_relative "../../../lib/herb/engine/visitors/instrumentation_visitor"
+
+module Engine
+  module Slots
+    class InstrumentationTest < Minitest::Spec
+      include SnapshotUtils
+
+      TEMPLATE = <<~ERB
+        <%# herb:slots client %>
+        <h2><%= @title %></h2>
+        <p class="<%= @tone %>">
+          <%= @summary %>
+        </p>
+        <% if @open %>
+          <span><%= @detail %></span>
+        <% end %>
+      ERB
+
+      def compile(template, instrumented:)
+        slots = Herb::Engine::Slots::Visitor.new(mode: :client)
+        visitors = instrumented ? [slots, Herb::Engine::InstrumentationVisitor.new] : [slots]
+
+        [Herb::Engine.new(template, visitors: visitors, filename: "app/views/test.html.erb").src, slots]
+      end
+
+      def anchors_in(source)
+        source.scan(/data-herb-slot=\\"[^"]*\\"|<!--herb-slot:\d+[^>]*-->/).sort
+      end
+
+      test "instrumentation after slots keeps every marker and anchor" do
+        plain, = compile(TEMPLATE, instrumented: false)
+        instrumented, = compile(TEMPLATE, instrumented: true)
+
+        assert_equal anchors_in(plain), anchors_in(instrumented)
+      end
+
+      test "the instrumented page compile keeps its markers" do
+        instrumented, = compile(TEMPLATE, instrumented: true)
+
+        assert_snapshot_matches(instrumented, TEMPLATE, { visitors: "slots, instrumentation" })
+      end
+    end
+  end
+end

--- a/test/engine/visitor_context_test.rb
+++ b/test/engine/visitor_context_test.rb
@@ -90,7 +90,7 @@ module Engine
 
       assert_equal "dark", subject[:theme]
       assert_equal 2, subject[:level]
-      assert_equal({ theme: "dark", level: 2 }, subject.data.except(:origin))
+      assert_equal({ theme: "dark", level: 2 }, subject.data.except(:origin, :replacements))
     end
 
     test "well known keys are readable through the bag" do

--- a/test/snapshots/engine/slots/instrumentation_test/test_0002_the_instrumented_page_compile_keeps_its_markers_20a4a063b59a7e0a452dd30768057d3f-193c631c6972dfcc56d8e8aec4375063.txt
+++ b/test/snapshots/engine/slots/instrumentation_test/test_0002_the_instrumented_page_compile_keeps_its_markers_20a4a063b59a7e0a452dd30768057d3f-193c631c6972dfcc56d8e8aec4375063.txt
@@ -1,0 +1,25 @@
+---
+source: "Engine::Slots::InstrumentationTest#test_0002_the instrumented page compile keeps its markers"
+input: |2-
+<%# herb:slots client %>
+<h2><%= @title %></h2>
+<p class="<%= @tone %>">
+  <%= @summary %>
+</p>
+<% if @open %>
+  <span><%= @detail %></span>
+<% end %>
+options: {visitors: "slots, instrumentation"}
+---
+_buf = ::String.new; @_herb_covered ||= {} ; _herb_occurrence = ((@_herb_region_occurrences ||= ::Hash.new(0))["app/views/test.html.erb"] += 1) - 1; _buf << '<!--herb-region:app/views/test.html.erb:1e89ea84:'.freeze; _buf << (_herb_occurrence).to_s; _buf << '-->'.freeze; ::Herb::Engine::Runtime::Session.enter_render("app/views/test.html.erb"); begin; _buf << '
+<h2 data-herb-slot="0:child">'.freeze; _buf << (::Herb::Engine::Runtime::Session.at("app/views/test.html.erb", 2, 4, nil, end_line: 2, end_column: 17) { @title }).to_s; _buf << '</h2>
+<p class="'.freeze; _buf << ::Herb::Engine.attr((@tone)); _buf << '" data-herb-slot="1:attribute:class">
+  <!--herb-slot:2-->'.freeze; _buf << (::Herb::Engine::Runtime::Session.at("app/views/test.html.erb", 4, 2, nil, end_line: 4, end_column: 17) { @summary }).to_s; _buf << '<!--/herb-slot:2-->
+</p>
+'.freeze; ::Herb::Engine::Runtime::Session.enter("app/views/test.html.erb", 6, 0, nil, end_line: 8, end_column: 9) ; _buf << '<!--herb-slot:3:conditional-->'.freeze; if @open; _buf << '<!--herb-branch:3:0-->
+  <span data-herb-slot="4:child">'.freeze; _buf << (::Herb::Engine::Runtime::Session.at("app/views/test.html.erb", 7, 8, nil, end_line: 7, end_column: 22) { @detail }).to_s; _buf << '</span>
+'.freeze; end ; _buf << '<!--/herb-slot:3-->'.freeze; ::Herb::Engine::Runtime::Session.leave; _buf << '
+'.freeze; ensure; ::Herb::Engine::Runtime::Session.leave_render; end ; _buf << '<!--/herb-region:app/views/test.html.erb-->'.freeze; unless @_herb_covered["app/views/test.html.erb:3:0"]; _buf << '<template data-herb-region="app/views/test.html.erb:1e89ea84">'.freeze; unless @_herb_covered["app/views/test.html.erb:3:0"]; _buf << '<!--herb-branch:3:0-->
+  <span data-herb-slot="4:child"></span>
+'.freeze; @_herb_covered["app/views/test.html.erb:3:0"] = true ; end; _buf << '</template>'.freeze; end;
+_buf.to_s


### PR DESCRIPTION
This pull request fixes a silent loss of every slot marker and anchor when a rewriting visitor runs after `Slots::Visitor`.

The engine runs every visitor's traversal before any visitor's `finish`. The slots visitor records what it found by node identity during its traversal and inserts markers in `finish`, which is the order #2420 chose so that later visitors see an unmarked tree. 

A rewriter that runs after it and replaces an ERB tag with a fresh node leaves the slots visitor holding keys that match nothing in the tree. `InstrumentationVisitor` does exactly that for every output and statement tag, so the one order the stack accepts, slots before instrumentation, compiled a page with no child anchors, no value markers and no parked branches, and reported nothing.

Compiled with `[Slots::Visitor.new, InstrumentationVisitor.new]`, the `<h2>` lost its `data-herb-slot="0:child"` anchor because the `<%= @title %>` node the annotation was keyed to had been swapped for the `Session.at { @title }` wrapper.

The compile now carries a `Replacements` record beside `Origin` on the visitor context, for the same reason `Origin` lives there. The visitor that swaps a node is never the one that recorded something about it, so the answer has to live where both can reach it. `InstrumentationVisitor` records each node it replaces, and `Slots::Visitor#finish` follows those records once, re-keying its annotations and indices to the nodes that took the originals' places, before it inserts anything. A chain of replacements collapses as it is recorded, so a node rewritten twice still resolves to the one the compile started from, and an untouched tree costs nothing.

The instrumented compile now keeps every marker, anchor and parked branch, with the `Session.at` wrappers in place around the outputs.