### PR TITLE
Dev Server: Send the real diagnostics for templates that were already broken

### DIFF
--- a/javascript/packages/dev-tools/src/dev-server/client.ts
+++ b/javascript/packages/dev-tools/src/dev-server/client.ts
@@ -4,10 +4,10 @@ import { ConnectionDot } from "./connection-dot"
 import { MismatchAlert } from "./mismatch-alert"
 import { UnavailableAlert } from "./unavailable-alert"
 
-import { diagnosticsFromError, diagnosticFromBrokenTemplate } from "./diagnostics"
+import { diagnosticsFromError, diagnosticsFromBrokenFile } from "./diagnostics"
 import { heldRuntime } from "./runtime-handle"
 
-import type { AssetMessage, DiagnosticSink, HerbClientOptions, HerbMessage, WelcomeMessage, SchemaMessage, InvalidateMessage, ErrorMessage } from "./types"
+import type { AssetMessage, BrokenFile, DiagnosticSink, HerbClientOptions, HerbMessage, WelcomeMessage, SchemaMessage, InvalidateMessage, ErrorMessage } from "./types"
 
 const DEFAULT_PORT = 8592
 const UNAVAILABLE_HINT_AFTER_ATTEMPTS = 3
@@ -168,13 +168,13 @@ export class HerbClient {
     }
   }
 
-  private reportBroken(files: string[]): void {
-    const diagnostics = this.getDiagnostics()
+  private reportBroken(files: BrokenFile[]): void {
+    const sink = this.getDiagnostics()
 
-    if (!diagnostics) return
+    if (!sink) return
 
-    for (const file of files) {
-      diagnostics.report(file, [diagnosticFromBrokenTemplate(file)])
+    for (const broken of files) {
+      sink.report(broken.file, diagnosticsFromBrokenFile(broken))
     }
   }
 

--- a/javascript/packages/dev-tools/src/dev-server/diagnostics.ts
+++ b/javascript/packages/dev-tools/src/dev-server/diagnostics.ts
@@ -1,6 +1,6 @@
 import type { SlotsRequestFailure } from "@herb-tools/client"
 
-import type { ErrorMessage } from "./types"
+import type { BrokenFile, ErrorMessage } from "./types"
 import type { RuntimeDiagnostic } from "../runtime/report"
 
 export const DEV_SERVER_ORIGIN = "Herb Dev Server"
@@ -20,15 +20,12 @@ export function diagnosticsFromError(message: ErrorMessage): RuntimeDiagnostic[]
   }))
 }
 
