### PR TITLE
Parser: Follow HTML5 tokenizer for attribute names/values and comments

### DIFF
--- a/.github/workflows/corpus.yml
+++ b/.github/workflows/corpus.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
   pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
   workflow_dispatch:
 
 permissions:
@@ -138,14 +139,20 @@ jobs:
         id: compare
         env:
           NO_COLOR: "1"
+          ACCEPT_REGRESSIONS: ${{ contains(github.event.pull_request.labels.*.name, 'corpus-accept-regressions') }}
         run: |-
           set -o pipefail
+
+          flags=(--markdown comment.md)
+
+          if [ "$ACCEPT_REGRESSIONS" != "true" ]; then
+            flags+=(--fail-on-regression)
+          fi
 
           corpus/bin/diff-runs \
             corpus/runs/baseline.json \
             corpus/runs/branch.json \
-            --markdown comment.md \
-            --fail-on-regression | tee comparison.txt
+            "${flags[@]}" | tee comparison.txt
 
       - name: Comment on the pull request
         if: (!cancelled()) && github.event_name == 'pull_request' && hashFiles('comment.md') != ''

--- a/config.yml
+++ b/config.yml
@@ -282,6 +282,19 @@ errors:
         - name: "tag_name"
           type: "token"
 
+    - name: "EndTagWithTrailingSolidusError"
+      message:
+        template: "Closing tag `</%s>` at (%u:%u) ends with `/>` instead of `>`."
+        arguments:
+          - "tag_name->value"
+          - "tag_name->location.start.line"
+          - "tag_name->location.start.column"
+      suggestion:
+        template: "Close it with `>`. A closing tag cannot self-close."
+      fields:
+        - name: "tag_name"
+          type: "token"
+
     - name: "UnclosedQuoteError"
       message:
         template: "Attribute value opened with %s at (%u:%u) was never closed."

--- a/config.yml
+++ b/config.yml
@@ -240,6 +240,23 @@ errors:
         - name: "comment_start"
           type: "token"
 
+    - name: "NestedCommentError"
+      message:
+        template: "Comment opened at (%u:%u) contains another `<!--` at (%u:%u)."
+        arguments:
+          - "comment_start->location.start.line"
+          - "comment_start->location.start.column"
+          - "nested_start->location.start.line"
+          - "nested_start->location.start.column"
+      suggestion:
+        template: "Comments cannot nest. The outer comment ends at the first `-->`, so remove the inner `<!--` or close the outer comment before it."
+      fields:
+        - name: "comment_start"
+          type: "token"
+
+        - name: "nested_start"
+          type: "token"
+
     - name: "InvalidCommentClosingTagError"
       message:
         template: "Invalid comment closing tag `%s` at (%u:%u). Use `-->` instead of `--!>`."

--- a/config.yml
+++ b/config.yml
@@ -228,6 +228,18 @@ errors:
         - name: "close_column"
           type: "size_t"
 
+    - name: "UnclosedCommentError"
+      message:
+        template: "Comment opened at (%u:%u) is missing its closing `-->`."
+        arguments:
+          - "comment_start->location.start.line"
+          - "comment_start->location.start.column"
+      suggestion:
+        template: "Add `-->` where the comment should end."
+      fields:
+        - name: "comment_start"
+          type: "token"
+
     - name: "InvalidCommentClosingTagError"
       message:
         template: "Invalid comment closing tag `%s` at (%u:%u). Use `-->` instead of `--!>`."

--- a/config.yml
+++ b/config.yml
@@ -309,6 +309,69 @@ errors:
         - name: "attribute_name"
           type: "string"
 
+    - name: "MissingWhitespaceBetweenAttributesError"
+      message:
+        template: "Missing whitespace between attributes at (%u:%u). `%s` is parsed as the start of a new attribute."
+        arguments:
+          - "found->location.start.line"
+          - "found->location.start.column"
+          - "found->value"
+      suggestion:
+        template: "Add a space before it."
+      fields:
+        - name: "found"
+          type: "token"
+
+    - name: "UnexpectedCharacterInAttributeNameError"
+      message:
+        template: "Unexpected `%s` in attribute name at (%u:%u)."
+        arguments:
+          - "character->value"
+          - "character->location.start.line"
+          - "character->location.start.column"
+      suggestion:
+        template: "Quotes cannot appear in an attribute name. Check the quoting of the previous attribute value."
+      fields:
+        - name: "character"
+          type: "token"
+
+    - name: "UnexpectedCharacterInUnquotedAttributeValueError"
+      message:
+        template: "Unexpected `%s` in unquoted attribute value at (%u:%u)."
+        arguments:
+          - "character->value"
+          - "character->location.start.line"
+          - "character->location.start.column"
+      suggestion:
+        template: "Wrap the value in quotes."
+      fields:
+        - name: "character"
+          type: "token"
+
+    - name: "UnexpectedEqualsSignBeforeAttributeNameError"
+      message:
+        template: "Unexpected `=` before attribute name at (%u:%u)."
+        arguments:
+          - "equals->location.start.line"
+          - "equals->location.start.column"
+      suggestion:
+        template: "Remove the `=`, or put an attribute name in front of it."
+      fields:
+        - name: "equals"
+          type: "token"
+
+    - name: "UnexpectedSolidusInTagError"
+      message:
+        template: "Unexpected `/` in tag at (%u:%u)."
+        arguments:
+          - "solidus->location.start.line"
+          - "solidus->location.start.column"
+      suggestion:
+        template: "Remove it, or use `/>` to self-close the tag."
+      fields:
+        - name: "solidus"
+          type: "token"
+
     - name: "UnclosedERBTagError"
       message:
         template: "ERB tag `%s` at (%u:%u) is missing closing `%%>`."

