### PR TITLE
Parser: Treat `<textarea>` content as raw text

### DIFF
--- a/javascript/packages/linter/src/rules/html-no-unescaped-entities.ts
+++ b/javascript/packages/linter/src/rules/html-no-unescaped-entities.ts
@@ -3,10 +3,10 @@ import { BaseRuleVisitor, locationFromContentOffset } from "../utils/rule-utils.
 import { getTagLocalName, isValidCharacterReference } from "@herb-tools/core"
 
 import type { UnboundLintOffense, LintOffense, LintContext, FullRuleConfig } from "../types.js"
-import type { ParseResult, ParserOptions, HTMLTextNode, HTMLElementNode } from "@herb-tools/core"
+import type { ParseResult, ParserOptions, HTMLTextNode, HTMLElementNode, LiteralNode } from "@herb-tools/core"
 
 interface UnescapedEntitiesAutofixContext extends BaseAutofixContext {
-  node: Mutable<HTMLTextNode>
+  node: Mutable<HTMLTextNode> | Mutable<LiteralNode>
   character: string
   entity: string
 }
@@ -72,6 +72,7 @@ function findUnescapedOccurrences(value: string): UnescapedOccurrence[] {
 }
 
 const RAW_TEXT_ELEMENTS = new Set(["script", "style"])
+const ESCAPABLE_RAW_TEXT_ELEMENTS = new Set(["textarea"])
 
 // Per the HTML5 spec (§13.2.5.36, §13.2.5.37), no characters are parse errors
 // in quoted attribute values. Entity checks only apply to text content.
@@ -96,12 +97,29 @@ class HTMLNoUnescapedEntitiesVisitor extends BaseRuleVisitor<UnescapedEntitiesAu
     return this.elementStack.some((tagName) => RAW_TEXT_ELEMENTS.has(tagName))
   }
 
-  visitHTMLTextNode(node: HTMLTextNode): void {
-    if (this.insideRawTextElement) {
-      super.visitHTMLTextNode(node)
-      return
+  private get insideEscapableRawTextElement(): boolean {
+    const innermost = this.elementStack[this.elementStack.length - 1]
+
+    return innermost !== undefined && ESCAPABLE_RAW_TEXT_ELEMENTS.has(innermost)
+  }
+
+  visitLiteralNode(node: LiteralNode): void {
+    if (this.insideEscapableRawTextElement) {
+      this.checkTextContent(node)
     }
 
+    super.visitLiteralNode(node)
+  }
+
+  visitHTMLTextNode(node: HTMLTextNode): void {
+    if (!this.insideRawTextElement) {
+      this.checkTextContent(node)
+    }
+
+    super.visitHTMLTextNode(node)
+  }
+
+  private checkTextContent(node: HTMLTextNode | LiteralNode): void {
     const content = node.content
     if (!content) return
 
@@ -118,8 +136,6 @@ class HTMLNoUnescapedEntitiesVisitor extends BaseRuleVisitor<UnescapedEntitiesAu
         { node, character, entity, unsafe: true },
       )
     }
-
-    super.visitHTMLTextNode(node)
   }
 }
 

--- a/src/include/parser/parser.h
+++ b/src/include/parser/parser.h
@@ -13,6 +13,7 @@ typedef enum {
   FOREIGN_CONTENT_UNKNOWN = 0,
   FOREIGN_CONTENT_SCRIPT,
   FOREIGN_CONTENT_STYLE,
+  FOREIGN_CONTENT_TEXTAREA,
   // FOREIGN_CONTENT_RUBY,
   // FOREIGN_CONTENT_TEMPLATE
 } foreign_content_type_T;