-export function diagnosticFromBrokenTemplate(file: string): RuntimeDiagnostic {
-  return {
-    template: file,
-    message: "This template did not parse when the dev server started. Edit it to see the errors.",
-    severity: "error" as const,
-    origin: DEV_SERVER_ORIGIN,
-    phase: "compile" as const,
-    overlay: "dismissible" as const,
+export function diagnosticsFromBrokenFile(broken: BrokenFile): RuntimeDiagnostic[] {
+  if (broken.errors) {
+    return diagnosticsFromError({ type: "error", file: broken.file, errors: broken.errors, source: broken.source })
   }
+
+  return broken.diagnostics ?? []
 }
 
 export function diagnosticFromRefreshFailure(file: string, status: number, failure: SlotsRequestFailure | null): RuntimeDiagnostic {

--- a/javascript/packages/dev-tools/src/dev-server/types.ts
+++ b/javascript/packages/dev-tools/src/dev-server/types.ts
@@ -54,11 +54,18 @@ export interface ErrorMessage {
   source?: string
 }
 
+export interface BrokenFile {
+  file: string
+  source?: string
+  errors?: ParseError[]
+  diagnostics?: RuntimeDiagnostic[]
+}
+
 export interface WelcomeMessage {
   type: "welcome"
   project: string
   compiler?: boolean
-  broken_files?: string[]
+  broken_files?: BrokenFile[]
 }
 
 export const DEV_SERVER_COMMAND = "bundle exec herb dev"

--- a/javascript/packages/dev-tools/test/dev-server-diagnostics.test.ts
+++ b/javascript/packages/dev-tools/test/dev-server-diagnostics.test.ts
@@ -2,12 +2,12 @@ import { DEV_SERVER_ORIGIN } from "../src/dev-server/diagnostics"
 
 import { afterEach, beforeEach, describe, expect, test } from "vitest"
 import { stripAnsiColors } from "@herb-tools/highlighter"
-import { diagnosticsFromError, diagnosticFromBrokenTemplate } from "../src/dev-server/diagnostics"
+import { diagnosticsFromError, diagnosticsFromBrokenFile } from "../src/dev-server/diagnostics"
 
 import { HerbClient } from "../src/dev-server/client"
 import { RuntimePanel } from "../src/runtime/panel"
 
-import type { ErrorMessage, WelcomeMessage } from "../src/dev-server/types"
+import type { BrokenFile, ErrorMessage, WelcomeMessage } from "../src/dev-server/types"
 
 let panels: RuntimePanel[] = []
 
@@ -160,7 +160,7 @@ describe("templates the server says were already broken", () => {
     }
   }
 
-  function welcome(broken?: string[]): WelcomeMessage {
+  function welcome(broken?: BrokenFile[]): WelcomeMessage {
     return { type: "welcome", project: "/app", ...(broken === undefined ? {} : { broken_files: broken }) } as WelcomeMessage
   }
 
@@ -168,7 +168,9 @@ describe("templates the server says were already broken", () => {
     const { reported, sink } = collectingSink()
     const client = new HerbClient({ diagnostics: () => sink })
 
-    client["handleWelcome"](welcome(["a.html.erb", "b.html.erb"]))
+    const errors = errorMessage().errors
+
+    client["handleWelcome"](welcome([{ file: "a.html.erb", errors }, { file: "b.html.erb", errors }]))
 
     expect(reported).toEqual([["a.html.erb", 1], ["b.html.erb", 1]])
   })
@@ -191,20 +193,33 @@ describe("templates the server says were already broken", () => {
     expect(reported).toEqual([])
   })
 
-  test("names the dev server as the origin, so a clearing schema takes it away", () => {
-    const diagnostic = diagnosticFromBrokenTemplate("a.html.erb")
+  test("turns a parse failure into the same diagnostics a live error would", () => {
+    const message = errorMessage()
+    const broken = { file: message.file, source: "<div>\n  <form>\n</div>\n", errors: message.errors }
 
-    expect(diagnostic.origin).toBe(DEV_SERVER_ORIGIN)
-    expect(diagnostic.overlay).toBe("dismissible")
-    expect(diagnostic.template).toBe("a.html.erb")
+    expect(diagnosticsFromBrokenFile(broken)).toEqual(diagnosticsFromError({ ...message, source: broken.source }))
   })
 
-  test("opens a card naming the template that did not parse", () => {
+  test("passes a compiled template's diagnostics through untouched", () => {
+    const diagnostics = [{ template: "b.html.erb", message: "slot outside a region", severity: "error" as const }]
+
+    expect(diagnosticsFromBrokenFile({ file: "b.html.erb", diagnostics })).toEqual(diagnostics)
+  })
+
+  test("reports nothing for an entry carrying neither errors nor diagnostics", () => {
+    expect(diagnosticsFromBrokenFile({ file: "a.html.erb" })).toEqual([])
+  })
+
+  test("opens a card with the real error, not a placeholder", () => {
     const panel = createPanel()
+    const message = errorMessage()
 
-    panel.report([diagnosticFromBrokenTemplate("app/views/posts/index.html.erb")])
+    panel.report(diagnosticsFromBrokenFile({ file: message.file, source: "<div>\n  <form>\n</div>\n", errors: message.errors }))
 
-    expect(document.querySelector(".herb-dev-tools-card")?.textContent).toContain("app/views/posts/index.html.erb")
+    const card = document.querySelector(".herb-dev-tools-card")?.textContent
+
+    expect(card).toContain("missing-closing-tag")
+    expect(card).toContain("has no matching closing tag")
 
     panel.clear(DEV_SERVER_ORIGIN)
 

--- a/lib/herb/dev.rb
+++ b/lib/herb/dev.rb
@@ -95,7 +95,7 @@ module Herb
       server = Server.new(port: port, project_path: expanded, kind: "embedded")
       pipeline = Pipeline.new(server: server, configuration: configuration)
 
-      server.on_welcome { pipeline.broken_files }
+      server.on_welcome { pipeline.broken_entries }
 
       server.on_client do |event, count|
         logger.call("Herb dev server client #{event} (#{count} #{count == 1 ? "connection" : "connections"} open)")
@@ -112,7 +112,7 @@ module Herb
       end
 
       watcher.index
-      pipeline.remember_broken(watcher.broken_files)
+      pipeline.remember_broken(watcher.sources)
       server.start
       watcher.spawn
 

--- a/lib/herb/dev/pipeline.rb
+++ b/lib/herb/dev/pipeline.rb
@@ -32,6 +32,7 @@ module Herb
         @state_manifests = {} #: Hash[String, untyped]
         @statics = {} #: Hash[String, Hash[String, String]?]
         @file_state = {} #: Hash[String, Symbol]
+        @broken = {} #: Hash[String, Hash[Symbol, untyped]]
         @on_classified = nil #: untyped
       end
 
@@ -40,14 +41,28 @@ module Herb
         @on_classified = block
       end
 
-      #: (Enumerable[String]) -> void
-      def remember_broken(files)
-        files.each { |file| @file_state[file] = :parse_error }
+      #: (Hash[String, String]) -> Array[String]
+      def remember_broken(sources)
+        sources.each do |file, source|
+          errors = Herb.parse(source, strict: true, analyze: true).errors
+
+          next if errors.empty?
+
+          @file_state[file] = :parse_error
+          @broken[file] = Protocol.broken(file: file, source: source, errors: errors)
+        end
+
+        broken_files
       end
 
       #: () -> Array[String]
       def broken_files
-        @file_state.select { |_, state| state == :parse_error }.keys
+        @broken.keys
+      end
+
+      #: () -> Array[Hash[Symbol, untyped]]
+      def broken_entries
+        @broken.values
       end
 
       #: () -> bool
@@ -82,6 +97,7 @@ module Herb
         @state_manifests.delete(file)
         @statics.delete(file)
         @file_state.delete(file)
+        @broken.delete(file)
 
         broadcast(Protocol.schema(file: file, mode: nil, from: from, to: nil)) if was_broken
 
@@ -95,14 +111,12 @@ module Herb
 
       #: (Watcher::Event) -> void
       def handle_changed(event)
-        file = event.relative_path
+        event.relative_path
         classification = @classifier.call(event.previous.to_s, event.current.to_s)
 
         case classification.kind
         when :parse_error
-          @file_state[file] = :parse_error
-
-          broadcast(Protocol.error(file: file, source: event.current.to_s, errors: classification.errors))
+          handle_parse_error(event, classification)
         when :none, :whitespace
           nil
         else
@@ -110,6 +124,17 @@ module Herb
         end
 
         notify(event, classification)
+      end
+
+      #: (Watcher::Event, Classifier::Classification) -> void
+      def handle_parse_error(event, classification)
+        file = event.relative_path
+        source = event.current.to_s
+
+        @file_state[file] = :parse_error
+        @broken[file] = Protocol.broken(file: file, source: source, errors: classification.errors)
+
+        broadcast(Protocol.error(file: file, source: source, errors: classification.errors))
       end
 
       #: (Watcher::Event, Classifier::Classification) -> void
@@ -151,9 +176,7 @@ module Herb
 
       #: (String, Watcher::Event, untyped, Classifier::Classification) -> Hash[Symbol, untyped]
       def schema_for(file, event, compiled, classification)
-        diagnostics = (compiled.diagnostics || []).map { |diagnostic|
-          diagnostic.respond_to?(:to_h) ? diagnostic.to_h : diagnostic
-        }
+        diagnostics = diagnostics_of(compiled)
 
         Protocol.schema(
           file: file,
@@ -225,7 +248,26 @@ module Herb
         @slot_entries[file] = compiled.slot_entries
         @state_manifests[file] = states_of(compiled)
         @statics[file] = compiled.statics
-        @file_state[file] = (compiled.diagnostics || []).empty? ? :ok : :diagnostics
+
+        record_diagnostics(file, diagnostics_of(compiled))
+      end
+
+      #: (String, Array[Hash[Symbol, untyped]]) -> void
+      def record_diagnostics(file, diagnostics)
+        if diagnostics.empty?
+          @file_state[file] = :ok
+          @broken.delete(file)
+        else
+          @file_state[file] = :diagnostics
+          @broken[file] = Protocol.broken(file: file, diagnostics: diagnostics)
+        end
+      end
+
+      #: (untyped) -> Array[Hash[Symbol, untyped]]
+      def diagnostics_of(compiled)
+        (compiled.diagnostics || []).map { |diagnostic|
+          diagnostic.respond_to?(:to_h) ? diagnostic.to_h : diagnostic
+        }
       end
 
       #: (Watcher::Event, Classifier::Classification) -> void
@@ -237,6 +279,7 @@ module Herb
         end
 
         @file_state[file] = :ok
+        @broken.delete(file)
 
         message = Protocol.invalidate(
           file: file,

--- a/lib/herb/dev/protocol.rb
+++ b/lib/herb/dev/protocol.rb
@@ -70,7 +70,12 @@ module Herb
 
       #: (file: String, source: String, errors: Array[untyped]) -> Hash[Symbol, untyped]
       def self.error(file:, source:, errors:)
-        entries = errors.map { |parse_error|
+        { type: "error", file: file, source: source, errors: error_entries(file, errors) }
+      end
+
+      #: (String, Array[untyped]) -> Array[Hash[Symbol, untyped]]
+      def self.error_entries(file, errors)
+        errors.map { |parse_error|
           diagnostic = parse_error.to_diagnostic(template: file)
 
           {
@@ -83,8 +88,17 @@ module Herb
             column: parse_error.location.start.column,
           }
         }
+      end
 
-        { type: "error", file: file, source: source, errors: entries }
+      #: (file: String, ?source: String?, ?errors: Array[untyped]?, ?diagnostics: Array[untyped]?) -> Hash[Symbol, untyped]
+      def self.broken(file:, source: nil, errors: nil, diagnostics: nil)
+        entry = { file: file } #: Hash[Symbol, untyped]
+
+        entry[:source] = source if source
+        entry[:errors] = error_entries(file, errors) if errors
+        entry[:diagnostics] = diagnostics if diagnostics
+
+        entry
       end
 
       #: (Array[Hash[Symbol, untyped]], Array[Hash[Symbol, untyped]], Array[Herb::Diff::Operation]) -> Hash[String, untyped]?

--- a/lib/herb/dev/runner.rb
+++ b/lib/herb/dev/runner.rb
@@ -261,8 +261,10 @@ module Herb
         fg(", #{broken} #{broken == 1 ? "doesn't" : "don't"} parse", 214)
       end
 
-      #: () -> Thread
+      #: () -> Thread?
       def watch_stdin
+        return nil unless $stdin.tty?
+
         Thread.new do
           $stdin.gets(nil)
           Thread.main.raise(Interrupt)

--- a/lib/herb/dev/runner.rb
+++ b/lib/herb/dev/runner.rb
@@ -58,7 +58,7 @@ module Herb
         @first_change = true
         @broken_files = Set.new
 
-        websocket.on_welcome { pipeline.broken_files }
+        websocket.on_welcome { pipeline.broken_entries }
 
         websocket.on_client do |event, count|
           announce_first_change
@@ -70,10 +70,7 @@ module Herb
           pipeline.handle_event(event)
         end
 
-        index_files(watcher)
-
-        @broken_files = watcher.broken_files.dup
-        pipeline.remember_broken(watcher.broken_files)
+        @broken_files = Set.new(index_files(watcher, pipeline))
 
         websocket.start
 
@@ -243,15 +240,17 @@ module Herb
         end
       end
 
-      #: (Watcher) -> void
-      def index_files(watcher)
+      #: (Watcher, Pipeline) -> Array[String]
+      def index_files(watcher, pipeline)
         puts "  #{fg("Indexing files...", 241)}" if interactive?
 
         count = watcher.index(@path)
-        broken = watcher.broken_files.size
+        broken = pipeline.remember_broken(watcher.sources)
 
         terminal("\e[1A\e[2K")
-        puts "  #{fg("Files:".ljust(11), 245)}#{fg("#{pluralize(count, "template")} indexed", 250)}#{broken_summary(broken)}"
+        puts "  #{fg("Files:".ljust(11), 245)}#{fg("#{pluralize(count, "template")} indexed", 250)}#{broken_summary(broken.size)}"
+
+        broken
       end
 
       #: (Integer) -> String

--- a/lib/herb/dev/server.rb
+++ b/lib/herb/dev/server.rb
@@ -34,7 +34,7 @@ module Herb
         @accept_thread = nil
         @entry = nil
         @on_client = nil #: (^(Symbol, Integer) -> void)?
-        @on_welcome = nil #: (^() -> Array[String])?
+        @on_welcome = nil #: (^() -> Array[Hash[Symbol, untyped]])?
       end
 
       #: () -> void
@@ -95,7 +95,7 @@ module Herb
         @on_client = block
       end
 
-      #: () { () -> Array[String] } -> void
+      #: () { () -> Array[Hash[Symbol, untyped]] } -> void
       def on_welcome(&block)
         @on_welcome = block
       end
@@ -173,8 +173,8 @@ module Herb
 
       private
 
-      #: () -> Array[String]
-      def broken_files
+      #: () -> Array[Hash[Symbol, untyped]]
+      def broken_entries
         @on_welcome&.call || []
       rescue StandardError
         []
@@ -217,7 +217,7 @@ module Herb
 
         welcome = WebSocket::Frame::Outgoing::Server.new(
           version: handshake.version,
-          data: JSON.generate(Protocol.welcome(project: @project_path, broken_files: broken_files)),
+          data: JSON.generate(Protocol.welcome(project: @project_path, broken_files: broken_entries)),
           type: :text
         )
 

--- a/lib/herb/dev/watcher.rb
+++ b/lib/herb/dev/watcher.rb
@@ -35,7 +35,6 @@ module Herb
 
       attr_reader :file_states #: Hash[String, String]
       attr_reader :watch_paths #: Array[String]
-      attr_reader :broken_files #: Set[String]
 
       #: (config: Herb::Configuration, root: String, ?watch_paths: Array[String]?) { (Event) -> void } -> void
       def initialize(config:, root:, watch_paths: nil, &on_event)
@@ -45,7 +44,6 @@ module Herb
         @watch_paths = resolve_watch_paths(watch_paths) #: Array[String]
         @file_states = {} #: Hash[String, String]
         @assets = Assets.new
-        @broken_files = Set.new #: Set[String]
         @include_patterns = config.file_include_patterns
         @exclude_patterns = config.file_exclude_patterns
         @thread = nil #: Thread?
@@ -55,9 +53,7 @@ module Herb
       #: (?String) -> Integer
       def index(path = @root)
         @config.find_files(path).each do |file_path|
-          content = File.read(file_path)
-          @file_states[file_path] = content
-          @broken_files.add(relative_for(file_path)) if Herb.parse(content, strict: true, analyze: true).errors.any?
+          @file_states[file_path] = File.read(file_path)
         rescue StandardError
           nil
         end
@@ -65,6 +61,11 @@ module Herb
         @assets.index(path)
 
         @file_states.size
+      end
+
+      #: () -> Hash[String, String]
+      def sources
+        @file_states.transform_keys { |path| relative_for(path) }
       end
 
       #: () -> void

--- a/sig/herb/dev/pipeline.rbs
+++ b/sig/herb/dev/pipeline.rbs
@@ -40,11 +40,14 @@ module Herb
       # : () { (untyped, Classifier::Classification?) -> void } -> void
       def on_classified: () { (untyped, Classifier::Classification?) -> void } -> void
 
-      # : (Enumerable[String]) -> void
-      def remember_broken: (Enumerable[String]) -> void
+      # : (Hash[String, String]) -> Array[String]
+      def remember_broken: (Hash[String, String]) -> Array[String]
 
       # : () -> Array[String]
       def broken_files: () -> Array[String]
+
+      # : () -> Array[Hash[Symbol, untyped]]
+      def broken_entries: () -> Array[Hash[Symbol, untyped]]
 
       # : () -> bool
       def compiles?: () -> bool
@@ -62,6 +65,9 @@ module Herb
 
       # : (Watcher::Event) -> void
       def handle_changed: (Watcher::Event) -> void
+
+      # : (Watcher::Event, Classifier::Classification) -> void
+      def handle_parse_error: (Watcher::Event, Classifier::Classification) -> void
 
       # : (Watcher::Event, Classifier::Classification) -> void
       def handle_content_change: (Watcher::Event, Classifier::Classification) -> void
@@ -92,6 +98,12 @@ module Herb
 
       # : (String, untyped) -> void
       def remember: (String, untyped) -> void
+
+      # : (String, Array[Hash[Symbol, untyped]]) -> void
+      def record_diagnostics: (String, Array[Hash[Symbol, untyped]]) -> void
+
+      # : (untyped) -> Array[Hash[Symbol, untyped]]
+      def diagnostics_of: (untyped) -> Array[Hash[Symbol, untyped]]
 
       # : (Watcher::Event, Classifier::Classification) -> void
       def handle_without_compiler: (Watcher::Event, Classifier::Classification) -> void

--- a/sig/herb/dev/protocol.rbs
+++ b/sig/herb/dev/protocol.rbs
@@ -32,6 +32,12 @@ module Herb
       # : (file: String, source: String, errors: Array[untyped]) -> Hash[Symbol, untyped]
       def self.error: (file: String, source: String, errors: Array[untyped]) -> Hash[Symbol, untyped]
 
+      # : (String, Array[untyped]) -> Array[Hash[Symbol, untyped]]
+      def self.error_entries: (String, Array[untyped]) -> Array[Hash[Symbol, untyped]]
+
+      # : (file: String, ?source: String?, ?errors: Array[untyped]?, ?diagnostics: Array[untyped]?) -> Hash[Symbol, untyped]
+      def self.broken: (file: String, ?source: String?, ?errors: Array[untyped]?, ?diagnostics: Array[untyped]?) -> Hash[Symbol, untyped]
+
       # : (Array[Hash[Symbol, untyped]], Array[Hash[Symbol, untyped]], Array[Herb::Diff::Operation]) -> Hash[String, untyped]?
       def self.remap: (Array[Hash[Symbol, untyped]], Array[Hash[Symbol, untyped]], Array[Herb::Diff::Operation]) -> Hash[String, untyped]?
 

--- a/sig/herb/dev/runner.rbs
+++ b/sig/herb/dev/runner.rbs
@@ -63,8 +63,8 @@ module Herb
       # : (Integer) -> String
       def broken_summary: (Integer) -> String
 
-      # : () -> Thread
-      def watch_stdin: () -> Thread
+      # : () -> Thread?
+      def watch_stdin: () -> Thread?
 
       # : () -> void
       def announce_first_change: () -> void

--- a/sig/herb/dev/runner.rbs
+++ b/sig/herb/dev/runner.rbs
@@ -57,8 +57,8 @@ module Herb
       # : (Herb::Configuration, String) -> void
       def print_header: (Herb::Configuration, String) -> void
 
-      # : (Watcher) -> void
-      def index_files: (Watcher) -> void
+      # : (Watcher, Pipeline) -> Array[String]
+      def index_files: (Watcher, Pipeline) -> Array[String]
 
       # : (Integer) -> String
       def broken_summary: (Integer) -> String

--- a/sig/herb/dev/server.rbs
+++ b/sig/herb/dev/server.rbs
@@ -41,8 +41,8 @@ module Herb
       # : () { (Symbol, Integer) -> void } -> void
       def on_client: () { (Symbol, Integer) -> void } -> void
 
-      # : () { () -> Array[String] } -> void
-      def on_welcome: () { () -> Array[String] } -> void
+      # : () { () -> Array[Hash[Symbol, untyped]] } -> void
+      def on_welcome: () { () -> Array[Hash[Symbol, untyped]] } -> void
 
       # : (Client) -> void
       def register: (Client) -> void
@@ -64,8 +64,8 @@ module Herb
 
       private
 
-      # : () -> Array[String]
-      def broken_files: () -> Array[String]
+      # : () -> Array[Hash[Symbol, untyped]]
+      def broken_entries: () -> Array[Hash[Symbol, untyped]]
 
       # : (untyped) -> void
       def safely_close: (untyped) -> void

--- a/sig/herb/dev/watcher.rbs
+++ b/sig/herb/dev/watcher.rbs
@@ -42,13 +42,14 @@ module Herb
 
       attr_reader watch_paths: Array[String]
 
-      attr_reader broken_files: Set[String]
-
       # : (config: Herb::Configuration, root: String, ?watch_paths: Array[String]?) { (Event) -> void } -> void
       def initialize: (config: Herb::Configuration, root: String, ?watch_paths: Array[String]?) { (Event) -> void } -> void
 
       # : (?String) -> Integer
       def index: (?String) -> Integer
+
+      # : () -> Hash[String, String]
+      def sources: () -> Hash[String, String]
 
       # : () -> void
       def run: () -> void

--- a/test/dev/protocol_test.rb
+++ b/test/dev/protocol_test.rb
@@ -32,9 +32,27 @@ module Dev
     end
 
     test "the welcome message carries the templates that don't parse" do
-      message = Herb::Dev::Protocol.welcome(project: "/app", broken_files: ["a.html.erb", "b.html.erb"])
+      entries = [{ file: "a.html.erb" }, { file: "b.html.erb" }]
+      message = Herb::Dev::Protocol.welcome(project: "/app", broken_files: entries)
 
-      assert_equal({ type: "welcome", project: "/app", broken_files: ["a.html.erb", "b.html.erb"] }, message)
+      assert_equal({ type: "welcome", project: "/app", broken_files: entries }, message)
+    end
+
+    test "a broken entry carries the source and the errors the overlay needs" do
+      source = "<div>\n  <form>\n</div>\n"
+      errors = Herb.parse(source, strict: true, analyze: true).errors
+      entry = Herb::Dev::Protocol.broken(file: "a.html.erb", source: source, errors: errors)
+
+      assert_equal ["a.html.erb", source], [entry[:file], entry[:source]]
+      assert_equal Herb::Dev::Protocol.error(file: "a.html.erb", source: source, errors: errors)[:errors], entry[:errors]
+      assert_nil entry[:diagnostics]
+    end
+
+    test "a broken entry for a compiled template carries its diagnostics instead" do
+      diagnostics = [{ message: "slot outside a region", severity: :error }]
+      entry = Herb::Dev::Protocol.broken(file: "b.html.erb", diagnostics: diagnostics)
+
+      assert_equal({ file: "b.html.erb", diagnostics: diagnostics }, entry)
     end
 
     test "a project with nothing broken welcomes with an empty list" do

--- a/test/dev/runner_test.rb
+++ b/test/dev/runner_test.rb
@@ -175,9 +175,10 @@ module Dev
       config = Herb::Configuration.load(directory)
 
       watcher = Herb::Dev::Watcher.new(config: config, root: directory) { |event| event }
+      pipeline = Herb::Dev::Pipeline.new(server: FakeWebSocket.new, compiler: -> {})
 
       output, = capture_io do
-        Herb::Dev::Runner.new(path: directory).send(:index_files, watcher)
+        Herb::Dev::Runner.new(path: directory).send(:index_files, watcher, pipeline)
       end
 
       assert_equal "  Files:     1 template indexed\n", output
@@ -243,13 +244,15 @@ module Dev
 
       config = Herb::Configuration.load(directory)
       watcher = Herb::Dev::Watcher.new(config: config, root: directory) { |event| event }
+      pipeline = Herb::Dev::Pipeline.new(server: FakeWebSocket.new, compiler: -> {})
+      broken = nil
 
       output, = capture_io do
-        Herb::Dev::Runner.new(path: directory).send(:index_files, watcher)
+        broken = Herb::Dev::Runner.new(path: directory).send(:index_files, watcher, pipeline)
       end
 
       assert_equal "  Files:     2 templates indexed, 1 doesn't parse\n", output
-      assert_equal ["broken.html.erb"], watcher.broken_files.to_a
+      assert_equal ["broken.html.erb"], broken
     ensure
       FileUtils.rm_rf(directory)
       Herb.reset_configuration!
@@ -258,7 +261,7 @@ module Dev
     test "a template remembered as broken broadcasts a clearing schema when it is repaired" do
       websocket = FakeWebSocket.new
       pipeline = Herb::Dev::Pipeline.new(server: websocket, compiler: -> {})
-      pipeline.remember_broken(["a.html.erb"])
+      pipeline.remember_broken({ "a.html.erb" => BROKEN })
 
       fixed = Herb::Dev::Watcher::Event.new(kind: :changed, path: "/a", relative_path: "a.html.erb", previous: BROKEN, current: "<div>\n  <form></form>\n</div>\n")
 
@@ -270,13 +273,58 @@ module Dev
     test "a template remembered as broken stays on the list until it is repaired" do
       websocket = FakeWebSocket.new
       pipeline = Herb::Dev::Pipeline.new(server: websocket, compiler: -> {})
-      pipeline.remember_broken(["a.html.erb"])
+      pipeline.remember_broken({ "a.html.erb" => BROKEN })
 
       assert_equal ["a.html.erb"], pipeline.broken_files
 
       fixed = Herb::Dev::Watcher::Event.new(kind: :changed, path: "/a", relative_path: "a.html.erb", previous: BROKEN, current: "<div>\n  <form></form>\n</div>\n")
 
       capture_io { pipeline.handle_event(fixed) }
+
+      assert_equal [], pipeline.broken_files
+    end
+
+    test "a template that only fails to compile is broken too, and carries its diagnostics" do
+      websocket = FakeWebSocket.new
+      compiled = Struct.new(:mode, :manifest, :version, :slot_entries, :statics, :static_markup, :diagnostics)
+      diagnostics = [{ message: "slot outside a region", severity: :error }]
+      compiler = ->(_source, _path) { compiled.new(:client, {}, "v1", [], {}, nil, diagnostics) }
+      pipeline = Herb::Dev::Pipeline.new(server: websocket, compiler: -> { compiler })
+
+      event = Herb::Dev::Watcher::Event.new(kind: :changed, path: "/b", relative_path: "b.html.erb", previous: "<div>Hello</div>\n", current: "<div>Bye</div>\n")
+
+      capture_io { pipeline.handle_event(event) }
+
+      assert_equal ["b.html.erb"], pipeline.broken_files
+      assert_equal [{ file: "b.html.erb", diagnostics: diagnostics }], pipeline.broken_entries
+    end
+
+    test "a broken template carries the source and errors, so a late browser can render them" do
+      websocket = FakeWebSocket.new
+      pipeline = Herb::Dev::Pipeline.new(server: websocket, compiler: -> {})
+
+      pipeline.remember_broken({ "a.html.erb" => BROKEN })
+
+      entry = pipeline.broken_entries.first
+      expected = Herb::Dev::Protocol.error(file: "a.html.erb", source: BROKEN, errors: Herb.parse(BROKEN, strict: true, analyze: true).errors)
+
+      assert_equal BROKEN, entry[:source]
+      assert_equal expected[:errors], entry[:errors]
+    end
+
+    test "a template that compiles clean drops off the broken list" do
+      websocket = FakeWebSocket.new
+      compiled = Struct.new(:mode, :manifest, :version, :slot_entries, :statics, :static_markup, :diagnostics)
+      compiler = ->(_source, _path) { compiled.new(:client, {}, "v1", [], {}, nil, []) }
+      pipeline = Herb::Dev::Pipeline.new(server: websocket, compiler: -> { compiler })
+
+      pipeline.remember_broken({ "b.html.erb" => BROKEN })
+
+      assert_equal ["b.html.erb"], pipeline.broken_files
+
+      event = Herb::Dev::Watcher::Event.new(kind: :changed, path: "/b", relative_path: "b.html.erb", previous: BROKEN, current: "<div>Bye</div>\n")
+
+      capture_io { pipeline.handle_event(event) }
 
       assert_equal [], pipeline.broken_files
     end

--- a/test/dev/server_test.rb
+++ b/test/dev/server_test.rb
@@ -38,20 +38,20 @@ module Dev
 
     test "the welcome payload reports what the server was told is broken" do
       server = build_server
-      server.on_welcome { ["a.html.erb"] }
+      server.on_welcome { [{ file: "a.html.erb" }] }
 
-      assert_equal ["a.html.erb"], server.send(:broken_files)
+      assert_equal [{ file: "a.html.erb" }], server.send(:broken_entries)
     end
 
     test "a server nobody told about broken templates welcomes with an empty list" do
-      assert_equal [], build_server.send(:broken_files)
+      assert_equal [], build_server.send(:broken_entries)
     end
 
     test "a welcome hook that raises still lets the client connect" do
       server = build_server
       server.on_welcome { raise "boom" }
 
-      assert_equal [], server.send(:broken_files)
+      assert_equal [], server.send(:broken_entries)
     end
 
     test "a hello frame sets the client's role" do


### PR DESCRIPTION
Follow up on #2528 which taught the dev server to notice templates that were already broken when it started, so a browser that connects later hears about them instead of staying silent. The welcome message only carries the file paths though, so the client has nothing to render and falls back to a placeholder card.

```
This template did not parse when the dev server started. Edit it to see the errors.
```

Editing the file is exactly what shows you the error today, so the card tells you to go do the thing that already worked. The information was there when the server indexed the file, it was thrown away before the browser could see it.

This pull request keeps it. The pipeline now retains what is wrong with each broken template, and the welcome carries enough for the overlay to render the same card a live edit produces.

**Before**

```json
{
  "type": "welcome",
  "project": "/app",
  "broken_files": ["app/views/posts/index.html.erb"]
}
```

**After**

```json
{
  "type": "welcome",
  "project": "/app",
  "broken_files": [
    {
      "file": "app/views/posts/index.html.erb",
      "source": "<div>\n  <form>\n</div>\n",
      "errors": [
        {
          "name": "MissingClosingTagError",
          "code": "MissingClosingTagError",
          "origin": "Herb Parser",
          "message": "Opening tag `<form>` at (2:3) doesn't have a matching closing tag `</form>` in the same scope.",
          "suggestion": "Add the closing tag, or make it self-closing.",
          "line": 2,
          "column": 2
        }
      ]
    }
  ]
}
```

Each entry carries either the source and the parse errors, or the diagnostics from a template that parsed but failed to compile. `diagnosticsFromBrokenFile` routes the first kind through the existing `diagnosticsFromError` and passes the second kind through untouched, so the overlay gets the real code, message, suggestion and source excerpt without any new rendering code. `diagnosticFromBrokenTemplate` and its placeholder are gone.