### PR TITLE
Engine: Follow replacements before the marking guard

### DIFF
--- a/lib/herb/engine/slots/visitor.rb
+++ b/lib/herb/engine/slots/visitor.rb
@@ -636,11 +636,12 @@ module Herb
 
         #: (untyped) -> void
         def finish(node)
+          follow_replacements
+
           return unless @mark
 
           return wrap_region(node) if @degraded
 
-          follow_replacements
           insert_markers(node)
           wrap_displaced
 


### PR DESCRIPTION
Follow up on #2582.

`Slots::Visitor#finish` followed the compile's replacements only on the marking path, after the `@mark` guard. A values compile runs the slots visitor unmarked, and `DynamicsCompiler` still resolves nodes through the visitor's indices after every traversal has run, so a rewriter in that stack would have orphaned those lookups the same way it orphaned the page markers. Following the replacements first keeps an unmarked compile honest too.