@@ -89,6 +90,7 @@ typedef struct PARSER_STRUCT {
   hb_array_T* open_tags_stack;
   parser_state_T state;
   foreign_content_type_T foreign_content_type;
+  size_t svg_depth;
   parser_options_T options;
   size_t consecutive_error_count;
   bool in_recovery_mode;

--- a/src/parser.c
+++ b/src/parser.c
@@ -69,6 +69,7 @@ void herb_parser_init(parser_T* parser, lexer_T* lexer, parser_options_T options
   parser->open_tags_stack = hb_array_init(16, parser->allocator);
   parser->state = PARSER_STATE_DATA;
   parser->foreign_content_type = FOREIGN_CONTENT_UNKNOWN;
+  parser->svg_depth = 0;
   parser->options = options;
   parser->consecutive_error_count = 0;
   parser->in_recovery_mode = false;
@@ -1308,6 +1309,10 @@ static AST_HTML_CLOSE_TAG_NODE_T* parser_parse_html_close_tag(parser_T* parser) 
 
   parser_consume_dot_notation_segments(parser, tag_name, &errors);
 
+  if (parser->svg_depth > 0 && hb_string_equals_case_insensitive(tag_name->value, hb_string("svg"))) {
+    parser->svg_depth--;
+  }
+
   parser_consume_whitespace(parser, children);
 
   token_T* tag_closing = parser_consume_if_present(parser, TOKEN_HTML_TAG_END);
@@ -1470,6 +1475,8 @@ static AST_NODE_T* parser_parse_html_element(parser_T* parser) {
 
   // <tag />
   if (open_tag->is_void) { return (AST_NODE_T*) parser_parse_html_self_closing_element(parser, open_tag); }
+
+  if (hb_string_equals_case_insensitive(open_tag->tag_name->value, hb_string("svg"))) { parser->svg_depth++; }
 
   // <tag>, in void element list, and not in inside an <svg> element
   if (!open_tag->is_void && is_void_element(open_tag->tag_name->value) && !parser_in_svg_context(parser)) {

--- a/src/parser/parser_helpers.c
+++ b/src/parser/parser_helpers.c
@@ -39,6 +39,7 @@ token_T* parser_pop_open_tag(const parser_T* parser) {
  */
 bool parser_in_svg_context(const parser_T* parser) {
   if (!parser || !parser->open_tags_stack) { return false; }
+  if (parser->svg_depth > 0) { return true; }
 
   size_t stack_size = hb_array_size(parser->open_tags_stack);
 
@@ -60,6 +61,7 @@ foreign_content_type_T parser_get_foreign_content_type(hb_string_T tag_name) {
 
   if (hb_string_equals_case_insensitive(tag_name, hb_string("script"))) { return FOREIGN_CONTENT_SCRIPT; }
   if (hb_string_equals_case_insensitive(tag_name, hb_string("style"))) { return FOREIGN_CONTENT_STYLE; }
+  if (hb_string_equals_case_insensitive(tag_name, hb_string("textarea"))) { return FOREIGN_CONTENT_TEXTAREA; }
 
   return FOREIGN_CONTENT_UNKNOWN;
 }
@@ -72,6 +74,7 @@ hb_string_T parser_get_foreign_content_closing_tag(foreign_content_type_T type) 
   switch (type) {
     case FOREIGN_CONTENT_SCRIPT: return hb_string("script");
     case FOREIGN_CONTENT_STYLE: return hb_string("style");
+    case FOREIGN_CONTENT_TEXTAREA: return hb_string("textarea");
     default: return HB_STRING_EMPTY;
   }
 }

--- a/test/parser/textarea_test.rb
+++ b/test/parser/textarea_test.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require_relative "../test_helper"
+
+module Parser
+  class TextareaTest < Minitest::Spec
+    include SnapshotUtils
+
+    test "textarea with plain text" do
+      assert_parsed_snapshot(%(<textarea>Hello</textarea>))
+    end
+
+    test "textarea with an unclosed script tag inside" do
+      assert_parsed_snapshot(<<~HTML)
+        <textarea class="form-control" onfocus="$(this).select()" readonly>
+          <script src='....' type='module' ...>
+        </textarea>
+      HTML
+    end
+
+    test "textarea with HTML elements inside" do
+      assert_parsed_snapshot(%(<textarea><b>bold</b> and <input type="text"></textarea>))
+    end
+
+    test "textarea with ERB output" do
+      assert_parsed_snapshot(%(<textarea name="body"><%= @post.body %></textarea>))
+    end
+
+    test "textarea with ERB control flow" do
+      assert_parsed_snapshot(<<~HTML)
+        <textarea><% if @draft %>Draft<% else %>Final<% end %></textarea>
+      HTML
+    end
+
+    test "textarea with an uppercase closing tag and trailing whitespace" do
+      assert_parsed_snapshot(%(<textarea>text</TEXTAREA >))
+    end
+
+    test "textarea with a closing tag for a different element" do
+      assert_parsed_snapshot(%(<textarea></div></textarea>))
+    end
+
+    test "unclosed textarea" do
+      assert_parsed_snapshot(%(<textarea>never closed<div>))
+    end
+
+    test "textarea inside a form with sibling elements" do
+      assert_parsed_snapshot(<<~HTML)
+        <form>
+          <label for="body">Body</label>
+          <textarea id="body"><p>not an element</p></textarea>
+          <button>Save</button>
+        </form>
+      HTML
+    end
+  end
+end

--- a/test/snapshots/parser/svg_test/test_0005_HTML_void_can_be_non-void_within_svg_1072d4c2f81d845d5c1f0fd86e40e23b.txt
+++ b/test/snapshots/parser/svg_test/test_0005_HTML_void_can_be_non-void_within_svg_1072d4c2f81d845d5c1f0fd86e40e23b.txt
@@ -17,11 +17,11 @@ input: |2-
     │   │       └── is_void: false
     │   │
     │   ├── tag_name: "svg" (location: (1:1)-(1:4))
-    │   ├── body: (4 items)
+    │   ├── body: (3 items)
     │   │   ├── @ HTMLTextNode (location: (1:5)-(2:2))
     │   │   │   └── content: "\n  "
     │   │   │
-    │   │   ├── @ HTMLElementNode (location: (2:2)-(2:6))
+    │   │   ├── @ HTMLElementNode (location: (2:2)-(2:11))
     │   │   │   ├── open_tag:
     │   │   │   │   └── @ HTMLOpenTagNode (location: (2:2)-(2:6))
     │   │   │   │       ├── tag_opening: "<" (location: (2:2)-(2:3))
@@ -32,22 +32,15 @@ input: |2-
     │   │   │   │
     │   │   │   ├── tag_name: "br" (location: (2:3)-(2:5))
     │   │   │   ├── body: []
-    │   │   │   ├── close_tag: ∅
-    │   │   │   ├── is_void: true
-    │   │   │   └── element_source: "HTML"
-    │   │   │
-    │   │   ├── @ HTMLCloseTagNode (location: (2:6)-(2:11))
-    │   │   │   ├── errors: (1 error)
-    │   │   │   │   └── @ VoidElementClosingTagError (location: (2:6)-(2:11))
-    │   │   │   │       ├── message: "`br` is a void element and should not be used as a closing tag. Use `<br>` or `<br />` instead of `</br>`."
+    │   │   │   ├── close_tag:
+    │   │   │   │   └── @ HTMLCloseTagNode (location: (2:6)-(2:11))
+    │   │   │   │       ├── tag_opening: "</" (location: (2:6)-(2:8))
     │   │   │   │       ├── tag_name: "br" (location: (2:8)-(2:10))
-    │   │   │   │       ├── expected: "<br />"
-    │   │   │   │       └── found: "</br>"
+    │   │   │   │       ├── children: []
+    │   │   │   │       └── tag_closing: ">" (location: (2:10)-(2:11))
     │   │   │   │
-    │   │   │   ├── tag_opening: "</" (location: (2:6)-(2:8))
-    │   │   │   ├── tag_name: "br" (location: (2:8)-(2:10))
-    │   │   │   ├── children: []
-    │   │   │   └── tag_closing: ">" (location: (2:10)-(2:11))
+    │   │   │   ├── is_void: false
+    │   │   │   └── element_source: "HTML"
     │   │   │
     │   │   └── @ HTMLTextNode (location: (2:11)-(3:0))
     │   │       └── content: "\n"

--- a/test/snapshots/parser/textarea_test/test_0001_textarea_with_plain_text_77990c0637b4c2eab0647996880183e4.txt
+++ b/test/snapshots/parser/textarea_test/test_0001_textarea_with_plain_text_77990c0637b4c2eab0647996880183e4.txt
@@ -1,0 +1,29 @@
+---
+source: "Parser::TextareaTest#test_0001_textarea with plain text"
+input: "<textarea>Hello</textarea>"
+---
+@ DocumentNode (location: (1:0)-(1:26))
+└── children: (1 item)
+    └── @ HTMLElementNode (location: (1:0)-(1:26))
+        ├── open_tag:
+        │   └── @ HTMLOpenTagNode (location: (1:0)-(1:10))
+        │       ├── tag_opening: "<" (location: (1:0)-(1:1))
+        │       ├── tag_name: "textarea" (location: (1:1)-(1:9))
+        │       ├── tag_closing: ">" (location: (1:9)-(1:10))
+        │       ├── children: []
+        │       └── is_void: false
+        │
+        ├── tag_name: "textarea" (location: (1:1)-(1:9))
+        ├── body: (1 item)
+        │   └── @ LiteralNode (location: (1:10)-(1:15))
+        │       └── content: "Hello"
+        │
+        ├── close_tag:
+        │   └── @ HTMLCloseTagNode (location: (1:15)-(1:26))
+        │       ├── tag_opening: "</" (location: (1:15)-(1:17))
+        │       ├── tag_name: "textarea" (location: (1:17)-(1:25))
+        │       ├── children: []
+        │       └── tag_closing: ">" (location: (1:25)-(1:26))
+        │
+        ├── is_void: false
+        └── element_source: "HTML"

--- a/test/snapshots/parser/textarea_test/test_0002_textarea_with_an_unclosed_script_tag_inside_409e60043f44f8bcf9a91977c8e308f8.txt
+++ b/test/snapshots/parser/textarea_test/test_0002_textarea_with_an_unclosed_script_tag_inside_409e60043f44f8bcf9a91977c8e308f8.txt
@@ -1,0 +1,86 @@
+---
+source: "Parser::TextareaTest#test_0002_textarea with an unclosed script tag inside"
+input: |2-
+<textarea class="form-control" onfocus="$(this).select()" readonly>
+  <script src='....' type='module' ...>
+</textarea>
+---
+@ DocumentNode (location: (1:0)-(4:0))
+└── children: (2 items)
+    ├── @ HTMLElementNode (location: (1:0)-(3:11))
+    │   ├── open_tag:
+    │   │   └── @ HTMLOpenTagNode (location: (1:0)-(1:67))
+    │   │       ├── tag_opening: "<" (location: (1:0)-(1:1))
+    │   │       ├── tag_name: "textarea" (location: (1:1)-(1:9))
+    │   │       ├── tag_closing: ">" (location: (1:66)-(1:67))
+    │   │       ├── children: (3 items)
+    │   │       │   ├── @ HTMLAttributeNode (location: (1:10)-(1:30))
+    │   │       │   │   ├── name:
+    │   │       │   │   │   └── @ HTMLAttributeNameNode (location: (1:10)-(1:15))
+    │   │       │   │   │       └── children: (1 item)
+    │   │       │   │   │           └── @ LiteralNode (location: (1:10)-(1:15))
+    │   │       │   │   │               └── content: "class"
+    │   │       │   │   │
+    │   │       │   │   │
+    │   │       │   │   ├── equals: "=" (location: (1:15)-(1:16))
+    │   │       │   │   └── value:
+    │   │       │   │       └── @ HTMLAttributeValueNode (location: (1:16)-(1:30))
+    │   │       │   │           ├── open_quote: """ (location: (1:16)-(1:17))
+    │   │       │   │           ├── children: (1 item)
+    │   │       │   │           │   └── @ LiteralNode (location: (1:17)-(1:29))
+    │   │       │   │           │       └── content: "form-control"
+    │   │       │   │           │
+    │   │       │   │           ├── close_quote: """ (location: (1:29)-(1:30))
+    │   │       │   │           └── quoted: true
+    │   │       │   │
+    │   │       │   │
+    │   │       │   ├── @ HTMLAttributeNode (location: (1:31)-(1:57))
+    │   │       │   │   ├── name:
+    │   │       │   │   │   └── @ HTMLAttributeNameNode (location: (1:31)-(1:38))
+    │   │       │   │   │       └── children: (1 item)
+    │   │       │   │   │           └── @ LiteralNode (location: (1:31)-(1:38))
+    │   │       │   │   │               └── content: "onfocus"
+    │   │       │   │   │
+    │   │       │   │   │
+    │   │       │   │   ├── equals: "=" (location: (1:38)-(1:39))
+    │   │       │   │   └── value:
+    │   │       │   │       └── @ HTMLAttributeValueNode (location: (1:39)-(1:57))
+    │   │       │   │           ├── open_quote: """ (location: (1:39)-(1:40))
+    │   │       │   │           ├── children: (1 item)
+    │   │       │   │           │   └── @ LiteralNode (location: (1:40)-(1:56))
+    │   │       │   │           │       └── content: "$(this).select()"
+    │   │       │   │           │
+    │   │       │   │           ├── close_quote: """ (location: (1:56)-(1:57))
+    │   │       │   │           └── quoted: true
+    │   │       │   │
+    │   │       │   │
+    │   │       │   └── @ HTMLAttributeNode (location: (1:58)-(1:66))
+    │   │       │       ├── name:
+    │   │       │       │   └── @ HTMLAttributeNameNode (location: (1:58)-(1:66))
+    │   │       │       │       └── children: (1 item)
+    │   │       │       │           └── @ LiteralNode (location: (1:58)-(1:66))
+    │   │       │       │               └── content: "readonly"
+    │   │       │       │
+    │   │       │       │
+    │   │       │       ├── equals: ∅
+    │   │       │       └── value: ∅
+    │   │       │
+    │   │       └── is_void: false
+    │   │
+    │   ├── tag_name: "textarea" (location: (1:1)-(1:9))
+    │   ├── body: (1 item)
+    │   │   └── @ LiteralNode (location: (1:67)-(3:0))
+    │   │       └── content: "\n  <script src='....' type='module' ...>\n"
+    │   │
+    │   ├── close_tag:
+    │   │   └── @ HTMLCloseTagNode (location: (3:0)-(3:11))
+    │   │       ├── tag_opening: "</" (location: (3:0)-(3:2))
+    │   │       ├── tag_name: "textarea" (location: (3:2)-(3:10))
+    │   │       ├── children: []
+    │   │       └── tag_closing: ">" (location: (3:10)-(3:11))
+    │   │
+    │   ├── is_void: false
+    │   └── element_source: "HTML"
+    │
+    └── @ HTMLTextNode (location: (3:11)-(4:0))
+        └── content: "\n"

--- a/test/snapshots/parser/textarea_test/test_0003_textarea_with_HTML_elements_inside_04b52d7de0554fe1198c64b8e173f36e.txt
+++ b/test/snapshots/parser/textarea_test/test_0003_textarea_with_HTML_elements_inside_04b52d7de0554fe1198c64b8e173f36e.txt
@@ -1,0 +1,29 @@
+---
+source: "Parser::TextareaTest#test_0003_textarea with HTML elements inside"
+input: "<textarea><b>bold</b> and <input type=\"text\"></textarea>"
+---
+@ DocumentNode (location: (1:0)-(1:56))
+└── children: (1 item)
+    └── @ HTMLElementNode (location: (1:0)-(1:56))
+        ├── open_tag:
+        │   └── @ HTMLOpenTagNode (location: (1:0)-(1:10))
+        │       ├── tag_opening: "<" (location: (1:0)-(1:1))
+        │       ├── tag_name: "textarea" (location: (1:1)-(1:9))
+        │       ├── tag_closing: ">" (location: (1:9)-(1:10))
+        │       ├── children: []
+        │       └── is_void: false
+        │
+        ├── tag_name: "textarea" (location: (1:1)-(1:9))
+        ├── body: (1 item)
+        │   └── @ LiteralNode (location: (1:10)-(1:45))
+        │       └── content: "<b>bold</b> and <input type=\"text\">"
+        │
+        ├── close_tag:
+        │   └── @ HTMLCloseTagNode (location: (1:45)-(1:56))
+        │       ├── tag_opening: "</" (location: (1:45)-(1:47))
+        │       ├── tag_name: "textarea" (location: (1:47)-(1:55))
+        │       ├── children: []
+        │       └── tag_closing: ">" (location: (1:55)-(1:56))
+        │
+        ├── is_void: false
+        └── element_source: "HTML"

--- a/test/snapshots/parser/textarea_test/test_0004_textarea_with_ERB_output_4a34e1762c13c68603316e85896713ef.txt
+++ b/test/snapshots/parser/textarea_test/test_0004_textarea_with_ERB_output_4a34e1762c13c68603316e85896713ef.txt
@@ -1,0 +1,53 @@
+---
+source: "Parser::TextareaTest#test_0004_textarea with ERB output"
+input: "<textarea name=\"body\"><%= @post.body %></textarea>"
+---
+@ DocumentNode (location: (1:0)-(1:50))
+└── children: (1 item)
+    └── @ HTMLElementNode (location: (1:0)-(1:50))
+        ├── open_tag:
+        │   └── @ HTMLOpenTagNode (location: (1:0)-(1:22))
+        │       ├── tag_opening: "<" (location: (1:0)-(1:1))
+        │       ├── tag_name: "textarea" (location: (1:1)-(1:9))
+        │       ├── tag_closing: ">" (location: (1:21)-(1:22))
+        │       ├── children: (1 item)
+        │       │   └── @ HTMLAttributeNode (location: (1:10)-(1:21))
+        │       │       ├── name:
+        │       │       │   └── @ HTMLAttributeNameNode (location: (1:10)-(1:14))
+        │       │       │       └── children: (1 item)
+        │       │       │           └── @ LiteralNode (location: (1:10)-(1:14))
+        │       │       │               └── content: "name"
+        │       │       │
+        │       │       │
+        │       │       ├── equals: "=" (location: (1:14)-(1:15))
+        │       │       └── value:
+        │       │           └── @ HTMLAttributeValueNode (location: (1:15)-(1:21))
+        │       │               ├── open_quote: """ (location: (1:15)-(1:16))
+        │       │               ├── children: (1 item)
+        │       │               │   └── @ LiteralNode (location: (1:16)-(1:20))
+        │       │               │       └── content: "body"
+        │       │               │
+        │       │               ├── close_quote: """ (location: (1:20)-(1:21))
+        │       │               └── quoted: true
+        │       │
+        │       │
+        │       └── is_void: false
+        │
+        ├── tag_name: "textarea" (location: (1:1)-(1:9))
+        ├── body: (1 item)
+        │   └── @ ERBContentNode (location: (1:22)-(1:39))
+        │       ├── tag_opening: "<%=" (location: (1:22)-(1:25))
+        │       ├── content: " @post.body " (location: (1:25)-(1:37))
+        │       ├── tag_closing: "%>" (location: (1:37)-(1:39))
+        │       ├── parsed: true
+        │       └── valid: true
+        │
+        ├── close_tag:
+        │   └── @ HTMLCloseTagNode (location: (1:39)-(1:50))
+        │       ├── tag_opening: "</" (location: (1:39)-(1:41))
+        │       ├── tag_name: "textarea" (location: (1:41)-(1:49))
+        │       ├── children: []
+        │       └── tag_closing: ">" (location: (1:49)-(1:50))
+        │
+        ├── is_void: false
+        └── element_source: "HTML"

--- a/test/snapshots/parser/textarea_test/test_0005_textarea_with_ERB_control_flow_e3b00f18d47b07c326406cd03d80aa35.txt
+++ b/test/snapshots/parser/textarea_test/test_0005_textarea_with_ERB_control_flow_e3b00f18d47b07c326406cd03d80aa35.txt
@@ -1,0 +1,56 @@
+---
+source: "Parser::TextareaTest#test_0005_textarea with ERB control flow"
+input: |2-
+<textarea><% if @draft %>Draft<% else %>Final<% end %></textarea>
+---
+@ DocumentNode (location: (1:0)-(2:0))
+└── children: (2 items)
+    ├── @ HTMLElementNode (location: (1:0)-(1:65))
+    │   ├── open_tag:
+    │   │   └── @ HTMLOpenTagNode (location: (1:0)-(1:10))
+    │   │       ├── tag_opening: "<" (location: (1:0)-(1:1))
+    │   │       ├── tag_name: "textarea" (location: (1:1)-(1:9))
+    │   │       ├── tag_closing: ">" (location: (1:9)-(1:10))
+    │   │       ├── children: []
+    │   │       └── is_void: false
+    │   │
+    │   ├── tag_name: "textarea" (location: (1:1)-(1:9))
+    │   ├── body: (1 item)
+    │   │   └── @ ERBIfNode (location: (1:10)-(1:54))
+    │   │       ├── tag_opening: "<%" (location: (1:10)-(1:12))
+    │   │       ├── content: " if @draft " (location: (1:12)-(1:23))
+    │   │       ├── tag_closing: "%>" (location: (1:23)-(1:25))
+    │   │       ├── then_keyword: ∅
+    │   │       ├── statements: (1 item)
+    │   │       │   └── @ LiteralNode (location: (1:25)-(1:30))
+    │   │       │       └── content: "Draft"
+    │   │       │
+    │   │       ├── subsequent:
+    │   │       │   └── @ ERBElseNode (location: (1:30)-(1:45))
+    │   │       │       ├── tag_opening: "<%" (location: (1:30)-(1:32))
+    │   │       │       ├── content: " else " (location: (1:32)-(1:38))
+    │   │       │       ├── tag_closing: "%>" (location: (1:38)-(1:40))
+    │   │       │       └── statements: (1 item)
+    │   │       │           └── @ LiteralNode (location: (1:40)-(1:45))
+    │   │       │               └── content: "Final"
+    │   │       │
+    │   │       │
+    │   │       └── end_node:
+    │   │           └── @ ERBEndNode (location: (1:45)-(1:54))
+    │   │               ├── tag_opening: "<%" (location: (1:45)-(1:47))
+    │   │               ├── content: " end " (location: (1:47)-(1:52))
+    │   │               └── tag_closing: "%>" (location: (1:52)-(1:54))
+    │   │
+    │   │
+    │   ├── close_tag:
+    │   │   └── @ HTMLCloseTagNode (location: (1:54)-(1:65))
+    │   │       ├── tag_opening: "</" (location: (1:54)-(1:56))
+    │   │       ├── tag_name: "textarea" (location: (1:56)-(1:64))
+    │   │       ├── children: []
+    │   │       └── tag_closing: ">" (location: (1:64)-(1:65))
+    │   │
+    │   ├── is_void: false
+    │   └── element_source: "HTML"
+    │
+    └── @ HTMLTextNode (location: (1:65)-(2:0))
+        └── content: "\n"

--- a/test/snapshots/parser/textarea_test/test_0006_textarea_with_an_uppercase_closing_tag_and_trailing_whitespace_c82f8be8fa8724b26d91dd8f0a7fee70.txt
+++ b/test/snapshots/parser/textarea_test/test_0006_textarea_with_an_uppercase_closing_tag_and_trailing_whitespace_c82f8be8fa8724b26d91dd8f0a7fee70.txt
@@ -1,0 +1,29 @@
+---
+source: "Parser::TextareaTest#test_0006_textarea with an uppercase closing tag and trailing whitespace"
+input: "<textarea>text</TEXTAREA >"
+---
+@ DocumentNode (location: (1:0)-(1:26))
+└── children: (1 item)
+    └── @ HTMLElementNode (location: (1:0)-(1:26))
+        ├── open_tag:
+        │   └── @ HTMLOpenTagNode (location: (1:0)-(1:10))
+        │       ├── tag_opening: "<" (location: (1:0)-(1:1))
+        │       ├── tag_name: "textarea" (location: (1:1)-(1:9))
+        │       ├── tag_closing: ">" (location: (1:9)-(1:10))
+        │       ├── children: []
+        │       └── is_void: false
+        │
+        ├── tag_name: "textarea" (location: (1:1)-(1:9))
+        ├── body: (1 item)
+        │   └── @ LiteralNode (location: (1:10)-(1:14))
+        │       └── content: "text"
+        │
+        ├── close_tag:
+        │   └── @ HTMLCloseTagNode (location: (1:14)-(1:26))
+        │       ├── tag_opening: "</" (location: (1:14)-(1:16))
+        │       ├── tag_name: "TEXTAREA" (location: (1:16)-(1:24))
+        │       ├── children: []
+        │       └── tag_closing: ">" (location: (1:25)-(1:26))
+        │
+        ├── is_void: false
+        └── element_source: "HTML"

--- a/test/snapshots/parser/textarea_test/test_0007_textarea_with_a_closing_tag_for_a_different_element_c34b10b044ef8e16e96571e89ce01447.txt
+++ b/test/snapshots/parser/textarea_test/test_0007_textarea_with_a_closing_tag_for_a_different_element_c34b10b044ef8e16e96571e89ce01447.txt
@@ -1,0 +1,29 @@
+---
+source: "Parser::TextareaTest#test_0007_textarea with a closing tag for a different element"
+input: "<textarea></div></textarea>"
+---
+@ DocumentNode (location: (1:0)-(1:27))
+└── children: (1 item)
+    └── @ HTMLElementNode (location: (1:0)-(1:27))
+        ├── open_tag:
+        │   └── @ HTMLOpenTagNode (location: (1:0)-(1:10))
+        │       ├── tag_opening: "<" (location: (1:0)-(1:1))
+        │       ├── tag_name: "textarea" (location: (1:1)-(1:9))
+        │       ├── tag_closing: ">" (location: (1:9)-(1:10))
+        │       ├── children: []
+        │       └── is_void: false
+        │
+        ├── tag_name: "textarea" (location: (1:1)-(1:9))
+        ├── body: (1 item)
+        │   └── @ LiteralNode (location: (1:10)-(1:16))
+        │       └── content: "</div>"
+        │
+        ├── close_tag:
+        │   └── @ HTMLCloseTagNode (location: (1:16)-(1:27))
+        │       ├── tag_opening: "</" (location: (1:16)-(1:18))
+        │       ├── tag_name: "textarea" (location: (1:18)-(1:26))
+        │       ├── children: []
+        │       └── tag_closing: ">" (location: (1:26)-(1:27))
+        │
+        ├── is_void: false
+        └── element_source: "HTML"

--- a/test/snapshots/parser/textarea_test/test_0008_unclosed_textarea_bce8bf51f7e2b96771fc30d354ab521f.txt
+++ b/test/snapshots/parser/textarea_test/test_0008_unclosed_textarea_bce8bf51f7e2b96771fc30d354ab521f.txt
@@ -1,0 +1,28 @@
+---
+source: "Parser::TextareaTest#test_0008_unclosed textarea"
+input: "<textarea>never closed<div>"
+---
+@ DocumentNode (location: (1:0)-(1:27))
+└── children: (1 item)
+    └── @ HTMLElementNode (location: (1:0)-(1:10))
+        ├── errors: (1 error)
+        │   └── @ MissingClosingTagError (location: (1:1)-(1:9))
+        │       ├── message: "Opening tag `<textarea>` at (1:1) doesn't have a matching closing tag `</textarea>` in the same scope."
+        │       └── opening_tag: "textarea" (location: (1:1)-(1:9))
+        │
+        ├── open_tag:
+        │   └── @ HTMLOpenTagNode (location: (1:0)-(1:10))
+        │       ├── tag_opening: "<" (location: (1:0)-(1:1))
+        │       ├── tag_name: "textarea" (location: (1:1)-(1:9))
+        │       ├── tag_closing: ">" (location: (1:9)-(1:10))
+        │       ├── children: []
+        │       └── is_void: false
+        │
+        ├── tag_name: "textarea" (location: (1:1)-(1:9))
+        ├── body: (1 item)
+        │   └── @ LiteralNode (location: (1:10)-(1:27))
+        │       └── content: "never closed<div>"
+        │
+        ├── close_tag: ∅
+        ├── is_void: false
+        └── element_source: "HTML"

--- a/test/snapshots/parser/textarea_test/test_0009_textarea_inside_a_form_with_sibling_elements_3ae6da1741b5c5df9c5d401b7d58e818.txt
+++ b/test/snapshots/parser/textarea_test/test_0009_textarea_inside_a_form_with_sibling_elements_3ae6da1741b5c5df9c5d401b7d58e818.txt
@@ -1,0 +1,158 @@
+---
+source: "Parser::TextareaTest#test_0009_textarea inside a form with sibling elements"
+input: |2-
+<form>
+  <label for="body">Body</label>
+  <textarea id="body"><p>not an element</p></textarea>
+  <button>Save</button>
+</form>
+---
+@ DocumentNode (location: (1:0)-(6:0))
+└── children: (2 items)
+    ├── @ HTMLElementNode (location: (1:0)-(5:7))
+    │   ├── open_tag:
+    │   │   └── @ HTMLOpenTagNode (location: (1:0)-(1:6))
+    │   │       ├── tag_opening: "<" (location: (1:0)-(1:1))
+    │   │       ├── tag_name: "form" (location: (1:1)-(1:5))
+    │   │       ├── tag_closing: ">" (location: (1:5)-(1:6))
+    │   │       ├── children: []
+    │   │       └── is_void: false
+    │   │
+    │   ├── tag_name: "form" (location: (1:1)-(1:5))
+    │   ├── body: (7 items)
+    │   │   ├── @ HTMLTextNode (location: (1:6)-(2:2))
+    │   │   │   └── content: "\n  "
+    │   │   │
+    │   │   ├── @ HTMLElementNode (location: (2:2)-(2:32))
+    │   │   │   ├── open_tag:
+    │   │   │   │   └── @ HTMLOpenTagNode (location: (2:2)-(2:20))
+    │   │   │   │       ├── tag_opening: "<" (location: (2:2)-(2:3))
+    │   │   │   │       ├── tag_name: "label" (location: (2:3)-(2:8))
+    │   │   │   │       ├── tag_closing: ">" (location: (2:19)-(2:20))
+    │   │   │   │       ├── children: (1 item)
+    │   │   │   │       │   └── @ HTMLAttributeNode (location: (2:9)-(2:19))
+    │   │   │   │       │       ├── name:
+    │   │   │   │       │       │   └── @ HTMLAttributeNameNode (location: (2:9)-(2:12))
+    │   │   │   │       │       │       └── children: (1 item)
+    │   │   │   │       │       │           └── @ LiteralNode (location: (2:9)-(2:12))
+    │   │   │   │       │       │               └── content: "for"
+    │   │   │   │       │       │
+    │   │   │   │       │       │
+    │   │   │   │       │       ├── equals: "=" (location: (2:12)-(2:13))
+    │   │   │   │       │       └── value:
+    │   │   │   │       │           └── @ HTMLAttributeValueNode (location: (2:13)-(2:19))
+    │   │   │   │       │               ├── open_quote: """ (location: (2:13)-(2:14))
+    │   │   │   │       │               ├── children: (1 item)
+    │   │   │   │       │               │   └── @ LiteralNode (location: (2:14)-(2:18))
+    │   │   │   │       │               │       └── content: "body"
+    │   │   │   │       │               │
+    │   │   │   │       │               ├── close_quote: """ (location: (2:18)-(2:19))
+    │   │   │   │       │               └── quoted: true
+    │   │   │   │       │
+    │   │   │   │       │
+    │   │   │   │       └── is_void: false
+    │   │   │   │
+    │   │   │   ├── tag_name: "label" (location: (2:3)-(2:8))
+    │   │   │   ├── body: (1 item)
+    │   │   │   │   └── @ HTMLTextNode (location: (2:20)-(2:24))
+    │   │   │   │       └── content: "Body"
+    │   │   │   │
+    │   │   │   ├── close_tag:
+    │   │   │   │   └── @ HTMLCloseTagNode (location: (2:24)-(2:32))
+    │   │   │   │       ├── tag_opening: "</" (location: (2:24)-(2:26))
+    │   │   │   │       ├── tag_name: "label" (location: (2:26)-(2:31))
+    │   │   │   │       ├── children: []
+    │   │   │   │       └── tag_closing: ">" (location: (2:31)-(2:32))
+    │   │   │   │
+    │   │   │   ├── is_void: false
+    │   │   │   └── element_source: "HTML"
+    │   │   │
+    │   │   ├── @ HTMLTextNode (location: (2:32)-(3:2))
+    │   │   │   └── content: "\n  "
+    │   │   │
+    │   │   ├── @ HTMLElementNode (location: (3:2)-(3:54))
+    │   │   │   ├── open_tag:
+    │   │   │   │   └── @ HTMLOpenTagNode (location: (3:2)-(3:22))
+    │   │   │   │       ├── tag_opening: "<" (location: (3:2)-(3:3))
+    │   │   │   │       ├── tag_name: "textarea" (location: (3:3)-(3:11))
+    │   │   │   │       ├── tag_closing: ">" (location: (3:21)-(3:22))
+    │   │   │   │       ├── children: (1 item)
+    │   │   │   │       │   └── @ HTMLAttributeNode (location: (3:12)-(3:21))
+    │   │   │   │       │       ├── name:
+    │   │   │   │       │       │   └── @ HTMLAttributeNameNode (location: (3:12)-(3:14))
+    │   │   │   │       │       │       └── children: (1 item)
+    │   │   │   │       │       │           └── @ LiteralNode (location: (3:12)-(3:14))
+    │   │   │   │       │       │               └── content: "id"
+    │   │   │   │       │       │
+    │   │   │   │       │       │
+    │   │   │   │       │       ├── equals: "=" (location: (3:14)-(3:15))
+    │   │   │   │       │       └── value:
+    │   │   │   │       │           └── @ HTMLAttributeValueNode (location: (3:15)-(3:21))
+    │   │   │   │       │               ├── open_quote: """ (location: (3:15)-(3:16))
+    │   │   │   │       │               ├── children: (1 item)
+    │   │   │   │       │               │   └── @ LiteralNode (location: (3:16)-(3:20))
+    │   │   │   │       │               │       └── content: "body"
+    │   │   │   │       │               │
+    │   │   │   │       │               ├── close_quote: """ (location: (3:20)-(3:21))
+    │   │   │   │       │               └── quoted: true
+    │   │   │   │       │
+    │   │   │   │       │
+    │   │   │   │       └── is_void: false
+    │   │   │   │
+    │   │   │   ├── tag_name: "textarea" (location: (3:3)-(3:11))
+    │   │   │   ├── body: (1 item)
+    │   │   │   │   └── @ LiteralNode (location: (3:22)-(3:43))
+    │   │   │   │       └── content: "<p>not an element</p>"
+    │   │   │   │
+    │   │   │   ├── close_tag:
+    │   │   │   │   └── @ HTMLCloseTagNode (location: (3:43)-(3:54))
+    │   │   │   │       ├── tag_opening: "</" (location: (3:43)-(3:45))
+    │   │   │   │       ├── tag_name: "textarea" (location: (3:45)-(3:53))
+    │   │   │   │       ├── children: []
+    │   │   │   │       └── tag_closing: ">" (location: (3:53)-(3:54))
+    │   │   │   │
+    │   │   │   ├── is_void: false
+    │   │   │   └── element_source: "HTML"
+    │   │   │
+    │   │   ├── @ HTMLTextNode (location: (3:54)-(4:2))
+    │   │   │   └── content: "\n  "
+    │   │   │
+    │   │   ├── @ HTMLElementNode (location: (4:2)-(4:23))
+    │   │   │   ├── open_tag:
+    │   │   │   │   └── @ HTMLOpenTagNode (location: (4:2)-(4:10))
+    │   │   │   │       ├── tag_opening: "<" (location: (4:2)-(4:3))
+    │   │   │   │       ├── tag_name: "button" (location: (4:3)-(4:9))
+    │   │   │   │       ├── tag_closing: ">" (location: (4:9)-(4:10))
+    │   │   │   │       ├── children: []
+    │   │   │   │       └── is_void: false
+    │   │   │   │
+    │   │   │   ├── tag_name: "button" (location: (4:3)-(4:9))
+    │   │   │   ├── body: (1 item)
+    │   │   │   │   └── @ HTMLTextNode (location: (4:10)-(4:14))
+    │   │   │   │       └── content: "Save"
+    │   │   │   │
+    │   │   │   ├── close_tag:
+    │   │   │   │   └── @ HTMLCloseTagNode (location: (4:14)-(4:23))
+    │   │   │   │       ├── tag_opening: "</" (location: (4:14)-(4:16))
+    │   │   │   │       ├── tag_name: "button" (location: (4:16)-(4:22))
+    │   │   │   │       ├── children: []
+    │   │   │   │       └── tag_closing: ">" (location: (4:22)-(4:23))
+    │   │   │   │
+    │   │   │   ├── is_void: false
+    │   │   │   └── element_source: "HTML"
+    │   │   │
+    │   │   └── @ HTMLTextNode (location: (4:23)-(5:0))
+    │   │       └── content: "\n"
+    │   │
+    │   ├── close_tag:
+    │   │   └── @ HTMLCloseTagNode (location: (5:0)-(5:7))
+    │   │       ├── tag_opening: "</" (location: (5:0)-(5:2))
+    │   │       ├── tag_name: "form" (location: (5:2)-(5:6))
+    │   │       ├── children: []
+    │   │       └── tag_closing: ">" (location: (5:6)-(5:7))
+    │   │
+    │   ├── is_void: false
+    │   └── element_source: "HTML"
+    │
+    └── @ HTMLTextNode (location: (5:7)-(6:0))
+        └── content: "\n"


### PR DESCRIPTION
This pull request makes the parser read the content of `<textarea>` as text instead of markup, the way the HTML5 tokenizer does for its RCDATA elements.

ERB tags inside it keep being parsed, exactly as they are inside `<script>`, so `<textarea><%= @post.body %></textarea>` still yields an ERB node.

```erb
<textarea class="form-control" onfocus="$(this).select()" readonly>
  <script src='....' type='module' ...>
</textarea>
```

**Before**

```js
@ HTMLElementNode textarea
├── errors: MissingClosingTagError
└── body:
    └── @ HTMLElementNode script (unclosed)
```

**After**

```js
@ HTMLElementNode textarea
└── body:
    └── @ LiteralNode "\n  <script src='....' type='module' ...>\n"
```

Resolves #2592 