### PR TITLE
Client: Settle request's own waiters and evaluate derived transforms

### DIFF
--- a/javascript/packages/client/src/state/refresh.ts
+++ b/javascript/packages/client/src/state/refresh.ts
@@ -72,7 +72,7 @@ export class Refresh {
 
     this.due = Infinity
     this.controller?.abort()
-    this.settle({ applied: 0, deferred: 0, stale: true, failed: false })
+    this.settle({ applied: 0, deferred: 0, stale: true, failed: false }, this.waiting.splice(0))
   }
 
   private async run(): Promise<void> {
@@ -83,6 +83,7 @@ export class Refresh {
 
     const controller = new AbortController()
     const epoch = (this.epoch += 1)
+    const waiting = this.waiting.splice(0)
 
     this.controller = controller
 
@@ -91,13 +92,15 @@ export class Refresh {
     try {
       payload = await this.transport()(this.steering(), controller.signal)
     } catch {
-      this.settle({ applied: 0, deferred: 0, stale: epoch !== this.epoch, failed: epoch === this.epoch })
+      const stale = epoch !== this.epoch || controller.signal.aborted
+
+      this.settle({ applied: 0, deferred: 0, stale, failed: !stale }, waiting)
 
       return
     }
 
     if (epoch !== this.epoch) {
-      this.settle({ applied: 0, deferred: 0, stale: true, failed: false })
+      this.settle({ applied: 0, deferred: 0, stale: true, failed: false }, waiting)
 
       return
     }
@@ -108,12 +111,10 @@ export class Refresh {
       report = this.slots.apply(payload)
     })
 
-    this.settle({ applied: report.applied, deferred: report.deferred.length, stale: false, failed: false })
+    this.settle({ applied: report.applied, deferred: report.deferred.length, stale: false, failed: false }, waiting)
   }
 
-  private settle(report: RefreshReport): void {
-    const waiting = this.waiting.splice(0)
-
+  private settle(report: RefreshReport, waiting: RefreshWaiter[]): void {
     for (const waiter of waiting) {
       waiter(report)
     }

--- a/javascript/packages/client/src/state/server.ts
+++ b/javascript/packages/client/src/state/server.ts
@@ -106,13 +106,15 @@ export class ServerState {
     const changes = this.pending
     const restores = this.restores
     const previous = this.previous
+    const waiting = this.waiting
 
     this.pending = new Map()
     this.restores = []
     this.previous = new Map()
+    this.waiting = []
 
     if (changes.size === 0) {
-      return this.settle(IDLE)
+      return this.settle(IDLE, waiting)
     }
 
     const changed = [...changes.keys()]
@@ -128,7 +130,7 @@ export class ServerState {
       payload = await this.options.transport({ state: this.all(), changed }, controller.signal)
     } catch (error) {
       if (controller.signal.aborted || this.superseded(taken)) {
-        return this.settle({ ...IDLE, written: restores.length, stale: true })
+        return this.settle({ ...IDLE, written: restores.length, stale: true }, waiting)
       }
 
       this.restore(restores)
@@ -141,11 +143,11 @@ export class ServerState {
         }
       }
 
-      return this.settle({ ...IDLE, written: restores.length, restored: restores.length, failed: true })
+      return this.settle({ ...IDLE, written: restores.length, restored: restores.length, failed: true }, waiting)
     }
 
     if (this.superseded(taken)) {
-      return this.settle({ ...IDLE, written: restores.length, stale: true })
+      return this.settle({ ...IDLE, written: restores.length, stale: true }, waiting)
     }
 
     let report: ApplyReport = { applied: 0, deferred: [] }
@@ -158,14 +160,10 @@ export class ServerState {
       })
     }
 
-    return this.settle({ ...report, written: restores.length, restored: 0, stale: false, failed: false })
+    return this.settle({ ...report, written: restores.length, restored: 0, stale: false, failed: false }, waiting)
   }
 
