### PR TITLE
Ruby: Add `Stack.arrange` to order visitors from what they declare

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -148,6 +148,7 @@ Metrics/ClassLength:
     - lib/herb/project.rb
     - lib/herb/source_path.rb
     - lib/herb/visitor.rb
+    - lib/herb/visitor/stack.rb
     - templates/template.rb
     - test/**/*_test.rb
 

--- a/lib/herb/visitor/stack.rb
+++ b/lib/herb/visitor/stack.rb
@@ -26,6 +26,28 @@ module Herb
         stack
       end
 
+      #: (untyped) -> Stack
+      def self.arrange(visitors)
+        build(visitors).arrange
+      end
+
+      #: () -> Stack
+      def arrange
+        remaining = to_a
+        ordered = [] #: Array[untyped]
+
+        until remaining.empty?
+          ready = remaining.find { |visitor| remaining.none? { |other| !other.equal?(visitor) && precedes?(other, visitor) } }
+
+          raise OrderError, unsatisfiable_message(remaining) unless ready
+
+          ordered << ready
+          remaining.delete_if { |visitor| visitor.equal?(ready) }
+        end
+
+        self.class.build(ordered)
+      end
+
       #: () -> Array[String]
       def descriptions
         map { |visitor|
@@ -85,6 +107,32 @@ module Herb
         klass = visitor.class
 
         klass.respond_to?(question) && klass.public_send(question)
+      end
+
+      #: (untyped, untyped) -> bool
+      def precedes?(earlier, later)
+        return true if answers?(earlier, :inlines_renders?)
+        return true if answers?(earlier, :reads_erb_source?) && answers?(later, :rewrites_erb_source?)
+
+        answers?(earlier, :rewrites_style_blocks?) && answers?(later, :reads_style_blocks?)
+      end
+
+      #: (Array[untyped]) -> String
+      def unsatisfiable_message(remaining)
+        knotted = remaining.select { |visitor| blocked?(visitor, remaining) && blocking?(visitor, remaining) }
+        names = (knotted.empty? ? remaining : knotted).map { |visitor| visitor.class.name }.uniq.join(" and ")
+
+        "#{names} each have to run before the other, so no order of the stack satisfies what they declare. Drop one of them, or change what it declares."
+      end
+
+      #: (untyped, Array[untyped]) -> bool
+      def blocked?(visitor, remaining)
+        remaining.any? { |other| !other.equal?(visitor) && precedes?(other, visitor) }
+      end
+
+      #: (untyped, Array[untyped]) -> bool
+      def blocking?(visitor, remaining)
+        remaining.any? { |other| !other.equal?(visitor) && precedes?(visitor, other) }
       end
 
       public

--- a/sig/herb/visitor/stack.rbs
+++ b/sig/herb/visitor/stack.rbs
@@ -24,6 +24,12 @@ module Herb
       # : (untyped) -> Stack
       def self.build: (untyped) -> Stack
 
+      # : (untyped) -> Stack
+      def self.arrange: (untyped) -> Stack
+
+      # : () -> Stack
+      def arrange: () -> Stack
+
       # : () -> Array[String]
       def descriptions: () -> Array[String]
 
@@ -43,6 +49,18 @@ module Herb
 
       # : (untyped, Symbol) -> bool
       def answers?: (untyped, Symbol) -> bool
+
+      # : (untyped, untyped) -> bool
+      def precedes?: (untyped, untyped) -> bool
+
+      # : (Array[untyped]) -> String
+      def unsatisfiable_message: (Array[untyped]) -> String
+
+      # : (untyped, Array[untyped]) -> bool
+      def blocked?: (untyped, Array[untyped]) -> bool
+
+      # : (untyped, Array[untyped]) -> bool
+      def blocking?: (untyped, Array[untyped]) -> bool
 
       public
 

--- a/test/engine/visitor_stack_test.rb
+++ b/test/engine/visitor_stack_test.rb
@@ -20,6 +20,19 @@ module Engine
       def self.inlines_renders? = true
     end
 
+    class StyleRewritingVisitor < Herb::Visitor
+      def self.rewrites_style_blocks? = true
+    end
+
+    class StyleReadingVisitor < Herb::Visitor
+      def self.reads_style_blocks? = true
+    end
+
+    class ReadingAndRewritingVisitor < Herb::Visitor
+      def self.reads_erb_source? = true
+      def self.rewrites_erb_source? = true
+    end
+
     def stack
       @stack ||= Herb::Visitor::Stack.build([FirstVisitor.new, SecondVisitor.new])
     end
@@ -165,6 +178,74 @@ module Engine
         engine = compile(visitors: [ThirdVisitor.new, Herb::Engine::DebugVisitor.new])
 
         assert engine.visitors.include_visitor?(Herb::Engine::DebugVisitor)
+      end
+    end
+
+    describe "#arrange" do
+      def arrange(*visitors)
+        Herb::Visitor::Stack.arrange(visitors)
+      end
+
+      test "leaves a stack that already validates as it was" do
+        visitors = [InliningVisitor.new, ReadingVisitor.new, FirstVisitor.new, RewritingVisitor.new]
+
+        assert_equal classes(visitors), classes(arrange(*visitors))
+      end
+
+      test "keeps visitors that declare nothing in the order they were given" do
+        assert_equal [FirstVisitor, SecondVisitor, ThirdVisitor], classes(arrange(FirstVisitor.new, SecondVisitor.new, ThirdVisitor.new))
+      end
+
+      test "moves a reader before the rewriter it was placed after" do
+        assert_equal [ReadingVisitor, RewritingVisitor], classes(arrange(RewritingVisitor.new, ReadingVisitor.new))
+      end
+
+      test "moves a style reader after the style rewriter it was placed before" do
+        assert_equal [StyleRewritingVisitor, StyleReadingVisitor], classes(arrange(StyleReadingVisitor.new, StyleRewritingVisitor.new))
+      end
+
+      test "moves an inlining visitor to the front" do
+        assert_equal [InliningVisitor, FirstVisitor, SecondVisitor], classes(arrange(FirstVisitor.new, SecondVisitor.new, InliningVisitor.new))
+      end
+
+      test "holds a rewriter back until its reader has run and leaves the rest in place" do
+        arranged = arrange(FirstVisitor.new, RewritingVisitor.new, SecondVisitor.new, ReadingVisitor.new, ThirdVisitor.new)
+
+        assert_equal [FirstVisitor, SecondVisitor, ReadingVisitor, RewritingVisitor, ThirdVisitor], classes(arranged)
+      end
+
+      test "produces an order validate_order! accepts" do
+        assert_nil arrange(StyleReadingVisitor.new, RewritingVisitor.new, FirstVisitor.new, ReadingVisitor.new, StyleRewritingVisitor.new, InliningVisitor.new).validate_order!
+      end
+
+      test "returns a stack, so placement keeps working on the result" do
+        arranged = arrange(RewritingVisitor.new, ReadingVisitor.new).insert_after(ReadingVisitor, FirstVisitor.new)
+
+        assert_equal [ReadingVisitor, FirstVisitor, RewritingVisitor], classes(arranged)
+      end
+
+      test "refuses two visitors that each have to run before the other" do
+        error = assert_raises(Herb::Visitor::Stack::OrderError) do
+          arrange(ReadingAndRewritingVisitor.new, ReadingAndRewritingVisitor.new)
+        end
+
+        assert_equal "Engine::VisitorStackTest::ReadingAndRewritingVisitor each have to run before the other, so no order of the stack satisfies what they declare. Drop one of them, or change what it declares.", error.message
+      end
+
+      test "refuses two inlining visitors, since only one can run first" do
+        error = assert_raises(Herb::Visitor::Stack::OrderError) do
+          arrange(FirstVisitor.new, InliningVisitor.new, InliningVisitor.new)
+        end
+
+        assert_equal "Engine::VisitorStackTest::InliningVisitor each have to run before the other, so no order of the stack satisfies what they declare. Drop one of them, or change what it declares.", error.message
+      end
+
+      test "names only the visitors in the knot, not the ones waiting behind it" do
+        error = assert_raises(Herb::Visitor::Stack::OrderError) do
+          arrange(RewritingVisitor.new, ReadingAndRewritingVisitor.new, ReadingAndRewritingVisitor.new)
+        end
+
+        assert_equal "Engine::VisitorStackTest::ReadingAndRewritingVisitor each have to run before the other, so no order of the stack satisfies what they declare. Drop one of them, or change what it declares.", error.message
       end
     end
 


### PR DESCRIPTION
This pull request adds `Herb::Visitor::Stack.arrange`, the constructor to the checker `validate_order!` already is.

`validate_order!` refuses a stack whose order breaks what its visitors declare about themselves, but leaves building a valid order to the caller. That is fine for one author writing one `visitors:` array. It is not fine for anyone assembling a stack from more than one source, an application's visitors on top of a framework's, because they end up re-deriving the ordering rules by hand. 

ReActionView does exactly that today: it partitions `transform_visitors` on one trait, `rewrites_erb_source?`, and gets the other three wrong. An application visitor that reads style blocks lands among the passive transforms in insertion order, before the scoped style rewriter it has to follow, and the compile refuses the stack for an author who did nothing wrong.

```ruby
Herb::Visitor::Stack.arrange([
  Herb::Engine::SourceAttributionVisitor.new,
  Herb::Engine::InstrumentationVisitor.new,
  Herb::Engine::Slots::Visitor.new,
])
#=> [SourceAttributionVisitor, Slots::Visitor, InstrumentationVisitor]
```

`arrange` orders the stack so that an inlining visitor runs first, a reader of ERB source runs before every rewriter of it, and a reader of style blocks runs after every rewriter of them. It moves a visitor only when a declaration forces the move: a visitor runs as soon as everything that has to precede it has run, and two visitors that say nothing about each other keep the order they were given in, so a stack that already validates arranges to itself. 

The result is a `Stack`, so `insert_after` and friends keep working on it. When no order can satisfy the declarations, two inliners or two visitors that each read what the other rewrites, it raises the same `OrderError` and names the visitors in the knot instead of the ones waiting behind it.