--- a/javascript/packages/formatter/src/comment-helpers.ts
+++ b/javascript/packages/formatter/src/comment-helpers.ts
@@ -51,7 +51,7 @@ export function formatHTMLCommentInner(rawInner: string, indentWidth: number, ba
 
   const trimmedInner = rawInner.trim()
 
-  if (trimmedInner.startsWith('[if ') && trimmedInner.endsWith('<![endif]')) {
+  if (trimmedInner.startsWith('[if ') || trimmedInner.endsWith('<![endif]')) {
     return rawInner
   }
 

--- a/javascript/packages/formatter/test/erb-formatter/erb-formatter-fixtures.test.ts
+++ b/javascript/packages/formatter/test/erb-formatter/erb-formatter-fixtures.test.ts
@@ -66,17 +66,28 @@ describe("ERB Formatter Fixture Tests", () => {
       const result = formatter.format(source)
 
       expect(result).toBe(dedent`
-        <button class="text-gray-700 bg-transparent hover:bg-gray-50 active:bg-gray-100 focus:bg-gray-50 focus:ring-gray-300 focus:ring-2
-        disabled:text-gray-300 disabled:bg-transparent disabled:border-gray-300 disabled:cursor-not-allowed
-        aria-disabled:text-gray-300 aria-disabled:bg-transparent aria-disabled:border-gray-300 aria-disabled:cursor-not-allowed">Button</button>
+        <button
+          class="
+            text-gray-700 bg-transparent hover:bg-gray-50 active:bg-gray-100 focus:bg-gray-50 focus:ring-gray-300 focus:ring-2
+            disabled:text-gray-300 disabled:bg-transparent disabled:border-gray-300 disabled:cursor-not-allowed
+            aria-disabled:text-gray-300 aria-disabled:bg-transparent aria-disabled:border-gray-300 aria-disabled:cursor-not-allowed
+          "
+        >
+          Button
+        </button>
 
-        <nav class="
-        flex flex-col bg-gray-15 p-4 w-full       " data-controller="<%= stimulus_id %>" data-<%= stimulus_id %>-cookie-value="solidus_admin"> Foooo </nav>
+        <nav
+          class="flex flex-col bg-gray-15 p-4 w-full"
+          data-controller="<%= stimulus_id %>"
+          data-<%= stimulus_id %>-cookie-value="solidus_admin"
+        >
+          Foooo
+        </nav>
 
         <p
-        single-double-quotes='"double" quotes'
-        double-single-quotes="'single' quotes"
-        escaped-quotes=escaped&quote;quotes
+          single-double-quotes='"double" quotes'
+          double-single-quotes="'single' quotes"
+          escaped-quotes="escaped&quote;quotes"
         ></p>
       `)
     })

--- a/javascript/packages/linter/test/__snapshots__/cli.test.ts.snap
+++ b/javascript/packages/linter/test/__snapshots__/cli.test.ts.snap
@@ -938,13 +938,13 @@ test/fixtures/tag-attributes.html.erb:5:0
 exports[`CLI Output Formatting > diplays only parsers errors if one is present 1`] = `
 "✓ Using Herb config file at /test/herb/javascript/packages/linter/.herb.yml
 
-[error] Unexpected Token. Expected: an identifier, \`@\`, \`<%\`, whitespace, or a newline, found: a character. (\`UNEXPECTED_ERROR\`) (parser-no-errors)
+[error] Missing whitespace between attributes at (2:22). \`alt\` is parsed as the start of a new attribute. (\`MISSING_WHITESPACE_BETWEEN_ATTRIBUTES_ERROR\`) (parser-no-errors)
 
-test/fixtures/parser-errors.html.erb:2:16
+test/fixtures/parser-errors.html.erb:2:22
 
       1 │ <div id=test class=foo>
-  →   2 │   <img src=image.jpg>
-        │                 ~
+  →   2 │   <img src="image.jpg"alt="Image">
+        │                       ~~~
       3 │ </div>
       4 │
 

--- a/javascript/packages/linter/test/fixtures/parser-errors.html.erb
+++ b/javascript/packages/linter/test/fixtures/parser-errors.html.erb
@@ -1,3 +1,3 @@
 <div id=test class=foo>
-  <img src=image.jpg>
+  <img src="image.jpg"alt="Image">
 </div>

--- a/javascript/packages/node-wasm/test/__snapshots__/utf8-strings.test.ts.snap
+++ b/javascript/packages/node-wasm/test/__snapshots__/utf8-strings.test.ts.snap
@@ -12,10 +12,9 @@ exports[`UTF-8 string handling > handles edge cases > incomplete comment has emp
 └── children: (1 item)
     └── @ HTMLCommentNode (location: (1:0)-(1:4))
         ├── errors: (1 item)
-        │   └── @ UnexpectedTokenError (location: (1:4)-(1:4))
-        │       ├── message: "Found end of file when expecting \`-->\` at (1:4)."
-        │       ├── expected_type: "TOKEN_HTML_COMMENT_END"
-        │       └── found: "" (location: (1:4)-(1:4))
+        │   └── @ UnclosedCommentError (location: (1:0)-(1:4))
+        │       ├── message: "Comment opened at (1:0) is missing its closing \`-->\`."
+        │       └── comment_start: "<!--" (location: (1:0)-(1:4))
         │       
         │   
         ├── comment_start: "<!--" (location: (1:0)-(1:4))
@@ -29,10 +28,9 @@ exports[`UTF-8 string handling > handles edge cases > incomplete comment preserv
 └── children: (1 item)
     └── @ HTMLCommentNode (location: (1:0)-(1:13))
         ├── errors: (1 item)
-        │   └── @ UnexpectedTokenError (location: (1:13)-(1:13))
-        │       ├── message: "Found end of file when expecting \`-->\` at (1:13)."
-        │       ├── expected_type: "TOKEN_HTML_COMMENT_END"
-        │       └── found: "" (location: (1:13)-(1:13))
+        │   └── @ UnclosedCommentError (location: (1:0)-(1:13))
+        │       ├── message: "Comment opened at (1:0) is missing its closing \`-->\`."
+        │       └── comment_start: "<!--" (location: (1:0)-(1:4))
         │       
         │   
         ├── comment_start: "<!--" (location: (1:0)-(1:4))

--- a/javascript/packages/node/test/__snapshots__/utf8-strings.test.ts.snap
+++ b/javascript/packages/node/test/__snapshots__/utf8-strings.test.ts.snap
@@ -12,10 +12,9 @@ exports[`UTF-8 string handling > handles edge cases > incomplete comment has emp
 └── children: (1 item)
     └── @ HTMLCommentNode (location: (1:0)-(1:4))
         ├── errors: (1 item)
-        │   └── @ UnexpectedTokenError (location: (1:4)-(1:4))
-        │       ├── message: "Found end of file when expecting \`-->\` at (1:4)."
-        │       ├── expected_type: "TOKEN_HTML_COMMENT_END"
-        │       └── found: "" (location: (1:4)-(1:4))
+        │   └── @ UnclosedCommentError (location: (1:0)-(1:4))
+        │       ├── message: "Comment opened at (1:0) is missing its closing \`-->\`."
+        │       └── comment_start: "<!--" (location: (1:0)-(1:4))
         │       
         │   
         ├── comment_start: "<!--" (location: (1:0)-(1:4))
@@ -29,10 +28,9 @@ exports[`UTF-8 string handling > handles edge cases > incomplete comment preserv
 └── children: (1 item)
     └── @ HTMLCommentNode (location: (1:0)-(1:13))
         ├── errors: (1 item)
-        │   └── @ UnexpectedTokenError (location: (1:13)-(1:13))
-        │       ├── message: "Found end of file when expecting \`-->\` at (1:13)."
-        │       ├── expected_type: "TOKEN_HTML_COMMENT_END"
-        │       └── found: "" (location: (1:13)-(1:13))
+        │   └── @ UnclosedCommentError (location: (1:0)-(1:13))
+        │       ├── message: "Comment opened at (1:0) is missing its closing \`-->\`."
+        │       └── comment_start: "<!--" (location: (1:0)-(1:4))
         │       
         │   
         ├── comment_start: "<!--" (location: (1:0)-(1:4))

--- a/lib/herb/project.rb
+++ b/lib/herb/project.rb
@@ -47,7 +47,8 @@ module Herb
       "UnexpectedCharacterInAttributeNameError",
       "UnexpectedCharacterInUnquotedAttributeValueError",
       "UnexpectedEqualsSignBeforeAttributeNameError",
-      "UnexpectedSolidusInTagError"
+      "UnexpectedSolidusInTagError",
+      "EndTagWithTrailingSolidusError"
     ].freeze
 
     ISSUE_TYPES = [

--- a/lib/herb/project.rb
+++ b/lib/herb/project.rb
@@ -48,7 +48,8 @@ module Herb
       "UnexpectedCharacterInUnquotedAttributeValueError",
       "UnexpectedEqualsSignBeforeAttributeNameError",
       "UnexpectedSolidusInTagError",
-      "EndTagWithTrailingSolidusError"
+      "EndTagWithTrailingSolidusError",
+      "UnclosedCommentError"
     ].freeze
 
     ISSUE_TYPES = [

--- a/lib/herb/project.rb
+++ b/lib/herb/project.rb
@@ -42,7 +42,12 @@ module Herb
       "UnclosedERBTagError",
       "MalformedERBClosingTagError",
       "StrayERBClosingTagError",
-      "NestedERBTagError"
+      "NestedERBTagError",
+      "MissingWhitespaceBetweenAttributesError",
+      "UnexpectedCharacterInAttributeNameError",
+      "UnexpectedCharacterInUnquotedAttributeValueError",
+      "UnexpectedEqualsSignBeforeAttributeNameError",
+      "UnexpectedSolidusInTagError"
     ].freeze
 
     ISSUE_TYPES = [

--- a/lib/herb/project.rb
+++ b/lib/herb/project.rb
@@ -49,7 +49,8 @@ module Herb
       "UnexpectedEqualsSignBeforeAttributeNameError",
       "UnexpectedSolidusInTagError",
       "EndTagWithTrailingSolidusError",
-      "UnclosedCommentError"
+      "UnclosedCommentError",
+      "NestedCommentError"
     ].freeze
 
     ISSUE_TYPES = [

--- a/sig/herb/errors.rbs
+++ b/sig/herb/errors.rbs
@@ -397,6 +397,27 @@ module Herb
       def tree_inspect: (?indent: Integer, ?depth: Integer, ?depth_limit: Integer) -> String
     end
 
+    class EndTagWithTrailingSolidusError < Error
+      include Colors
+
+      attr_reader tag_name: Herb::Token?
+
+      # : (String, Location?, String, Herb::Token) -> void
+      def initialize: (String, Location?, String, Herb::Token) -> void
+
+      # : () -> String?
+      def suggestion: () -> String?
+
+      # : () -> String
+      def inspect: () -> String
+
+      # : () -> serialized_end_tag_with_trailing_solidus_error
+      def to_hash: () -> serialized_end_tag_with_trailing_solidus_error
+
+      # : (?indent: Integer, ?depth: Integer, ?depth_limit: Integer) -> String
+      def tree_inspect: (?indent: Integer, ?depth: Integer, ?depth_limit: Integer) -> String
+    end
+
     class UnclosedQuoteError < Error
       include Colors
 

--- a/sig/herb/errors.rbs
+++ b/sig/herb/errors.rbs
@@ -323,6 +323,27 @@ module Herb
       def tree_inspect: (?indent: Integer, ?depth: Integer, ?depth_limit: Integer) -> String
     end
 
+    class UnclosedCommentError < Error
+      include Colors
+
+      attr_reader comment_start: Herb::Token?
+
+      # : (String, Location?, String, Herb::Token) -> void
+      def initialize: (String, Location?, String, Herb::Token) -> void
+
+      # : () -> String?
+      def suggestion: () -> String?
+
+      # : () -> String
+      def inspect: () -> String
+
+      # : () -> serialized_unclosed_comment_error
+      def to_hash: () -> serialized_unclosed_comment_error
+
+      # : (?indent: Integer, ?depth: Integer, ?depth_limit: Integer) -> String
+      def tree_inspect: (?indent: Integer, ?depth: Integer, ?depth_limit: Integer) -> String
+    end
+
     class InvalidCommentClosingTagError < Error
       include Colors
 

--- a/sig/herb/errors.rbs
+++ b/sig/herb/errors.rbs
@@ -344,6 +344,29 @@ module Herb
       def tree_inspect: (?indent: Integer, ?depth: Integer, ?depth_limit: Integer) -> String
     end
 
+    class NestedCommentError < Error
+      include Colors
+
+      attr_reader comment_start: Herb::Token?
+
+      attr_reader nested_start: Herb::Token?
+
+      # : (String, Location?, String, Herb::Token, Herb::Token) -> void
+      def initialize: (String, Location?, String, Herb::Token, Herb::Token) -> void
+
+      # : () -> String?
+      def suggestion: () -> String?
+
+      # : () -> String
+      def inspect: () -> String
+
+      # : () -> serialized_nested_comment_error
+      def to_hash: () -> serialized_nested_comment_error
+
+      # : (?indent: Integer, ?depth: Integer, ?depth_limit: Integer) -> String
+      def tree_inspect: (?indent: Integer, ?depth: Integer, ?depth_limit: Integer) -> String
+    end
+
     class InvalidCommentClosingTagError < Error
       include Colors
 

--- a/sig/herb/errors.rbs
+++ b/sig/herb/errors.rbs
@@ -436,6 +436,111 @@ module Herb
       def tree_inspect: (?indent: Integer, ?depth: Integer, ?depth_limit: Integer) -> String
     end
 
+    class MissingWhitespaceBetweenAttributesError < Error
+      include Colors
+
+      attr_reader found: Herb::Token?
+
+      # : (String, Location?, String, Herb::Token) -> void
+      def initialize: (String, Location?, String, Herb::Token) -> void
+
+      # : () -> String?
+      def suggestion: () -> String?
+
+      # : () -> String
+      def inspect: () -> String
+
+      # : () -> serialized_missing_whitespace_between_attributes_error
+      def to_hash: () -> serialized_missing_whitespace_between_attributes_error
+
+      # : (?indent: Integer, ?depth: Integer, ?depth_limit: Integer) -> String
+      def tree_inspect: (?indent: Integer, ?depth: Integer, ?depth_limit: Integer) -> String
+    end
+
+    class UnexpectedCharacterInAttributeNameError < Error
+      include Colors
+
+      attr_reader character: Herb::Token?
+
+      # : (String, Location?, String, Herb::Token) -> void
+      def initialize: (String, Location?, String, Herb::Token) -> void
+
+      # : () -> String?
+      def suggestion: () -> String?
+
+      # : () -> String
+      def inspect: () -> String
+
+      # : () -> serialized_unexpected_character_in_attribute_name_error
+      def to_hash: () -> serialized_unexpected_character_in_attribute_name_error
+
+      # : (?indent: Integer, ?depth: Integer, ?depth_limit: Integer) -> String
+      def tree_inspect: (?indent: Integer, ?depth: Integer, ?depth_limit: Integer) -> String
+    end
+
+    class UnexpectedCharacterInUnquotedAttributeValueError < Error
+      include Colors
+
+      attr_reader character: Herb::Token?
+
+      # : (String, Location?, String, Herb::Token) -> void
+      def initialize: (String, Location?, String, Herb::Token) -> void
+
+      # : () -> String?
+      def suggestion: () -> String?
+
+      # : () -> String
+      def inspect: () -> String
+
+      # : () -> serialized_unexpected_character_in_unquoted_attribute_value_error
+      def to_hash: () -> serialized_unexpected_character_in_unquoted_attribute_value_error
+
+      # : (?indent: Integer, ?depth: Integer, ?depth_limit: Integer) -> String
+      def tree_inspect: (?indent: Integer, ?depth: Integer, ?depth_limit: Integer) -> String
+    end
+
+    class UnexpectedEqualsSignBeforeAttributeNameError < Error
+      include Colors
+
+      attr_reader equals: Herb::Token?
+
+      # : (String, Location?, String, Herb::Token) -> void
+      def initialize: (String, Location?, String, Herb::Token) -> void
+
+      # : () -> String?
+      def suggestion: () -> String?
+
+      # : () -> String
+      def inspect: () -> String
+
+      # : () -> serialized_unexpected_equals_sign_before_attribute_name_error
+      def to_hash: () -> serialized_unexpected_equals_sign_before_attribute_name_error
+
+      # : (?indent: Integer, ?depth: Integer, ?depth_limit: Integer) -> String
+      def tree_inspect: (?indent: Integer, ?depth: Integer, ?depth_limit: Integer) -> String
+    end
+
+    class UnexpectedSolidusInTagError < Error
+      include Colors
+
+      attr_reader solidus: Herb::Token?
+
+      # : (String, Location?, String, Herb::Token) -> void
+      def initialize: (String, Location?, String, Herb::Token) -> void
+
+      # : () -> String?
+      def suggestion: () -> String?
+
+      # : () -> String
+      def inspect: () -> String
+
+      # : () -> serialized_unexpected_solidus_in_tag_error
+      def to_hash: () -> serialized_unexpected_solidus_in_tag_error
+
+      # : (?indent: Integer, ?depth: Integer, ?depth_limit: Integer) -> String
+      def tree_inspect: (?indent: Integer, ?depth: Integer, ?depth_limit: Integer) -> String
+    end
+
     class UnclosedERBTagError < Error
       include Colors
 

--- a/src/parser.c
+++ b/src/parser.c
@@ -115,6 +115,39 @@ static AST_CDATA_NODE_T* parser_parse_cdata(parser_T* parser) {
   return cdata;
 }
 
+// <!-- a <!-->
+static token_T* parser_parse_html_comment_abrupt_end(
+  parser_T* parser,
+  hb_buffer_T* comment,
+  hb_array_T* children,
+  position_T start
+) {
+  token_T* nested_start = parser_advance(parser);
+  token_T* tag_end = parser_advance(parser);
+
+  position_T dashes_start = nested_start->location.start;
+  dashes_start.column += 2;
+
+  hb_buffer_append_string(comment, hb_string("<!"));
+
+  hb_string_T content = { .data = comment->value, .length = (uint32_t) comment->length };
+  hb_array_append(children, ast_literal_node_init(content, start, dashes_start, NULL, parser->allocator));
+  hb_buffer_clear(comment);
+
+  token_T* comment_end = hb_allocator_alloc(parser->allocator, sizeof(token_T));
+
+  comment_end->type = TOKEN_HTML_COMMENT_END;
+  comment_end->value = hb_string_from_data(hb_allocator_strndup(parser->allocator, "-->", 3), 3);
+  comment_end->owns_value = true;
+  comment_end->location = (location_T) { .start = dashes_start, .end = tag_end->location.end };
+  comment_end->range = (range_T) { .from = nested_start->range.from + 2, .to = tag_end->range.to };
+
+  token_free(nested_start, parser->allocator);
+  token_free(tag_end, parser->allocator);
+
+  return comment_end;
+}
+
 static AST_HTML_COMMENT_NODE_T* parser_parse_html_comment(parser_T* parser) {
   hb_array_T* errors = NULL;
   hb_array_T* children = hb_array_init(8, parser->allocator);
@@ -123,6 +156,8 @@ static AST_HTML_COMMENT_NODE_T* parser_parse_html_comment(parser_T* parser) {
 
   hb_buffer_T comment;
   hb_buffer_init(&comment, 512, parser->allocator);
+
+  token_T* comment_end = NULL;
 
   while (token_is_none_of(parser, TOKEN_HTML_COMMENT_END, TOKEN_HTML_COMMENT_INVALID_END, TOKEN_EOF)) {
     if (token_is(parser, TOKEN_ERB_START)) {
@@ -136,17 +171,31 @@ static AST_HTML_COMMENT_NODE_T* parser_parse_html_comment(parser_T* parser) {
       continue;
     }
 
-    // <!-- outer <!-- inner -->
     if (token_is(parser, TOKEN_HTML_COMMENT_START)) {
-      append_nested_comment_error(
-        comment_start,
-        parser->current_token,
-        parser->current_token->location.start,
-        parser->current_token->location.end,
-        parser->allocator,
-        &errors,
-        &parser->options
-      );
+      lexer_T lexer_copy = *parser->lexer;
+      token_T* next_token = lexer_next_token(&lexer_copy);
+      token_type_T next_type = next_token ? next_token->type : TOKEN_EOF;
+
+      if (next_token) { token_free(next_token, parser->allocator); }
+
+      // <!--[if !mso]><!--><meta><!--<![endif]-->
+      if (next_type == TOKEN_HTML_TAG_END) {
+        comment_end = parser_parse_html_comment_abrupt_end(parser, &comment, children, start);
+        break;
+      }
+
+      // <!-- outer <!-- inner -->
+      if (next_type != TOKEN_EOF) {
+        append_nested_comment_error(
+          comment_start,
+          parser->current_token,
+          parser->current_token->location.start,
+          parser->current_token->location.end,
+          parser->allocator,
+          &errors,
+          &parser->options
+        );
+      }
     }
 
     token_T* token = parser_advance(parser);
@@ -156,9 +205,9 @@ static AST_HTML_COMMENT_NODE_T* parser_parse_html_comment(parser_T* parser) {
 
   parser_append_literal_node_from_buffer(parser, &comment, children, start);
 
-  token_T* comment_end = NULL;
-
-  if (token_is(parser, TOKEN_HTML_COMMENT_INVALID_END)) {
+  if (comment_end != NULL) {
+    // closed by <!-->
+  } else if (token_is(parser, TOKEN_HTML_COMMENT_INVALID_END)) {
     comment_end = parser_advance(parser);
     append_invalid_comment_closing_tag_error(
       comment_end,

--- a/src/parser.c
+++ b/src/parser.c
@@ -155,6 +155,17 @@ static AST_HTML_COMMENT_NODE_T* parser_parse_html_comment(parser_T* parser) {
       &errors,
       &parser->options
     );
+  } else if (token_is(parser, TOKEN_EOF)) {
+    append_unclosed_comment_error(
+      comment_start,
+      comment_start->location.start,
+      parser->current_token->location.start,
+      parser->allocator,
+      &errors,
+      &parser->options
+    );
+
+    comment_end = parser_advance(parser);
   } else {
     comment_end = parser_consume_expected(parser, TOKEN_HTML_COMMENT_END, &errors);
   }

--- a/src/parser.c
+++ b/src/parser.c
@@ -136,6 +136,19 @@ static AST_HTML_COMMENT_NODE_T* parser_parse_html_comment(parser_T* parser) {
       continue;
     }
 
+    // <!-- outer <!-- inner -->
+    if (token_is(parser, TOKEN_HTML_COMMENT_START)) {
+      append_nested_comment_error(
+        comment_start,
+        parser->current_token,
+        parser->current_token->location.start,
+        parser->current_token->location.end,
+        parser->allocator,
+        &errors,
+        &parser->options
+      );
+    }
+
     token_T* token = parser_advance(parser);
     hb_buffer_append_string(&comment, token->value);
     token_free(token, parser->allocator);

--- a/src/parser.c
+++ b/src/parser.c
@@ -1239,6 +1239,20 @@ static AST_HTML_CLOSE_TAG_NODE_T* parser_parse_html_close_tag(parser_T* parser) 
 
   token_T* tag_closing = parser_consume_if_present(parser, TOKEN_HTML_TAG_END);
 
+  // </div/>
+  if (tag_closing == NULL && token_is(parser, TOKEN_HTML_TAG_SELF_CLOSE) && tag_name != NULL) {
+    tag_closing = parser_advance(parser);
+
+    append_end_tag_with_trailing_solidus_error(
+      tag_name,
+      tag_closing->location.start,
+      tag_closing->location.end,
+      parser->allocator,
+      &errors,
+      &parser->options
+    );
+  }
+
   if (tag_closing == NULL) {
     append_unclosed_close_tag_error(
       tag_name,

--- a/src/parser.c
+++ b/src/parser.c
@@ -391,6 +391,17 @@ static AST_HTML_TEXT_NODE_T* parser_parse_text_content(parser_T* parser, hb_arra
   return text_node;
 }
 
+static bool parser_token_starts_tag(const parser_T* parser) {
+  return token_is_any_of(
+    parser,
+    TOKEN_HTML_TAG_START,
+    TOKEN_HTML_TAG_START_CLOSE,
+    TOKEN_HTML_COMMENT_START,
+    TOKEN_HTML_DOCTYPE,
+    TOKEN_XML_PROCESSING_INSTRUCTION_START
+  );
+}
+
 static AST_HTML_ATTRIBUTE_NAME_NODE_T* parser_parse_html_attribute_name(parser_T* parser) {
   hb_array_T* errors = NULL;
   hb_array_T* children = hb_array_init(8, parser->allocator);
@@ -398,15 +409,24 @@ static AST_HTML_ATTRIBUTE_NAME_NODE_T* parser_parse_html_attribute_name(parser_T
   hb_buffer_init(&buffer, 128, parser->allocator);
   position_T start = parser->current_token->location.start;
 
+  // <div =foo>
+  if (token_is(parser, TOKEN_EQUALS)) {
+    token_T* equals = parser_advance(parser);
+    hb_buffer_append_string(&buffer, equals->value);
+    token_free(equals, parser->allocator);
+  }
+
   while (token_is_none_of(
-    parser,
-    TOKEN_EQUALS,
-    TOKEN_WHITESPACE,
-    TOKEN_NEWLINE,
-    TOKEN_HTML_TAG_END,
-    TOKEN_HTML_TAG_SELF_CLOSE,
-    TOKEN_EOF
-  )) {
+           parser,
+           TOKEN_EQUALS,
+           TOKEN_WHITESPACE,
+           TOKEN_NEWLINE,
+           TOKEN_SLASH,
+           TOKEN_HTML_TAG_END,
+           TOKEN_HTML_TAG_SELF_CLOSE,
+           TOKEN_EOF
+         )
+         && !parser_token_starts_tag(parser)) {
     if (token_is(parser, TOKEN_ERB_START)) {
       hb_string_T tag = parser->current_token->value;
       bool is_output_tag = (tag.length >= 3 && tag.data[2] == '=');
@@ -425,6 +445,17 @@ static AST_HTML_ATTRIBUTE_NAME_NODE_T* parser_parse_html_attribute_name(parser_T
 
       start = parser->current_token->location.start;
       continue;
+    }
+
+    if (token_is(parser, TOKEN_QUOTE)) {
+      append_unexpected_character_in_attribute_name_error(
+        parser->current_token,
+        parser->current_token->location.start,
+        parser->current_token->location.end,
+        parser->allocator,
+        &errors,
+        &parser->options
+      );
     }
 
     token_T* token = parser_advance(parser);
@@ -587,62 +618,6 @@ static AST_HTML_ATTRIBUTE_VALUE_NODE_T* parser_parse_quoted_html_attribute_value
     parser->current_token = lexer_next_token(parser->lexer);
   }
 
-  if (token_is(parser, TOKEN_QUOTE) && opening_quote != NULL
-      && hb_string_equals(parser->current_token->value, opening_quote->value)) {
-    lexer_state_snapshot_T saved_state = lexer_save_state(parser->lexer);
-
-    token_T* potential_closing = parser->current_token;
-    parser->current_token = lexer_next_token(parser->lexer);
-
-    if (token_is(parser, TOKEN_IDENTIFIER) || token_is(parser, TOKEN_CHARACTER)) {
-      append_unexpected_error(
-        hb_string("Unescaped quote character in attribute value"),
-        hb_string("HTML entity (&apos;/&quot;) or different quote style"),
-        opening_quote->value,
-        potential_closing->location.start,
-        potential_closing->location.end,
-        parser->allocator,
-        errors,
-        &parser->options
-      );
-
-      lexer_restore_state(parser->lexer, saved_state);
-
-      token_free(parser->current_token, parser->allocator);
-      parser->current_token = potential_closing;
-
-      hb_buffer_append_string(&buffer, parser->current_token->value);
-      token_free(parser->current_token, parser->allocator);
-      parser->current_token = lexer_next_token(parser->lexer);
-
-      while (!token_is(parser, TOKEN_EOF)
-             && !(
-               token_is(parser, TOKEN_QUOTE) && opening_quote != NULL
-               && hb_string_equals(parser->current_token->value, opening_quote->value)
-             )) {
-        if (token_is(parser, TOKEN_ERB_START)) {
-          parser_append_literal_node_from_buffer(parser, &buffer, children, start);
-
-          hb_array_append(children, parser_parse_erb_tag(parser));
-
-          start = parser->current_token->location.start;
-
-          continue;
-        }
-
-        hb_buffer_append_string(&buffer, parser->current_token->value);
-        token_free(parser->current_token, parser->allocator);
-
-        parser->current_token = lexer_next_token(parser->lexer);
-      }
-    } else {
-      token_free(parser->current_token, parser->allocator);
-      parser->current_token = potential_closing;
-
-      lexer_restore_state(parser->lexer, saved_state);
-    }
-  }
-
   parser_append_literal_node_from_buffer(parser, &buffer, children, start);
   hb_buffer_free(&buffer);
 
@@ -660,97 +635,114 @@ static AST_HTML_ATTRIBUTE_VALUE_NODE_T* parser_parse_quoted_html_attribute_value
   );
 }
 
+static bool parser_attribute_value_is_missing(const parser_T* parser) {
+  return token_is_any_of(parser, TOKEN_HTML_TAG_END, TOKEN_HTML_TAG_SELF_CLOSE, TOKEN_EOF)
+      || parser_token_starts_tag(parser);
+}
+
 static AST_HTML_ATTRIBUTE_VALUE_NODE_T* parser_parse_html_attribute_value(parser_T* parser) {
   hb_array_T* children = hb_array_init(8, parser->allocator);
   hb_array_T* errors = NULL;
 
-  // <div id=<%= "home" %>>
-  if (token_is(parser, TOKEN_ERB_START)) {
-    AST_ERB_CONTENT_NODE_T* erb_node = parser_parse_erb_tag(parser);
-    hb_array_append(children, erb_node);
-
-    return ast_html_attribute_value_node_init(
-      NULL,
-      children,
-      NULL,
-      false,
-      erb_node->base.location.start,
-      erb_node->base.location.end,
-      errors,
-      parser->allocator
-    );
-  }
-
-  // <div id=home>
-  if (token_is(parser, TOKEN_IDENTIFIER)) {
-    token_T* identifier = parser_consume_expected(parser, TOKEN_IDENTIFIER, &errors);
-    AST_LITERAL_NODE_T* literal = ast_literal_node_init_from_token(identifier, parser->allocator);
-    token_free(identifier, parser->allocator);
-
-    hb_array_append(children, literal);
-
-    return ast_html_attribute_value_node_init(
-      NULL,
-      children,
-      NULL,
-      false,
-      literal->base.location.start,
-      literal->base.location.end,
-      errors,
-      parser->allocator
-    );
-  }
-
   // <div id="home">
   if (token_is(parser, TOKEN_QUOTE)) { return parser_parse_quoted_html_attribute_value(parser, children, &errors); }
 
-  if (token_is(parser, TOKEN_BACKTICK)) {
+  // <div id=home> or <div id=<%= "home" %>>
+  hb_buffer_T buffer;
+  hb_buffer_init(&buffer, 128, parser->allocator);
+  position_T value_start = parser->current_token->location.start;
+  position_T value_end = value_start;
+  position_T start = value_start;
+
+  while (
+    token_is_none_of(parser, TOKEN_WHITESPACE, TOKEN_NEWLINE, TOKEN_HTML_TAG_END, TOKEN_HTML_TAG_SELF_CLOSE, TOKEN_EOF)
+    && !parser_token_starts_tag(parser)
+  ) {
+    if (token_is(parser, TOKEN_ERB_START)) {
+      parser_append_literal_node_from_buffer(parser, &buffer, children, start);
+
+      AST_ERB_CONTENT_NODE_T* erb_node = parser_parse_erb_tag(parser);
+      hb_array_append(children, erb_node);
+
+      value_end = erb_node->base.location.end;
+      start = parser->current_token->location.start;
+
+      continue;
+    }
+
+    if (token_is_any_of(parser, TOKEN_QUOTE, TOKEN_BACKTICK, TOKEN_EQUALS)) {
+      append_unexpected_character_in_unquoted_attribute_value_error(
+        parser->current_token,
+        parser->current_token->location.start,
+        parser->current_token->location.end,
+        parser->allocator,
+        &errors,
+        &parser->options
+      );
+    }
+
     token_T* token = parser_advance(parser);
-    position_T start = token->location.start;
-    position_T end = token->location.end;
-
-    append_unexpected_error(
-      hb_string("Invalid quote character for HTML attribute"),
-      hb_string("single quote (') or double quote (\")"),
-      hb_string("a backtick"),
-      start,
-      end,
-      parser->allocator,
-      &errors,
-      &parser->options
-    );
-
-    AST_HTML_ATTRIBUTE_VALUE_NODE_T* value =
-      ast_html_attribute_value_node_init(NULL, children, NULL, false, start, end, errors, parser->allocator);
-
+    hb_buffer_append_string(&buffer, token->value);
+    value_end = token->location.end;
     token_free(token, parser->allocator);
-
-    return value;
   }
 
-  char* expected = token_types_to_friendly_string(parser->allocator, TOKEN_IDENTIFIER, TOKEN_QUOTE, TOKEN_ERB_START);
-
-  append_unexpected_error(
-    hb_string("Unexpected Token"),
-    hb_string(expected),
-    token_type_to_friendly_string(parser->current_token->type),
-    parser->current_token->location.start,
-    parser->current_token->location.end,
-    parser->allocator,
-    &errors,
-    &parser->options
-  );
-
-  hb_allocator_dealloc(parser->allocator, expected);
+  parser_append_literal_node_from_buffer(parser, &buffer, children, start);
+  hb_buffer_free(&buffer);
 
   return ast_html_attribute_value_node_init(
     NULL,
     children,
     NULL,
     false,
-    parser->current_token->location.start,
-    parser->current_token->location.end,
+    value_start,
+    value_end,
     errors,
+    parser->allocator
+  );
+}
+
+static AST_HTML_ATTRIBUTE_NODE_T* parser_parse_html_attribute_missing_value(
+  parser_T* parser,
+  AST_HTML_ATTRIBUTE_NAME_NODE_T* attribute_name,
+  token_T* equals
+) {
+  hb_array_T* errors = NULL;
+  hb_string_T attribute_name_string = hb_string("unknown");
+
+  if (hb_array_size(attribute_name->children) > 0) {
+    AST_LITERAL_NODE_T* first_child = (AST_LITERAL_NODE_T*) hb_array_get(attribute_name->children, 0);
+
+    if (first_child && !hb_string_is_empty(first_child->content)) { attribute_name_string = first_child->content; }
+  }
+
+  append_missing_attribute_value_error(
+    attribute_name_string,
+    equals->location.start,
+    parser->current_token->location.start,
+    parser->allocator,
+    &errors,
+    &parser->options
+  );
+
+  AST_HTML_ATTRIBUTE_VALUE_NODE_T* empty_value = ast_html_attribute_value_node_init(
+    NULL,
+    hb_array_init(8, parser->allocator),
+    NULL,
+    false,
+    equals->location.end,
+    parser->current_token->location.start,
+    errors,
+    parser->allocator
+  );
+
+  return ast_html_attribute_node_init(
+    attribute_name,
+    equals,
+    empty_value,
+    attribute_name->base.location.start,
+    parser->current_token->location.start,
+    NULL,
     parser->allocator
   );
 }
@@ -832,6 +824,11 @@ static AST_HTML_ATTRIBUTE_NODE_T* parser_parse_html_attribute(parser_T* parser) 
       equals_with_whitespace->location = (location_T) { .start = equals_start, .end = equals_end };
       equals_with_whitespace->range = (range_T) { .from = range_start, .to = range_end };
 
+      // <div class = >
+      if (parser_attribute_value_is_missing(parser)) {
+        return parser_parse_html_attribute_missing_value(parser, attribute_name, equals_with_whitespace);
+      }
+
       AST_HTML_ATTRIBUTE_VALUE_NODE_T* attribute_value = parser_parse_html_attribute_value(parser);
 
       return ast_html_attribute_node_init(
@@ -864,45 +861,8 @@ static AST_HTML_ATTRIBUTE_NODE_T* parser_parse_html_attribute(parser_T* parser) 
     parser_consume_whitespace(parser, NULL);
 
     // <div class= >
-    if (token_is(parser, TOKEN_HTML_TAG_END) || token_is(parser, TOKEN_HTML_TAG_SELF_CLOSE)) {
-      hb_array_T* errors = NULL;
-      hb_string_T attribute_name_string = hb_string("unknown");
-
-      if (hb_array_size(attribute_name->children) > 0) {
-        AST_LITERAL_NODE_T* first_child = (AST_LITERAL_NODE_T*) hb_array_get(attribute_name->children, 0);
-
-        if (first_child && !hb_string_is_empty(first_child->content)) { attribute_name_string = first_child->content; }
-      }
-
-      append_missing_attribute_value_error(
-        attribute_name_string,
-        equals->location.start,
-        parser->current_token->location.start,
-        parser->allocator,
-        &errors,
-        &parser->options
-      );
-
-      AST_HTML_ATTRIBUTE_VALUE_NODE_T* empty_value = ast_html_attribute_value_node_init(
-        NULL,
-        hb_array_init(8, parser->allocator),
-        NULL,
-        false,
-        equals->location.end,
-        parser->current_token->location.start,
-        errors,
-        parser->allocator
-      );
-
-      return ast_html_attribute_node_init(
-        attribute_name,
-        equals,
-        empty_value,
-        attribute_name->base.location.start,
-        parser->current_token->location.start,
-        NULL,
-        parser->allocator
-      );
+    if (parser_attribute_value_is_missing(parser)) {
+      return parser_parse_html_attribute_missing_value(parser, attribute_name, equals);
     }
 
     AST_HTML_ATTRIBUTE_VALUE_NODE_T* attribute_value = parser_parse_html_attribute_value(parser);
@@ -1079,8 +1039,10 @@ static AST_HTML_OPEN_TAG_NODE_T* parser_parse_html_open_tag(parser_T* parser) {
 
   parser_consume_dot_notation_segments(parser, tag_name, &errors);
 
+  bool previous_was_quoted_value = false;
+
   while (token_is_none_of(parser, TOKEN_HTML_TAG_END, TOKEN_HTML_TAG_SELF_CLOSE, TOKEN_EOF)) {
-    if (token_is_any_of(parser, TOKEN_HTML_TAG_START, TOKEN_HTML_TAG_START_CLOSE)) {
+    if (parser_token_starts_tag(parser)) {
       append_unclosed_open_tag_error(
         tag_name,
         tag_name->location.start,
@@ -1104,40 +1066,18 @@ static AST_HTML_OPEN_TAG_NODE_T* parser_parse_html_open_tag(parser_T* parser) {
     }
 
     if (token_is_any_of(parser, TOKEN_WHITESPACE, TOKEN_NEWLINE)) {
+      previous_was_quoted_value = false;
       parser_handle_whitespace_in_open_tag(parser, children);
       continue;
     }
 
-    if (parser->current_token->type == TOKEN_IDENTIFIER) {
-      hb_array_append(children, parser_parse_html_attribute(parser));
-      continue;
-    }
-
-    if (parser->current_token->type == TOKEN_ERB_START) {
+    if (token_is(parser, TOKEN_ERB_START)) {
+      previous_was_quoted_value = false;
       parser_handle_erb_in_open_tag(parser, children);
       continue;
     }
 
-    if (parser->current_token->type == TOKEN_AT) {
-      hb_array_append(children, parser_parse_html_attribute(parser));
-      continue;
-    }
-
-    if (parser->current_token->type == TOKEN_COLON) {
-      lexer_T lexer_copy = *parser->lexer;
-      token_T* next_token = lexer_next_token(&lexer_copy);
-
-      if (next_token && next_token->type == TOKEN_IDENTIFIER) {
-        token_free(next_token, parser->allocator);
-        hb_array_append(children, parser_parse_html_attribute(parser));
-
-        continue;
-      }
-
-      token_free(next_token, parser->allocator);
-    }
-
-    if (parser->current_token->type == TOKEN_PERCENT) {
+    if (token_is(parser, TOKEN_PERCENT)) {
       lexer_T lexer_copy = *parser->lexer;
       token_T* peek_token = lexer_next_token(&lexer_copy);
 
@@ -1158,22 +1098,73 @@ static AST_HTML_OPEN_TAG_NODE_T* parser_parse_html_open_tag(parser_T* parser) {
         token_free(percent, parser->allocator);
         token_free(gt, parser->allocator);
 
+        previous_was_quoted_value = false;
         continue;
       }
 
       token_free(peek_token, parser->allocator);
     }
 
-    parser_append_unexpected_error(
-      parser,
-      &errors,
-      "Unexpected Token",
-      TOKEN_IDENTIFIER,
-      TOKEN_AT,
-      TOKEN_ERB_START,
-      TOKEN_WHITESPACE,
-      TOKEN_NEWLINE
-    );
+    // <div / class="a">
+    if (token_is(parser, TOKEN_SLASH)) {
+      token_T* solidus = parser_advance(parser);
+
+      append_unexpected_solidus_in_tag_error(
+        solidus,
+        solidus->location.start,
+        solidus->location.end,
+        parser->allocator,
+        &errors,
+        &parser->options
+      );
+
+      token_free(solidus, parser->allocator);
+      previous_was_quoted_value = false;
+      continue;
+    }
+
+    if (token_is(parser, TOKEN_ERROR)) {
+      parser_append_unexpected_error(
+        parser,
+        &errors,
+        "Unexpected Token",
+        TOKEN_IDENTIFIER,
+        TOKEN_AT,
+        TOKEN_ERB_START,
+        TOKEN_WHITESPACE,
+        TOKEN_NEWLINE
+      );
+      continue;
+    }
+
+    // <div class="a"id="b">
+    if (previous_was_quoted_value) {
+      append_missing_whitespace_between_attributes_error(
+        parser->current_token,
+        parser->current_token->location.start,
+        parser->current_token->location.end,
+        parser->allocator,
+        &errors,
+        &parser->options
+      );
+    }
+
+    // <div =foo>
+    if (token_is(parser, TOKEN_EQUALS)) {
+      append_unexpected_equals_sign_before_attribute_name_error(
+        parser->current_token,
+        parser->current_token->location.start,
+        parser->current_token->location.end,
+        parser->allocator,
+        &errors,
+        &parser->options
+      );
+    }
+
+    AST_HTML_ATTRIBUTE_NODE_T* attribute = parser_parse_html_attribute(parser);
+    hb_array_append(children, attribute);
+
+    previous_was_quoted_value = attribute->value != NULL && attribute->value->close_quote != NULL;
   }
 
   if (token_is(parser, TOKEN_EOF)) {

--- a/templates/src/errors.c.erb
+++ b/templates/src/errors.c.erb
@@ -144,7 +144,7 @@ static void error_free_<%= error.human %>(<%= error.struct_type %>* <%= error.hu
   <%- when Herb::Template::PositionField -%>
   // position_T is part of struct
   <%- when Herb::Template::StringField -%>
-  if (<%= error.human %>-><%= field.name %>.data != NULL) { hb_allocator_dealloc(allocator, <%= error.human %>-><%= field.name %>.data); }
+  if (!hb_string_is_empty(<%= error.human %>-><%= field.name %>)) { hb_allocator_dealloc(allocator, <%= error.human %>-><%= field.name %>.data); }
   <%- else -%>
   <%= field.inspect %>
   <%- end -%>

--- a/test/analyze/strict_locals_test.rb
+++ b/test/analyze/strict_locals_test.rb
@@ -385,5 +385,11 @@ module Analyze
         <%# locals: (greeting: "grüß", after: 1) %>
       HTML
     end
+
+    test "missing parentheses with nothing after the prefix and whitespace trimming" do
+      assert_parsed_snapshot(<<~HTML, strict_locals: true)
+        <%# locals: -%>
+      HTML
+    end
   end
 end

--- a/test/c/test_herb.c
+++ b/test/c/test_herb.c
@@ -1,14 +1,30 @@
 #include "include/test.h"
 #include "../../src/include/herb.h"
+#include "../../src/include/lib/hb_allocator.h"
 
 TEST(test_herb_version)
   ck_assert_str_eq(herb_version(), "0.10.3");
+END
+
+TEST(test_herb_frees_an_error_with_an_empty_string_field)
+  parser_options_T options = HERB_DEFAULT_PARSER_OPTIONS;
+  options.strict_locals = true;
+
+  hb_allocator_T allocator = hb_allocator_with_malloc();
+
+  AST_DOCUMENT_NODE_T* document = herb_parse("<%# locals: %>", &options, &allocator);
+
+  ck_assert_ptr_nonnull(document);
+
+  ast_node_free((AST_NODE_T*) document, &allocator);
+  hb_allocator_destroy(&allocator);
 END
 
 TCase *herb_tests(void) {
   TCase *herb = tcase_create("Herb");
 
   tcase_add_test(herb, test_herb_version);
+  tcase_add_test(herb, test_herb_frees_an_error_with_an_empty_string_field);
 
   return herb;
 }

--- a/test/parser/attributes_test.rb
+++ b/test/parser/attributes_test.rb
@@ -589,5 +589,93 @@ module Parser
     test "attribute value with ERB between angle brackets" do
       assert_parsed_snapshot(%(<div data-html="<<%= tag %>>"></div>))
     end
+
+    test "stray character after quoted double quote value" do
+      assert_parsed_snapshot(%[<div onclick="true")></div>])
+    end
+
+    test "stray character after quoted single quote value" do
+      assert_parsed_snapshot(%[<div onclick='true')></div>])
+    end
+
+    test "stray identifier after quoted value" do
+      assert_parsed_snapshot(%(<div title="foo"bar></div>))
+    end
+
+    test "stray character after quoted value followed by another attribute" do
+      assert_parsed_snapshot(%[<div onclick="true") class="box"></div>])
+    end
+
+    test "comma between quoted attributes" do
+      assert_parsed_snapshot(%(<div class="a", id="b"></div>))
+    end
+
+    test "mustache braces in attribute position" do
+      assert_parsed_snapshot(%(<div {{element_hidden}}></div>))
+    end
+
+    test "mustache braces around an attribute with a value" do
+      assert_parsed_snapshot(%(<div {{attr="x"}}></div>))
+    end
+
+    test "attribute with equals followed by a stray character" do
+      assert_parsed_snapshot(%[<div class=)></div>])
+    end
+
+    test "attribute with spaced equals followed by a stray character" do
+      assert_parsed_snapshot(%[<div class = )></div>])
+    end
+
+    test "attribute with equals followed by another attribute" do
+      assert_parsed_snapshot(%(<div class=@click="go"></div>))
+    end
+
+    test "unquoted attribute value with a dot" do
+      assert_parsed_snapshot(%(<img src=image.jpg>))
+    end
+
+    test "unquoted attribute value with slashes" do
+      assert_parsed_snapshot(%(<a href=/foo/bar></a>))
+    end
+
+    test "unquoted attribute value followed by ERB" do
+      assert_parsed_snapshot(%(<div class=foo<%= bar %>></div>))
+    end
+
+    test "unquoted attribute value with two ERB tags" do
+      assert_parsed_snapshot(%(<div class=<%= a %><%= b %>></div>))
+    end
+
+    test "unquoted attribute value with a quote" do
+      assert_parsed_snapshot(%(<div class=a"b></div>))
+    end
+
+    test "unquoted attribute value with an equals sign" do
+      assert_parsed_snapshot(%(<div a==b></div>))
+    end
+
+    test "quote inside quoted value splits the attribute" do
+      assert_parsed_snapshot(%(<div title="It"s fine"></div>))
+    end
+
+    test "equals sign before attribute name" do
+      assert_parsed_snapshot(%(<div =foo></div>))
+    end
+
+    test "quoted token in attribute name position" do
+      assert_parsed_snapshot(%(<div "quoted"></div>))
+    end
+
+    test "stray solidus in tag" do
+      assert_parsed_snapshot(%(<div / class="a"></div>))
+    end
+
+    test "solidus ends attribute name" do
+      assert_parsed_snapshot(%(<div a/b></div>))
+    end
+
+    test "brackets and parentheses in attribute names" do
+      assert_parsed_snapshot(%(<div {{x}} [y] (z)></div>))
+    end
   end
 end

--- a/test/parser/comments_test.rb
+++ b/test/parser/comments_test.rb
@@ -54,5 +54,13 @@ module Parser
     test "unclosed HTML comment with ERB inside" do
       assert_parsed_snapshot(%(<!-- <% presenter = featured.presenter %>\n<div data-id="<%= presenter.id %>"></div>))
     end
+
+    test "nested HTML comment opener" do
+      assert_parsed_snapshot(%(<!-- a <!-- b --> c -->))
+    end
+
+    test "nested HTML comment opener in an unclosed comment" do
+      assert_parsed_snapshot(%(<!-- outer <!-- inner))
+    end
   end
 end

--- a/test/parser/comments_test.rb
+++ b/test/parser/comments_test.rb
@@ -46,5 +46,13 @@ module Parser
     test "HTML comment with invalid closing tag --!> followed by html tag" do
       assert_parsed_snapshot(%(<!--Hello World--!><h1>Hello</h1>))
     end
+
+    test "unclosed HTML comment" do
+      assert_parsed_snapshot(%(<!-- never closed\n<div></div>))
+    end
+
+    test "unclosed HTML comment with ERB inside" do
+      assert_parsed_snapshot(%(<!-- <% presenter = featured.presenter %>\n<div data-id="<%= presenter.id %>"></div>))
+    end
   end
 end

--- a/test/parser/comments_test.rb
+++ b/test/parser/comments_test.rb
@@ -62,5 +62,13 @@ module Parser
     test "nested HTML comment opener in an unclosed comment" do
       assert_parsed_snapshot(%(<!-- outer <!-- inner))
     end
+
+    test "conditional comment closed by an abrupt opener" do
+      assert_parsed_snapshot(%(<!--[if !mso]><!--><meta http-equiv="X-UA-Compatible" content="IE=edge"><!--<![endif]-->))
+    end
+
+    test "nested HTML comment opener at end of file" do
+      assert_parsed_snapshot(%(<!-- a <!--))
+    end
   end
 end

--- a/test/parser/tags_test.rb
+++ b/test/parser/tags_test.rb
@@ -354,5 +354,13 @@ module Parser
     test "dot-notation component tag with three segments and lowercase middle" do
       assert_parsed_snapshot("<Namespace.dialog.Button></Namespace.dialog.Button>", dot_notation_tags: true)
     end
+
+    test "closing tag with trailing solidus" do
+      assert_parsed_snapshot("<div></div/>")
+    end
+
+    test "void element closing tag with trailing solidus" do
+      assert_parsed_snapshot("<p><br/></br/></p>")
+    end
   end
 end

--- a/test/snapshots/analyze/action_view/java_script_helper/java_script_tag_test/test_0007_javascript_tag_with_URL_in_comment_using_non-output_tag_(gh-991)_ffcbd0a310aada3e3db5700317bcb79a-ef4af315cb33925c38d24ea3c2e8a1cd.txt
+++ b/test/snapshots/analyze/action_view/java_script_helper/java_script_tag_test/test_0007_javascript_tag_with_URL_in_comment_using_non-output_tag_(gh-991)_ffcbd0a310aada3e3db5700317bcb79a-ef4af315cb33925c38d24ea3c2e8a1cd.txt
@@ -18,17 +18,13 @@ options: {action_view_helpers: true}
     │   │   │
     │   │   ├── @ HTMLOpenTagNode (location: (2:5)-(2:25))
     │   │   │   ├── errors: (2 errors)
-    │   │   │   │   ├── @ UnexpectedError (location: (2:11)-(2:12))
-    │   │   │   │   │   ├── message: "Unexpected Token. Expected: an identifier, `@`, `<%`, whitespace, or a newline, found: `/`."
-    │   │   │   │   │   ├── description: "Unexpected Token"
-    │   │   │   │   │   ├── expected: "an identifier, `@`, `<%`, whitespace, or a newline"
-    │   │   │   │   │   └── found: "`/`"
+    │   │   │   │   ├── @ UnexpectedSolidusInTagError (location: (2:11)-(2:12))
+    │   │   │   │   │   ├── message: "Unexpected `/` in tag at (2:11)."
+    │   │   │   │   │   └── solidus: "/" (location: (2:11)-(2:12))
     │   │   │   │   │
-    │   │   │   │   └── @ UnexpectedError (location: (2:12)-(2:13))
-    │   │   │   │       ├── message: "Unexpected Token. Expected: an identifier, `@`, `<%`, whitespace, or a newline, found: `/`."
-    │   │   │   │       ├── description: "Unexpected Token"
-    │   │   │   │       ├── expected: "an identifier, `@`, `<%`, whitespace, or a newline"
-    │   │   │   │       └── found: "`/`"
+    │   │   │   │   └── @ UnexpectedSolidusInTagError (location: (2:12)-(2:13))
+    │   │   │   │       ├── message: "Unexpected `/` in tag at (2:12)."
+    │   │   │   │       └── solidus: "/" (location: (2:12)-(2:13))
     │   │   │   │
     │   │   │   ├── tag_opening: "<" (location: (2:5)-(2:6))
     │   │   │   ├── tag_name: "http:" (location: (2:6)-(2:11))

--- a/test/snapshots/analyze/action_view/java_script_helper/java_script_tag_test/test_0009_javascript_tag_with_HTML-like_content_in_block_(gh-1426)_0cf334dcc33fbec3a50e20bce62ae526.txt
+++ b/test/snapshots/analyze/action_view/java_script_helper/java_script_tag_test/test_0009_javascript_tag_with_HTML-like_content_in_block_(gh-1426)_0cf334dcc33fbec3a50e20bce62ae526.txt
@@ -21,13 +21,7 @@ input: |2-
         │   │   └── content: "\n  n "
         │   │
         │   └── @ HTMLOpenTagNode (location: (2:4)-(4:0))
-        │       ├── errors: (2 errors)
-        │       │   ├── @ UnexpectedError (location: (2:6)-(2:7))
-        │       │   │   ├── message: "Unexpected Token. Expected: an identifier, `@`, `<%`, whitespace, or a newline, found: a character."
-        │       │   │   ├── description: "Unexpected Token"
-        │       │   │   ├── expected: "an identifier, `@`, `<%`, whitespace, or a newline"
-        │       │   │   └── found: "a character"
-        │       │   │
+        │       ├── errors: (1 error)
         │       │   └── @ UnclosedOpenTagError (location: (2:5)-(4:0))
         │       │       ├── message: "Opening tag `<o>` at (2:5) is missing closing `>`."
         │       │       └── tag_name: "o" (location: (2:5)-(2:6))
@@ -36,12 +30,12 @@ input: |2-
         │       ├── tag_name: "o" (location: (2:5)-(2:6))
         │       ├── tag_closing: ∅
         │       ├── children: (2 items)
-        │       │   ├── @ HTMLAttributeNode (location: (2:7)-(2:13))
+        │       │   ├── @ HTMLAttributeNode (location: (2:6)-(2:13))
         │       │   │   ├── name:
-        │       │   │   │   └── @ HTMLAttributeNameNode (location: (2:7)-(2:13))
+        │       │   │   │   └── @ HTMLAttributeNameNode (location: (2:6)-(2:13))
         │       │   │   │       └── children: (1 item)
-        │       │   │   │           └── @ LiteralNode (location: (2:7)-(2:13))
-        │       │   │   │               └── content: "length"
+        │       │   │   │           └── @ LiteralNode (location: (2:6)-(2:13))
+        │       │   │   │               └── content: ".length"
         │       │   │   │
         │       │   │   │
         │       │   │   ├── equals: ∅

--- a/test/snapshots/analyze/action_view/java_script_helper/java_script_tag_test/test_0013_javascript_tag_with_less-than_in_for_loop_condition_(gh-1426)_8f08ad531748d59d9f663e1cec7134e6.txt
+++ b/test/snapshots/analyze/action_view/java_script_helper/java_script_tag_test/test_0013_javascript_tag_with_less-than_in_for_loop_condition_(gh-1426)_8f08ad531748d59d9f663e1cec7134e6.txt
@@ -21,25 +21,7 @@ input: |2-
         │   │   └── content: "\n  for (let i = 0; i"
         │   │
         │   └── @ HTMLOpenTagNode (location: (2:19)-(4:0))
-        │       ├── errors: (4 errors)
-        │       │   ├── @ UnexpectedError (location: (2:25)-(2:26))
-        │       │   │   ├── message: "Unexpected Token. Expected: an identifier, `@`, `<%`, whitespace, or a newline, found: a character."
-        │       │   │   ├── description: "Unexpected Token"
-        │       │   │   ├── expected: "an identifier, `@`, `<%`, whitespace, or a newline"
-        │       │   │   └── found: "a character"
-        │       │   │
-        │       │   ├── @ UnexpectedError (location: (2:39)-(2:40))
-        │       │   │   ├── message: "Unexpected Token. Expected: an identifier, `@`, `<%`, whitespace, or a newline, found: a character."
-        │       │   │   ├── description: "Unexpected Token"
-        │       │   │   ├── expected: "an identifier, `@`, `<%`, whitespace, or a newline"
-        │       │   │   └── found: "a character"
-        │       │   │
-        │       │   ├── @ UnexpectedError (location: (2:63)-(2:64))
-        │       │   │   ├── message: "Unexpected Token. Expected: an identifier, `@`, `<%`, whitespace, or a newline, found: a character."
-        │       │   │   ├── description: "Unexpected Token"
-        │       │   │   ├── expected: "an identifier, `@`, `<%`, whitespace, or a newline"
-        │       │   │   └── found: "a character"
-        │       │   │
+        │       ├── errors: (1 error)
         │       │   └── @ UnclosedOpenTagError (location: (2:20)-(4:0))
         │       │       ├── message: "Opening tag `<items>` at (2:20) is missing closing `>`."
         │       │       └── tag_name: "items" (location: (2:20)-(2:25))
@@ -47,13 +29,13 @@ input: |2-
         │       ├── tag_opening: "<" (location: (2:19)-(2:20))
         │       ├── tag_name: "items" (location: (2:20)-(2:25))
         │       ├── tag_closing: ∅
-        │       ├── children: (4 items)
-        │       │   ├── @ HTMLAttributeNode (location: (2:26)-(2:33))
+        │       ├── children: (6 items)
+        │       │   ├── @ HTMLAttributeNode (location: (2:25)-(2:33))
         │       │   │   ├── name:
-        │       │   │   │   └── @ HTMLAttributeNameNode (location: (2:26)-(2:33))
+        │       │   │   │   └── @ HTMLAttributeNameNode (location: (2:25)-(2:33))
         │       │   │   │       └── children: (1 item)
-        │       │   │   │           └── @ LiteralNode (location: (2:26)-(2:33))
-        │       │   │   │               └── content: "length;"
+        │       │   │   │           └── @ LiteralNode (location: (2:25)-(2:33))
+        │       │   │   │               └── content: ".length;"
         │       │   │   │
         │       │   │   │
         │       │   │   ├── equals: ∅
@@ -70,12 +52,34 @@ input: |2-
         │       │   │   ├── equals: ∅
         │       │   │   └── value: ∅
         │       │   │
+        │       │   ├── @ HTMLAttributeNode (location: (2:39)-(2:40))
+        │       │   │   ├── name:
+        │       │   │   │   └── @ HTMLAttributeNameNode (location: (2:39)-(2:40))
+        │       │   │   │       └── children: (1 item)
+        │       │   │   │           └── @ LiteralNode (location: (2:39)-(2:40))
+        │       │   │   │               └── content: "{"
+        │       │   │   │
+        │       │   │   │
+        │       │   │   ├── equals: ∅
+        │       │   │   └── value: ∅
+        │       │   │
         │       │   ├── @ HTMLAttributeNode (location: (2:41)-(2:62))
         │       │   │   ├── name:
         │       │   │   │   └── @ HTMLAttributeNameNode (location: (2:41)-(2:62))
         │       │   │   │       └── children: (1 item)
         │       │   │   │           └── @ LiteralNode (location: (2:41)-(2:62))
         │       │   │   │               └── content: "console.log(items[i])"
+        │       │   │   │
+        │       │   │   │
+        │       │   │   ├── equals: ∅
+        │       │   │   └── value: ∅
+        │       │   │
+        │       │   ├── @ HTMLAttributeNode (location: (2:63)-(2:64))
+        │       │   │   ├── name:
+        │       │   │   │   └── @ HTMLAttributeNameNode (location: (2:63)-(2:64))
+        │       │   │   │       └── children: (1 item)
+        │       │   │   │           └── @ LiteralNode (location: (2:63)-(2:64))
+        │       │   │   │               └── content: "}"
         │       │   │   │
         │       │   │   │
         │       │   │   ├── equals: ∅

--- a/test/snapshots/analyze/action_view/java_script_helper/java_script_tag_test/test_0014_javascript_tag_with_less-than_in_arrow_function_(gh-1426)_5f1f670ffeb7a1b21251107fba17bc48.txt
+++ b/test/snapshots/analyze/action_view/java_script_helper/java_script_tag_test/test_0014_javascript_tag_with_less-than_in_arrow_function_(gh-1426)_5f1f670ffeb7a1b21251107fba17bc48.txt
@@ -21,13 +21,7 @@ input: |2-
         │   │   └── content: "\n  const filtered = items.filter(x => x"
         │   │
         │   └── @ HTMLOpenTagNode (location: (2:38)-(4:0))
-        │       ├── errors: (2 errors)
-        │       │   ├── @ UnexpectedError (location: (2:48)-(2:49))
-        │       │   │   ├── message: "Unexpected Token. Expected: an identifier, `@`, `<%`, whitespace, or a newline, found: a character."
-        │       │   │   ├── description: "Unexpected Token"
-        │       │   │   ├── expected: "an identifier, `@`, `<%`, whitespace, or a newline"
-        │       │   │   └── found: "a character"
-        │       │   │
+        │       ├── errors: (1 error)
         │       │   └── @ UnclosedOpenTagError (location: (2:39)-(4:0))
         │       │       ├── message: "Opening tag `<threshold>` at (2:39) is missing closing `>`."
         │       │       └── tag_name: "threshold" (location: (2:39)-(2:48))
@@ -35,7 +29,18 @@ input: |2-
         │       ├── tag_opening: "<" (location: (2:38)-(2:39))
         │       ├── tag_name: "threshold" (location: (2:39)-(2:48))
         │       ├── tag_closing: ∅
-        │       ├── children: (1 item)
+        │       ├── children: (2 items)
+        │       │   ├── @ HTMLAttributeNode (location: (2:48)-(2:49))
+        │       │   │   ├── name:
+        │       │   │   │   └── @ HTMLAttributeNameNode (location: (2:48)-(2:49))
+        │       │   │   │       └── children: (1 item)
+        │       │   │   │           └── @ LiteralNode (location: (2:48)-(2:49))
+        │       │   │   │               └── content: ")"
+        │       │   │   │
+        │       │   │   │
+        │       │   │   ├── equals: ∅
+        │       │   │   └── value: ∅
+        │       │   │
         │       │   └── @ ERBContentNode (location: (3:0)-(3:9))
         │       │       ├── errors: (1 error)
         │       │       │   └── @ ERBControlFlowScopeError (location: (3:0)-(3:9))

--- a/test/snapshots/analyze/action_view/java_script_helper/java_script_tag_test/test_0015_javascript_tag_with_less-than_and_nested_ERB_control_flow_(gh-1426)_00d223eab531334742567daecbec46bf.txt
+++ b/test/snapshots/analyze/action_view/java_script_helper/java_script_tag_test/test_0015_javascript_tag_with_less-than_and_nested_ERB_control_flow_(gh-1426)_00d223eab531334742567daecbec46bf.txt
@@ -25,25 +25,7 @@ input: |2-
         │   │   └── content: "\n  if (n"
         │   │
         │   └── @ HTMLOpenTagNode (location: (2:7)-(8:0))
-        │       ├── errors: (4 errors)
-        │       │   ├── @ UnexpectedError (location: (2:9)-(2:10))
-        │       │   │   ├── message: "Unexpected Token. Expected: an identifier, `@`, `<%`, whitespace, or a newline, found: a character."
-        │       │   │   ├── description: "Unexpected Token"
-        │       │   │   ├── expected: "an identifier, `@`, `<%`, whitespace, or a newline"
-        │       │   │   └── found: "a character"
-        │       │   │
-        │       │   ├── @ UnexpectedError (location: (2:18)-(2:19))
-        │       │   │   ├── message: "Unexpected Token. Expected: an identifier, `@`, `<%`, whitespace, or a newline, found: a character."
-        │       │   │   ├── description: "Unexpected Token"
-        │       │   │   ├── expected: "an identifier, `@`, `<%`, whitespace, or a newline"
-        │       │   │   └── found: "a character"
-        │       │   │
-        │       │   ├── @ UnexpectedError (location: (6:2)-(6:3))
-        │       │   │   ├── message: "Unexpected Token. Expected: an identifier, `@`, `<%`, whitespace, or a newline, found: a character."
-        │       │   │   ├── description: "Unexpected Token"
-        │       │   │   ├── expected: "an identifier, `@`, `<%`, whitespace, or a newline"
-        │       │   │   └── found: "a character"
-        │       │   │
+        │       ├── errors: (1 error)
         │       │   └── @ UnclosedOpenTagError (location: (2:8)-(8:0))
         │       │       ├── message: "Opening tag `<o>` at (2:8) is missing closing `>`."
         │       │       └── tag_name: "o" (location: (2:8)-(2:9))
@@ -51,13 +33,24 @@ input: |2-
         │       ├── tag_opening: "<" (location: (2:7)-(2:8))
         │       ├── tag_name: "o" (location: (2:8)-(2:9))
         │       ├── tag_closing: ∅
-        │       ├── children: (3 items)
-        │       │   ├── @ HTMLAttributeNode (location: (2:10)-(2:17))
+        │       ├── children: (5 items)
+        │       │   ├── @ HTMLAttributeNode (location: (2:9)-(2:17))
         │       │   │   ├── name:
-        │       │   │   │   └── @ HTMLAttributeNameNode (location: (2:10)-(2:17))
+        │       │   │   │   └── @ HTMLAttributeNameNode (location: (2:9)-(2:17))
         │       │   │   │       └── children: (1 item)
-        │       │   │   │           └── @ LiteralNode (location: (2:10)-(2:17))
-        │       │   │   │               └── content: "length)"
+        │       │   │   │           └── @ LiteralNode (location: (2:9)-(2:17))
+        │       │   │   │               └── content: ".length)"
+        │       │   │   │
+        │       │   │   │
+        │       │   │   ├── equals: ∅
+        │       │   │   └── value: ∅
+        │       │   │
+        │       │   ├── @ HTMLAttributeNode (location: (2:18)-(2:19))
+        │       │   │   ├── name:
+        │       │   │   │   └── @ HTMLAttributeNameNode (location: (2:18)-(2:19))
+        │       │   │   │       └── children: (1 item)
+        │       │   │   │           └── @ LiteralNode (location: (2:18)-(2:19))
+        │       │   │   │               └── content: "{"
         │       │   │   │
         │       │   │   │
         │       │   │   ├── equals: ∅
@@ -87,6 +80,17 @@ input: |2-
         │       │   │           ├── content: " end " (location: (5:6)-(5:11))
         │       │   │           └── tag_closing: "%>" (location: (5:11)-(5:13))
         │       │   │
+        │       │   │
+        │       │   ├── @ HTMLAttributeNode (location: (6:2)-(6:3))
+        │       │   │   ├── name:
+        │       │   │   │   └── @ HTMLAttributeNameNode (location: (6:2)-(6:3))
+        │       │   │   │       └── children: (1 item)
+        │       │   │   │           └── @ LiteralNode (location: (6:2)-(6:3))
+        │       │   │   │               └── content: "}"
+        │       │   │   │
+        │       │   │   │
+        │       │   │   ├── equals: ∅
+        │       │   │   └── value: ∅
         │       │   │
         │       │   └── @ ERBContentNode (location: (7:0)-(7:9))
         │       │       ├── errors: (1 error)

--- a/test/snapshots/analyze/action_view/tag_helper/content_tag_test/test_0033_content_tag_script_with_HTML-like_content_in_block_(gh-1426)_d51af3d6d26fb19f2ba4800c56b12fc4.txt
+++ b/test/snapshots/analyze/action_view/tag_helper/content_tag_test/test_0033_content_tag_script_with_HTML-like_content_in_block_(gh-1426)_d51af3d6d26fb19f2ba4800c56b12fc4.txt
@@ -21,13 +21,7 @@ input: |2-
         │   │   └── content: "\n  n "
         │   │
         │   └── @ HTMLOpenTagNode (location: (2:4)-(4:0))
-        │       ├── errors: (2 errors)
-        │       │   ├── @ UnexpectedError (location: (2:6)-(2:7))
-        │       │   │   ├── message: "Unexpected Token. Expected: an identifier, `@`, `<%`, whitespace, or a newline, found: a character."
-        │       │   │   ├── description: "Unexpected Token"
-        │       │   │   ├── expected: "an identifier, `@`, `<%`, whitespace, or a newline"
-        │       │   │   └── found: "a character"
-        │       │   │
+        │       ├── errors: (1 error)
         │       │   └── @ UnclosedOpenTagError (location: (2:5)-(4:0))
         │       │       ├── message: "Opening tag `<o>` at (2:5) is missing closing `>`."
         │       │       └── tag_name: "o" (location: (2:5)-(2:6))
@@ -36,12 +30,12 @@ input: |2-
         │       ├── tag_name: "o" (location: (2:5)-(2:6))
         │       ├── tag_closing: ∅
         │       ├── children: (2 items)
-        │       │   ├── @ HTMLAttributeNode (location: (2:7)-(2:13))
+        │       │   ├── @ HTMLAttributeNode (location: (2:6)-(2:13))
         │       │   │   ├── name:
-        │       │   │   │   └── @ HTMLAttributeNameNode (location: (2:7)-(2:13))
+        │       │   │   │   └── @ HTMLAttributeNameNode (location: (2:6)-(2:13))
         │       │   │   │       └── children: (1 item)
-        │       │   │   │           └── @ LiteralNode (location: (2:7)-(2:13))
-        │       │   │   │               └── content: "length"
+        │       │   │   │           └── @ LiteralNode (location: (2:6)-(2:13))
+        │       │   │   │               └── content: ".length"
         │       │   │   │
         │       │   │   │
         │       │   │   ├── equals: ∅

--- a/test/snapshots/analyze/action_view/tag_helper/content_tag_test/test_0034_content_tag_script_with_less-than_in_for_loop_condition_(gh-1426)_174a15bd22aa2f6c6ec8ecf27252ea4d.txt
+++ b/test/snapshots/analyze/action_view/tag_helper/content_tag_test/test_0034_content_tag_script_with_less-than_in_for_loop_condition_(gh-1426)_174a15bd22aa2f6c6ec8ecf27252ea4d.txt
@@ -21,25 +21,7 @@ input: |2-
         │   │   └── content: "\n  for (let i = 0; i"
         │   │
         │   └── @ HTMLOpenTagNode (location: (2:19)-(4:0))
-        │       ├── errors: (4 errors)
-        │       │   ├── @ UnexpectedError (location: (2:25)-(2:26))
-        │       │   │   ├── message: "Unexpected Token. Expected: an identifier, `@`, `<%`, whitespace, or a newline, found: a character."
-        │       │   │   ├── description: "Unexpected Token"
-        │       │   │   ├── expected: "an identifier, `@`, `<%`, whitespace, or a newline"
-        │       │   │   └── found: "a character"
-        │       │   │
-        │       │   ├── @ UnexpectedError (location: (2:39)-(2:40))
-        │       │   │   ├── message: "Unexpected Token. Expected: an identifier, `@`, `<%`, whitespace, or a newline, found: a character."
-        │       │   │   ├── description: "Unexpected Token"
-        │       │   │   ├── expected: "an identifier, `@`, `<%`, whitespace, or a newline"
-        │       │   │   └── found: "a character"
-        │       │   │
-        │       │   ├── @ UnexpectedError (location: (2:63)-(2:64))
-        │       │   │   ├── message: "Unexpected Token. Expected: an identifier, `@`, `<%`, whitespace, or a newline, found: a character."
-        │       │   │   ├── description: "Unexpected Token"
-        │       │   │   ├── expected: "an identifier, `@`, `<%`, whitespace, or a newline"
-        │       │   │   └── found: "a character"
-        │       │   │
+        │       ├── errors: (1 error)
         │       │   └── @ UnclosedOpenTagError (location: (2:20)-(4:0))
         │       │       ├── message: "Opening tag `<items>` at (2:20) is missing closing `>`."
         │       │       └── tag_name: "items" (location: (2:20)-(2:25))
@@ -47,13 +29,13 @@ input: |2-
         │       ├── tag_opening: "<" (location: (2:19)-(2:20))
         │       ├── tag_name: "items" (location: (2:20)-(2:25))
         │       ├── tag_closing: ∅
-        │       ├── children: (4 items)
-        │       │   ├── @ HTMLAttributeNode (location: (2:26)-(2:33))
+        │       ├── children: (6 items)
+        │       │   ├── @ HTMLAttributeNode (location: (2:25)-(2:33))
         │       │   │   ├── name:
-        │       │   │   │   └── @ HTMLAttributeNameNode (location: (2:26)-(2:33))
+        │       │   │   │   └── @ HTMLAttributeNameNode (location: (2:25)-(2:33))
         │       │   │   │       └── children: (1 item)
-        │       │   │   │           └── @ LiteralNode (location: (2:26)-(2:33))
-        │       │   │   │               └── content: "length;"
+        │       │   │   │           └── @ LiteralNode (location: (2:25)-(2:33))
+        │       │   │   │               └── content: ".length;"
         │       │   │   │
         │       │   │   │
         │       │   │   ├── equals: ∅
@@ -70,12 +52,34 @@ input: |2-
         │       │   │   ├── equals: ∅
         │       │   │   └── value: ∅
         │       │   │
+        │       │   ├── @ HTMLAttributeNode (location: (2:39)-(2:40))
+        │       │   │   ├── name:
+        │       │   │   │   └── @ HTMLAttributeNameNode (location: (2:39)-(2:40))
+        │       │   │   │       └── children: (1 item)
+        │       │   │   │           └── @ LiteralNode (location: (2:39)-(2:40))
+        │       │   │   │               └── content: "{"
+        │       │   │   │
+        │       │   │   │
+        │       │   │   ├── equals: ∅
+        │       │   │   └── value: ∅
+        │       │   │
         │       │   ├── @ HTMLAttributeNode (location: (2:41)-(2:62))
         │       │   │   ├── name:
         │       │   │   │   └── @ HTMLAttributeNameNode (location: (2:41)-(2:62))
         │       │   │   │       └── children: (1 item)
         │       │   │   │           └── @ LiteralNode (location: (2:41)-(2:62))
         │       │   │   │               └── content: "console.log(items[i])"
+        │       │   │   │
+        │       │   │   │
+        │       │   │   ├── equals: ∅
+        │       │   │   └── value: ∅
+        │       │   │
+        │       │   ├── @ HTMLAttributeNode (location: (2:63)-(2:64))
+        │       │   │   ├── name:
+        │       │   │   │   └── @ HTMLAttributeNameNode (location: (2:63)-(2:64))
+        │       │   │   │       └── children: (1 item)
+        │       │   │   │           └── @ LiteralNode (location: (2:63)-(2:64))
+        │       │   │   │               └── content: "}"
         │       │   │   │
         │       │   │   │
         │       │   │   ├── equals: ∅

--- a/test/snapshots/analyze/action_view/tag_helper/tag_test/test_0036_tag.script_with_HTML-like_content_in_block_(gh-1426)_8afd8ec54729e073f5d0f71081559ff1.txt
+++ b/test/snapshots/analyze/action_view/tag_helper/tag_test/test_0036_tag.script_with_HTML-like_content_in_block_(gh-1426)_8afd8ec54729e073f5d0f71081559ff1.txt
@@ -21,13 +21,7 @@ input: |2-
         │   │   └── content: "\n  n "
         │   │
         │   └── @ HTMLOpenTagNode (location: (2:4)-(4:0))
-        │       ├── errors: (2 errors)
-        │       │   ├── @ UnexpectedError (location: (2:6)-(2:7))
-        │       │   │   ├── message: "Unexpected Token. Expected: an identifier, `@`, `<%`, whitespace, or a newline, found: a character."
-        │       │   │   ├── description: "Unexpected Token"
-        │       │   │   ├── expected: "an identifier, `@`, `<%`, whitespace, or a newline"
-        │       │   │   └── found: "a character"
-        │       │   │
+        │       ├── errors: (1 error)
         │       │   └── @ UnclosedOpenTagError (location: (2:5)-(4:0))
         │       │       ├── message: "Opening tag `<o>` at (2:5) is missing closing `>`."
         │       │       └── tag_name: "o" (location: (2:5)-(2:6))
@@ -36,12 +30,12 @@ input: |2-
         │       ├── tag_name: "o" (location: (2:5)-(2:6))
         │       ├── tag_closing: ∅
         │       ├── children: (2 items)
-        │       │   ├── @ HTMLAttributeNode (location: (2:7)-(2:13))
+        │       │   ├── @ HTMLAttributeNode (location: (2:6)-(2:13))
         │       │   │   ├── name:
-        │       │   │   │   └── @ HTMLAttributeNameNode (location: (2:7)-(2:13))
+        │       │   │   │   └── @ HTMLAttributeNameNode (location: (2:6)-(2:13))
         │       │   │   │       └── children: (1 item)
-        │       │   │   │           └── @ LiteralNode (location: (2:7)-(2:13))
-        │       │   │   │               └── content: "length"
+        │       │   │   │           └── @ LiteralNode (location: (2:6)-(2:13))
+        │       │   │   │               └── content: ".length"
         │       │   │   │
         │       │   │   │
         │       │   │   ├── equals: ∅

--- a/test/snapshots/analyze/action_view/tag_helper/tag_test/test_0037_tag.script_with_less-than_in_for_loop_condition_(gh-1426)_f58e9e191d999e4fae8f60dba09f8295.txt
+++ b/test/snapshots/analyze/action_view/tag_helper/tag_test/test_0037_tag.script_with_less-than_in_for_loop_condition_(gh-1426)_f58e9e191d999e4fae8f60dba09f8295.txt
@@ -21,25 +21,7 @@ input: |2-
         │   │   └── content: "\n  for (let i = 0; i"
         │   │
         │   └── @ HTMLOpenTagNode (location: (2:19)-(4:0))
-        │       ├── errors: (4 errors)
-        │       │   ├── @ UnexpectedError (location: (2:25)-(2:26))
-        │       │   │   ├── message: "Unexpected Token. Expected: an identifier, `@`, `<%`, whitespace, or a newline, found: a character."
-        │       │   │   ├── description: "Unexpected Token"
-        │       │   │   ├── expected: "an identifier, `@`, `<%`, whitespace, or a newline"
-        │       │   │   └── found: "a character"
-        │       │   │
-        │       │   ├── @ UnexpectedError (location: (2:39)-(2:40))
-        │       │   │   ├── message: "Unexpected Token. Expected: an identifier, `@`, `<%`, whitespace, or a newline, found: a character."
-        │       │   │   ├── description: "Unexpected Token"
-        │       │   │   ├── expected: "an identifier, `@`, `<%`, whitespace, or a newline"
-        │       │   │   └── found: "a character"
-        │       │   │
-        │       │   ├── @ UnexpectedError (location: (2:63)-(2:64))
-        │       │   │   ├── message: "Unexpected Token. Expected: an identifier, `@`, `<%`, whitespace, or a newline, found: a character."
-        │       │   │   ├── description: "Unexpected Token"
-        │       │   │   ├── expected: "an identifier, `@`, `<%`, whitespace, or a newline"
-        │       │   │   └── found: "a character"
-        │       │   │
+        │       ├── errors: (1 error)
         │       │   └── @ UnclosedOpenTagError (location: (2:20)-(4:0))
         │       │       ├── message: "Opening tag `<items>` at (2:20) is missing closing `>`."
         │       │       └── tag_name: "items" (location: (2:20)-(2:25))
@@ -47,13 +29,13 @@ input: |2-
         │       ├── tag_opening: "<" (location: (2:19)-(2:20))
         │       ├── tag_name: "items" (location: (2:20)-(2:25))
         │       ├── tag_closing: ∅
-        │       ├── children: (4 items)
-        │       │   ├── @ HTMLAttributeNode (location: (2:26)-(2:33))
+        │       ├── children: (6 items)
+        │       │   ├── @ HTMLAttributeNode (location: (2:25)-(2:33))
         │       │   │   ├── name:
-        │       │   │   │   └── @ HTMLAttributeNameNode (location: (2:26)-(2:33))
+        │       │   │   │   └── @ HTMLAttributeNameNode (location: (2:25)-(2:33))
         │       │   │   │       └── children: (1 item)
-        │       │   │   │           └── @ LiteralNode (location: (2:26)-(2:33))
-        │       │   │   │               └── content: "length;"
+        │       │   │   │           └── @ LiteralNode (location: (2:25)-(2:33))
+        │       │   │   │               └── content: ".length;"
         │       │   │   │
         │       │   │   │
         │       │   │   ├── equals: ∅
@@ -70,12 +52,34 @@ input: |2-
         │       │   │   ├── equals: ∅
         │       │   │   └── value: ∅
         │       │   │
+        │       │   ├── @ HTMLAttributeNode (location: (2:39)-(2:40))
+        │       │   │   ├── name:
+        │       │   │   │   └── @ HTMLAttributeNameNode (location: (2:39)-(2:40))
+        │       │   │   │       └── children: (1 item)
+        │       │   │   │           └── @ LiteralNode (location: (2:39)-(2:40))
+        │       │   │   │               └── content: "{"
+        │       │   │   │
+        │       │   │   │
+        │       │   │   ├── equals: ∅
+        │       │   │   └── value: ∅
+        │       │   │
         │       │   ├── @ HTMLAttributeNode (location: (2:41)-(2:62))
         │       │   │   ├── name:
         │       │   │   │   └── @ HTMLAttributeNameNode (location: (2:41)-(2:62))
         │       │   │   │       └── children: (1 item)
         │       │   │   │           └── @ LiteralNode (location: (2:41)-(2:62))
         │       │   │   │               └── content: "console.log(items[i])"
+        │       │   │   │
+        │       │   │   │
+        │       │   │   ├── equals: ∅
+        │       │   │   └── value: ∅
+        │       │   │
+        │       │   ├── @ HTMLAttributeNode (location: (2:63)-(2:64))
+        │       │   │   ├── name:
+        │       │   │   │   └── @ HTMLAttributeNameNode (location: (2:63)-(2:64))
+        │       │   │   │       └── children: (1 item)
+        │       │   │   │           └── @ LiteralNode (location: (2:63)-(2:64))
+        │       │   │   │               └── content: "}"
         │       │   │   │
         │       │   │   │
         │       │   │   ├── equals: ∅

--- a/test/snapshots/analyze/strict_locals_test/test_0063_missing_parentheses_with_nothing_after_the_prefix_and_whitespace_trimming_0bafcbcb2e69fbc75e2c0e72d5ece8dc-be06ef2eb1a2807fc4c599b8cd1ada02.txt
+++ b/test/snapshots/analyze/strict_locals_test/test_0063_missing_parentheses_with_nothing_after_the_prefix_and_whitespace_trimming_0bafcbcb2e69fbc75e2c0e72d5ece8dc-be06ef2eb1a2807fc4c599b8cd1ada02.txt
@@ -1,0 +1,21 @@
+---
+source: "Analyze::StrictLocalsTest#test_0063_missing parentheses with nothing after the prefix and whitespace trimming"
+input: |2-
+<%# locals: -%>
+options: {strict_locals: true}
+---
+@ DocumentNode (location: (1:0)-(2:0))
+└── children: (2 items)
+    ├── @ ERBStrictLocalsNode (location: (1:0)-(1:15))
+    │   ├── errors: (1 error)
+    │   │   └── @ StrictLocalsMissingParenthesisError (location: (1:12)-(1:12))
+    │   │       ├── message: "Strict locals declaration requires parentheses. Expected `locals: (...)` but got `locals: `."
+    │   │       └── rest: ""
+    │   │
+    │   ├── tag_opening: "<%#" (location: (1:0)-(1:3))
+    │   ├── content: " locals: " (location: (1:3)-(1:12))
+    │   ├── tag_closing: "-%>" (location: (1:12)-(1:15))
+    │   └── locals: []
+    │
+    └── @ HTMLTextNode (location: (1:15)-(2:0))
+        └── content: "\n"

--- a/test/snapshots/parser/attributes_test/test_0018_apostrophe_inside_single_quotes_e431474b58446f910c9425491add27a0.txt
+++ b/test/snapshots/parser/attributes_test/test_0018_apostrophe_inside_single_quotes_e431474b58446f910c9425491add27a0.txt
@@ -7,36 +7,61 @@ input: "<div data-msg='Don't worry'>Text</div>"
     └── @ HTMLElementNode (location: (1:0)-(1:38))
         ├── open_tag:
         │   └── @ HTMLOpenTagNode (location: (1:0)-(1:28))
+        │       ├── errors: (1 error)
+        │       │   └── @ MissingWhitespaceBetweenAttributesError (location: (1:19)-(1:20))
+        │       │       ├── message: "Missing whitespace between attributes at (1:19). `t` is parsed as the start of a new attribute."
+        │       │       └── found: "t" (location: (1:19)-(1:20))
+        │       │
         │       ├── tag_opening: "<" (location: (1:0)-(1:1))
         │       ├── tag_name: "div" (location: (1:1)-(1:4))
         │       ├── tag_closing: ">" (location: (1:27)-(1:28))
-        │       ├── children: (1 item)
-        │       │   └── @ HTMLAttributeNode (location: (1:5)-(1:27))
+        │       ├── children: (3 items)
+        │       │   ├── @ HTMLAttributeNode (location: (1:5)-(1:19))
+        │       │   │   ├── name:
+        │       │   │   │   └── @ HTMLAttributeNameNode (location: (1:5)-(1:13))
+        │       │   │   │       └── children: (1 item)
+        │       │   │   │           └── @ LiteralNode (location: (1:5)-(1:13))
+        │       │   │   │               └── content: "data-msg"
+        │       │   │   │
+        │       │   │   │
+        │       │   │   ├── equals: "=" (location: (1:13)-(1:14))
+        │       │   │   └── value:
+        │       │   │       └── @ HTMLAttributeValueNode (location: (1:14)-(1:19))
+        │       │   │           ├── open_quote: "'" (location: (1:14)-(1:15))
+        │       │   │           ├── children: (1 item)
+        │       │   │           │   └── @ LiteralNode (location: (1:15)-(1:18))
+        │       │   │           │       └── content: "Don"
+        │       │   │           │
+        │       │   │           ├── close_quote: "'" (location: (1:18)-(1:19))
+        │       │   │           └── quoted: true
+        │       │   │
+        │       │   │
+        │       │   ├── @ HTMLAttributeNode (location: (1:19)-(1:20))
+        │       │   │   ├── name:
+        │       │   │   │   └── @ HTMLAttributeNameNode (location: (1:19)-(1:20))
+        │       │   │   │       └── children: (1 item)
+        │       │   │   │           └── @ LiteralNode (location: (1:19)-(1:20))
+        │       │   │   │               └── content: "t"
+        │       │   │   │
+        │       │   │   │
+        │       │   │   ├── equals: ∅
+        │       │   │   └── value: ∅
+        │       │   │
+        │       │   └── @ HTMLAttributeNode (location: (1:21)-(1:27))
         │       │       ├── name:
-        │       │       │   └── @ HTMLAttributeNameNode (location: (1:5)-(1:13))
+        │       │       │   └── @ HTMLAttributeNameNode (location: (1:21)-(1:27))
+        │       │       │       ├── errors: (1 error)
+        │       │       │       │   └── @ UnexpectedCharacterInAttributeNameError (location: (1:26)-(1:27))
+        │       │       │       │       ├── message: "Unexpected `'` in attribute name at (1:26)."
+        │       │       │       │       └── character: "'" (location: (1:26)-(1:27))
+        │       │       │       │
         │       │       │       └── children: (1 item)
-        │       │       │           └── @ LiteralNode (location: (1:5)-(1:13))
-        │       │       │               └── content: "data-msg"
+        │       │       │           └── @ LiteralNode (location: (1:21)-(1:27))
+        │       │       │               └── content: "worry'"
         │       │       │
         │       │       │
-        │       │       ├── equals: "=" (location: (1:13)-(1:14))
-        │       │       └── value:
-        │       │           └── @ HTMLAttributeValueNode (location: (1:14)-(1:27))
-        │       │               ├── errors: (1 error)
-        │       │               │   └── @ UnexpectedError (location: (1:18)-(1:19))
-        │       │               │       ├── message: "Unescaped quote character in attribute value. Expected: HTML entity (&apos;/&quot;) or different quote style, found: '."
-        │       │               │       ├── description: "Unescaped quote character in attribute value"
-        │       │               │       ├── expected: "HTML entity (&apos;/&quot;) or different quote style"
-        │       │               │       └── found: "'"
-        │       │               │
-        │       │               ├── open_quote: "'" (location: (1:14)-(1:15))
-        │       │               ├── children: (1 item)
-        │       │               │   └── @ LiteralNode (location: (1:15)-(1:26))
-        │       │               │       └── content: "Don't worry"
-        │       │               │
-        │       │               ├── close_quote: "'" (location: (1:26)-(1:27))
-        │       │               └── quoted: true
-        │       │
+        │       │       ├── equals: ∅
+        │       │       └── value: ∅
         │       │
         │       └── is_void: false
         │

--- a/test/snapshots/parser/attributes_test/test_0019_escaped_apostrophe_inside_single_quotes_73b1e8ba6af89da5d178df9a5b3781fc.txt
+++ b/test/snapshots/parser/attributes_test/test_0019_escaped_apostrophe_inside_single_quotes_73b1e8ba6af89da5d178df9a5b3781fc.txt
@@ -7,36 +7,61 @@ input: "<div data-msg='Don\\'t worry'>Text</div>"
     └── @ HTMLElementNode (location: (1:0)-(1:39))
         ├── open_tag:
         │   └── @ HTMLOpenTagNode (location: (1:0)-(1:29))
+        │       ├── errors: (1 error)
+        │       │   └── @ MissingWhitespaceBetweenAttributesError (location: (1:20)-(1:21))
+        │       │       ├── message: "Missing whitespace between attributes at (1:20). `t` is parsed as the start of a new attribute."
+        │       │       └── found: "t" (location: (1:20)-(1:21))
+        │       │
         │       ├── tag_opening: "<" (location: (1:0)-(1:1))
         │       ├── tag_name: "div" (location: (1:1)-(1:4))
         │       ├── tag_closing: ">" (location: (1:28)-(1:29))
-        │       ├── children: (1 item)
-        │       │   └── @ HTMLAttributeNode (location: (1:5)-(1:28))
+        │       ├── children: (3 items)
+        │       │   ├── @ HTMLAttributeNode (location: (1:5)-(1:20))
+        │       │   │   ├── name:
+        │       │   │   │   └── @ HTMLAttributeNameNode (location: (1:5)-(1:13))
+        │       │   │   │       └── children: (1 item)
+        │       │   │   │           └── @ LiteralNode (location: (1:5)-(1:13))
+        │       │   │   │               └── content: "data-msg"
+        │       │   │   │
+        │       │   │   │
+        │       │   │   ├── equals: "=" (location: (1:13)-(1:14))
+        │       │   │   └── value:
+        │       │   │       └── @ HTMLAttributeValueNode (location: (1:14)-(1:20))
+        │       │   │           ├── open_quote: "'" (location: (1:14)-(1:15))
+        │       │   │           ├── children: (1 item)
+        │       │   │           │   └── @ LiteralNode (location: (1:15)-(1:19))
+        │       │   │           │       └── content: "Don\\"
+        │       │   │           │
+        │       │   │           ├── close_quote: "'" (location: (1:19)-(1:20))
+        │       │   │           └── quoted: true
+        │       │   │
+        │       │   │
+        │       │   ├── @ HTMLAttributeNode (location: (1:20)-(1:21))
+        │       │   │   ├── name:
+        │       │   │   │   └── @ HTMLAttributeNameNode (location: (1:20)-(1:21))
+        │       │   │   │       └── children: (1 item)
+        │       │   │   │           └── @ LiteralNode (location: (1:20)-(1:21))
+        │       │   │   │               └── content: "t"
+        │       │   │   │
+        │       │   │   │
+        │       │   │   ├── equals: ∅
+        │       │   │   └── value: ∅
+        │       │   │
+        │       │   └── @ HTMLAttributeNode (location: (1:22)-(1:28))
         │       │       ├── name:
-        │       │       │   └── @ HTMLAttributeNameNode (location: (1:5)-(1:13))
+        │       │       │   └── @ HTMLAttributeNameNode (location: (1:22)-(1:28))
+        │       │       │       ├── errors: (1 error)
+        │       │       │       │   └── @ UnexpectedCharacterInAttributeNameError (location: (1:27)-(1:28))
+        │       │       │       │       ├── message: "Unexpected `'` in attribute name at (1:27)."
+        │       │       │       │       └── character: "'" (location: (1:27)-(1:28))
+        │       │       │       │
         │       │       │       └── children: (1 item)
-        │       │       │           └── @ LiteralNode (location: (1:5)-(1:13))
-        │       │       │               └── content: "data-msg"
+        │       │       │           └── @ LiteralNode (location: (1:22)-(1:28))
+        │       │       │               └── content: "worry'"
         │       │       │
         │       │       │
-        │       │       ├── equals: "=" (location: (1:13)-(1:14))
-        │       │       └── value:
-        │       │           └── @ HTMLAttributeValueNode (location: (1:14)-(1:28))
-        │       │               ├── errors: (1 error)
-        │       │               │   └── @ UnexpectedError (location: (1:19)-(1:20))
-        │       │               │       ├── message: "Unescaped quote character in attribute value. Expected: HTML entity (&apos;/&quot;) or different quote style, found: '."
-        │       │               │       ├── description: "Unescaped quote character in attribute value"
-        │       │               │       ├── expected: "HTML entity (&apos;/&quot;) or different quote style"
-        │       │               │       └── found: "'"
-        │       │               │
-        │       │               ├── open_quote: "'" (location: (1:14)-(1:15))
-        │       │               ├── children: (1 item)
-        │       │               │   └── @ LiteralNode (location: (1:15)-(1:27))
-        │       │               │       └── content: "Don\\'t worry"
-        │       │               │
-        │       │               ├── close_quote: "'" (location: (1:27)-(1:28))
-        │       │               └── quoted: true
-        │       │
+        │       │       ├── equals: ∅
+        │       │       └── value: ∅
         │       │
         │       └── is_void: false
         │

--- a/test/snapshots/parser/attributes_test/test_0020_escaped_double_quote_inside_double_quotes_1ad5f48462c267e84580003c8ac9abac.txt
+++ b/test/snapshots/parser/attributes_test/test_0020_escaped_double_quote_inside_double_quotes_1ad5f48462c267e84580003c8ac9abac.txt
@@ -8,42 +8,53 @@ input: "<div data-msg=\"She said \\\"Hello\\\"\">Text</div>"
         ├── open_tag:
         │   └── @ HTMLOpenTagNode (location: (1:0)-(1:35))
         │       ├── errors: (1 error)
-        │       │   └── @ UnexpectedError (location: (1:33)-(1:34))
-        │       │       ├── message: "Unexpected Token. Expected: an identifier, `@`, `<%`, whitespace, or a newline, found: a quote."
-        │       │       ├── description: "Unexpected Token"
-        │       │       ├── expected: "an identifier, `@`, `<%`, whitespace, or a newline"
-        │       │       └── found: "a quote"
+        │       │   └── @ MissingWhitespaceBetweenAttributesError (location: (1:26)-(1:31))
+        │       │       ├── message: "Missing whitespace between attributes at (1:26). `Hello` is parsed as the start of a new attribute."
+        │       │       └── found: "Hello" (location: (1:26)-(1:31))
         │       │
         │       ├── tag_opening: "<" (location: (1:0)-(1:1))
         │       ├── tag_name: "div" (location: (1:1)-(1:4))
         │       ├── tag_closing: ">" (location: (1:34)-(1:35))
-        │       ├── children: (1 item)
-        │       │   └── @ HTMLAttributeNode (location: (1:5)-(1:33))
+        │       ├── children: (2 items)
+        │       │   ├── @ HTMLAttributeNode (location: (1:5)-(1:26))
+        │       │   │   ├── name:
+        │       │   │   │   └── @ HTMLAttributeNameNode (location: (1:5)-(1:13))
+        │       │   │   │       └── children: (1 item)
+        │       │   │   │           └── @ LiteralNode (location: (1:5)-(1:13))
+        │       │   │   │               └── content: "data-msg"
+        │       │   │   │
+        │       │   │   │
+        │       │   │   ├── equals: "=" (location: (1:13)-(1:14))
+        │       │   │   └── value:
+        │       │   │       └── @ HTMLAttributeValueNode (location: (1:14)-(1:26))
+        │       │   │           ├── open_quote: """ (location: (1:14)-(1:15))
+        │       │   │           ├── children: (1 item)
+        │       │   │           │   └── @ LiteralNode (location: (1:15)-(1:25))
+        │       │   │           │       └── content: "She said \\"
+        │       │   │           │
+        │       │   │           ├── close_quote: """ (location: (1:25)-(1:26))
+        │       │   │           └── quoted: true
+        │       │   │
+        │       │   │
+        │       │   └── @ HTMLAttributeNode (location: (1:26)-(1:34))
         │       │       ├── name:
-        │       │       │   └── @ HTMLAttributeNameNode (location: (1:5)-(1:13))
+        │       │       │   └── @ HTMLAttributeNameNode (location: (1:26)-(1:34))
+        │       │       │       ├── errors: (2 errors)
+        │       │       │       │   ├── @ UnexpectedCharacterInAttributeNameError (location: (1:32)-(1:33))
+        │       │       │       │   │   ├── message: "Unexpected `\"` in attribute name at (1:32)."
+        │       │       │       │   │   └── character: """ (location: (1:32)-(1:33))
+        │       │       │       │   │
+        │       │       │       │   └── @ UnexpectedCharacterInAttributeNameError (location: (1:33)-(1:34))
+        │       │       │       │       ├── message: "Unexpected `\"` in attribute name at (1:33)."
+        │       │       │       │       └── character: """ (location: (1:33)-(1:34))
+        │       │       │       │
         │       │       │       └── children: (1 item)
-        │       │       │           └── @ LiteralNode (location: (1:5)-(1:13))
-        │       │       │               └── content: "data-msg"
+        │       │       │           └── @ LiteralNode (location: (1:26)-(1:34))
+        │       │       │               └── content: "Hello\\\"\""
         │       │       │
         │       │       │
-        │       │       ├── equals: "=" (location: (1:13)-(1:14))
-        │       │       └── value:
-        │       │           └── @ HTMLAttributeValueNode (location: (1:14)-(1:33))
-        │       │               ├── errors: (1 error)
-        │       │               │   └── @ UnexpectedError (location: (1:25)-(1:26))
-        │       │               │       ├── message: "Unescaped quote character in attribute value. Expected: HTML entity (&apos;/&quot;) or different quote style, found: \"."
-        │       │               │       ├── description: "Unescaped quote character in attribute value"
-        │       │               │       ├── expected: "HTML entity (&apos;/&quot;) or different quote style"
-        │       │               │       └── found: "\""
-        │       │               │
-        │       │               ├── open_quote: """ (location: (1:14)-(1:15))
-        │       │               ├── children: (1 item)
-        │       │               │   └── @ LiteralNode (location: (1:15)-(1:32))
-        │       │               │       └── content: "She said \\\"Hello\\"
-        │       │               │
-        │       │               ├── close_quote: """ (location: (1:32)-(1:33))
-        │       │               └── quoted: true
-        │       │
+        │       │       ├── equals: ∅
+        │       │       └── value: ∅
         │       │
         │       └── is_void: false
         │

--- a/test/snapshots/parser/attributes_test/test_0033_attribute_with_backtick_quotes_(invalid)_8718691f5760feaae83ee2b77c476b95.txt
+++ b/test/snapshots/parser/attributes_test/test_0033_attribute_with_backtick_quotes_(invalid)_8718691f5760feaae83ee2b77c476b95.txt
@@ -10,41 +10,35 @@ input: "<div class=`hello`></div>"
         │       ├── tag_opening: "<" (location: (1:0)-(1:1))
         │       ├── tag_name: "div" (location: (1:1)-(1:4))
         │       ├── tag_closing: ">" (location: (1:18)-(1:19))
-        │       ├── children: (2 items)
-        │       │   ├── @ HTMLAttributeNode (location: (1:5)-(1:12))
-        │       │   │   ├── name:
-        │       │   │   │   └── @ HTMLAttributeNameNode (location: (1:5)-(1:10))
-        │       │   │   │       └── children: (1 item)
-        │       │   │   │           └── @ LiteralNode (location: (1:5)-(1:10))
-        │       │   │   │               └── content: "class"
-        │       │   │   │
-        │       │   │   │
-        │       │   │   ├── equals: "=" (location: (1:10)-(1:11))
-        │       │   │   └── value:
-        │       │   │       └── @ HTMLAttributeValueNode (location: (1:11)-(1:12))
-        │       │   │           ├── errors: (1 error)
-        │       │   │           │   └── @ UnexpectedError (location: (1:11)-(1:12))
-        │       │   │           │       ├── message: "Invalid quote character for HTML attribute. Expected: single quote (') or double quote (\"), found: a backtick."
-        │       │   │           │       ├── description: "Invalid quote character for HTML attribute"
-        │       │   │           │       ├── expected: "single quote (') or double quote (\")"
-        │       │   │           │       └── found: "a backtick"
-        │       │   │           │
-        │       │   │           ├── open_quote: ∅
-        │       │   │           ├── children: []
-        │       │   │           ├── close_quote: ∅
-        │       │   │           └── quoted: false
-        │       │   │
-        │       │   │
-        │       │   └── @ HTMLAttributeNode (location: (1:12)-(1:18))
+        │       ├── children: (1 item)
+        │       │   └── @ HTMLAttributeNode (location: (1:5)-(1:18))
         │       │       ├── name:
-        │       │       │   └── @ HTMLAttributeNameNode (location: (1:12)-(1:18))
+        │       │       │   └── @ HTMLAttributeNameNode (location: (1:5)-(1:10))
         │       │       │       └── children: (1 item)
-        │       │       │           └── @ LiteralNode (location: (1:12)-(1:18))
-        │       │       │               └── content: "hello`"
+        │       │       │           └── @ LiteralNode (location: (1:5)-(1:10))
+        │       │       │               └── content: "class"
         │       │       │
         │       │       │
-        │       │       ├── equals: ∅
-        │       │       └── value: ∅
+        │       │       ├── equals: "=" (location: (1:10)-(1:11))
+        │       │       └── value:
+        │       │           └── @ HTMLAttributeValueNode (location: (1:11)-(1:18))
+        │       │               ├── errors: (2 errors)
+        │       │               │   ├── @ UnexpectedCharacterInUnquotedAttributeValueError (location: (1:11)-(1:12))
+        │       │               │   │   ├── message: "Unexpected ``` in unquoted attribute value at (1:11)."
+        │       │               │   │   └── character: "`" (location: (1:11)-(1:12))
+        │       │               │   │
+        │       │               │   └── @ UnexpectedCharacterInUnquotedAttributeValueError (location: (1:17)-(1:18))
+        │       │               │       ├── message: "Unexpected ``` in unquoted attribute value at (1:17)."
+        │       │               │       └── character: "`" (location: (1:17)-(1:18))
+        │       │               │
+        │       │               ├── open_quote: ∅
+        │       │               ├── children: (1 item)
+        │       │               │   └── @ LiteralNode (location: (1:11)-(1:18))
+        │       │               │       └── content: "`hello`"
+        │       │               │
+        │       │               ├── close_quote: ∅
+        │       │               └── quoted: false
+        │       │
         │       │
         │       └── is_void: false
         │

--- a/test/snapshots/parser/attributes_test/test_0034_attribute_with_backtick_quotes_and_whitespace_(invalid)_237e4c11b70033b3f49f29b7e3c9cb70.txt
+++ b/test/snapshots/parser/attributes_test/test_0034_attribute_with_backtick_quotes_and_whitespace_(invalid)_237e4c11b70033b3f49f29b7e3c9cb70.txt
@@ -10,8 +10,8 @@ input: "<div class=`hello world`></div>"
         │       ├── tag_opening: "<" (location: (1:0)-(1:1))
         │       ├── tag_name: "div" (location: (1:1)-(1:4))
         │       ├── tag_closing: ">" (location: (1:24)-(1:25))
-        │       ├── children: (3 items)
-        │       │   ├── @ HTMLAttributeNode (location: (1:5)-(1:12))
+        │       ├── children: (2 items)
+        │       │   ├── @ HTMLAttributeNode (location: (1:5)-(1:17))
         │       │   │   ├── name:
         │       │   │   │   └── @ HTMLAttributeNameNode (location: (1:5)-(1:10))
         │       │   │   │       └── children: (1 item)
@@ -21,30 +21,20 @@ input: "<div class=`hello world`></div>"
         │       │   │   │
         │       │   │   ├── equals: "=" (location: (1:10)-(1:11))
         │       │   │   └── value:
-        │       │   │       └── @ HTMLAttributeValueNode (location: (1:11)-(1:12))
+        │       │   │       └── @ HTMLAttributeValueNode (location: (1:11)-(1:17))
         │       │   │           ├── errors: (1 error)
-        │       │   │           │   └── @ UnexpectedError (location: (1:11)-(1:12))
-        │       │   │           │       ├── message: "Invalid quote character for HTML attribute. Expected: single quote (') or double quote (\"), found: a backtick."
-        │       │   │           │       ├── description: "Invalid quote character for HTML attribute"
-        │       │   │           │       ├── expected: "single quote (') or double quote (\")"
-        │       │   │           │       └── found: "a backtick"
+        │       │   │           │   └── @ UnexpectedCharacterInUnquotedAttributeValueError (location: (1:11)-(1:12))
+        │       │   │           │       ├── message: "Unexpected ``` in unquoted attribute value at (1:11)."
+        │       │   │           │       └── character: "`" (location: (1:11)-(1:12))
         │       │   │           │
         │       │   │           ├── open_quote: ∅
-        │       │   │           ├── children: []
+        │       │   │           ├── children: (1 item)
+        │       │   │           │   └── @ LiteralNode (location: (1:11)-(1:17))
+        │       │   │           │       └── content: "`hello"
+        │       │   │           │
         │       │   │           ├── close_quote: ∅
         │       │   │           └── quoted: false
         │       │   │
-        │       │   │
-        │       │   ├── @ HTMLAttributeNode (location: (1:12)-(1:17))
-        │       │   │   ├── name:
-        │       │   │   │   └── @ HTMLAttributeNameNode (location: (1:12)-(1:17))
-        │       │   │   │       └── children: (1 item)
-        │       │   │   │           └── @ LiteralNode (location: (1:12)-(1:17))
-        │       │   │   │               └── content: "hello"
-        │       │   │   │
-        │       │   │   │
-        │       │   │   ├── equals: ∅
-        │       │   │   └── value: ∅
         │       │   │
         │       │   └── @ HTMLAttributeNode (location: (1:18)-(1:24))
         │       │       ├── name:

--- a/test/snapshots/parser/attributes_test/test_0035_multiple_attributes_with_mixed_quotes_including_backticks_(invalid)_5eb53ae0e5d34773abdd248e275f8c51.txt
+++ b/test/snapshots/parser/attributes_test/test_0035_multiple_attributes_with_mixed_quotes_including_backticks_(invalid)_5eb53ae0e5d34773abdd248e275f8c51.txt
@@ -10,7 +10,7 @@ input: "<div class=\"valid\" id=`invalid` data-test='also-valid'></div>"
         │       ├── tag_opening: "<" (location: (1:0)-(1:1))
         │       ├── tag_name: "div" (location: (1:1)-(1:4))
         │       ├── tag_closing: ">" (location: (1:54)-(1:55))
-        │       ├── children: (4 items)
+        │       ├── children: (3 items)
         │       │   ├── @ HTMLAttributeNode (location: (1:5)-(1:18))
         │       │   │   ├── name:
         │       │   │   │   └── @ HTMLAttributeNameNode (location: (1:5)-(1:10))
@@ -31,7 +31,7 @@ input: "<div class=\"valid\" id=`invalid` data-test='also-valid'></div>"
         │       │   │           └── quoted: true
         │       │   │
         │       │   │
-        │       │   ├── @ HTMLAttributeNode (location: (1:19)-(1:23))
+        │       │   ├── @ HTMLAttributeNode (location: (1:19)-(1:31))
         │       │   │   ├── name:
         │       │   │   │   └── @ HTMLAttributeNameNode (location: (1:19)-(1:21))
         │       │   │   │       └── children: (1 item)
@@ -41,30 +41,24 @@ input: "<div class=\"valid\" id=`invalid` data-test='also-valid'></div>"
         │       │   │   │
         │       │   │   ├── equals: "=" (location: (1:21)-(1:22))
         │       │   │   └── value:
-        │       │   │       └── @ HTMLAttributeValueNode (location: (1:22)-(1:23))
-        │       │   │           ├── errors: (1 error)
-        │       │   │           │   └── @ UnexpectedError (location: (1:22)-(1:23))
-        │       │   │           │       ├── message: "Invalid quote character for HTML attribute. Expected: single quote (') or double quote (\"), found: a backtick."
-        │       │   │           │       ├── description: "Invalid quote character for HTML attribute"
-        │       │   │           │       ├── expected: "single quote (') or double quote (\")"
-        │       │   │           │       └── found: "a backtick"
+        │       │   │       └── @ HTMLAttributeValueNode (location: (1:22)-(1:31))
+        │       │   │           ├── errors: (2 errors)
+        │       │   │           │   ├── @ UnexpectedCharacterInUnquotedAttributeValueError (location: (1:22)-(1:23))
+        │       │   │           │   │   ├── message: "Unexpected ``` in unquoted attribute value at (1:22)."
+        │       │   │           │   │   └── character: "`" (location: (1:22)-(1:23))
+        │       │   │           │   │
+        │       │   │           │   └── @ UnexpectedCharacterInUnquotedAttributeValueError (location: (1:30)-(1:31))
+        │       │   │           │       ├── message: "Unexpected ``` in unquoted attribute value at (1:30)."
+        │       │   │           │       └── character: "`" (location: (1:30)-(1:31))
         │       │   │           │
         │       │   │           ├── open_quote: ∅
-        │       │   │           ├── children: []
+        │       │   │           ├── children: (1 item)
+        │       │   │           │   └── @ LiteralNode (location: (1:22)-(1:31))
+        │       │   │           │       └── content: "`invalid`"
+        │       │   │           │
         │       │   │           ├── close_quote: ∅
         │       │   │           └── quoted: false
         │       │   │
-        │       │   │
-        │       │   ├── @ HTMLAttributeNode (location: (1:23)-(1:31))
-        │       │   │   ├── name:
-        │       │   │   │   └── @ HTMLAttributeNameNode (location: (1:23)-(1:31))
-        │       │   │   │       └── children: (1 item)
-        │       │   │   │           └── @ LiteralNode (location: (1:23)-(1:31))
-        │       │   │   │               └── content: "invalid`"
-        │       │   │   │
-        │       │   │   │
-        │       │   │   ├── equals: ∅
-        │       │   │   └── value: ∅
         │       │   │
         │       │   └── @ HTMLAttributeNode (location: (1:32)-(1:54))
         │       │       ├── name:

--- a/test/snapshots/parser/attributes_test/test_0036_self-closing_tag_with_backtick_attribute_(invalid)_0545b512ba1dfae2fd7c90ec643b4cca.txt
+++ b/test/snapshots/parser/attributes_test/test_0036_self-closing_tag_with_backtick_attribute_(invalid)_0545b512ba1dfae2fd7c90ec643b4cca.txt
@@ -10,41 +10,35 @@ input: "<img src=`image.jpg` />"
         │       ├── tag_opening: "<" (location: (1:0)-(1:1))
         │       ├── tag_name: "img" (location: (1:1)-(1:4))
         │       ├── tag_closing: "/>" (location: (1:21)-(1:23))
-        │       ├── children: (2 items)
-        │       │   ├── @ HTMLAttributeNode (location: (1:5)-(1:10))
-        │       │   │   ├── name:
-        │       │   │   │   └── @ HTMLAttributeNameNode (location: (1:5)-(1:8))
-        │       │   │   │       └── children: (1 item)
-        │       │   │   │           └── @ LiteralNode (location: (1:5)-(1:8))
-        │       │   │   │               └── content: "src"
-        │       │   │   │
-        │       │   │   │
-        │       │   │   ├── equals: "=" (location: (1:8)-(1:9))
-        │       │   │   └── value:
-        │       │   │       └── @ HTMLAttributeValueNode (location: (1:9)-(1:10))
-        │       │   │           ├── errors: (1 error)
-        │       │   │           │   └── @ UnexpectedError (location: (1:9)-(1:10))
-        │       │   │           │       ├── message: "Invalid quote character for HTML attribute. Expected: single quote (') or double quote (\"), found: a backtick."
-        │       │   │           │       ├── description: "Invalid quote character for HTML attribute"
-        │       │   │           │       ├── expected: "single quote (') or double quote (\")"
-        │       │   │           │       └── found: "a backtick"
-        │       │   │           │
-        │       │   │           ├── open_quote: ∅
-        │       │   │           ├── children: []
-        │       │   │           ├── close_quote: ∅
-        │       │   │           └── quoted: false
-        │       │   │
-        │       │   │
-        │       │   └── @ HTMLAttributeNode (location: (1:10)-(1:20))
+        │       ├── children: (1 item)
+        │       │   └── @ HTMLAttributeNode (location: (1:5)-(1:20))
         │       │       ├── name:
-        │       │       │   └── @ HTMLAttributeNameNode (location: (1:10)-(1:20))
+        │       │       │   └── @ HTMLAttributeNameNode (location: (1:5)-(1:8))
         │       │       │       └── children: (1 item)
-        │       │       │           └── @ LiteralNode (location: (1:10)-(1:20))
-        │       │       │               └── content: "image.jpg`"
+        │       │       │           └── @ LiteralNode (location: (1:5)-(1:8))
+        │       │       │               └── content: "src"
         │       │       │
         │       │       │
-        │       │       ├── equals: ∅
-        │       │       └── value: ∅
+        │       │       ├── equals: "=" (location: (1:8)-(1:9))
+        │       │       └── value:
+        │       │           └── @ HTMLAttributeValueNode (location: (1:9)-(1:20))
+        │       │               ├── errors: (2 errors)
+        │       │               │   ├── @ UnexpectedCharacterInUnquotedAttributeValueError (location: (1:9)-(1:10))
+        │       │               │   │   ├── message: "Unexpected ``` in unquoted attribute value at (1:9)."
+        │       │               │   │   └── character: "`" (location: (1:9)-(1:10))
+        │       │               │   │
+        │       │               │   └── @ UnexpectedCharacterInUnquotedAttributeValueError (location: (1:19)-(1:20))
+        │       │               │       ├── message: "Unexpected ``` in unquoted attribute value at (1:19)."
+        │       │               │       └── character: "`" (location: (1:19)-(1:20))
+        │       │               │
+        │       │               ├── open_quote: ∅
+        │       │               ├── children: (1 item)
+        │       │               │   └── @ LiteralNode (location: (1:9)-(1:20))
+        │       │               │       └── content: "`image.jpg`"
+        │       │               │
+        │       │               ├── close_quote: ∅
+        │       │               └── quoted: false
+        │       │
         │       │
         │       └── is_void: true
         │

--- a/test/snapshots/parser/attributes_test/test_0037_attribute_with_backtick_containing_HTML_(invalid)_542130e358dadabeb4a1629bc9bcf4f3.txt
+++ b/test/snapshots/parser/attributes_test/test_0037_attribute_with_backtick_containing_HTML_(invalid)_542130e358dadabeb4a1629bc9bcf4f3.txt
@@ -28,14 +28,15 @@ input: "<div data-template=`<span>Hello</span>`></div>"
         │       │       └── value:
         │       │           └── @ HTMLAttributeValueNode (location: (1:19)-(1:20))
         │       │               ├── errors: (1 error)
-        │       │               │   └── @ UnexpectedError (location: (1:19)-(1:20))
-        │       │               │       ├── message: "Invalid quote character for HTML attribute. Expected: single quote (') or double quote (\"), found: a backtick."
-        │       │               │       ├── description: "Invalid quote character for HTML attribute"
-        │       │               │       ├── expected: "single quote (') or double quote (\")"
-        │       │               │       └── found: "a backtick"
+        │       │               │   └── @ UnexpectedCharacterInUnquotedAttributeValueError (location: (1:19)-(1:20))
+        │       │               │       ├── message: "Unexpected ``` in unquoted attribute value at (1:19)."
+        │       │               │       └── character: "`" (location: (1:19)-(1:20))
         │       │               │
         │       │               ├── open_quote: ∅
-        │       │               ├── children: []
+        │       │               ├── children: (1 item)
+        │       │               │   └── @ LiteralNode (location: (1:19)-(1:20))
+        │       │               │       └── content: "`"
+        │       │               │
         │       │               ├── close_quote: ∅
         │       │               └── quoted: false
         │       │

--- a/test/snapshots/parser/attributes_test/test_0042_Standalone_colon_with_space_is_invalid_c037b25064b31d22c6c195361999c5b8.txt
+++ b/test/snapshots/parser/attributes_test/test_0042_Standalone_colon_with_space_is_invalid_c037b25064b31d22c6c195361999c5b8.txt
@@ -7,17 +7,21 @@ input: "<div : class=\"hello\"></div>"
     └── @ HTMLElementNode (location: (1:0)-(1:27))
         ├── open_tag:
         │   └── @ HTMLOpenTagNode (location: (1:0)-(1:21))
-        │       ├── errors: (1 error)
-        │       │   └── @ UnexpectedError (location: (1:5)-(1:6))
-        │       │       ├── message: "Unexpected Token. Expected: an identifier, `@`, `<%`, whitespace, or a newline, found: `:`."
-        │       │       ├── description: "Unexpected Token"
-        │       │       ├── expected: "an identifier, `@`, `<%`, whitespace, or a newline"
-        │       │       └── found: "`:`"
-        │       │
         │       ├── tag_opening: "<" (location: (1:0)-(1:1))
         │       ├── tag_name: "div" (location: (1:1)-(1:4))
         │       ├── tag_closing: ">" (location: (1:20)-(1:21))
-        │       ├── children: (1 item)
+        │       ├── children: (2 items)
+        │       │   ├── @ HTMLAttributeNode (location: (1:5)-(1:6))
+        │       │   │   ├── name:
+        │       │   │   │   └── @ HTMLAttributeNameNode (location: (1:5)-(1:6))
+        │       │   │   │       └── children: (1 item)
+        │       │   │   │           └── @ LiteralNode (location: (1:5)-(1:6))
+        │       │   │   │               └── content: ":"
+        │       │   │   │
+        │       │   │   │
+        │       │   │   ├── equals: ∅
+        │       │   │   └── value: ∅
+        │       │   │
         │       │   └── @ HTMLAttributeNode (location: (1:7)-(1:20))
         │       │       ├── name:
         │       │       │   └── @ HTMLAttributeNameNode (location: (1:7)-(1:12))

--- a/test/snapshots/parser/attributes_test/test_0044_Double_colon_is_invalid_f2b2354b82896dec0458b506ae56eb58.txt
+++ b/test/snapshots/parser/attributes_test/test_0044_Double_colon_is_invalid_f2b2354b82896dec0458b506ae56eb58.txt
@@ -7,23 +7,16 @@ input: "<div ::value=\"hello\"></div>"
     └── @ HTMLElementNode (location: (1:0)-(1:27))
         ├── open_tag:
         │   └── @ HTMLOpenTagNode (location: (1:0)-(1:21))
-        │       ├── errors: (1 error)
-        │       │   └── @ UnexpectedError (location: (1:5)-(1:6))
-        │       │       ├── message: "Unexpected Token. Expected: an identifier, `@`, `<%`, whitespace, or a newline, found: `:`."
-        │       │       ├── description: "Unexpected Token"
-        │       │       ├── expected: "an identifier, `@`, `<%`, whitespace, or a newline"
-        │       │       └── found: "`:`"
-        │       │
         │       ├── tag_opening: "<" (location: (1:0)-(1:1))
         │       ├── tag_name: "div" (location: (1:1)-(1:4))
         │       ├── tag_closing: ">" (location: (1:20)-(1:21))
         │       ├── children: (1 item)
-        │       │   └── @ HTMLAttributeNode (location: (1:6)-(1:20))
+        │       │   └── @ HTMLAttributeNode (location: (1:5)-(1:20))
         │       │       ├── name:
-        │       │       │   └── @ HTMLAttributeNameNode (location: (1:6)-(1:12))
+        │       │       │   └── @ HTMLAttributeNameNode (location: (1:5)-(1:12))
         │       │       │       └── children: (1 item)
-        │       │       │           └── @ LiteralNode (location: (1:6)-(1:12))
-        │       │       │               └── content: ":value"
+        │       │       │           └── @ LiteralNode (location: (1:5)-(1:12))
+        │       │       │               └── content: "::value"
         │       │       │
         │       │       │
         │       │       ├── equals: "=" (location: (1:12)-(1:13))

--- a/test/snapshots/parser/attributes_test/test_0115_attribute_with_equals_followed_by_new_tag_start_53797bc03ba9eee20bb33d3346e15f50.txt
+++ b/test/snapshots/parser/attributes_test/test_0115_attribute_with_equals_followed_by_new_tag_start_53797bc03ba9eee20bb33d3346e15f50.txt
@@ -16,7 +16,7 @@ input: "<div class=<span>test</span></div>"
         │       ├── tag_name: "div" (location: (1:1)-(1:4))
         │       ├── tag_closing: ∅
         │       ├── children: (1 item)
-        │       │   └── @ HTMLAttributeNode (location: (1:5)-(1:12))
+        │       │   └── @ HTMLAttributeNode (location: (1:5)-(1:11))
         │       │       ├── name:
         │       │       │   └── @ HTMLAttributeNameNode (location: (1:5)-(1:10))
         │       │       │       └── children: (1 item)
@@ -26,13 +26,11 @@ input: "<div class=<span>test</span></div>"
         │       │       │
         │       │       ├── equals: "=" (location: (1:10)-(1:11))
         │       │       └── value:
-        │       │           └── @ HTMLAttributeValueNode (location: (1:11)-(1:12))
+        │       │           └── @ HTMLAttributeValueNode (location: (1:11)-(1:11))
         │       │               ├── errors: (1 error)
-        │       │               │   └── @ UnexpectedError (location: (1:11)-(1:12))
-        │       │               │       ├── message: "Unexpected Token. Expected: an identifier, a quote, or `<%`, found: `<`."
-        │       │               │       ├── description: "Unexpected Token"
-        │       │               │       ├── expected: "an identifier, a quote, or `<%`"
-        │       │               │       └── found: "`<`"
+        │       │               │   └── @ MissingAttributeValueError (location: (1:10)-(1:11))
+        │       │               │       ├── message: "Attribute `class` at (1:10) is missing a value after the equals sign."
+        │       │               │       └── attribute_name: "class"
         │       │               │
         │       │               ├── open_quote: ∅
         │       │               ├── children: []

--- a/test/snapshots/parser/attributes_test/test_0116_attribute_with_equals_and_space_followed_by_new_tag_start_c4d65ef876cd7488aa38dfab522aafbd.txt
+++ b/test/snapshots/parser/attributes_test/test_0116_attribute_with_equals_and_space_followed_by_new_tag_start_c4d65ef876cd7488aa38dfab522aafbd.txt
@@ -16,7 +16,7 @@ input: "<div class= <span>test</span></div>"
         │       ├── tag_name: "div" (location: (1:1)-(1:4))
         │       ├── tag_closing: ∅
         │       ├── children: (1 item)
-        │       │   └── @ HTMLAttributeNode (location: (1:5)-(1:13))
+        │       │   └── @ HTMLAttributeNode (location: (1:5)-(1:12))
         │       │       ├── name:
         │       │       │   └── @ HTMLAttributeNameNode (location: (1:5)-(1:10))
         │       │       │       └── children: (1 item)
@@ -26,13 +26,11 @@ input: "<div class= <span>test</span></div>"
         │       │       │
         │       │       ├── equals: "=" (location: (1:10)-(1:11))
         │       │       └── value:
-        │       │           └── @ HTMLAttributeValueNode (location: (1:12)-(1:13))
+        │       │           └── @ HTMLAttributeValueNode (location: (1:11)-(1:12))
         │       │               ├── errors: (1 error)
-        │       │               │   └── @ UnexpectedError (location: (1:12)-(1:13))
-        │       │               │       ├── message: "Unexpected Token. Expected: an identifier, a quote, or `<%`, found: `<`."
-        │       │               │       ├── description: "Unexpected Token"
-        │       │               │       ├── expected: "an identifier, a quote, or `<%`"
-        │       │               │       └── found: "`<`"
+        │       │               │   └── @ MissingAttributeValueError (location: (1:10)-(1:12))
+        │       │               │       ├── message: "Attribute `class` at (1:10) is missing a value after the equals sign."
+        │       │               │       └── attribute_name: "class"
         │       │               │
         │       │               ├── open_quote: ∅
         │       │               ├── children: []

--- a/test/snapshots/parser/attributes_test/test_0117_attribute_with_equals_at_EOF_899de3e17c281d1fbde88f0b3a016fc7.txt
+++ b/test/snapshots/parser/attributes_test/test_0117_attribute_with_equals_at_EOF_899de3e17c281d1fbde88f0b3a016fc7.txt
@@ -26,11 +26,9 @@ input: "<div class="
         │       └── value:
         │           └── @ HTMLAttributeValueNode (location: (1:11)-(1:11))
         │               ├── errors: (1 error)
-        │               │   └── @ UnexpectedError (location: (1:11)-(1:11))
-        │               │       ├── message: "Unexpected Token. Expected: an identifier, a quote, or `<%`, found: end of file."
-        │               │       ├── description: "Unexpected Token"
-        │               │       ├── expected: "an identifier, a quote, or `<%`"
-        │               │       └── found: "end of file"
+        │               │   └── @ MissingAttributeValueError (location: (1:10)-(1:11))
+        │               │       ├── message: "Attribute `class` at (1:10) is missing a value after the equals sign."
+        │               │       └── attribute_name: "class"
         │               │
         │               ├── open_quote: ∅
         │               ├── children: []

--- a/test/snapshots/parser/attributes_test/test_0118_attribute_with_equals_and_space_at_EOF_2ff25ac24722c9994968817ad35fd66e.txt
+++ b/test/snapshots/parser/attributes_test/test_0118_attribute_with_equals_and_space_at_EOF_2ff25ac24722c9994968817ad35fd66e.txt
@@ -24,13 +24,11 @@ input: "<div class= "
         │       │
         │       ├── equals: "=" (location: (1:10)-(1:11))
         │       └── value:
-        │           └── @ HTMLAttributeValueNode (location: (1:12)-(1:12))
+        │           └── @ HTMLAttributeValueNode (location: (1:11)-(1:12))
         │               ├── errors: (1 error)
-        │               │   └── @ UnexpectedError (location: (1:12)-(1:12))
-        │               │       ├── message: "Unexpected Token. Expected: an identifier, a quote, or `<%`, found: end of file."
-        │               │       ├── description: "Unexpected Token"
-        │               │       ├── expected: "an identifier, a quote, or `<%`"
-        │               │       └── found: "end of file"
+        │               │   └── @ MissingAttributeValueError (location: (1:10)-(1:12))
+        │               │       ├── message: "Attribute `class` at (1:10) is missing a value after the equals sign."
+        │               │       └── attribute_name: "class"
         │               │
         │               ├── open_quote: ∅
         │               ├── children: []

--- a/test/snapshots/parser/attributes_test/test_0120_attribute_with_equals_followed_by_closing_tag_c8cfc11d3772c91f3dbb9a45f21c07a0.txt
+++ b/test/snapshots/parser/attributes_test/test_0120_attribute_with_equals_followed_by_closing_tag_c8cfc11d3772c91f3dbb9a45f21c07a0.txt
@@ -16,7 +16,7 @@ input: "<div class=</div>"
         │       ├── tag_name: "div" (location: (1:1)-(1:4))
         │       ├── tag_closing: ∅
         │       ├── children: (1 item)
-        │       │   └── @ HTMLAttributeNode (location: (1:5)-(1:13))
+        │       │   └── @ HTMLAttributeNode (location: (1:5)-(1:11))
         │       │       ├── name:
         │       │       │   └── @ HTMLAttributeNameNode (location: (1:5)-(1:10))
         │       │       │       └── children: (1 item)
@@ -26,13 +26,11 @@ input: "<div class=</div>"
         │       │       │
         │       │       ├── equals: "=" (location: (1:10)-(1:11))
         │       │       └── value:
-        │       │           └── @ HTMLAttributeValueNode (location: (1:11)-(1:13))
+        │       │           └── @ HTMLAttributeValueNode (location: (1:11)-(1:11))
         │       │               ├── errors: (1 error)
-        │       │               │   └── @ UnexpectedError (location: (1:11)-(1:13))
-        │       │               │       ├── message: "Unexpected Token. Expected: an identifier, a quote, or `<%`, found: `</`."
-        │       │               │       ├── description: "Unexpected Token"
-        │       │               │       ├── expected: "an identifier, a quote, or `<%`"
-        │       │               │       └── found: "`</`"
+        │       │               │   └── @ MissingAttributeValueError (location: (1:10)-(1:11))
+        │       │               │       ├── message: "Attribute `class` at (1:10) is missing a value after the equals sign."
+        │       │               │       └── attribute_name: "class"
         │       │               │
         │       │               ├── open_quote: ∅
         │       │               ├── children: []

--- a/test/snapshots/parser/attributes_test/test_0141_stray_character_after_quoted_double_quote_value_0c0296fa3e0ccf9cde8b3f6a388979f8.txt
+++ b/test/snapshots/parser/attributes_test/test_0141_stray_character_after_quoted_double_quote_value_0c0296fa3e0ccf9cde8b3f6a388979f8.txt
@@ -1,0 +1,62 @@
+---
+source: "Parser::AttributesTest#test_0141_stray character after quoted double quote value"
+input: "<div onclick=\"true\")></div>"
+---
+@ DocumentNode (location: (1:0)-(1:27))
+└── children: (1 item)
+    └── @ HTMLElementNode (location: (1:0)-(1:27))
+        ├── open_tag:
+        │   └── @ HTMLOpenTagNode (location: (1:0)-(1:21))
+        │       ├── errors: (1 error)
+        │       │   └── @ MissingWhitespaceBetweenAttributesError (location: (1:19)-(1:20))
+        │       │       ├── message: "Missing whitespace between attributes at (1:19). `)` is parsed as the start of a new attribute."
+        │       │       └── found: ")" (location: (1:19)-(1:20))
+        │       │
+        │       ├── tag_opening: "<" (location: (1:0)-(1:1))
+        │       ├── tag_name: "div" (location: (1:1)-(1:4))
+        │       ├── tag_closing: ">" (location: (1:20)-(1:21))
+        │       ├── children: (2 items)
+        │       │   ├── @ HTMLAttributeNode (location: (1:5)-(1:19))
+        │       │   │   ├── name:
+        │       │   │   │   └── @ HTMLAttributeNameNode (location: (1:5)-(1:12))
+        │       │   │   │       └── children: (1 item)
+        │       │   │   │           └── @ LiteralNode (location: (1:5)-(1:12))
+        │       │   │   │               └── content: "onclick"
+        │       │   │   │
+        │       │   │   │
+        │       │   │   ├── equals: "=" (location: (1:12)-(1:13))
+        │       │   │   └── value:
+        │       │   │       └── @ HTMLAttributeValueNode (location: (1:13)-(1:19))
+        │       │   │           ├── open_quote: """ (location: (1:13)-(1:14))
+        │       │   │           ├── children: (1 item)
+        │       │   │           │   └── @ LiteralNode (location: (1:14)-(1:18))
+        │       │   │           │       └── content: "true"
+        │       │   │           │
+        │       │   │           ├── close_quote: """ (location: (1:18)-(1:19))
+        │       │   │           └── quoted: true
+        │       │   │
+        │       │   │
+        │       │   └── @ HTMLAttributeNode (location: (1:19)-(1:20))
+        │       │       ├── name:
+        │       │       │   └── @ HTMLAttributeNameNode (location: (1:19)-(1:20))
+        │       │       │       └── children: (1 item)
+        │       │       │           └── @ LiteralNode (location: (1:19)-(1:20))
+        │       │       │               └── content: ")"
+        │       │       │
+        │       │       │
+        │       │       ├── equals: ∅
+        │       │       └── value: ∅
+        │       │
+        │       └── is_void: false
+        │
+        ├── tag_name: "div" (location: (1:1)-(1:4))
+        ├── body: []
+        ├── close_tag:
+        │   └── @ HTMLCloseTagNode (location: (1:21)-(1:27))
+        │       ├── tag_opening: "</" (location: (1:21)-(1:23))
+        │       ├── tag_name: "div" (location: (1:23)-(1:26))
+        │       ├── children: []
+        │       └── tag_closing: ">" (location: (1:26)-(1:27))
+        │
+        ├── is_void: false
+        └── element_source: "HTML"

--- a/test/snapshots/parser/attributes_test/test_0142_stray_character_after_quoted_single_quote_value_b85be821a0082f2aaf977d60341eb188.txt
+++ b/test/snapshots/parser/attributes_test/test_0142_stray_character_after_quoted_single_quote_value_b85be821a0082f2aaf977d60341eb188.txt
@@ -1,0 +1,62 @@
+---
+source: "Parser::AttributesTest#test_0142_stray character after quoted single quote value"
+input: "<div onclick='true')></div>"
+---
+@ DocumentNode (location: (1:0)-(1:27))
+└── children: (1 item)
+    └── @ HTMLElementNode (location: (1:0)-(1:27))
+        ├── open_tag:
+        │   └── @ HTMLOpenTagNode (location: (1:0)-(1:21))
+        │       ├── errors: (1 error)
+        │       │   └── @ MissingWhitespaceBetweenAttributesError (location: (1:19)-(1:20))
+        │       │       ├── message: "Missing whitespace between attributes at (1:19). `)` is parsed as the start of a new attribute."
+        │       │       └── found: ")" (location: (1:19)-(1:20))
+        │       │
+        │       ├── tag_opening: "<" (location: (1:0)-(1:1))
+        │       ├── tag_name: "div" (location: (1:1)-(1:4))
+        │       ├── tag_closing: ">" (location: (1:20)-(1:21))
+        │       ├── children: (2 items)
+        │       │   ├── @ HTMLAttributeNode (location: (1:5)-(1:19))
+        │       │   │   ├── name:
+        │       │   │   │   └── @ HTMLAttributeNameNode (location: (1:5)-(1:12))
+        │       │   │   │       └── children: (1 item)
+        │       │   │   │           └── @ LiteralNode (location: (1:5)-(1:12))
+        │       │   │   │               └── content: "onclick"
+        │       │   │   │
+        │       │   │   │
+        │       │   │   ├── equals: "=" (location: (1:12)-(1:13))
+        │       │   │   └── value:
+        │       │   │       └── @ HTMLAttributeValueNode (location: (1:13)-(1:19))
+        │       │   │           ├── open_quote: "'" (location: (1:13)-(1:14))
+        │       │   │           ├── children: (1 item)
+        │       │   │           │   └── @ LiteralNode (location: (1:14)-(1:18))
+        │       │   │           │       └── content: "true"
+        │       │   │           │
+        │       │   │           ├── close_quote: "'" (location: (1:18)-(1:19))
+        │       │   │           └── quoted: true
+        │       │   │
+        │       │   │
+        │       │   └── @ HTMLAttributeNode (location: (1:19)-(1:20))
+        │       │       ├── name:
+        │       │       │   └── @ HTMLAttributeNameNode (location: (1:19)-(1:20))
+        │       │       │       └── children: (1 item)
+        │       │       │           └── @ LiteralNode (location: (1:19)-(1:20))
+        │       │       │               └── content: ")"
+        │       │       │
+        │       │       │
+        │       │       ├── equals: ∅
+        │       │       └── value: ∅
+        │       │
+        │       └── is_void: false
+        │
+        ├── tag_name: "div" (location: (1:1)-(1:4))
+        ├── body: []
+        ├── close_tag:
+        │   └── @ HTMLCloseTagNode (location: (1:21)-(1:27))
+        │       ├── tag_opening: "</" (location: (1:21)-(1:23))
+        │       ├── tag_name: "div" (location: (1:23)-(1:26))
+        │       ├── children: []
+        │       └── tag_closing: ">" (location: (1:26)-(1:27))
+        │
+        ├── is_void: false
+        └── element_source: "HTML"

--- a/test/snapshots/parser/attributes_test/test_0143_stray_identifier_after_quoted_value_b0085c055113a99fcf335542baa3a4d1.txt
+++ b/test/snapshots/parser/attributes_test/test_0143_stray_identifier_after_quoted_value_b0085c055113a99fcf335542baa3a4d1.txt
@@ -1,0 +1,62 @@
+---
+source: "Parser::AttributesTest#test_0143_stray identifier after quoted value"
+input: "<div title=\"foo\"bar></div>"
+---
+@ DocumentNode (location: (1:0)-(1:26))
+└── children: (1 item)
+    └── @ HTMLElementNode (location: (1:0)-(1:26))
+        ├── open_tag:
+        │   └── @ HTMLOpenTagNode (location: (1:0)-(1:20))
+        │       ├── errors: (1 error)
+        │       │   └── @ MissingWhitespaceBetweenAttributesError (location: (1:16)-(1:19))
+        │       │       ├── message: "Missing whitespace between attributes at (1:16). `bar` is parsed as the start of a new attribute."
+        │       │       └── found: "bar" (location: (1:16)-(1:19))
+        │       │
+        │       ├── tag_opening: "<" (location: (1:0)-(1:1))
+        │       ├── tag_name: "div" (location: (1:1)-(1:4))
+        │       ├── tag_closing: ">" (location: (1:19)-(1:20))
+        │       ├── children: (2 items)
+        │       │   ├── @ HTMLAttributeNode (location: (1:5)-(1:16))
+        │       │   │   ├── name:
+        │       │   │   │   └── @ HTMLAttributeNameNode (location: (1:5)-(1:10))
+        │       │   │   │       └── children: (1 item)
+        │       │   │   │           └── @ LiteralNode (location: (1:5)-(1:10))
+        │       │   │   │               └── content: "title"
+        │       │   │   │
+        │       │   │   │
+        │       │   │   ├── equals: "=" (location: (1:10)-(1:11))
+        │       │   │   └── value:
+        │       │   │       └── @ HTMLAttributeValueNode (location: (1:11)-(1:16))
+        │       │   │           ├── open_quote: """ (location: (1:11)-(1:12))
+        │       │   │           ├── children: (1 item)
+        │       │   │           │   └── @ LiteralNode (location: (1:12)-(1:15))
+        │       │   │           │       └── content: "foo"
+        │       │   │           │
+        │       │   │           ├── close_quote: """ (location: (1:15)-(1:16))
+        │       │   │           └── quoted: true
+        │       │   │
+        │       │   │
+        │       │   └── @ HTMLAttributeNode (location: (1:16)-(1:19))
+        │       │       ├── name:
+        │       │       │   └── @ HTMLAttributeNameNode (location: (1:16)-(1:19))
+        │       │       │       └── children: (1 item)
+        │       │       │           └── @ LiteralNode (location: (1:16)-(1:19))
+        │       │       │               └── content: "bar"
+        │       │       │
+        │       │       │
+        │       │       ├── equals: ∅
+        │       │       └── value: ∅
+        │       │
+        │       └── is_void: false
+        │
+        ├── tag_name: "div" (location: (1:1)-(1:4))
+        ├── body: []
+        ├── close_tag:
+        │   └── @ HTMLCloseTagNode (location: (1:20)-(1:26))
+        │       ├── tag_opening: "</" (location: (1:20)-(1:22))
+        │       ├── tag_name: "div" (location: (1:22)-(1:25))
+        │       ├── children: []
+        │       └── tag_closing: ">" (location: (1:25)-(1:26))
+        │
+        ├── is_void: false
+        └── element_source: "HTML"

--- a/test/snapshots/parser/attributes_test/test_0144_stray_character_after_quoted_value_followed_by_another_attribute_c1778197fa7f671db0cc1c7d0a150584.txt
+++ b/test/snapshots/parser/attributes_test/test_0144_stray_character_after_quoted_value_followed_by_another_attribute_c1778197fa7f671db0cc1c7d0a150584.txt
@@ -1,0 +1,82 @@
+---
+source: "Parser::AttributesTest#test_0144_stray character after quoted value followed by another attribute"
+input: "<div onclick=\"true\") class=\"box\"></div>"
+---
+@ DocumentNode (location: (1:0)-(1:39))
+└── children: (1 item)
+    └── @ HTMLElementNode (location: (1:0)-(1:39))
+        ├── open_tag:
+        │   └── @ HTMLOpenTagNode (location: (1:0)-(1:33))
+        │       ├── errors: (1 error)
+        │       │   └── @ MissingWhitespaceBetweenAttributesError (location: (1:19)-(1:20))
+        │       │       ├── message: "Missing whitespace between attributes at (1:19). `)` is parsed as the start of a new attribute."
+        │       │       └── found: ")" (location: (1:19)-(1:20))
+        │       │
+        │       ├── tag_opening: "<" (location: (1:0)-(1:1))
+        │       ├── tag_name: "div" (location: (1:1)-(1:4))
+        │       ├── tag_closing: ">" (location: (1:32)-(1:33))
+        │       ├── children: (3 items)
+        │       │   ├── @ HTMLAttributeNode (location: (1:5)-(1:19))
+        │       │   │   ├── name:
+        │       │   │   │   └── @ HTMLAttributeNameNode (location: (1:5)-(1:12))
+        │       │   │   │       └── children: (1 item)
+        │       │   │   │           └── @ LiteralNode (location: (1:5)-(1:12))
+        │       │   │   │               └── content: "onclick"
+        │       │   │   │
+        │       │   │   │
+        │       │   │   ├── equals: "=" (location: (1:12)-(1:13))
+        │       │   │   └── value:
+        │       │   │       └── @ HTMLAttributeValueNode (location: (1:13)-(1:19))
+        │       │   │           ├── open_quote: """ (location: (1:13)-(1:14))
+        │       │   │           ├── children: (1 item)
+        │       │   │           │   └── @ LiteralNode (location: (1:14)-(1:18))
+        │       │   │           │       └── content: "true"
+        │       │   │           │
+        │       │   │           ├── close_quote: """ (location: (1:18)-(1:19))
+        │       │   │           └── quoted: true
+        │       │   │
+        │       │   │
+        │       │   ├── @ HTMLAttributeNode (location: (1:19)-(1:20))
+        │       │   │   ├── name:
+        │       │   │   │   └── @ HTMLAttributeNameNode (location: (1:19)-(1:20))
+        │       │   │   │       └── children: (1 item)
+        │       │   │   │           └── @ LiteralNode (location: (1:19)-(1:20))
+        │       │   │   │               └── content: ")"
+        │       │   │   │
+        │       │   │   │
+        │       │   │   ├── equals: ∅
+        │       │   │   └── value: ∅
+        │       │   │
+        │       │   └── @ HTMLAttributeNode (location: (1:21)-(1:32))
+        │       │       ├── name:
+        │       │       │   └── @ HTMLAttributeNameNode (location: (1:21)-(1:26))
+        │       │       │       └── children: (1 item)
+        │       │       │           └── @ LiteralNode (location: (1:21)-(1:26))
+        │       │       │               └── content: "class"
+        │       │       │
+        │       │       │
+        │       │       ├── equals: "=" (location: (1:26)-(1:27))
+        │       │       └── value:
+        │       │           └── @ HTMLAttributeValueNode (location: (1:27)-(1:32))
+        │       │               ├── open_quote: """ (location: (1:27)-(1:28))
+        │       │               ├── children: (1 item)
+        │       │               │   └── @ LiteralNode (location: (1:28)-(1:31))
+        │       │               │       └── content: "box"
+        │       │               │
+        │       │               ├── close_quote: """ (location: (1:31)-(1:32))
+        │       │               └── quoted: true
+        │       │
+        │       │
+        │       └── is_void: false
+        │
+        ├── tag_name: "div" (location: (1:1)-(1:4))
+        ├── body: []
+        ├── close_tag:
+        │   └── @ HTMLCloseTagNode (location: (1:33)-(1:39))
+        │       ├── tag_opening: "</" (location: (1:33)-(1:35))
+        │       ├── tag_name: "div" (location: (1:35)-(1:38))
+        │       ├── children: []
+        │       └── tag_closing: ">" (location: (1:38)-(1:39))
+        │
+        ├── is_void: false
+        └── element_source: "HTML"

--- a/test/snapshots/parser/attributes_test/test_0145_comma_between_quoted_attributes_ab7348acbaa147018b88f8fdfa2301c0.txt
+++ b/test/snapshots/parser/attributes_test/test_0145_comma_between_quoted_attributes_ab7348acbaa147018b88f8fdfa2301c0.txt
@@ -1,0 +1,82 @@
+---
+source: "Parser::AttributesTest#test_0145_comma between quoted attributes"
+input: "<div class=\"a\", id=\"b\"></div>"
+---
+@ DocumentNode (location: (1:0)-(1:29))
+└── children: (1 item)
+    └── @ HTMLElementNode (location: (1:0)-(1:29))
+        ├── open_tag:
+        │   └── @ HTMLOpenTagNode (location: (1:0)-(1:23))
+        │       ├── errors: (1 error)
+        │       │   └── @ MissingWhitespaceBetweenAttributesError (location: (1:14)-(1:15))
+        │       │       ├── message: "Missing whitespace between attributes at (1:14). `,` is parsed as the start of a new attribute."
+        │       │       └── found: "," (location: (1:14)-(1:15))
+        │       │
+        │       ├── tag_opening: "<" (location: (1:0)-(1:1))
+        │       ├── tag_name: "div" (location: (1:1)-(1:4))
+        │       ├── tag_closing: ">" (location: (1:22)-(1:23))
+        │       ├── children: (3 items)
+        │       │   ├── @ HTMLAttributeNode (location: (1:5)-(1:14))
+        │       │   │   ├── name:
+        │       │   │   │   └── @ HTMLAttributeNameNode (location: (1:5)-(1:10))
+        │       │   │   │       └── children: (1 item)
+        │       │   │   │           └── @ LiteralNode (location: (1:5)-(1:10))
+        │       │   │   │               └── content: "class"
+        │       │   │   │
+        │       │   │   │
+        │       │   │   ├── equals: "=" (location: (1:10)-(1:11))
+        │       │   │   └── value:
+        │       │   │       └── @ HTMLAttributeValueNode (location: (1:11)-(1:14))
+        │       │   │           ├── open_quote: """ (location: (1:11)-(1:12))
+        │       │   │           ├── children: (1 item)
+        │       │   │           │   └── @ LiteralNode (location: (1:12)-(1:13))
+        │       │   │           │       └── content: "a"
+        │       │   │           │
+        │       │   │           ├── close_quote: """ (location: (1:13)-(1:14))
+        │       │   │           └── quoted: true
+        │       │   │
+        │       │   │
+        │       │   ├── @ HTMLAttributeNode (location: (1:14)-(1:15))
+        │       │   │   ├── name:
+        │       │   │   │   └── @ HTMLAttributeNameNode (location: (1:14)-(1:15))
+        │       │   │   │       └── children: (1 item)
+        │       │   │   │           └── @ LiteralNode (location: (1:14)-(1:15))
+        │       │   │   │               └── content: ","
+        │       │   │   │
+        │       │   │   │
+        │       │   │   ├── equals: ∅
+        │       │   │   └── value: ∅
+        │       │   │
+        │       │   └── @ HTMLAttributeNode (location: (1:16)-(1:22))
+        │       │       ├── name:
+        │       │       │   └── @ HTMLAttributeNameNode (location: (1:16)-(1:18))
+        │       │       │       └── children: (1 item)
+        │       │       │           └── @ LiteralNode (location: (1:16)-(1:18))
+        │       │       │               └── content: "id"
+        │       │       │
+        │       │       │
+        │       │       ├── equals: "=" (location: (1:18)-(1:19))
+        │       │       └── value:
+        │       │           └── @ HTMLAttributeValueNode (location: (1:19)-(1:22))
+        │       │               ├── open_quote: """ (location: (1:19)-(1:20))
+        │       │               ├── children: (1 item)
+        │       │               │   └── @ LiteralNode (location: (1:20)-(1:21))
+        │       │               │       └── content: "b"
+        │       │               │
+        │       │               ├── close_quote: """ (location: (1:21)-(1:22))
+        │       │               └── quoted: true
+        │       │
+        │       │
+        │       └── is_void: false
+        │
+        ├── tag_name: "div" (location: (1:1)-(1:4))
+        ├── body: []
+        ├── close_tag:
+        │   └── @ HTMLCloseTagNode (location: (1:23)-(1:29))
+        │       ├── tag_opening: "</" (location: (1:23)-(1:25))
+        │       ├── tag_name: "div" (location: (1:25)-(1:28))
+        │       ├── children: []
+        │       └── tag_closing: ">" (location: (1:28)-(1:29))
+        │
+        ├── is_void: false
+        └── element_source: "HTML"

--- a/test/snapshots/parser/attributes_test/test_0146_mustache_braces_in_attribute_position_f38a0c4441fc68e5c9b479ce08f91f57.txt
+++ b/test/snapshots/parser/attributes_test/test_0146_mustache_braces_in_attribute_position_f38a0c4441fc68e5c9b479ce08f91f57.txt
@@ -1,0 +1,37 @@
+---
+source: "Parser::AttributesTest#test_0146_mustache braces in attribute position"
+input: "<div {{element_hidden}}></div>"
+---
+@ DocumentNode (location: (1:0)-(1:30))
+└── children: (1 item)
+    └── @ HTMLElementNode (location: (1:0)-(1:30))
+        ├── open_tag:
+        │   └── @ HTMLOpenTagNode (location: (1:0)-(1:24))
+        │       ├── tag_opening: "<" (location: (1:0)-(1:1))
+        │       ├── tag_name: "div" (location: (1:1)-(1:4))
+        │       ├── tag_closing: ">" (location: (1:23)-(1:24))
+        │       ├── children: (1 item)
+        │       │   └── @ HTMLAttributeNode (location: (1:5)-(1:23))
+        │       │       ├── name:
+        │       │       │   └── @ HTMLAttributeNameNode (location: (1:5)-(1:23))
+        │       │       │       └── children: (1 item)
+        │       │       │           └── @ LiteralNode (location: (1:5)-(1:23))
+        │       │       │               └── content: "{{element_hidden}}"
+        │       │       │
+        │       │       │
+        │       │       ├── equals: ∅
+        │       │       └── value: ∅
+        │       │
+        │       └── is_void: false
+        │
+        ├── tag_name: "div" (location: (1:1)-(1:4))
+        ├── body: []
+        ├── close_tag:
+        │   └── @ HTMLCloseTagNode (location: (1:24)-(1:30))
+        │       ├── tag_opening: "</" (location: (1:24)-(1:26))
+        │       ├── tag_name: "div" (location: (1:26)-(1:29))
+        │       ├── children: []
+        │       └── tag_closing: ">" (location: (1:29)-(1:30))
+        │
+        ├── is_void: false
+        └── element_source: "HTML"

--- a/test/snapshots/parser/attributes_test/test_0147_mustache_braces_around_an_attribute_with_a_value_0fbdcbd76ac8499977d8f64c36e9ae2e.txt
+++ b/test/snapshots/parser/attributes_test/test_0147_mustache_braces_around_an_attribute_with_a_value_0fbdcbd76ac8499977d8f64c36e9ae2e.txt
@@ -1,0 +1,62 @@
+---
+source: "Parser::AttributesTest#test_0147_mustache braces around an attribute with a value"
+input: "<div {{attr=\"x\"}}></div>"
+---
+@ DocumentNode (location: (1:0)-(1:24))
+└── children: (1 item)
+    └── @ HTMLElementNode (location: (1:0)-(1:24))
+        ├── open_tag:
+        │   └── @ HTMLOpenTagNode (location: (1:0)-(1:18))
+        │       ├── errors: (1 error)
+        │       │   └── @ MissingWhitespaceBetweenAttributesError (location: (1:15)-(1:16))
+        │       │       ├── message: "Missing whitespace between attributes at (1:15). `}` is parsed as the start of a new attribute."
+        │       │       └── found: "}" (location: (1:15)-(1:16))
+        │       │
+        │       ├── tag_opening: "<" (location: (1:0)-(1:1))
+        │       ├── tag_name: "div" (location: (1:1)-(1:4))
+        │       ├── tag_closing: ">" (location: (1:17)-(1:18))
+        │       ├── children: (2 items)
+        │       │   ├── @ HTMLAttributeNode (location: (1:5)-(1:15))
+        │       │   │   ├── name:
+        │       │   │   │   └── @ HTMLAttributeNameNode (location: (1:5)-(1:11))
+        │       │   │   │       └── children: (1 item)
+        │       │   │   │           └── @ LiteralNode (location: (1:5)-(1:11))
+        │       │   │   │               └── content: "{{attr"
+        │       │   │   │
+        │       │   │   │
+        │       │   │   ├── equals: "=" (location: (1:11)-(1:12))
+        │       │   │   └── value:
+        │       │   │       └── @ HTMLAttributeValueNode (location: (1:12)-(1:15))
+        │       │   │           ├── open_quote: """ (location: (1:12)-(1:13))
+        │       │   │           ├── children: (1 item)
+        │       │   │           │   └── @ LiteralNode (location: (1:13)-(1:14))
+        │       │   │           │       └── content: "x"
+        │       │   │           │
+        │       │   │           ├── close_quote: """ (location: (1:14)-(1:15))
+        │       │   │           └── quoted: true
+        │       │   │
+        │       │   │
+        │       │   └── @ HTMLAttributeNode (location: (1:15)-(1:17))
+        │       │       ├── name:
+        │       │       │   └── @ HTMLAttributeNameNode (location: (1:15)-(1:17))
+        │       │       │       └── children: (1 item)
+        │       │       │           └── @ LiteralNode (location: (1:15)-(1:17))
+        │       │       │               └── content: "}}"
+        │       │       │
+        │       │       │
+        │       │       ├── equals: ∅
+        │       │       └── value: ∅
+        │       │
+        │       └── is_void: false
+        │
+        ├── tag_name: "div" (location: (1:1)-(1:4))
+        ├── body: []
+        ├── close_tag:
+        │   └── @ HTMLCloseTagNode (location: (1:18)-(1:24))
+        │       ├── tag_opening: "</" (location: (1:18)-(1:20))
+        │       ├── tag_name: "div" (location: (1:20)-(1:23))
+        │       ├── children: []
+        │       └── tag_closing: ">" (location: (1:23)-(1:24))
+        │
+        ├── is_void: false
+        └── element_source: "HTML"

--- a/test/snapshots/parser/attributes_test/test_0148_attribute_with_equals_followed_by_a_stray_character_81a5f6714c16752472fb55fba64d0461.txt
+++ b/test/snapshots/parser/attributes_test/test_0148_attribute_with_equals_followed_by_a_stray_character_81a5f6714c16752472fb55fba64d0461.txt
@@ -1,17 +1,17 @@
 ---
-source: "Parser::AttributesTest#test_0119_multiple attributes with missing values"
-input: "<div class= id= ></div>"
+source: "Parser::AttributesTest#test_0148_attribute with equals followed by a stray character"
+input: "<div class=)></div>"
 ---
-@ DocumentNode (location: (1:0)-(1:23))
+@ DocumentNode (location: (1:0)-(1:19))
 └── children: (1 item)
-    └── @ HTMLElementNode (location: (1:0)-(1:23))
+    └── @ HTMLElementNode (location: (1:0)-(1:19))
         ├── open_tag:
-        │   └── @ HTMLOpenTagNode (location: (1:0)-(1:17))
+        │   └── @ HTMLOpenTagNode (location: (1:0)-(1:13))
         │       ├── tag_opening: "<" (location: (1:0)-(1:1))
         │       ├── tag_name: "div" (location: (1:1)-(1:4))
-        │       ├── tag_closing: ">" (location: (1:16)-(1:17))
+        │       ├── tag_closing: ">" (location: (1:12)-(1:13))
         │       ├── children: (1 item)
-        │       │   └── @ HTMLAttributeNode (location: (1:5)-(1:15))
+        │       │   └── @ HTMLAttributeNode (location: (1:5)-(1:12))
         │       │       ├── name:
         │       │       │   └── @ HTMLAttributeNameNode (location: (1:5)-(1:10))
         │       │       │       └── children: (1 item)
@@ -21,16 +21,11 @@ input: "<div class= id= ></div>"
         │       │       │
         │       │       ├── equals: "=" (location: (1:10)-(1:11))
         │       │       └── value:
-        │       │           └── @ HTMLAttributeValueNode (location: (1:12)-(1:15))
-        │       │               ├── errors: (1 error)
-        │       │               │   └── @ UnexpectedCharacterInUnquotedAttributeValueError (location: (1:14)-(1:15))
-        │       │               │       ├── message: "Unexpected `=` in unquoted attribute value at (1:14)."
-        │       │               │       └── character: "=" (location: (1:14)-(1:15))
-        │       │               │
+        │       │           └── @ HTMLAttributeValueNode (location: (1:11)-(1:12))
         │       │               ├── open_quote: ∅
         │       │               ├── children: (1 item)
-        │       │               │   └── @ LiteralNode (location: (1:12)-(1:15))
-        │       │               │       └── content: "id="
+        │       │               │   └── @ LiteralNode (location: (1:11)-(1:12))
+        │       │               │       └── content: ")"
         │       │               │
         │       │               ├── close_quote: ∅
         │       │               └── quoted: false
@@ -41,11 +36,11 @@ input: "<div class= id= ></div>"
         ├── tag_name: "div" (location: (1:1)-(1:4))
         ├── body: []
         ├── close_tag:
-        │   └── @ HTMLCloseTagNode (location: (1:17)-(1:23))
-        │       ├── tag_opening: "</" (location: (1:17)-(1:19))
-        │       ├── tag_name: "div" (location: (1:19)-(1:22))
+        │   └── @ HTMLCloseTagNode (location: (1:13)-(1:19))
+        │       ├── tag_opening: "</" (location: (1:13)-(1:15))
+        │       ├── tag_name: "div" (location: (1:15)-(1:18))
         │       ├── children: []
-        │       └── tag_closing: ">" (location: (1:22)-(1:23))
+        │       └── tag_closing: ">" (location: (1:18)-(1:19))
         │
         ├── is_void: false
         └── element_source: "HTML"

--- a/test/snapshots/parser/attributes_test/test_0149_attribute_with_spaced_equals_followed_by_a_stray_character_8d267c86dcbf4a48cb78952cd5cc81ef.txt
+++ b/test/snapshots/parser/attributes_test/test_0149_attribute_with_spaced_equals_followed_by_a_stray_character_8d267c86dcbf4a48cb78952cd5cc81ef.txt
@@ -1,0 +1,46 @@
+---
+source: "Parser::AttributesTest#test_0149_attribute with spaced equals followed by a stray character"
+input: "<div class = )></div>"
+---
+@ DocumentNode (location: (1:0)-(1:21))
+└── children: (1 item)
+    └── @ HTMLElementNode (location: (1:0)-(1:21))
+        ├── open_tag:
+        │   └── @ HTMLOpenTagNode (location: (1:0)-(1:15))
+        │       ├── tag_opening: "<" (location: (1:0)-(1:1))
+        │       ├── tag_name: "div" (location: (1:1)-(1:4))
+        │       ├── tag_closing: ">" (location: (1:14)-(1:15))
+        │       ├── children: (1 item)
+        │       │   └── @ HTMLAttributeNode (location: (1:5)-(1:14))
+        │       │       ├── name:
+        │       │       │   └── @ HTMLAttributeNameNode (location: (1:5)-(1:10))
+        │       │       │       └── children: (1 item)
+        │       │       │           └── @ LiteralNode (location: (1:5)-(1:10))
+        │       │       │               └── content: "class"
+        │       │       │
+        │       │       │
+        │       │       ├── equals: "=" (location: (1:11)-(1:12))
+        │       │       └── value:
+        │       │           └── @ HTMLAttributeValueNode (location: (1:13)-(1:14))
+        │       │               ├── open_quote: ∅
+        │       │               ├── children: (1 item)
+        │       │               │   └── @ LiteralNode (location: (1:13)-(1:14))
+        │       │               │       └── content: ")"
+        │       │               │
+        │       │               ├── close_quote: ∅
+        │       │               └── quoted: false
+        │       │
+        │       │
+        │       └── is_void: false
+        │
+        ├── tag_name: "div" (location: (1:1)-(1:4))
+        ├── body: []
+        ├── close_tag:
+        │   └── @ HTMLCloseTagNode (location: (1:15)-(1:21))
+        │       ├── tag_opening: "</" (location: (1:15)-(1:17))
+        │       ├── tag_name: "div" (location: (1:17)-(1:20))
+        │       ├── children: []
+        │       └── tag_closing: ">" (location: (1:20)-(1:21))
+        │
+        ├── is_void: false
+        └── element_source: "HTML"

--- a/test/snapshots/parser/attributes_test/test_0150_attribute_with_equals_followed_by_another_attribute_c9120ee1a2fdbfe153c66a1319d2ae3f.txt
+++ b/test/snapshots/parser/attributes_test/test_0150_attribute_with_equals_followed_by_another_attribute_c9120ee1a2fdbfe153c66a1319d2ae3f.txt
@@ -1,0 +1,59 @@
+---
+source: "Parser::AttributesTest#test_0150_attribute with equals followed by another attribute"
+input: "<div class=@click=\"go\"></div>"
+---
+@ DocumentNode (location: (1:0)-(1:29))
+└── children: (1 item)
+    └── @ HTMLElementNode (location: (1:0)-(1:29))
+        ├── open_tag:
+        │   └── @ HTMLOpenTagNode (location: (1:0)-(1:23))
+        │       ├── tag_opening: "<" (location: (1:0)-(1:1))
+        │       ├── tag_name: "div" (location: (1:1)-(1:4))
+        │       ├── tag_closing: ">" (location: (1:22)-(1:23))
+        │       ├── children: (1 item)
+        │       │   └── @ HTMLAttributeNode (location: (1:5)-(1:22))
+        │       │       ├── name:
+        │       │       │   └── @ HTMLAttributeNameNode (location: (1:5)-(1:10))
+        │       │       │       └── children: (1 item)
+        │       │       │           └── @ LiteralNode (location: (1:5)-(1:10))
+        │       │       │               └── content: "class"
+        │       │       │
+        │       │       │
+        │       │       ├── equals: "=" (location: (1:10)-(1:11))
+        │       │       └── value:
+        │       │           └── @ HTMLAttributeValueNode (location: (1:11)-(1:22))
+        │       │               ├── errors: (3 errors)
+        │       │               │   ├── @ UnexpectedCharacterInUnquotedAttributeValueError (location: (1:17)-(1:18))
+        │       │               │   │   ├── message: "Unexpected `=` in unquoted attribute value at (1:17)."
+        │       │               │   │   └── character: "=" (location: (1:17)-(1:18))
+        │       │               │   │
+        │       │               │   ├── @ UnexpectedCharacterInUnquotedAttributeValueError (location: (1:18)-(1:19))
+        │       │               │   │   ├── message: "Unexpected `\"` in unquoted attribute value at (1:18)."
+        │       │               │   │   └── character: """ (location: (1:18)-(1:19))
+        │       │               │   │
+        │       │               │   └── @ UnexpectedCharacterInUnquotedAttributeValueError (location: (1:21)-(1:22))
+        │       │               │       ├── message: "Unexpected `\"` in unquoted attribute value at (1:21)."
+        │       │               │       └── character: """ (location: (1:21)-(1:22))
+        │       │               │
+        │       │               ├── open_quote: ∅
+        │       │               ├── children: (1 item)
+        │       │               │   └── @ LiteralNode (location: (1:11)-(1:22))
+        │       │               │       └── content: "@click=\"go\""
+        │       │               │
+        │       │               ├── close_quote: ∅
+        │       │               └── quoted: false
+        │       │
+        │       │
+        │       └── is_void: false
+        │
+        ├── tag_name: "div" (location: (1:1)-(1:4))
+        ├── body: []
+        ├── close_tag:
+        │   └── @ HTMLCloseTagNode (location: (1:23)-(1:29))
+        │       ├── tag_opening: "</" (location: (1:23)-(1:25))
+        │       ├── tag_name: "div" (location: (1:25)-(1:28))
+        │       ├── children: []
+        │       └── tag_closing: ">" (location: (1:28)-(1:29))
+        │
+        ├── is_void: false
+        └── element_source: "HTML"

--- a/test/snapshots/parser/attributes_test/test_0151_unquoted_attribute_value_with_a_dot_d20b9a75507cc9db4537b560f0e141ee.txt
+++ b/test/snapshots/parser/attributes_test/test_0151_unquoted_attribute_value_with_a_dot_d20b9a75507cc9db4537b560f0e141ee.txt
@@ -1,0 +1,40 @@
+---
+source: "Parser::AttributesTest#test_0151_unquoted attribute value with a dot"
+input: "<img src=image.jpg>"
+---
+@ DocumentNode (location: (1:0)-(1:19))
+└── children: (1 item)
+    └── @ HTMLElementNode (location: (1:0)-(1:19))
+        ├── open_tag:
+        │   └── @ HTMLOpenTagNode (location: (1:0)-(1:19))
+        │       ├── tag_opening: "<" (location: (1:0)-(1:1))
+        │       ├── tag_name: "img" (location: (1:1)-(1:4))
+        │       ├── tag_closing: ">" (location: (1:18)-(1:19))
+        │       ├── children: (1 item)
+        │       │   └── @ HTMLAttributeNode (location: (1:5)-(1:18))
+        │       │       ├── name:
+        │       │       │   └── @ HTMLAttributeNameNode (location: (1:5)-(1:8))
+        │       │       │       └── children: (1 item)
+        │       │       │           └── @ LiteralNode (location: (1:5)-(1:8))
+        │       │       │               └── content: "src"
+        │       │       │
+        │       │       │
+        │       │       ├── equals: "=" (location: (1:8)-(1:9))
+        │       │       └── value:
+        │       │           └── @ HTMLAttributeValueNode (location: (1:9)-(1:18))
+        │       │               ├── open_quote: ∅
+        │       │               ├── children: (1 item)
+        │       │               │   └── @ LiteralNode (location: (1:9)-(1:18))
+        │       │               │       └── content: "image.jpg"
+        │       │               │
+        │       │               ├── close_quote: ∅
+        │       │               └── quoted: false
+        │       │
+        │       │
+        │       └── is_void: false
+        │
+        ├── tag_name: "img" (location: (1:1)-(1:4))
+        ├── body: []
+        ├── close_tag: ∅
+        ├── is_void: true
+        └── element_source: "HTML"

--- a/test/snapshots/parser/attributes_test/test_0152_unquoted_attribute_value_with_slashes_c1d2884b999971833a53d09b31e351ca.txt
+++ b/test/snapshots/parser/attributes_test/test_0152_unquoted_attribute_value_with_slashes_c1d2884b999971833a53d09b31e351ca.txt
@@ -1,0 +1,46 @@
+---
+source: "Parser::AttributesTest#test_0152_unquoted attribute value with slashes"
+input: "<a href=/foo/bar></a>"
+---
+@ DocumentNode (location: (1:0)-(1:21))
+└── children: (1 item)
+    └── @ HTMLElementNode (location: (1:0)-(1:21))
+        ├── open_tag:
+        │   └── @ HTMLOpenTagNode (location: (1:0)-(1:17))
+        │       ├── tag_opening: "<" (location: (1:0)-(1:1))
+        │       ├── tag_name: "a" (location: (1:1)-(1:2))
+        │       ├── tag_closing: ">" (location: (1:16)-(1:17))
+        │       ├── children: (1 item)
+        │       │   └── @ HTMLAttributeNode (location: (1:3)-(1:16))
+        │       │       ├── name:
+        │       │       │   └── @ HTMLAttributeNameNode (location: (1:3)-(1:7))
+        │       │       │       └── children: (1 item)
+        │       │       │           └── @ LiteralNode (location: (1:3)-(1:7))
+        │       │       │               └── content: "href"
+        │       │       │
+        │       │       │
+        │       │       ├── equals: "=" (location: (1:7)-(1:8))
+        │       │       └── value:
+        │       │           └── @ HTMLAttributeValueNode (location: (1:8)-(1:16))
+        │       │               ├── open_quote: ∅
+        │       │               ├── children: (1 item)
+        │       │               │   └── @ LiteralNode (location: (1:8)-(1:16))
+        │       │               │       └── content: "/foo/bar"
+        │       │               │
+        │       │               ├── close_quote: ∅
+        │       │               └── quoted: false
+        │       │
+        │       │
+        │       └── is_void: false
+        │
+        ├── tag_name: "a" (location: (1:1)-(1:2))
+        ├── body: []
+        ├── close_tag:
+        │   └── @ HTMLCloseTagNode (location: (1:17)-(1:21))
+        │       ├── tag_opening: "</" (location: (1:17)-(1:19))
+        │       ├── tag_name: "a" (location: (1:19)-(1:20))
+        │       ├── children: []
+        │       └── tag_closing: ">" (location: (1:20)-(1:21))
+        │
+        ├── is_void: false
+        └── element_source: "HTML"

--- a/test/snapshots/parser/attributes_test/test_0153_unquoted_attribute_value_followed_by_ERB_ce60c750f301505991578a7d32ce6443.txt
+++ b/test/snapshots/parser/attributes_test/test_0153_unquoted_attribute_value_followed_by_ERB_ce60c750f301505991578a7d32ce6443.txt
@@ -1,0 +1,53 @@
+---
+source: "Parser::AttributesTest#test_0153_unquoted attribute value followed by ERB"
+input: "<div class=foo<%= bar %>></div>"
+---
+@ DocumentNode (location: (1:0)-(1:31))
+└── children: (1 item)
+    └── @ HTMLElementNode (location: (1:0)-(1:31))
+        ├── open_tag:
+        │   └── @ HTMLOpenTagNode (location: (1:0)-(1:25))
+        │       ├── tag_opening: "<" (location: (1:0)-(1:1))
+        │       ├── tag_name: "div" (location: (1:1)-(1:4))
+        │       ├── tag_closing: ">" (location: (1:24)-(1:25))
+        │       ├── children: (1 item)
+        │       │   └── @ HTMLAttributeNode (location: (1:5)-(1:24))
+        │       │       ├── name:
+        │       │       │   └── @ HTMLAttributeNameNode (location: (1:5)-(1:10))
+        │       │       │       └── children: (1 item)
+        │       │       │           └── @ LiteralNode (location: (1:5)-(1:10))
+        │       │       │               └── content: "class"
+        │       │       │
+        │       │       │
+        │       │       ├── equals: "=" (location: (1:10)-(1:11))
+        │       │       └── value:
+        │       │           └── @ HTMLAttributeValueNode (location: (1:11)-(1:24))
+        │       │               ├── open_quote: ∅
+        │       │               ├── children: (2 items)
+        │       │               │   ├── @ LiteralNode (location: (1:11)-(1:14))
+        │       │               │   │   └── content: "foo"
+        │       │               │   │
+        │       │               │   └── @ ERBContentNode (location: (1:14)-(1:24))
+        │       │               │       ├── tag_opening: "<%=" (location: (1:14)-(1:17))
+        │       │               │       ├── content: " bar " (location: (1:17)-(1:22))
+        │       │               │       ├── tag_closing: "%>" (location: (1:22)-(1:24))
+        │       │               │       ├── parsed: true
+        │       │               │       └── valid: true
+        │       │               │
+        │       │               ├── close_quote: ∅
+        │       │               └── quoted: false
+        │       │
+        │       │
+        │       └── is_void: false
+        │
+        ├── tag_name: "div" (location: (1:1)-(1:4))
+        ├── body: []
+        ├── close_tag:
+        │   └── @ HTMLCloseTagNode (location: (1:25)-(1:31))
+        │       ├── tag_opening: "</" (location: (1:25)-(1:27))
+        │       ├── tag_name: "div" (location: (1:27)-(1:30))
+        │       ├── children: []
+        │       └── tag_closing: ">" (location: (1:30)-(1:31))
+        │
+        ├── is_void: false
+        └── element_source: "HTML"

--- a/test/snapshots/parser/attributes_test/test_0154_unquoted_attribute_value_with_two_ERB_tags_f7ce54516cc88d9006413f7440f24c56.txt
+++ b/test/snapshots/parser/attributes_test/test_0154_unquoted_attribute_value_with_two_ERB_tags_f7ce54516cc88d9006413f7440f24c56.txt
@@ -1,0 +1,57 @@
+---
+source: "Parser::AttributesTest#test_0154_unquoted attribute value with two ERB tags"
+input: "<div class=<%= a %><%= b %>></div>"
+---
+@ DocumentNode (location: (1:0)-(1:34))
+└── children: (1 item)
+    └── @ HTMLElementNode (location: (1:0)-(1:34))
+        ├── open_tag:
+        │   └── @ HTMLOpenTagNode (location: (1:0)-(1:28))
+        │       ├── tag_opening: "<" (location: (1:0)-(1:1))
+        │       ├── tag_name: "div" (location: (1:1)-(1:4))
+        │       ├── tag_closing: ">" (location: (1:27)-(1:28))
+        │       ├── children: (1 item)
+        │       │   └── @ HTMLAttributeNode (location: (1:5)-(1:27))
+        │       │       ├── name:
+        │       │       │   └── @ HTMLAttributeNameNode (location: (1:5)-(1:10))
+        │       │       │       └── children: (1 item)
+        │       │       │           └── @ LiteralNode (location: (1:5)-(1:10))
+        │       │       │               └── content: "class"
+        │       │       │
+        │       │       │
+        │       │       ├── equals: "=" (location: (1:10)-(1:11))
+        │       │       └── value:
+        │       │           └── @ HTMLAttributeValueNode (location: (1:11)-(1:27))
+        │       │               ├── open_quote: ∅
+        │       │               ├── children: (2 items)
+        │       │               │   ├── @ ERBContentNode (location: (1:11)-(1:19))
+        │       │               │   │   ├── tag_opening: "<%=" (location: (1:11)-(1:14))
+        │       │               │   │   ├── content: " a " (location: (1:14)-(1:17))
+        │       │               │   │   ├── tag_closing: "%>" (location: (1:17)-(1:19))
+        │       │               │   │   ├── parsed: true
+        │       │               │   │   └── valid: true
+        │       │               │   │
+        │       │               │   └── @ ERBContentNode (location: (1:19)-(1:27))
+        │       │               │       ├── tag_opening: "<%=" (location: (1:19)-(1:22))
+        │       │               │       ├── content: " b " (location: (1:22)-(1:25))
+        │       │               │       ├── tag_closing: "%>" (location: (1:25)-(1:27))
+        │       │               │       ├── parsed: true
+        │       │               │       └── valid: true
+        │       │               │
+        │       │               ├── close_quote: ∅
+        │       │               └── quoted: false
+        │       │
+        │       │
+        │       └── is_void: false
+        │
+        ├── tag_name: "div" (location: (1:1)-(1:4))
+        ├── body: []
+        ├── close_tag:
+        │   └── @ HTMLCloseTagNode (location: (1:28)-(1:34))
+        │       ├── tag_opening: "</" (location: (1:28)-(1:30))
+        │       ├── tag_name: "div" (location: (1:30)-(1:33))
+        │       ├── children: []
+        │       └── tag_closing: ">" (location: (1:33)-(1:34))
+        │
+        ├── is_void: false
+        └── element_source: "HTML"

--- a/test/snapshots/parser/attributes_test/test_0155_unquoted_attribute_value_with_a_quote_e1f865391a08d716d2341052d1339dd2.txt
+++ b/test/snapshots/parser/attributes_test/test_0155_unquoted_attribute_value_with_a_quote_e1f865391a08d716d2341052d1339dd2.txt
@@ -1,17 +1,17 @@
 ---
-source: "Parser::AttributesTest#test_0119_multiple attributes with missing values"
-input: "<div class= id= ></div>"
+source: "Parser::AttributesTest#test_0155_unquoted attribute value with a quote"
+input: "<div class=a\"b></div>"
 ---
-@ DocumentNode (location: (1:0)-(1:23))
+@ DocumentNode (location: (1:0)-(1:21))
 └── children: (1 item)
-    └── @ HTMLElementNode (location: (1:0)-(1:23))
+    └── @ HTMLElementNode (location: (1:0)-(1:21))
         ├── open_tag:
-        │   └── @ HTMLOpenTagNode (location: (1:0)-(1:17))
+        │   └── @ HTMLOpenTagNode (location: (1:0)-(1:15))
         │       ├── tag_opening: "<" (location: (1:0)-(1:1))
         │       ├── tag_name: "div" (location: (1:1)-(1:4))
-        │       ├── tag_closing: ">" (location: (1:16)-(1:17))
+        │       ├── tag_closing: ">" (location: (1:14)-(1:15))
         │       ├── children: (1 item)
-        │       │   └── @ HTMLAttributeNode (location: (1:5)-(1:15))
+        │       │   └── @ HTMLAttributeNode (location: (1:5)-(1:14))
         │       │       ├── name:
         │       │       │   └── @ HTMLAttributeNameNode (location: (1:5)-(1:10))
         │       │       │       └── children: (1 item)
@@ -21,16 +21,16 @@ input: "<div class= id= ></div>"
         │       │       │
         │       │       ├── equals: "=" (location: (1:10)-(1:11))
         │       │       └── value:
-        │       │           └── @ HTMLAttributeValueNode (location: (1:12)-(1:15))
+        │       │           └── @ HTMLAttributeValueNode (location: (1:11)-(1:14))
         │       │               ├── errors: (1 error)
-        │       │               │   └── @ UnexpectedCharacterInUnquotedAttributeValueError (location: (1:14)-(1:15))
-        │       │               │       ├── message: "Unexpected `=` in unquoted attribute value at (1:14)."
-        │       │               │       └── character: "=" (location: (1:14)-(1:15))
+        │       │               │   └── @ UnexpectedCharacterInUnquotedAttributeValueError (location: (1:12)-(1:13))
+        │       │               │       ├── message: "Unexpected `\"` in unquoted attribute value at (1:12)."
+        │       │               │       └── character: """ (location: (1:12)-(1:13))
         │       │               │
         │       │               ├── open_quote: ∅
         │       │               ├── children: (1 item)
-        │       │               │   └── @ LiteralNode (location: (1:12)-(1:15))
-        │       │               │       └── content: "id="
+        │       │               │   └── @ LiteralNode (location: (1:11)-(1:14))
+        │       │               │       └── content: "a\"b"
         │       │               │
         │       │               ├── close_quote: ∅
         │       │               └── quoted: false
@@ -41,11 +41,11 @@ input: "<div class= id= ></div>"
         ├── tag_name: "div" (location: (1:1)-(1:4))
         ├── body: []
         ├── close_tag:
-        │   └── @ HTMLCloseTagNode (location: (1:17)-(1:23))
-        │       ├── tag_opening: "</" (location: (1:17)-(1:19))
-        │       ├── tag_name: "div" (location: (1:19)-(1:22))
+        │   └── @ HTMLCloseTagNode (location: (1:15)-(1:21))
+        │       ├── tag_opening: "</" (location: (1:15)-(1:17))
+        │       ├── tag_name: "div" (location: (1:17)-(1:20))
         │       ├── children: []
-        │       └── tag_closing: ">" (location: (1:22)-(1:23))
+        │       └── tag_closing: ">" (location: (1:20)-(1:21))
         │
         ├── is_void: false
         └── element_source: "HTML"

--- a/test/snapshots/parser/attributes_test/test_0156_unquoted_attribute_value_with_an_equals_sign_a91a09742f3c00e4efeef8fdda72142b.txt
+++ b/test/snapshots/parser/attributes_test/test_0156_unquoted_attribute_value_with_an_equals_sign_a91a09742f3c00e4efeef8fdda72142b.txt
@@ -1,0 +1,51 @@
+---
+source: "Parser::AttributesTest#test_0156_unquoted attribute value with an equals sign"
+input: "<div a==b></div>"
+---
+@ DocumentNode (location: (1:0)-(1:16))
+└── children: (1 item)
+    └── @ HTMLElementNode (location: (1:0)-(1:16))
+        ├── open_tag:
+        │   └── @ HTMLOpenTagNode (location: (1:0)-(1:10))
+        │       ├── tag_opening: "<" (location: (1:0)-(1:1))
+        │       ├── tag_name: "div" (location: (1:1)-(1:4))
+        │       ├── tag_closing: ">" (location: (1:9)-(1:10))
+        │       ├── children: (1 item)
+        │       │   └── @ HTMLAttributeNode (location: (1:5)-(1:9))
+        │       │       ├── name:
+        │       │       │   └── @ HTMLAttributeNameNode (location: (1:5)-(1:6))
+        │       │       │       └── children: (1 item)
+        │       │       │           └── @ LiteralNode (location: (1:5)-(1:6))
+        │       │       │               └── content: "a"
+        │       │       │
+        │       │       │
+        │       │       ├── equals: "=" (location: (1:6)-(1:7))
+        │       │       └── value:
+        │       │           └── @ HTMLAttributeValueNode (location: (1:7)-(1:9))
+        │       │               ├── errors: (1 error)
+        │       │               │   └── @ UnexpectedCharacterInUnquotedAttributeValueError (location: (1:7)-(1:8))
+        │       │               │       ├── message: "Unexpected `=` in unquoted attribute value at (1:7)."
+        │       │               │       └── character: "=" (location: (1:7)-(1:8))
+        │       │               │
+        │       │               ├── open_quote: ∅
+        │       │               ├── children: (1 item)
+        │       │               │   └── @ LiteralNode (location: (1:7)-(1:9))
+        │       │               │       └── content: "=b"
+        │       │               │
+        │       │               ├── close_quote: ∅
+        │       │               └── quoted: false
+        │       │
+        │       │
+        │       └── is_void: false
+        │
+        ├── tag_name: "div" (location: (1:1)-(1:4))
+        ├── body: []
+        ├── close_tag:
+        │   └── @ HTMLCloseTagNode (location: (1:10)-(1:16))
+        │       ├── tag_opening: "</" (location: (1:10)-(1:12))
+        │       ├── tag_name: "div" (location: (1:12)-(1:15))
+        │       ├── children: []
+        │       └── tag_closing: ">" (location: (1:15)-(1:16))
+        │
+        ├── is_void: false
+        └── element_source: "HTML"

--- a/test/snapshots/parser/attributes_test/test_0157_quote_inside_quoted_value_splits_the_attribute_7730307086f17d83095197bac8f6ee9e.txt
+++ b/test/snapshots/parser/attributes_test/test_0157_quote_inside_quoted_value_splits_the_attribute_7730307086f17d83095197bac8f6ee9e.txt
@@ -1,0 +1,78 @@
+---
+source: "Parser::AttributesTest#test_0157_quote inside quoted value splits the attribute"
+input: "<div title=\"It\"s fine\"></div>"
+---
+@ DocumentNode (location: (1:0)-(1:29))
+└── children: (1 item)
+    └── @ HTMLElementNode (location: (1:0)-(1:29))
+        ├── open_tag:
+        │   └── @ HTMLOpenTagNode (location: (1:0)-(1:23))
+        │       ├── errors: (1 error)
+        │       │   └── @ MissingWhitespaceBetweenAttributesError (location: (1:15)-(1:16))
+        │       │       ├── message: "Missing whitespace between attributes at (1:15). `s` is parsed as the start of a new attribute."
+        │       │       └── found: "s" (location: (1:15)-(1:16))
+        │       │
+        │       ├── tag_opening: "<" (location: (1:0)-(1:1))
+        │       ├── tag_name: "div" (location: (1:1)-(1:4))
+        │       ├── tag_closing: ">" (location: (1:22)-(1:23))
+        │       ├── children: (3 items)
+        │       │   ├── @ HTMLAttributeNode (location: (1:5)-(1:15))
+        │       │   │   ├── name:
+        │       │   │   │   └── @ HTMLAttributeNameNode (location: (1:5)-(1:10))
+        │       │   │   │       └── children: (1 item)
+        │       │   │   │           └── @ LiteralNode (location: (1:5)-(1:10))
+        │       │   │   │               └── content: "title"
+        │       │   │   │
+        │       │   │   │
+        │       │   │   ├── equals: "=" (location: (1:10)-(1:11))
+        │       │   │   └── value:
+        │       │   │       └── @ HTMLAttributeValueNode (location: (1:11)-(1:15))
+        │       │   │           ├── open_quote: """ (location: (1:11)-(1:12))
+        │       │   │           ├── children: (1 item)
+        │       │   │           │   └── @ LiteralNode (location: (1:12)-(1:14))
+        │       │   │           │       └── content: "It"
+        │       │   │           │
+        │       │   │           ├── close_quote: """ (location: (1:14)-(1:15))
+        │       │   │           └── quoted: true
+        │       │   │
+        │       │   │
+        │       │   ├── @ HTMLAttributeNode (location: (1:15)-(1:16))
+        │       │   │   ├── name:
+        │       │   │   │   └── @ HTMLAttributeNameNode (location: (1:15)-(1:16))
+        │       │   │   │       └── children: (1 item)
+        │       │   │   │           └── @ LiteralNode (location: (1:15)-(1:16))
+        │       │   │   │               └── content: "s"
+        │       │   │   │
+        │       │   │   │
+        │       │   │   ├── equals: ∅
+        │       │   │   └── value: ∅
+        │       │   │
+        │       │   └── @ HTMLAttributeNode (location: (1:17)-(1:22))
+        │       │       ├── name:
+        │       │       │   └── @ HTMLAttributeNameNode (location: (1:17)-(1:22))
+        │       │       │       ├── errors: (1 error)
+        │       │       │       │   └── @ UnexpectedCharacterInAttributeNameError (location: (1:21)-(1:22))
+        │       │       │       │       ├── message: "Unexpected `\"` in attribute name at (1:21)."
+        │       │       │       │       └── character: """ (location: (1:21)-(1:22))
+        │       │       │       │
+        │       │       │       └── children: (1 item)
+        │       │       │           └── @ LiteralNode (location: (1:17)-(1:22))
+        │       │       │               └── content: "fine\""
+        │       │       │
+        │       │       │
+        │       │       ├── equals: ∅
+        │       │       └── value: ∅
+        │       │
+        │       └── is_void: false
+        │
+        ├── tag_name: "div" (location: (1:1)-(1:4))
+        ├── body: []
+        ├── close_tag:
+        │   └── @ HTMLCloseTagNode (location: (1:23)-(1:29))
+        │       ├── tag_opening: "</" (location: (1:23)-(1:25))
+        │       ├── tag_name: "div" (location: (1:25)-(1:28))
+        │       ├── children: []
+        │       └── tag_closing: ">" (location: (1:28)-(1:29))
+        │
+        ├── is_void: false
+        └── element_source: "HTML"

--- a/test/snapshots/parser/attributes_test/test_0158_equals_sign_before_attribute_name_f42be8c15bb6c36ad9ba9d15a6b26f26.txt
+++ b/test/snapshots/parser/attributes_test/test_0158_equals_sign_before_attribute_name_f42be8c15bb6c36ad9ba9d15a6b26f26.txt
@@ -1,0 +1,42 @@
+---
+source: "Parser::AttributesTest#test_0158_equals sign before attribute name"
+input: "<div =foo></div>"
+---
+@ DocumentNode (location: (1:0)-(1:16))
+└── children: (1 item)
+    └── @ HTMLElementNode (location: (1:0)-(1:16))
+        ├── open_tag:
+        │   └── @ HTMLOpenTagNode (location: (1:0)-(1:10))
+        │       ├── errors: (1 error)
+        │       │   └── @ UnexpectedEqualsSignBeforeAttributeNameError (location: (1:5)-(1:6))
+        │       │       ├── message: "Unexpected `=` before attribute name at (1:5)."
+        │       │       └── equals: "=" (location: (1:5)-(1:6))
+        │       │
+        │       ├── tag_opening: "<" (location: (1:0)-(1:1))
+        │       ├── tag_name: "div" (location: (1:1)-(1:4))
+        │       ├── tag_closing: ">" (location: (1:9)-(1:10))
+        │       ├── children: (1 item)
+        │       │   └── @ HTMLAttributeNode (location: (1:5)-(1:9))
+        │       │       ├── name:
+        │       │       │   └── @ HTMLAttributeNameNode (location: (1:5)-(1:9))
+        │       │       │       └── children: (1 item)
+        │       │       │           └── @ LiteralNode (location: (1:5)-(1:9))
+        │       │       │               └── content: "=foo"
+        │       │       │
+        │       │       │
+        │       │       ├── equals: ∅
+        │       │       └── value: ∅
+        │       │
+        │       └── is_void: false
+        │
+        ├── tag_name: "div" (location: (1:1)-(1:4))
+        ├── body: []
+        ├── close_tag:
+        │   └── @ HTMLCloseTagNode (location: (1:10)-(1:16))
+        │       ├── tag_opening: "</" (location: (1:10)-(1:12))
+        │       ├── tag_name: "div" (location: (1:12)-(1:15))
+        │       ├── children: []
+        │       └── tag_closing: ">" (location: (1:15)-(1:16))
+        │
+        ├── is_void: false
+        └── element_source: "HTML"

--- a/test/snapshots/parser/attributes_test/test_0159_quoted_token_in_attribute_name_position_402fe4ffb2f377fdd1f6529e478c054d.txt
+++ b/test/snapshots/parser/attributes_test/test_0159_quoted_token_in_attribute_name_position_402fe4ffb2f377fdd1f6529e478c054d.txt
@@ -1,0 +1,46 @@
+---
+source: "Parser::AttributesTest#test_0159_quoted token in attribute name position"
+input: "<div \"quoted\"></div>"
+---
+@ DocumentNode (location: (1:0)-(1:20))
+└── children: (1 item)
+    └── @ HTMLElementNode (location: (1:0)-(1:20))
+        ├── open_tag:
+        │   └── @ HTMLOpenTagNode (location: (1:0)-(1:14))
+        │       ├── tag_opening: "<" (location: (1:0)-(1:1))
+        │       ├── tag_name: "div" (location: (1:1)-(1:4))
+        │       ├── tag_closing: ">" (location: (1:13)-(1:14))
+        │       ├── children: (1 item)
+        │       │   └── @ HTMLAttributeNode (location: (1:5)-(1:13))
+        │       │       ├── name:
+        │       │       │   └── @ HTMLAttributeNameNode (location: (1:5)-(1:13))
+        │       │       │       ├── errors: (2 errors)
+        │       │       │       │   ├── @ UnexpectedCharacterInAttributeNameError (location: (1:5)-(1:6))
+        │       │       │       │   │   ├── message: "Unexpected `\"` in attribute name at (1:5)."
+        │       │       │       │   │   └── character: """ (location: (1:5)-(1:6))
+        │       │       │       │   │
+        │       │       │       │   └── @ UnexpectedCharacterInAttributeNameError (location: (1:12)-(1:13))
+        │       │       │       │       ├── message: "Unexpected `\"` in attribute name at (1:12)."
+        │       │       │       │       └── character: """ (location: (1:12)-(1:13))
+        │       │       │       │
+        │       │       │       └── children: (1 item)
+        │       │       │           └── @ LiteralNode (location: (1:5)-(1:13))
+        │       │       │               └── content: "\"quoted\""
+        │       │       │
+        │       │       │
+        │       │       ├── equals: ∅
+        │       │       └── value: ∅
+        │       │
+        │       └── is_void: false
+        │
+        ├── tag_name: "div" (location: (1:1)-(1:4))
+        ├── body: []
+        ├── close_tag:
+        │   └── @ HTMLCloseTagNode (location: (1:14)-(1:20))
+        │       ├── tag_opening: "</" (location: (1:14)-(1:16))
+        │       ├── tag_name: "div" (location: (1:16)-(1:19))
+        │       ├── children: []
+        │       └── tag_closing: ">" (location: (1:19)-(1:20))
+        │
+        ├── is_void: false
+        └── element_source: "HTML"

--- a/test/snapshots/parser/attributes_test/test_0160_stray_solidus_in_tag_06b303fb184f0ee48d1dfe3cc48ee6be.txt
+++ b/test/snapshots/parser/attributes_test/test_0160_stray_solidus_in_tag_06b303fb184f0ee48d1dfe3cc48ee6be.txt
@@ -1,39 +1,39 @@
 ---
-source: "Parser::AttributesTest#test_0119_multiple attributes with missing values"
-input: "<div class= id= ></div>"
+source: "Parser::AttributesTest#test_0160_stray solidus in tag"
+input: "<div / class=\"a\"></div>"
 ---
 @ DocumentNode (location: (1:0)-(1:23))
 └── children: (1 item)
     └── @ HTMLElementNode (location: (1:0)-(1:23))
         ├── open_tag:
         │   └── @ HTMLOpenTagNode (location: (1:0)-(1:17))
+        │       ├── errors: (1 error)
+        │       │   └── @ UnexpectedSolidusInTagError (location: (1:5)-(1:6))
+        │       │       ├── message: "Unexpected `/` in tag at (1:5)."
+        │       │       └── solidus: "/" (location: (1:5)-(1:6))
+        │       │
         │       ├── tag_opening: "<" (location: (1:0)-(1:1))
         │       ├── tag_name: "div" (location: (1:1)-(1:4))
         │       ├── tag_closing: ">" (location: (1:16)-(1:17))
         │       ├── children: (1 item)
-        │       │   └── @ HTMLAttributeNode (location: (1:5)-(1:15))
+        │       │   └── @ HTMLAttributeNode (location: (1:7)-(1:16))
         │       │       ├── name:
-        │       │       │   └── @ HTMLAttributeNameNode (location: (1:5)-(1:10))
+        │       │       │   └── @ HTMLAttributeNameNode (location: (1:7)-(1:12))
         │       │       │       └── children: (1 item)
-        │       │       │           └── @ LiteralNode (location: (1:5)-(1:10))
+        │       │       │           └── @ LiteralNode (location: (1:7)-(1:12))
         │       │       │               └── content: "class"
         │       │       │
         │       │       │
-        │       │       ├── equals: "=" (location: (1:10)-(1:11))
+        │       │       ├── equals: "=" (location: (1:12)-(1:13))
         │       │       └── value:
-        │       │           └── @ HTMLAttributeValueNode (location: (1:12)-(1:15))
-        │       │               ├── errors: (1 error)
-        │       │               │   └── @ UnexpectedCharacterInUnquotedAttributeValueError (location: (1:14)-(1:15))
-        │       │               │       ├── message: "Unexpected `=` in unquoted attribute value at (1:14)."
-        │       │               │       └── character: "=" (location: (1:14)-(1:15))
-        │       │               │
-        │       │               ├── open_quote: ∅
+        │       │           └── @ HTMLAttributeValueNode (location: (1:13)-(1:16))
+        │       │               ├── open_quote: """ (location: (1:13)-(1:14))
         │       │               ├── children: (1 item)
-        │       │               │   └── @ LiteralNode (location: (1:12)-(1:15))
-        │       │               │       └── content: "id="
+        │       │               │   └── @ LiteralNode (location: (1:14)-(1:15))
+        │       │               │       └── content: "a"
         │       │               │
-        │       │               ├── close_quote: ∅
-        │       │               └── quoted: false
+        │       │               ├── close_quote: """ (location: (1:15)-(1:16))
+        │       │               └── quoted: true
         │       │
         │       │
         │       └── is_void: false

--- a/test/snapshots/parser/attributes_test/test_0161_solidus_ends_attribute_name_f8d27e543672f6bc8a42b9c8883611a7.txt
+++ b/test/snapshots/parser/attributes_test/test_0161_solidus_ends_attribute_name_f8d27e543672f6bc8a42b9c8883611a7.txt
@@ -1,0 +1,53 @@
+---
+source: "Parser::AttributesTest#test_0161_solidus ends attribute name"
+input: "<div a/b></div>"
+---
+@ DocumentNode (location: (1:0)-(1:15))
+└── children: (1 item)
+    └── @ HTMLElementNode (location: (1:0)-(1:15))
+        ├── open_tag:
+        │   └── @ HTMLOpenTagNode (location: (1:0)-(1:9))
+        │       ├── errors: (1 error)
+        │       │   └── @ UnexpectedSolidusInTagError (location: (1:6)-(1:7))
+        │       │       ├── message: "Unexpected `/` in tag at (1:6)."
+        │       │       └── solidus: "/" (location: (1:6)-(1:7))
+        │       │
+        │       ├── tag_opening: "<" (location: (1:0)-(1:1))
+        │       ├── tag_name: "div" (location: (1:1)-(1:4))
+        │       ├── tag_closing: ">" (location: (1:8)-(1:9))
+        │       ├── children: (2 items)
+        │       │   ├── @ HTMLAttributeNode (location: (1:5)-(1:6))
+        │       │   │   ├── name:
+        │       │   │   │   └── @ HTMLAttributeNameNode (location: (1:5)-(1:6))
+        │       │   │   │       └── children: (1 item)
+        │       │   │   │           └── @ LiteralNode (location: (1:5)-(1:6))
+        │       │   │   │               └── content: "a"
+        │       │   │   │
+        │       │   │   │
+        │       │   │   ├── equals: ∅
+        │       │   │   └── value: ∅
+        │       │   │
+        │       │   └── @ HTMLAttributeNode (location: (1:7)-(1:8))
+        │       │       ├── name:
+        │       │       │   └── @ HTMLAttributeNameNode (location: (1:7)-(1:8))
+        │       │       │       └── children: (1 item)
+        │       │       │           └── @ LiteralNode (location: (1:7)-(1:8))
+        │       │       │               └── content: "b"
+        │       │       │
+        │       │       │
+        │       │       ├── equals: ∅
+        │       │       └── value: ∅
+        │       │
+        │       └── is_void: false
+        │
+        ├── tag_name: "div" (location: (1:1)-(1:4))
+        ├── body: []
+        ├── close_tag:
+        │   └── @ HTMLCloseTagNode (location: (1:9)-(1:15))
+        │       ├── tag_opening: "</" (location: (1:9)-(1:11))
+        │       ├── tag_name: "div" (location: (1:11)-(1:14))
+        │       ├── children: []
+        │       └── tag_closing: ">" (location: (1:14)-(1:15))
+        │
+        ├── is_void: false
+        └── element_source: "HTML"

--- a/test/snapshots/parser/attributes_test/test_0162_brackets_and_parentheses_in_attribute_names_63998d85a7ecaa7aec405292069478e2.txt
+++ b/test/snapshots/parser/attributes_test/test_0162_brackets_and_parentheses_in_attribute_names_63998d85a7ecaa7aec405292069478e2.txt
@@ -1,0 +1,59 @@
+---
+source: "Parser::AttributesTest#test_0162_brackets and parentheses in attribute names"
+input: "<div {{x}} [y] (z)></div>"
+---
+@ DocumentNode (location: (1:0)-(1:25))
+└── children: (1 item)
+    └── @ HTMLElementNode (location: (1:0)-(1:25))
+        ├── open_tag:
+        │   └── @ HTMLOpenTagNode (location: (1:0)-(1:19))
+        │       ├── tag_opening: "<" (location: (1:0)-(1:1))
+        │       ├── tag_name: "div" (location: (1:1)-(1:4))
+        │       ├── tag_closing: ">" (location: (1:18)-(1:19))
+        │       ├── children: (3 items)
+        │       │   ├── @ HTMLAttributeNode (location: (1:5)-(1:10))
+        │       │   │   ├── name:
+        │       │   │   │   └── @ HTMLAttributeNameNode (location: (1:5)-(1:10))
+        │       │   │   │       └── children: (1 item)
+        │       │   │   │           └── @ LiteralNode (location: (1:5)-(1:10))
+        │       │   │   │               └── content: "{{x}}"
+        │       │   │   │
+        │       │   │   │
+        │       │   │   ├── equals: ∅
+        │       │   │   └── value: ∅
+        │       │   │
+        │       │   ├── @ HTMLAttributeNode (location: (1:11)-(1:14))
+        │       │   │   ├── name:
+        │       │   │   │   └── @ HTMLAttributeNameNode (location: (1:11)-(1:14))
+        │       │   │   │       └── children: (1 item)
+        │       │   │   │           └── @ LiteralNode (location: (1:11)-(1:14))
+        │       │   │   │               └── content: "[y]"
+        │       │   │   │
+        │       │   │   │
+        │       │   │   ├── equals: ∅
+        │       │   │   └── value: ∅
+        │       │   │
+        │       │   └── @ HTMLAttributeNode (location: (1:15)-(1:18))
+        │       │       ├── name:
+        │       │       │   └── @ HTMLAttributeNameNode (location: (1:15)-(1:18))
+        │       │       │       └── children: (1 item)
+        │       │       │           └── @ LiteralNode (location: (1:15)-(1:18))
+        │       │       │               └── content: "(z)"
+        │       │       │
+        │       │       │
+        │       │       ├── equals: ∅
+        │       │       └── value: ∅
+        │       │
+        │       └── is_void: false
+        │
+        ├── tag_name: "div" (location: (1:1)-(1:4))
+        ├── body: []
+        ├── close_tag:
+        │   └── @ HTMLCloseTagNode (location: (1:19)-(1:25))
+        │       ├── tag_opening: "</" (location: (1:19)-(1:21))
+        │       ├── tag_name: "div" (location: (1:21)-(1:24))
+        │       ├── children: []
+        │       └── tag_closing: ">" (location: (1:24)-(1:25))
+        │
+        ├── is_void: false
+        └── element_source: "HTML"

--- a/test/snapshots/parser/comments_test/test_0009_unclosed_HTML_comment_4c1c664b1e62c37a3f491d6380bd2623.txt
+++ b/test/snapshots/parser/comments_test/test_0009_unclosed_HTML_comment_4c1c664b1e62c37a3f491d6380bd2623.txt
@@ -1,0 +1,20 @@
+---
+source: "Parser::CommentsTest#test_0009_unclosed HTML comment"
+input: |2-
+<!-- never closed
+<div></div>
+---
+@ DocumentNode (location: (1:0)-(2:11))
+└── children: (1 item)
+    └── @ HTMLCommentNode (location: (1:0)-(2:11))
+        ├── errors: (1 error)
+        │   └── @ UnclosedCommentError (location: (1:0)-(2:11))
+        │       ├── message: "Comment opened at (1:0) is missing its closing `-->`."
+        │       └── comment_start: "<!--" (location: (1:0)-(1:4))
+        │
+        ├── comment_start: "<!--" (location: (1:0)-(1:4))
+        ├── children: (1 item)
+        │   └── @ LiteralNode (location: (1:4)-(2:11))
+        │       └── content: " never closed\n<div></div>"
+        │
+        └── comment_end: "" (location: (2:11)-(2:11))

--- a/test/snapshots/parser/comments_test/test_0010_unclosed_HTML_comment_with_ERB_inside_57021b8b9571e19b2744d543c107e2d1.txt
+++ b/test/snapshots/parser/comments_test/test_0010_unclosed_HTML_comment_with_ERB_inside_57021b8b9571e19b2744d543c107e2d1.txt
@@ -1,0 +1,40 @@
+---
+source: "Parser::CommentsTest#test_0010_unclosed HTML comment with ERB inside"
+input: |2-
+<!-- <% presenter = featured.presenter %>
+<div data-id="<%= presenter.id %>"></div>
+---
+@ DocumentNode (location: (1:0)-(2:41))
+└── children: (1 item)
+    └── @ HTMLCommentNode (location: (1:0)-(2:41))
+        ├── errors: (1 error)
+        │   └── @ UnclosedCommentError (location: (1:0)-(2:41))
+        │       ├── message: "Comment opened at (1:0) is missing its closing `-->`."
+        │       └── comment_start: "<!--" (location: (1:0)-(1:4))
+        │
+        ├── comment_start: "<!--" (location: (1:0)-(1:4))
+        ├── children: (5 items)
+        │   ├── @ LiteralNode (location: (1:4)-(1:5))
+        │   │   └── content: " "
+        │   │
+        │   ├── @ ERBContentNode (location: (1:5)-(1:41))
+        │   │   ├── tag_opening: "<%" (location: (1:5)-(1:7))
+        │   │   ├── content: " presenter = featured.presenter " (location: (1:7)-(1:39))
+        │   │   ├── tag_closing: "%>" (location: (1:39)-(1:41))
+        │   │   ├── parsed: true
+        │   │   └── valid: true
+        │   │
+        │   ├── @ LiteralNode (location: (1:41)-(2:14))
+        │   │   └── content: "\n<div data-id=\""
+        │   │
+        │   ├── @ ERBContentNode (location: (2:14)-(2:33))
+        │   │   ├── tag_opening: "<%=" (location: (2:14)-(2:17))
+        │   │   ├── content: " presenter.id " (location: (2:17)-(2:31))
+        │   │   ├── tag_closing: "%>" (location: (2:31)-(2:33))
+        │   │   ├── parsed: true
+        │   │   └── valid: true
+        │   │
+        │   └── @ LiteralNode (location: (2:33)-(2:41))
+        │       └── content: "\"></div>"
+        │
+        └── comment_end: "" (location: (2:41)-(2:41))

--- a/test/snapshots/parser/comments_test/test_0011_nested_HTML_comment_opener_1fa7d7e18493c321ce25c032c81938ca.txt
+++ b/test/snapshots/parser/comments_test/test_0011_nested_HTML_comment_opener_1fa7d7e18493c321ce25c032c81938ca.txt
@@ -1,0 +1,22 @@
+---
+source: "Parser::CommentsTest#test_0011_nested HTML comment opener"
+input: "<!-- a <!-- b --> c -->"
+---
+@ DocumentNode (location: (1:0)-(1:23))
+└── children: (2 items)
+    ├── @ HTMLCommentNode (location: (1:0)-(1:17))
+    │   ├── errors: (1 error)
+    │   │   └── @ NestedCommentError (location: (1:7)-(1:11))
+    │   │       ├── message: "Comment opened at (1:0) contains another `<!--` at (1:7)."
+    │   │       ├── comment_start: "<!--" (location: (1:0)-(1:4))
+    │   │       └── nested_start: "<!--" (location: (1:7)-(1:11))
+    │   │
+    │   ├── comment_start: "<!--" (location: (1:0)-(1:4))
+    │   ├── children: (1 item)
+    │   │   └── @ LiteralNode (location: (1:4)-(1:14))
+    │   │       └── content: " a <!-- b "
+    │   │
+    │   └── comment_end: "-->" (location: (1:14)-(1:17))
+    │
+    └── @ HTMLTextNode (location: (1:17)-(1:23))
+        └── content: " c -->"

--- a/test/snapshots/parser/comments_test/test_0012_nested_HTML_comment_opener_in_an_unclosed_comment_269b4844a88465fe76b669bc988c82b6.txt
+++ b/test/snapshots/parser/comments_test/test_0012_nested_HTML_comment_opener_in_an_unclosed_comment_269b4844a88465fe76b669bc988c82b6.txt
@@ -1,0 +1,23 @@
+---
+source: "Parser::CommentsTest#test_0012_nested HTML comment opener in an unclosed comment"
+input: "<!-- outer <!-- inner"
+---
+@ DocumentNode (location: (1:0)-(1:21))
+└── children: (1 item)
+    └── @ HTMLCommentNode (location: (1:0)-(1:21))
+        ├── errors: (2 errors)
+        │   ├── @ NestedCommentError (location: (1:11)-(1:15))
+        │   │   ├── message: "Comment opened at (1:0) contains another `<!--` at (1:11)."
+        │   │   ├── comment_start: "<!--" (location: (1:0)-(1:4))
+        │   │   └── nested_start: "<!--" (location: (1:11)-(1:15))
+        │   │
+        │   └── @ UnclosedCommentError (location: (1:0)-(1:21))
+        │       ├── message: "Comment opened at (1:0) is missing its closing `-->`."
+        │       └── comment_start: "<!--" (location: (1:0)-(1:4))
+        │
+        ├── comment_start: "<!--" (location: (1:0)-(1:4))
+        ├── children: (1 item)
+        │   └── @ LiteralNode (location: (1:4)-(1:21))
+        │       └── content: " outer <!-- inner"
+        │
+        └── comment_end: "" (location: (1:21)-(1:21))

--- a/test/snapshots/parser/comments_test/test_0013_conditional_comment_closed_by_an_abrupt_opener_a60cd7112fb0585db22e3ad36a5e9ef8.txt
+++ b/test/snapshots/parser/comments_test/test_0013_conditional_comment_closed_by_an_abrupt_opener_a60cd7112fb0585db22e3ad36a5e9ef8.txt
@@ -1,0 +1,76 @@
+---
+source: "Parser::CommentsTest#test_0013_conditional comment closed by an abrupt opener"
+input: "<!--[if !mso]><!--><meta http-equiv=\"X-UA-Compatible\" content=\"IE=edge\"><!--<![endif]-->"
+---
+@ DocumentNode (location: (1:0)-(1:88))
+└── children: (3 items)
+    ├── @ HTMLCommentNode (location: (1:0)-(1:19))
+    │   ├── comment_start: "<!--" (location: (1:0)-(1:4))
+    │   ├── children: (1 item)
+    │   │   └── @ LiteralNode (location: (1:4)-(1:16))
+    │   │       └── content: "[if !mso]><!"
+    │   │
+    │   └── comment_end: "-->" (location: (1:16)-(1:19))
+    │
+    ├── @ HTMLElementNode (location: (1:19)-(1:72))
+    │   ├── open_tag:
+    │   │   └── @ HTMLOpenTagNode (location: (1:19)-(1:72))
+    │   │       ├── tag_opening: "<" (location: (1:19)-(1:20))
+    │   │       ├── tag_name: "meta" (location: (1:20)-(1:24))
+    │   │       ├── tag_closing: ">" (location: (1:71)-(1:72))
+    │   │       ├── children: (2 items)
+    │   │       │   ├── @ HTMLAttributeNode (location: (1:25)-(1:53))
+    │   │       │   │   ├── name:
+    │   │       │   │   │   └── @ HTMLAttributeNameNode (location: (1:25)-(1:35))
+    │   │       │   │   │       └── children: (1 item)
+    │   │       │   │   │           └── @ LiteralNode (location: (1:25)-(1:35))
+    │   │       │   │   │               └── content: "http-equiv"
+    │   │       │   │   │
+    │   │       │   │   │
+    │   │       │   │   ├── equals: "=" (location: (1:35)-(1:36))
+    │   │       │   │   └── value:
+    │   │       │   │       └── @ HTMLAttributeValueNode (location: (1:36)-(1:53))
+    │   │       │   │           ├── open_quote: """ (location: (1:36)-(1:37))
+    │   │       │   │           ├── children: (1 item)
+    │   │       │   │           │   └── @ LiteralNode (location: (1:37)-(1:52))
+    │   │       │   │           │       └── content: "X-UA-Compatible"
+    │   │       │   │           │
+    │   │       │   │           ├── close_quote: """ (location: (1:52)-(1:53))
+    │   │       │   │           └── quoted: true
+    │   │       │   │
+    │   │       │   │
+    │   │       │   └── @ HTMLAttributeNode (location: (1:54)-(1:71))
+    │   │       │       ├── name:
+    │   │       │       │   └── @ HTMLAttributeNameNode (location: (1:54)-(1:61))
+    │   │       │       │       └── children: (1 item)
+    │   │       │       │           └── @ LiteralNode (location: (1:54)-(1:61))
+    │   │       │       │               └── content: "content"
+    │   │       │       │
+    │   │       │       │
+    │   │       │       ├── equals: "=" (location: (1:61)-(1:62))
+    │   │       │       └── value:
+    │   │       │           └── @ HTMLAttributeValueNode (location: (1:62)-(1:71))
+    │   │       │               ├── open_quote: """ (location: (1:62)-(1:63))
+    │   │       │               ├── children: (1 item)
+    │   │       │               │   └── @ LiteralNode (location: (1:63)-(1:70))
+    │   │       │               │       └── content: "IE=edge"
+    │   │       │               │
+    │   │       │               ├── close_quote: """ (location: (1:70)-(1:71))
+    │   │       │               └── quoted: true
+    │   │       │
+    │   │       │
+    │   │       └── is_void: false
+    │   │
+    │   ├── tag_name: "meta" (location: (1:20)-(1:24))
+    │   ├── body: []
+    │   ├── close_tag: ∅
+    │   ├── is_void: true
+    │   └── element_source: "HTML"
+    │
+    └── @ HTMLCommentNode (location: (1:72)-(1:88))
+        ├── comment_start: "<!--" (location: (1:72)-(1:76))
+        ├── children: (1 item)
+        │   └── @ LiteralNode (location: (1:76)-(1:85))
+        │       └── content: "<![endif]"
+        │
+        └── comment_end: "-->" (location: (1:85)-(1:88))

--- a/test/snapshots/parser/comments_test/test_0014_nested_HTML_comment_opener_at_end_of_file_ed3e686523102c34562557455a55915d.txt
+++ b/test/snapshots/parser/comments_test/test_0014_nested_HTML_comment_opener_at_end_of_file_ed3e686523102c34562557455a55915d.txt
@@ -1,0 +1,18 @@
+---
+source: "Parser::CommentsTest#test_0014_nested HTML comment opener at end of file"
+input: "<!-- a <!--"
+---
+@ DocumentNode (location: (1:0)-(1:11))
+└── children: (1 item)
+    └── @ HTMLCommentNode (location: (1:0)-(1:11))
+        ├── errors: (1 error)
+        │   └── @ UnclosedCommentError (location: (1:0)-(1:11))
+        │       ├── message: "Comment opened at (1:0) is missing its closing `-->`."
+        │       └── comment_start: "<!--" (location: (1:0)-(1:4))
+        │
+        ├── comment_start: "<!--" (location: (1:0)-(1:4))
+        ├── children: (1 item)
+        │   └── @ LiteralNode (location: (1:4)-(1:11))
+        │       └── content: " a <!--"
+        │
+        └── comment_end: "" (location: (1:11)-(1:11))

--- a/test/snapshots/parser/tags_test/test_0016_colon_inside_html_tag_b7b46dcd10fad620a00a95b27daab204.txt
+++ b/test/snapshots/parser/tags_test/test_0016_colon_inside_html_tag_b7b46dcd10fad620a00a95b27daab204.txt
@@ -7,17 +7,21 @@ input: "<div : class=\"\"></div>"
     └── @ HTMLElementNode (location: (1:0)-(1:22))
         ├── open_tag:
         │   └── @ HTMLOpenTagNode (location: (1:0)-(1:16))
-        │       ├── errors: (1 error)
-        │       │   └── @ UnexpectedError (location: (1:5)-(1:6))
-        │       │       ├── message: "Unexpected Token. Expected: an identifier, `@`, `<%`, whitespace, or a newline, found: `:`."
-        │       │       ├── description: "Unexpected Token"
-        │       │       ├── expected: "an identifier, `@`, `<%`, whitespace, or a newline"
-        │       │       └── found: "`:`"
-        │       │
         │       ├── tag_opening: "<" (location: (1:0)-(1:1))
         │       ├── tag_name: "div" (location: (1:1)-(1:4))
         │       ├── tag_closing: ">" (location: (1:15)-(1:16))
-        │       ├── children: (1 item)
+        │       ├── children: (2 items)
+        │       │   ├── @ HTMLAttributeNode (location: (1:5)-(1:6))
+        │       │   │   ├── name:
+        │       │   │   │   └── @ HTMLAttributeNameNode (location: (1:5)-(1:6))
+        │       │   │   │       └── children: (1 item)
+        │       │   │   │           └── @ LiteralNode (location: (1:5)-(1:6))
+        │       │   │   │               └── content: ":"
+        │       │   │   │
+        │       │   │   │
+        │       │   │   ├── equals: ∅
+        │       │   │   └── value: ∅
+        │       │   │
         │       │   └── @ HTMLAttributeNode (location: (1:7)-(1:15))
         │       │       ├── name:
         │       │       │   └── @ HTMLAttributeNameNode (location: (1:7)-(1:12))

--- a/test/snapshots/parser/tags_test/test_0055_less-than_operator_with_dot_method_access_is_parsed_as_text_not_a_tag_(gh-1426)_1348f72d270454c0c4e6035084d4694e.txt
+++ b/test/snapshots/parser/tags_test/test_0055_less-than_operator_with_dot_method_access_is_parsed_as_text_not_a_tag_(gh-1426)_1348f72d270454c0c4e6035084d4694e.txt
@@ -8,13 +8,7 @@ input: "n <o.length"
     │   └── content: "n "
     │
     └── @ HTMLOpenTagNode (location: (1:2)-(1:11))
-        ├── errors: (2 errors)
-        │   ├── @ UnexpectedError (location: (1:4)-(1:5))
-        │   │   ├── message: "Unexpected Token. Expected: an identifier, `@`, `<%`, whitespace, or a newline, found: a character."
-        │   │   ├── description: "Unexpected Token"
-        │   │   ├── expected: "an identifier, `@`, `<%`, whitespace, or a newline"
-        │   │   └── found: "a character"
-        │   │
+        ├── errors: (1 error)
         │   └── @ UnclosedOpenTagError (location: (1:3)-(1:11))
         │       ├── message: "Opening tag `<o>` at (1:3) is missing closing `>`."
         │       └── tag_name: "o" (location: (1:3)-(1:4))
@@ -23,12 +17,12 @@ input: "n <o.length"
         ├── tag_name: "o" (location: (1:3)-(1:4))
         ├── tag_closing: ∅
         ├── children: (1 item)
-        │   └── @ HTMLAttributeNode (location: (1:5)-(1:11))
+        │   └── @ HTMLAttributeNode (location: (1:4)-(1:11))
         │       ├── name:
-        │       │   └── @ HTMLAttributeNameNode (location: (1:5)-(1:11))
+        │       │   └── @ HTMLAttributeNameNode (location: (1:4)-(1:11))
         │       │       └── children: (1 item)
-        │       │           └── @ LiteralNode (location: (1:5)-(1:11))
-        │       │               └── content: "length"
+        │       │           └── @ LiteralNode (location: (1:4)-(1:11))
+        │       │               └── content: ".length"
         │       │
         │       │
         │       ├── equals: ∅

--- a/test/snapshots/parser/tags_test/test_0058_dot-notation_component_tag_without_option_is_parsed_as_regular_HTML_16a392acb745a4b3370d03cdd3397334.txt
+++ b/test/snapshots/parser/tags_test/test_0058_dot-notation_component_tag_without_option_is_parsed_as_regular_HTML_16a392acb745a4b3370d03cdd3397334.txt
@@ -7,23 +7,16 @@ input: "<Dialog.Button></Dialog.Button>"
     ├── @ HTMLElementNode (location: (1:0)-(1:23))
     │   ├── open_tag:
     │   │   └── @ HTMLOpenTagNode (location: (1:0)-(1:15))
-    │   │       ├── errors: (1 error)
-    │   │       │   └── @ UnexpectedError (location: (1:7)-(1:8))
-    │   │       │       ├── message: "Unexpected Token. Expected: an identifier, `@`, `<%`, whitespace, or a newline, found: a character."
-    │   │       │       ├── description: "Unexpected Token"
-    │   │       │       ├── expected: "an identifier, `@`, `<%`, whitespace, or a newline"
-    │   │       │       └── found: "a character"
-    │   │       │
     │   │       ├── tag_opening: "<" (location: (1:0)-(1:1))
     │   │       ├── tag_name: "Dialog" (location: (1:1)-(1:7))
     │   │       ├── tag_closing: ">" (location: (1:14)-(1:15))
     │   │       ├── children: (1 item)
-    │   │       │   └── @ HTMLAttributeNode (location: (1:8)-(1:14))
+    │   │       │   └── @ HTMLAttributeNode (location: (1:7)-(1:14))
     │   │       │       ├── name:
-    │   │       │       │   └── @ HTMLAttributeNameNode (location: (1:8)-(1:14))
+    │   │       │       │   └── @ HTMLAttributeNameNode (location: (1:7)-(1:14))
     │   │       │       │       └── children: (1 item)
-    │   │       │       │           └── @ LiteralNode (location: (1:8)-(1:14))
-    │   │       │       │               └── content: "Button"
+    │   │       │       │           └── @ LiteralNode (location: (1:7)-(1:14))
+    │   │       │       │               └── content: ".Button"
     │   │       │       │
     │   │       │       │
     │   │       │       ├── equals: ∅

--- a/test/snapshots/parser/tags_test/test_0061_dot-notation_component_tag_with_three_segments_without_option_is_parsed_as_regular_HTML_6fc9b4937b1489b96d1680e67e269fa4.txt
+++ b/test/snapshots/parser/tags_test/test_0061_dot-notation_component_tag_with_three_segments_without_option_is_parsed_as_regular_HTML_6fc9b4937b1489b96d1680e67e269fa4.txt
@@ -7,23 +7,16 @@ input: "<Namespace.Dialog.Button></Namespace.Dialog.Button>"
     ├── @ HTMLElementNode (location: (1:0)-(1:36))
     │   ├── open_tag:
     │   │   └── @ HTMLOpenTagNode (location: (1:0)-(1:25))
-    │   │       ├── errors: (1 error)
-    │   │       │   └── @ UnexpectedError (location: (1:10)-(1:11))
-    │   │       │       ├── message: "Unexpected Token. Expected: an identifier, `@`, `<%`, whitespace, or a newline, found: a character."
-    │   │       │       ├── description: "Unexpected Token"
-    │   │       │       ├── expected: "an identifier, `@`, `<%`, whitespace, or a newline"
-    │   │       │       └── found: "a character"
-    │   │       │
     │   │       ├── tag_opening: "<" (location: (1:0)-(1:1))
     │   │       ├── tag_name: "Namespace" (location: (1:1)-(1:10))
     │   │       ├── tag_closing: ">" (location: (1:24)-(1:25))
     │   │       ├── children: (1 item)
-    │   │       │   └── @ HTMLAttributeNode (location: (1:11)-(1:24))
+    │   │       │   └── @ HTMLAttributeNode (location: (1:10)-(1:24))
     │   │       │       ├── name:
-    │   │       │       │   └── @ HTMLAttributeNameNode (location: (1:11)-(1:24))
+    │   │       │       │   └── @ HTMLAttributeNameNode (location: (1:10)-(1:24))
     │   │       │       │       └── children: (1 item)
-    │   │       │       │           └── @ LiteralNode (location: (1:11)-(1:24))
-    │   │       │       │               └── content: "Dialog.Button"
+    │   │       │       │           └── @ LiteralNode (location: (1:10)-(1:24))
+    │   │       │       │               └── content: ".Dialog.Button"
     │   │       │       │
     │   │       │       │
     │   │       │       ├── equals: ∅

--- a/test/snapshots/parser/tags_test/test_0067_closing_tag_with_trailing_solidus_0f83c28ea76023835a064e11e620e5a0.txt
+++ b/test/snapshots/parser/tags_test/test_0067_closing_tag_with_trailing_solidus_0f83c28ea76023835a064e11e620e5a0.txt
@@ -1,0 +1,31 @@
+---
+source: "Parser::TagsTest#test_0067_closing tag with trailing solidus"
+input: "<div></div/>"
+---
+@ DocumentNode (location: (1:0)-(1:12))
+└── children: (1 item)
+    └── @ HTMLElementNode (location: (1:0)-(1:12))
+        ├── open_tag:
+        │   └── @ HTMLOpenTagNode (location: (1:0)-(1:5))
+        │       ├── tag_opening: "<" (location: (1:0)-(1:1))
+        │       ├── tag_name: "div" (location: (1:1)-(1:4))
+        │       ├── tag_closing: ">" (location: (1:4)-(1:5))
+        │       ├── children: []
+        │       └── is_void: false
+        │
+        ├── tag_name: "div" (location: (1:1)-(1:4))
+        ├── body: []
+        ├── close_tag:
+        │   └── @ HTMLCloseTagNode (location: (1:5)-(1:12))
+        │       ├── errors: (1 error)
+        │       │   └── @ EndTagWithTrailingSolidusError (location: (1:10)-(1:12))
+        │       │       ├── message: "Closing tag `</div>` at (1:7) ends with `/>` instead of `>`."
+        │       │       └── tag_name: "div" (location: (1:7)-(1:10))
+        │       │
+        │       ├── tag_opening: "</" (location: (1:5)-(1:7))
+        │       ├── tag_name: "div" (location: (1:7)-(1:10))
+        │       ├── children: []
+        │       └── tag_closing: "/>" (location: (1:10)-(1:12))
+        │
+        ├── is_void: false
+        └── element_source: "HTML"

--- a/test/snapshots/parser/tags_test/test_0068_void_element_closing_tag_with_trailing_solidus_327d7d7dff5611acd256c37314fa6b6c.txt
+++ b/test/snapshots/parser/tags_test/test_0068_void_element_closing_tag_with_trailing_solidus_327d7d7dff5611acd256c37314fa6b6c.txt
@@ -1,0 +1,58 @@
+---
+source: "Parser::TagsTest#test_0068_void element closing tag with trailing solidus"
+input: "<p><br/></br/></p>"
+---
+@ DocumentNode (location: (1:0)-(1:18))
+└── children: (1 item)
+    └── @ HTMLElementNode (location: (1:0)-(1:18))
+        ├── open_tag:
+        │   └── @ HTMLOpenTagNode (location: (1:0)-(1:3))
+        │       ├── tag_opening: "<" (location: (1:0)-(1:1))
+        │       ├── tag_name: "p" (location: (1:1)-(1:2))
+        │       ├── tag_closing: ">" (location: (1:2)-(1:3))
+        │       ├── children: []
+        │       └── is_void: false
+        │
+        ├── tag_name: "p" (location: (1:1)-(1:2))
+        ├── body: (2 items)
+        │   ├── @ HTMLElementNode (location: (1:3)-(1:8))
+        │   │   ├── open_tag:
+        │   │   │   └── @ HTMLOpenTagNode (location: (1:3)-(1:8))
+        │   │   │       ├── tag_opening: "<" (location: (1:3)-(1:4))
+        │   │   │       ├── tag_name: "br" (location: (1:4)-(1:6))
+        │   │   │       ├── tag_closing: "/>" (location: (1:6)-(1:8))
+        │   │   │       ├── children: []
+        │   │   │       └── is_void: true
+        │   │   │
+        │   │   ├── tag_name: "br" (location: (1:4)-(1:6))
+        │   │   ├── body: []
+        │   │   ├── close_tag: ∅
+        │   │   ├── is_void: true
+        │   │   └── element_source: "HTML"
+        │   │
+        │   └── @ HTMLCloseTagNode (location: (1:8)-(1:14))
+        │       ├── errors: (2 errors)
+        │       │   ├── @ EndTagWithTrailingSolidusError (location: (1:12)-(1:14))
+        │       │   │   ├── message: "Closing tag `</br>` at (1:10) ends with `/>` instead of `>`."
+        │       │   │   └── tag_name: "br" (location: (1:10)-(1:12))
+        │       │   │
+        │       │   └── @ VoidElementClosingTagError (location: (1:8)-(1:14))
+        │       │       ├── message: "`br` is a void element and should not be used as a closing tag. Use `<br>` or `<br />` instead of `</br>`."
+        │       │       ├── tag_name: "br" (location: (1:10)-(1:12))
+        │       │       ├── expected: "<br />"
+        │       │       └── found: "</br>"
+        │       │
+        │       ├── tag_opening: "</" (location: (1:8)-(1:10))
+        │       ├── tag_name: "br" (location: (1:10)-(1:12))
+        │       ├── children: []
+        │       └── tag_closing: "/>" (location: (1:12)-(1:14))
+        │
+        ├── close_tag:
+        │   └── @ HTMLCloseTagNode (location: (1:14)-(1:18))
+        │       ├── tag_opening: "</" (location: (1:14)-(1:16))
+        │       ├── tag_name: "p" (location: (1:16)-(1:17))
+        │       ├── children: []
+        │       └── tag_closing: ">" (location: (1:17)-(1:18))
+        │
+        ├── is_void: false
+        └── element_source: "HTML"


### PR DESCRIPTION
This pull request reworks how the parser reads attribute names and values inside an open tag so that the tree it builds matches what the HTML5 tokenizer builds, and so that the parse errors it reports carry the names the specification gives them.

A stray `)` after a quoted value (#2588), a comma between two quoted attributes (#2589), and a Mustache style `{{element_hidden}}` in attribute position (#2590) all ended up with tokens swallowed into a neighbouring attribute. 

The cause was a heuristic that treated a closing quote followed by an identifier or a character as an unescaped quote and kept reading the value, plus an attribute name loop that absorbed any character it did not recognise as a terminator. Both were guesses at the author's intent, and both guessed wrong in the cases above.

The tokenizer does not guess. A quoted value ends at its first matching quote. Anything after a closed quoted value that is not whitespace, `/`, or `>` is a `missing-whitespace-between-attributes` parse error and starts a new attribute. 

Any character can start or continue an attribute name, so `{{x}}`, `[y]`, `(z)`, and `,` are ordinary names. An unquoted value runs until whitespace or `>`, so `src=image.jpg` is one value and a backtick is just a value character. This pull request implements those states and drops the heuristics. The resulting trees were checked against Nokogiri's HTML5 parser (Gumbo) for every input in the new tests.

```html
<div onclick="true")></div>
```

**Before**

```js
@ HTMLOpenTagNode (location: (1:0)-(2:0))
├── errors: (1 error)
│   └── @ UnclosedOpenTagError (location: (1:1)-(2:0))
│       └── message: "Opening tag `<div>` at (1:1) is missing closing `>`."
│
├── tag_closing: ∅
└── children: (1 item)
    └── @ HTMLAttributeNode (location: (1:5)-(2:0))
        ├── name: onclick
        └── value: "true\")></div>\n"
```

**After**

```js
@ HTMLOpenTagNode (location: (1:0)-(1:21))
├── errors: (1 error)
│   └── @ MissingWhitespaceBetweenAttributesError (location: (1:19)-(1:20))
│       ├── message: "Missing whitespace between attributes at (1:19). `)` is parsed as the start of a new attribute."
│       └── found: ")" (location: (1:19)-(1:20))
│
├── tag_closing: ">" (location: (1:20)-(1:21))
└── children: (2 items)
    ├── @ HTMLAttributeNode (location: (1:5)-(1:19))
    │   ├── name: onclick
    │   └── value: "true" (quoted)
    │
    └── @ HTMLAttributeNode (location: (1:19)-(1:20))
        └── name: ")"
```

The generic `UnexpectedError` is what `herb analyze` files under "Unexpected parse errors" and asks users to report as a possible parser bug. Every tag level use of it for a template mistake is replaced by an error named after the tokenizer's parse error, and the new names are on the analyzer's template error list.

```html
<div class="a"id="b">
  MissingWhitespaceBetweenAttributesError
  Missing whitespace between attributes at (1:14). `id` is parsed as the start of a new attribute.

<div "quoted">
  UnexpectedCharacterInAttributeNameError
  Unexpected `"` in attribute name at (1:5).
  Unexpected `"` in attribute name at (1:12).

<div class=`a`>
  UnexpectedCharacterInUnquotedAttributeValueError
  Unexpected ``` in unquoted attribute value at (1:11).
  Unexpected ``` in unquoted attribute value at (1:13).

<div =foo>
  UnexpectedEqualsSignBeforeAttributeNameError
  Unexpected `=` before attribute name at (1:5).

<div / class="a">
  UnexpectedSolidusInTagError
  Unexpected `/` in tag at (1:5).

<div></div/>
  EndTagWithTrailingSolidusError
  Closing tag `</div>` at (1:7) ends with `/>` instead of `>`.

<!-- never closed
  UnclosedCommentError
  Comment opened at (1:0) is missing its closing `-->`.

<!-- a <!-- b --> c -->
  NestedCommentError
  Comment opened at (1:0) contains another `<!--` at (1:7).
```

Each one maps onto the tokenizer's parse error of the same name: `missing-whitespace-between-attributes`, `unexpected-character-in-attribute-name`, `unexpected-character-in-unquoted-attribute-value`, `unexpected-equals-sign-before-attribute-name`, `unexpected-solidus-in-tag`, `end-tag-with-trailing-solidus`, `eof-in-comment`, and `nested-comment`.

Inside a tag, `UnexpectedError` now only fires on an error token from the lexer. A missing value after `=` (`<div class=>`, `<div class=` at end of file) reports the existing `MissingAttributeValueError` instead of a generic unexpected token. A close tag ending in `/>` keeps that token as its closing and reports the trailing solidus instead of an unclosed close tag followed by a stray `/>` in the element body. An unclosed comment still receives the end of file token as its `comment_end`, since the compiler and the editor providers read that field without a null check, and only the error changes. Across the 37,813 templates in the corpus, neither `UnexpectedError` nor `UnexpectedTokenError` is reported anywhere after this change.

Fixes #2588
Fixes #2589
Fixes #2590