-  private settle(report: StateReport): StateReport {
-    const waiting = this.waiting
-
-    this.waiting = []
-
+  private settle(report: StateReport, waiting: StateWaiter[]): StateReport {
     for (const resolve of waiting) {
       resolve(report)
     }

--- a/javascript/packages/client/src/state/state.ts
+++ b/javascript/packages/client/src/state/state.ts
@@ -856,7 +856,7 @@ export class State implements ElementObserverDelegate, SlotsDelegate, SeedsDeleg
       return this.valueAt(entry[0], scope)
     }
 
-    return matches(entry, (name) => this.valueAt(name, scope))
+    return evaluate(entry, (name) => this.valueAt(name, scope))
   }
 
   derivedDependents(manifest: StateManifest, scope: StateScope, written: string[]): string[] {

--- a/javascript/packages/client/test/refresh.test.ts
+++ b/javascript/packages/client/test/refresh.test.ts
@@ -218,6 +218,39 @@ describe("refetching server-derived slots", () => {
     expect(calls[0][FILE].q).toBe("abc")
   })
 
+  test("a refresh requested during another answers with its own outcome", async () => {
+    document.body.innerHTML = PAGE
+
+    let calls = 0
+    const transport = vi.fn((_state: Record<string, Record<string, unknown>>, signal: AbortSignal) => {
+      calls += 1
+
+      if (calls === 1) {
+        return new Promise<Payload>((_resolve, reject) => {
+          signal.addEventListener("abort", () => reject(new DOMException("aborted", "AbortError")))
+        })
+      }
+
+      return Promise.resolve(payloadFor({ 3: "second answer" }))
+    })
+
+    const live = start({ state: { refetchTransport: transport, refetchDebounce: 0 } })
+
+    const first = live.refresh()
+
+    await vi.waitFor(() => {
+      if (calls === 0) {
+        throw new Error("still waiting")
+      }
+    })
+
+    const second = live.refresh()
+
+    expect(await second).toEqual({ applied: 1, deferred: 0, stale: false, failed: false })
+    expect((await first).stale).toBe(true)
+    expect(document.body.innerHTML).toContain("second answer")
+  })
+
   test("a settled mutation refetches the server reads, steered", async () => {
     document.body.innerHTML = PAGE
 

--- a/javascript/packages/client/test/state-scoped.test.ts
+++ b/javascript/packages/client/test/state-scoped.test.ts
@@ -531,6 +531,7 @@ describe("derived states", () => {
     `<p><!--herb-slot:1-->0<!--/herb-slot:1--></p>` +
     `<input data-herb-slot="2:boolean_attribute:disabled">` +
     `<b><!--herb-slot:3:conditional--><!--herb-branch:3:1-->Calm<!--/herb-slot:3--></b>` +
+    `<i><!--herb-slot:4-->0<!--/herb-slot:4--></i>` +
     `<template data-herb-region="${DERIVED_FILE}:ffffffff">` +
     `<!--herb-branch:0:0-->Busy<!--herb-branch:0:1-->Idle` +
     `<!--herb-branch:3:0-->Deep<!--herb-branch:3:1-->Calm` +
@@ -549,8 +550,10 @@ describe("derived states", () => {
           { name: "busy", kind: "boolean", default: "pending || failed", derived: { any: [["pending", null], ["failed", null]] }, scope: "region" },
           { name: "total", kind: "integer", default: "attempts", derived: ["attempts", null], scope: "region" },
           { name: "deep", kind: "boolean", default: "busy && attempts > 2", derived: { all: [["busy", null], ["attempts", "2", ">"]] }, scope: "region" },
+          { name: "draft", kind: "string", default: '""', value: "", scope: "region" },
+          { name: "chars", kind: "integer", default: "draft.length", derived: ["draft", null, null, "length"], scope: "region" },
         ],
-        reads: { total: [1] },
+        reads: { total: [1], chars: [4] },
         conditionals: {
           0: { arms: [["busy", null, 0]], else: 1 },
           3: { arms: [["deep", null, 0]], else: 1 },
@@ -603,6 +606,15 @@ describe("derived states", () => {
     derivedState.setState({ attempts: 5 })
 
     expect(document.querySelector("p")?.textContent).toContain("5")
+  })
+
+  test("a derived transform reads as the transformed value", () => {
+    expect(derivedState.getState("chars")).toBe(0)
+
+    derivedState.setState({ draft: "hello" })
+
+    expect(derivedState.getState("chars")).toBe(5)
+    expect(document.querySelector("i")?.textContent).toBe("5")
   })
 
   test("a derivation cascades through another derivation", () => {

--- a/javascript/packages/client/test/state.test.ts
+++ b/javascript/packages/client/test/state.test.ts
@@ -272,6 +272,49 @@ describe("two flushes racing", () => {
     expect(text(0, slots)).toBe("new-a")
     expect(state.get("a")).toBe("new-a")
   })
+
+  test("a debounced write made during a request waits for its own reply", async () => {
+    const slots = mounted(RACE_PAGE + `<template data-herb-dependencies>${JSON.stringify(RACE_MAP)}</template>`)
+
+    let release: (() => void) | null = null
+    const seen: string[][] = []
+
+    const transport = async (request: StateRequest): Promise<Payload | null> => {
+      seen.push(request.changed)
+
+      if (seen.length === 1) {
+        await new Promise<void>((resolve) => {
+          release = resolve
+        })
+
+        return payload({ 0: "served-a" })
+      }
+
+      return null
+    }
+
+    const state = new State(slots, { debounce: 20, transport })
+
+    state.adopt()
+
+    const first = state.set("a", "new-a")
+
+    await vi.waitFor(() => {
+      if (seen.length === 0) {
+        throw new Error("still waiting")
+      }
+    })
+
+    const second = state.set("b", "new-b")
+
+    release!()
+
+    expect((await first).applied).toBe(1)
+    expect(await second).toMatchObject({ applied: 0, written: 1, stale: false, failed: false })
+    expect(seen).toEqual([["a"], ["b"]])
+    expect(text(0, slots)).toBe("served-a")
+    expect(text(1, slots)).toBe("new-b")
+  })
 })
 
 describe("reconciling with the server", () => {


### PR DESCRIPTION
This pull request fixes two request queues in `@herb-tools/client` that resolved with another request's result, and one derived value that was computed as `true`.

`ServerState` and `Refresh` both hold a list of waiters for the in-flight request and drained the whole list whenever any request settled. With a debounce configured, a `state.set` made while an earlier request was still in flight resolved with that earlier request's report, before its own request had even been sent. If its own request then failed, the rollback had no waiters left to settle. The same shape in `Refresh` meant that a refresh requested during another one resolved as `stale` as soon as the earlier run was aborted, so `Fragments.settle` returned early and the fallback presentation stayed on screen until some later refetch settled cleanly.

Each run now takes its waiters at the start and settles only those. A `Refresh` run that is aborted also settles as `stale` rather than `failed`, because `stop()` no longer drains the waiters of the run it aborts.

`State.deriveValue` routed a derived entry carrying a transform through `matches`, which converts any value into a boolean. The declaration below was therefore computed as `true` and wrote `true` into its slot:

```erb
<%# herb:state (draft: "", chars: draft.length) %>
<%= chars %>
```

It now goes through `evaluate`, which already resolves a bare transformed read to its value, so `chars` is `0`, and `5` once `draft` is set to `hello`.