### PR TITLE
Parser: Treat `<title>` content as text

### DIFF
--- a/javascript/packages/linter/src/rules/html-no-unescaped-entities.ts
+++ b/javascript/packages/linter/src/rules/html-no-unescaped-entities.ts
@@ -3,10 +3,10 @@ import { BaseRuleVisitor, locationFromContentOffset } from "../utils/rule-utils.
 import { getTagLocalName, isValidCharacterReference } from "@herb-tools/core"
 
 import type { UnboundLintOffense, LintOffense, LintContext, FullRuleConfig } from "../types.js"
-import type { ParseResult, ParserOptions, HTMLTextNode, HTMLElementNode, LiteralNode } from "@herb-tools/core"
+import type { ParseResult, ParserOptions, HTMLTextNode, HTMLElementNode } from "@herb-tools/core"
 
 interface UnescapedEntitiesAutofixContext extends BaseAutofixContext {
-  node: Mutable<HTMLTextNode> | Mutable<LiteralNode>
+  node: Mutable<HTMLTextNode>
   character: string
   entity: string
 }
@@ -72,7 +72,6 @@ function findUnescapedOccurrences(value: string): UnescapedOccurrence[] {
 }
 
 const RAW_TEXT_ELEMENTS = new Set(["script", "style"])
-const ESCAPABLE_RAW_TEXT_ELEMENTS = new Set(["textarea"])
 
 // Per the HTML5 spec (§13.2.5.36, §13.2.5.37), no characters are parse errors
 // in quoted attribute values. Entity checks only apply to text content.
@@ -97,29 +96,12 @@ class HTMLNoUnescapedEntitiesVisitor extends BaseRuleVisitor<UnescapedEntitiesAu
     return this.elementStack.some((tagName) => RAW_TEXT_ELEMENTS.has(tagName))
   }
 
-  private get insideEscapableRawTextElement(): boolean {
-    const innermost = this.elementStack[this.elementStack.length - 1]
-
-    return innermost !== undefined && ESCAPABLE_RAW_TEXT_ELEMENTS.has(innermost)
-  }
-
-  visitLiteralNode(node: LiteralNode): void {
-    if (this.insideEscapableRawTextElement) {
-      this.checkTextContent(node)
-    }
-
-    super.visitLiteralNode(node)
-  }
-
   visitHTMLTextNode(node: HTMLTextNode): void {
-    if (!this.insideRawTextElement) {
-      this.checkTextContent(node)
+    if (this.insideRawTextElement) {
+      super.visitHTMLTextNode(node)
+      return
     }
 
-    super.visitHTMLTextNode(node)
-  }
-
-  private checkTextContent(node: HTMLTextNode | LiteralNode): void {
     const content = node.content
     if (!content) return
 
@@ -136,6 +118,8 @@ class HTMLNoUnescapedEntitiesVisitor extends BaseRuleVisitor<UnescapedEntitiesAu
         { node, character, entity, unsafe: true },
       )
     }
+
+    super.visitHTMLTextNode(node)
   }
 }
 

--- a/javascript/packages/linter/test/rules/html-head-only-elements.test.ts
+++ b/javascript/packages/linter/test/rules/html-head-only-elements.test.ts
@@ -518,7 +518,7 @@ describe("html-head-only-elements", () => {
     })
 
     test("treats a javascript_tag body as script text rather than markup", () => {
-      expectNoOffenses(`<html><head><%= javascript_tag do %>\n  var s = '<title>' + 'x';\n<% end %></head></html>`)
+      expectNoOffenses(`<html><body><%= javascript_tag do %>\n  var s = '<meta charset="utf-8">' + 'x';\n<% end %></body></html>`)
     })
   })
 

--- a/src/include/parser/parser.h
+++ b/src/include/parser/parser.h
@@ -14,6 +14,7 @@ typedef enum {
   FOREIGN_CONTENT_SCRIPT,
   FOREIGN_CONTENT_STYLE,
   FOREIGN_CONTENT_TEXTAREA,
+  FOREIGN_CONTENT_TITLE,
   // FOREIGN_CONTENT_RUBY,
   // FOREIGN_CONTENT_TEMPLATE
 } foreign_content_type_T;
@@ -91,6 +92,7 @@ typedef struct PARSER_STRUCT {
   parser_state_T state;
   foreign_content_type_T foreign_content_type;
   size_t svg_depth;
+  bool xml_document;
   parser_options_T options;
   size_t consecutive_error_count;
   bool in_recovery_mode;

--- a/src/parser.c
+++ b/src/parser.c
@@ -25,6 +25,7 @@
 #define MAX_CONSECUTIVE_ERRORS 10
 static void parser_parse_in_data_state(parser_T* parser, hb_array_T* children, hb_array_T** errors);
 static void parser_parse_foreign_content(parser_T* parser, hb_array_T* children, hb_array_T** errors);
+static bool parser_element_has_foreign_content(const parser_T* parser, hb_string_T tag_name);
 static AST_ERB_CONTENT_NODE_T* parser_parse_erb_tag(parser_T* parser);
 static void parser_handle_whitespace(parser_T* parser, token_T* whitespace_token, hb_array_T* children);
 static void parser_consume_whitespace(parser_T* parser, hb_array_T* children);
@@ -70,6 +71,7 @@ void herb_parser_init(parser_T* parser, lexer_T* lexer, parser_options_T options
   parser->state = PARSER_STATE_DATA;
   parser->foreign_content_type = FOREIGN_CONTENT_UNKNOWN;
   parser->svg_depth = 0;
+  parser->xml_document = false;
   parser->options = options;
   parser->consecutive_error_count = 0;
   parser->in_recovery_mode = false;
@@ -299,6 +301,8 @@ static AST_XML_DECLARATION_NODE_T* parser_parse_xml_declaration(parser_T* parser
   hb_buffer_init(&content, 64, parser->allocator);
 
   token_T* tag_opening = parser_consume_expected(parser, TOKEN_XML_DECLARATION, &errors);
+
+  parser->xml_document = true;
 
   position_T start = parser->current_token->location.start;
 
@@ -1404,7 +1408,7 @@ static AST_HTML_ELEMENT_NODE_T* parser_parse_html_regular_element(
 
   parser_push_open_tag(parser, open_tag->tag_name);
 
-  if (!hb_string_is_empty(open_tag->tag_name->value) && parser_is_foreign_content_tag(open_tag->tag_name->value)) {
+  if (parser_element_has_foreign_content(parser, open_tag->tag_name->value)) {
     foreign_content_type_T content_type = parser_get_foreign_content_type(open_tag->tag_name->value);
     parser_enter_foreign_content(parser, content_type);
     parser_parse_foreign_content(parser, body, &errors);
@@ -1483,7 +1487,7 @@ static AST_NODE_T* parser_parse_html_element(parser_T* parser) {
     return (AST_NODE_T*) parser_parse_html_self_closing_element(parser, open_tag);
   }
 
-  if (!hb_string_is_empty(open_tag->tag_name->value) && parser_is_foreign_content_tag(open_tag->tag_name->value)) {
+  if (parser_element_has_foreign_content(parser, open_tag->tag_name->value)) {
     AST_HTML_ELEMENT_NODE_T* regular_element = parser_parse_html_regular_element(parser, open_tag);
 
     if (regular_element != NULL) { return (AST_NODE_T*) regular_element; }
@@ -1560,6 +1564,46 @@ static AST_ERB_CONTENT_NODE_T* parser_parse_erb_tag(parser_T* parser) {
   );
 }
 
+// <title> is raw text in HTML, an ordinary element inside <svg> and in XML documents
+static bool parser_element_has_foreign_content(const parser_T* parser, hb_string_T tag_name) {
+  if (hb_string_is_empty(tag_name)) { return false; }
+
+  foreign_content_type_T content_type = parser_get_foreign_content_type(tag_name);
+
+  if (content_type == FOREIGN_CONTENT_UNKNOWN) { return false; }
+  if (content_type == FOREIGN_CONTENT_TITLE && (parser_in_svg_context(parser) || parser->xml_document)) {
+    return false;
+  }
+
+  return true;
+}
+
+// <textarea> and <title> hold text, <script> and <style> hold raw source
+static void parser_append_foreign_content_from_buffer(
+  const parser_T* parser,
+  hb_buffer_T* buffer,
+  hb_array_T* children,
+  position_T start
+) {
+  bool is_text =
+    parser->foreign_content_type == FOREIGN_CONTENT_TEXTAREA || parser->foreign_content_type == FOREIGN_CONTENT_TITLE;
+
+  if (!is_text || buffer->length == 0) {
+    parser_append_literal_node_from_buffer(parser, buffer, children, start);
+    return;
+  }
+
+  hb_string_T content = { .data = buffer->value, .length = (uint32_t) buffer->length };
+
+  hb_array_append(
+    children,
+    ast_html_text_node_init(content, start, parser->current_token->location.start, NULL, parser->allocator)
+  );
+
+  hb_buffer_free(buffer);
+  hb_buffer_init(buffer, 128, parser->allocator);
+}
+
 static void parser_parse_foreign_content(parser_T* parser, hb_array_T* children, hb_array_T** errors) {
   hb_buffer_T content;
   hb_buffer_init(&content, 1024, parser->allocator);
@@ -1569,7 +1613,7 @@ static void parser_parse_foreign_content(parser_T* parser, hb_array_T* children,
 
   while (!token_is(parser, TOKEN_EOF)) {
     if (token_is(parser, TOKEN_ERB_START)) {
-      parser_append_literal_node_from_buffer(parser, &content, children, start);
+      parser_append_foreign_content_from_buffer(parser, &content, children, start);
 
       AST_ERB_CONTENT_NODE_T* erb_node = parser_parse_erb_tag(parser);
       hb_array_append(children, erb_node);
@@ -1594,7 +1638,7 @@ static void parser_parse_foreign_content(parser_T* parser, hb_array_T* children,
       if (next_token) { token_free(next_token, parser->allocator); }
 
       if (is_potential_match) {
-        parser_append_literal_node_from_buffer(parser, &content, children, start);
+        parser_append_foreign_content_from_buffer(parser, &content, children, start);
         parser_exit_foreign_content(parser);
 
         hb_buffer_free(&content);
@@ -1608,7 +1652,7 @@ static void parser_parse_foreign_content(parser_T* parser, hb_array_T* children,
     token_free(token, parser->allocator);
   }
 
-  parser_append_literal_node_from_buffer(parser, &content, children, start);
+  parser_append_foreign_content_from_buffer(parser, &content, children, start);
   parser_exit_foreign_content(parser);
   hb_buffer_free(&content);
 }

--- a/src/parser/parser_helpers.c
+++ b/src/parser/parser_helpers.c
@@ -62,6 +62,7 @@ foreign_content_type_T parser_get_foreign_content_type(hb_string_T tag_name) {
   if (hb_string_equals_case_insensitive(tag_name, hb_string("script"))) { return FOREIGN_CONTENT_SCRIPT; }
   if (hb_string_equals_case_insensitive(tag_name, hb_string("style"))) { return FOREIGN_CONTENT_STYLE; }
   if (hb_string_equals_case_insensitive(tag_name, hb_string("textarea"))) { return FOREIGN_CONTENT_TEXTAREA; }
+  if (hb_string_equals_case_insensitive(tag_name, hb_string("title"))) { return FOREIGN_CONTENT_TITLE; }
 
   return FOREIGN_CONTENT_UNKNOWN;
 }
@@ -75,6 +76,7 @@ hb_string_T parser_get_foreign_content_closing_tag(foreign_content_type_T type) 
     case FOREIGN_CONTENT_SCRIPT: return hb_string("script");
     case FOREIGN_CONTENT_STYLE: return hb_string("style");
     case FOREIGN_CONTENT_TEXTAREA: return hb_string("textarea");
+    case FOREIGN_CONTENT_TITLE: return hb_string("title");
     default: return HB_STRING_EMPTY;
   }
 }

--- a/test/parser/title_test.rb
+++ b/test/parser/title_test.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require_relative "../test_helper"
+
+module Parser
+  class TitleTest < Minitest::Spec
+    include SnapshotUtils
+
+    test "title with plain text" do
+      assert_parsed_snapshot(%(<head><title>Hello</title></head>))
+    end
+
+    test "title with HTML elements inside" do
+      assert_parsed_snapshot(%(<title>a <b>bold</b> title</title>))
+    end
+
+    test "title with ERB output" do
+      assert_parsed_snapshot(%(<head><title><%= page_title %> | App</title></head>))
+    end
+
+    test "title with ERB control flow" do
+      assert_parsed_snapshot(%(<title><% if @page_title %><%= @page_title %><% else %>App<% end %></title>))
+    end
+
+    test "title with an uppercase closing tag" do
+      assert_parsed_snapshot(%(<title>text</TITLE>))
+    end
+
+    test "unclosed title" do
+      assert_parsed_snapshot(%(<title>never closed<div>))
+    end
+
+    test "svg title keeps its elements" do
+      assert_parsed_snapshot(%(<svg><title>Icon <tspan>x</tspan></title><path d="M0 0"/></svg>))
+    end
+
+    test "html title after an svg is text again" do
+      assert_parsed_snapshot(%(<svg><title>Icon</title></svg><title>a <b>bold</b></title>))
+    end
+
+    test "title in an xml document keeps its elements" do
+      assert_parsed_snapshot(<<~XML)
+        <?xml version="1.0" encoding="UTF-8"?>
+        <rss version="2.0">
+          <channel>
+            <title><%= @feed.title %></title>
+            <item><title>Post <b>one</b></title></item>
+          </channel>
+        </rss>
+      XML
+    end
+  end
+end

--- a/test/snapshots/parser/textarea_test/test_0001_textarea_with_plain_text_77990c0637b4c2eab0647996880183e4.txt
+++ b/test/snapshots/parser/textarea_test/test_0001_textarea_with_plain_text_77990c0637b4c2eab0647996880183e4.txt
@@ -15,7 +15,7 @@ input: "<textarea>Hello</textarea>"
         │
         ├── tag_name: "textarea" (location: (1:1)-(1:9))
         ├── body: (1 item)
-        │   └── @ LiteralNode (location: (1:10)-(1:15))
+        │   └── @ HTMLTextNode (location: (1:10)-(1:15))
         │       └── content: "Hello"
         │
         ├── close_tag:

--- a/test/snapshots/parser/textarea_test/test_0002_textarea_with_an_unclosed_script_tag_inside_409e60043f44f8bcf9a91977c8e308f8.txt
+++ b/test/snapshots/parser/textarea_test/test_0002_textarea_with_an_unclosed_script_tag_inside_409e60043f44f8bcf9a91977c8e308f8.txt
@@ -69,7 +69,7 @@ input: |2-
     │   │
     │   ├── tag_name: "textarea" (location: (1:1)-(1:9))
     │   ├── body: (1 item)
-    │   │   └── @ LiteralNode (location: (1:67)-(3:0))
+    │   │   └── @ HTMLTextNode (location: (1:67)-(3:0))
     │   │       └── content: "\n  <script src='....' type='module' ...>\n"
     │   │
     │   ├── close_tag:

--- a/test/snapshots/parser/textarea_test/test_0003_textarea_with_HTML_elements_inside_04b52d7de0554fe1198c64b8e173f36e.txt
+++ b/test/snapshots/parser/textarea_test/test_0003_textarea_with_HTML_elements_inside_04b52d7de0554fe1198c64b8e173f36e.txt
@@ -15,7 +15,7 @@ input: "<textarea><b>bold</b> and <input type=\"text\"></textarea>"
         │
         ├── tag_name: "textarea" (location: (1:1)-(1:9))
         ├── body: (1 item)
-        │   └── @ LiteralNode (location: (1:10)-(1:45))
+        │   └── @ HTMLTextNode (location: (1:10)-(1:45))
         │       └── content: "<b>bold</b> and <input type=\"text\">"
         │
         ├── close_tag:

--- a/test/snapshots/parser/textarea_test/test_0005_textarea_with_ERB_control_flow_e3b00f18d47b07c326406cd03d80aa35.txt
+++ b/test/snapshots/parser/textarea_test/test_0005_textarea_with_ERB_control_flow_e3b00f18d47b07c326406cd03d80aa35.txt
@@ -22,7 +22,7 @@ input: |2-
     │   │       ├── tag_closing: "%>" (location: (1:23)-(1:25))
     │   │       ├── then_keyword: ∅
     │   │       ├── statements: (1 item)
-    │   │       │   └── @ LiteralNode (location: (1:25)-(1:30))
+    │   │       │   └── @ HTMLTextNode (location: (1:25)-(1:30))
     │   │       │       └── content: "Draft"
     │   │       │
     │   │       ├── subsequent:
@@ -31,7 +31,7 @@ input: |2-
     │   │       │       ├── content: " else " (location: (1:32)-(1:38))
     │   │       │       ├── tag_closing: "%>" (location: (1:38)-(1:40))
     │   │       │       └── statements: (1 item)
-    │   │       │           └── @ LiteralNode (location: (1:40)-(1:45))
+    │   │       │           └── @ HTMLTextNode (location: (1:40)-(1:45))
     │   │       │               └── content: "Final"
     │   │       │
     │   │       │

--- a/test/snapshots/parser/textarea_test/test_0006_textarea_with_an_uppercase_closing_tag_and_trailing_whitespace_c82f8be8fa8724b26d91dd8f0a7fee70.txt
+++ b/test/snapshots/parser/textarea_test/test_0006_textarea_with_an_uppercase_closing_tag_and_trailing_whitespace_c82f8be8fa8724b26d91dd8f0a7fee70.txt
@@ -15,7 +15,7 @@ input: "<textarea>text</TEXTAREA >"
         │
         ├── tag_name: "textarea" (location: (1:1)-(1:9))
         ├── body: (1 item)
-        │   └── @ LiteralNode (location: (1:10)-(1:14))
+        │   └── @ HTMLTextNode (location: (1:10)-(1:14))
         │       └── content: "text"
         │
         ├── close_tag:

--- a/test/snapshots/parser/textarea_test/test_0007_textarea_with_a_closing_tag_for_a_different_element_c34b10b044ef8e16e96571e89ce01447.txt
+++ b/test/snapshots/parser/textarea_test/test_0007_textarea_with_a_closing_tag_for_a_different_element_c34b10b044ef8e16e96571e89ce01447.txt
@@ -15,7 +15,7 @@ input: "<textarea></div></textarea>"
         │
         ├── tag_name: "textarea" (location: (1:1)-(1:9))
         ├── body: (1 item)
-        │   └── @ LiteralNode (location: (1:10)-(1:16))
+        │   └── @ HTMLTextNode (location: (1:10)-(1:16))
         │       └── content: "</div>"
         │
         ├── close_tag:

--- a/test/snapshots/parser/textarea_test/test_0008_unclosed_textarea_bce8bf51f7e2b96771fc30d354ab521f.txt
+++ b/test/snapshots/parser/textarea_test/test_0008_unclosed_textarea_bce8bf51f7e2b96771fc30d354ab521f.txt
@@ -20,7 +20,7 @@ input: "<textarea>never closed<div>"
         │
         ├── tag_name: "textarea" (location: (1:1)-(1:9))
         ├── body: (1 item)
-        │   └── @ LiteralNode (location: (1:10)-(1:27))
+        │   └── @ HTMLTextNode (location: (1:10)-(1:27))
         │       └── content: "never closed<div>"
         │
         ├── close_tag: ∅

--- a/test/snapshots/parser/textarea_test/test_0009_textarea_inside_a_form_with_sibling_elements_3ae6da1741b5c5df9c5d401b7d58e818.txt
+++ b/test/snapshots/parser/textarea_test/test_0009_textarea_inside_a_form_with_sibling_elements_3ae6da1741b5c5df9c5d401b7d58e818.txt
@@ -101,7 +101,7 @@ input: |2-
     │   │   │   │
     │   │   │   ├── tag_name: "textarea" (location: (3:3)-(3:11))
     │   │   │   ├── body: (1 item)
-    │   │   │   │   └── @ LiteralNode (location: (3:22)-(3:43))
+    │   │   │   │   └── @ HTMLTextNode (location: (3:22)-(3:43))
     │   │   │   │       └── content: "<p>not an element</p>"
     │   │   │   │
     │   │   │   ├── close_tag:

--- a/test/snapshots/parser/title_test/test_0001_title_with_plain_text_a196c06c47de947dbba4bafe61fc7acc.txt
+++ b/test/snapshots/parser/title_test/test_0001_title_with_plain_text_a196c06c47de947dbba4bafe61fc7acc.txt
@@ -1,0 +1,50 @@
+---
+source: "Parser::TitleTest#test_0001_title with plain text"
+input: "<head><title>Hello</title></head>"
+---
+@ DocumentNode (location: (1:0)-(1:33))
+└── children: (1 item)
+    └── @ HTMLElementNode (location: (1:0)-(1:33))
+        ├── open_tag:
+        │   └── @ HTMLOpenTagNode (location: (1:0)-(1:6))
+        │       ├── tag_opening: "<" (location: (1:0)-(1:1))
+        │       ├── tag_name: "head" (location: (1:1)-(1:5))
+        │       ├── tag_closing: ">" (location: (1:5)-(1:6))
+        │       ├── children: []
+        │       └── is_void: false
+        │
+        ├── tag_name: "head" (location: (1:1)-(1:5))
+        ├── body: (1 item)
+        │   └── @ HTMLElementNode (location: (1:6)-(1:26))
+        │       ├── open_tag:
+        │       │   └── @ HTMLOpenTagNode (location: (1:6)-(1:13))
+        │       │       ├── tag_opening: "<" (location: (1:6)-(1:7))
+        │       │       ├── tag_name: "title" (location: (1:7)-(1:12))
+        │       │       ├── tag_closing: ">" (location: (1:12)-(1:13))
+        │       │       ├── children: []
+        │       │       └── is_void: false
+        │       │
+        │       ├── tag_name: "title" (location: (1:7)-(1:12))
+        │       ├── body: (1 item)
+        │       │   └── @ HTMLTextNode (location: (1:13)-(1:18))
+        │       │       └── content: "Hello"
+        │       │
+        │       ├── close_tag:
+        │       │   └── @ HTMLCloseTagNode (location: (1:18)-(1:26))
+        │       │       ├── tag_opening: "</" (location: (1:18)-(1:20))
+        │       │       ├── tag_name: "title" (location: (1:20)-(1:25))
+        │       │       ├── children: []
+        │       │       └── tag_closing: ">" (location: (1:25)-(1:26))
+        │       │
+        │       ├── is_void: false
+        │       └── element_source: "HTML"
+        │
+        ├── close_tag:
+        │   └── @ HTMLCloseTagNode (location: (1:26)-(1:33))
+        │       ├── tag_opening: "</" (location: (1:26)-(1:28))
+        │       ├── tag_name: "head" (location: (1:28)-(1:32))
+        │       ├── children: []
+        │       └── tag_closing: ">" (location: (1:32)-(1:33))
+        │
+        ├── is_void: false
+        └── element_source: "HTML"

--- a/test/snapshots/parser/title_test/test_0002_title_with_HTML_elements_inside_7cec4bc5d70e1e3af00c18e2ab16475b.txt
+++ b/test/snapshots/parser/title_test/test_0002_title_with_HTML_elements_inside_7cec4bc5d70e1e3af00c18e2ab16475b.txt
@@ -1,0 +1,29 @@
+---
+source: "Parser::TitleTest#test_0002_title with HTML elements inside"
+input: "<title>a <b>bold</b> title</title>"
+---
+@ DocumentNode (location: (1:0)-(1:34))
+└── children: (1 item)
+    └── @ HTMLElementNode (location: (1:0)-(1:34))
+        ├── open_tag:
+        │   └── @ HTMLOpenTagNode (location: (1:0)-(1:7))
+        │       ├── tag_opening: "<" (location: (1:0)-(1:1))
+        │       ├── tag_name: "title" (location: (1:1)-(1:6))
+        │       ├── tag_closing: ">" (location: (1:6)-(1:7))
+        │       ├── children: []
+        │       └── is_void: false
+        │
+        ├── tag_name: "title" (location: (1:1)-(1:6))
+        ├── body: (1 item)
+        │   └── @ HTMLTextNode (location: (1:7)-(1:26))
+        │       └── content: "a <b>bold</b> title"
+        │
+        ├── close_tag:
+        │   └── @ HTMLCloseTagNode (location: (1:26)-(1:34))
+        │       ├── tag_opening: "</" (location: (1:26)-(1:28))
+        │       ├── tag_name: "title" (location: (1:28)-(1:33))
+        │       ├── children: []
+        │       └── tag_closing: ">" (location: (1:33)-(1:34))
+        │
+        ├── is_void: false
+        └── element_source: "HTML"

--- a/test/snapshots/parser/title_test/test_0003_title_with_ERB_output_d6b457497b214c6f39a64a35faddea92.txt
+++ b/test/snapshots/parser/title_test/test_0003_title_with_ERB_output_d6b457497b214c6f39a64a35faddea92.txt
@@ -1,0 +1,57 @@
+---
+source: "Parser::TitleTest#test_0003_title with ERB output"
+input: "<head><title><%= page_title %> | App</title></head>"
+---
+@ DocumentNode (location: (1:0)-(1:51))
+└── children: (1 item)
+    └── @ HTMLElementNode (location: (1:0)-(1:51))
+        ├── open_tag:
+        │   └── @ HTMLOpenTagNode (location: (1:0)-(1:6))
+        │       ├── tag_opening: "<" (location: (1:0)-(1:1))
+        │       ├── tag_name: "head" (location: (1:1)-(1:5))
+        │       ├── tag_closing: ">" (location: (1:5)-(1:6))
+        │       ├── children: []
+        │       └── is_void: false
+        │
+        ├── tag_name: "head" (location: (1:1)-(1:5))
+        ├── body: (1 item)
+        │   └── @ HTMLElementNode (location: (1:6)-(1:44))
+        │       ├── open_tag:
+        │       │   └── @ HTMLOpenTagNode (location: (1:6)-(1:13))
+        │       │       ├── tag_opening: "<" (location: (1:6)-(1:7))
+        │       │       ├── tag_name: "title" (location: (1:7)-(1:12))
+        │       │       ├── tag_closing: ">" (location: (1:12)-(1:13))
+        │       │       ├── children: []
+        │       │       └── is_void: false
+        │       │
+        │       ├── tag_name: "title" (location: (1:7)-(1:12))
+        │       ├── body: (2 items)
+        │       │   ├── @ ERBContentNode (location: (1:13)-(1:30))
+        │       │   │   ├── tag_opening: "<%=" (location: (1:13)-(1:16))
+        │       │   │   ├── content: " page_title " (location: (1:16)-(1:28))
+        │       │   │   ├── tag_closing: "%>" (location: (1:28)-(1:30))
+        │       │   │   ├── parsed: true
+        │       │   │   └── valid: true
+        │       │   │
+        │       │   └── @ HTMLTextNode (location: (1:30)-(1:36))
+        │       │       └── content: " | App"
+        │       │
+        │       ├── close_tag:
+        │       │   └── @ HTMLCloseTagNode (location: (1:36)-(1:44))
+        │       │       ├── tag_opening: "</" (location: (1:36)-(1:38))
+        │       │       ├── tag_name: "title" (location: (1:38)-(1:43))
+        │       │       ├── children: []
+        │       │       └── tag_closing: ">" (location: (1:43)-(1:44))
+        │       │
+        │       ├── is_void: false
+        │       └── element_source: "HTML"
+        │
+        ├── close_tag:
+        │   └── @ HTMLCloseTagNode (location: (1:44)-(1:51))
+        │       ├── tag_opening: "</" (location: (1:44)-(1:46))
+        │       ├── tag_name: "head" (location: (1:46)-(1:50))
+        │       ├── children: []
+        │       └── tag_closing: ">" (location: (1:50)-(1:51))
+        │
+        ├── is_void: false
+        └── element_source: "HTML"

--- a/test/snapshots/parser/title_test/test_0004_title_with_ERB_control_flow_ce0e05322cf7d42c5d5c68a0976adbed.txt
+++ b/test/snapshots/parser/title_test/test_0004_title_with_ERB_control_flow_ce0e05322cf7d42c5d5c68a0976adbed.txt
@@ -1,0 +1,56 @@
+---
+source: "Parser::TitleTest#test_0004_title with ERB control flow"
+input: "<title><% if @page_title %><%= @page_title %><% else %>App<% end %></title>"
+---
+@ DocumentNode (location: (1:0)-(1:75))
+└── children: (1 item)
+    └── @ HTMLElementNode (location: (1:0)-(1:75))
+        ├── open_tag:
+        │   └── @ HTMLOpenTagNode (location: (1:0)-(1:7))
+        │       ├── tag_opening: "<" (location: (1:0)-(1:1))
+        │       ├── tag_name: "title" (location: (1:1)-(1:6))
+        │       ├── tag_closing: ">" (location: (1:6)-(1:7))
+        │       ├── children: []
+        │       └── is_void: false
+        │
+        ├── tag_name: "title" (location: (1:1)-(1:6))
+        ├── body: (1 item)
+        │   └── @ ERBIfNode (location: (1:7)-(1:67))
+        │       ├── tag_opening: "<%" (location: (1:7)-(1:9))
+        │       ├── content: " if @page_title " (location: (1:9)-(1:25))
+        │       ├── tag_closing: "%>" (location: (1:25)-(1:27))
+        │       ├── then_keyword: ∅
+        │       ├── statements: (1 item)
+        │       │   └── @ ERBContentNode (location: (1:27)-(1:45))
+        │       │       ├── tag_opening: "<%=" (location: (1:27)-(1:30))
+        │       │       ├── content: " @page_title " (location: (1:30)-(1:43))
+        │       │       ├── tag_closing: "%>" (location: (1:43)-(1:45))
+        │       │       ├── parsed: true
+        │       │       └── valid: true
+        │       │
+        │       ├── subsequent:
+        │       │   └── @ ERBElseNode (location: (1:45)-(1:58))
+        │       │       ├── tag_opening: "<%" (location: (1:45)-(1:47))
+        │       │       ├── content: " else " (location: (1:47)-(1:53))
+        │       │       ├── tag_closing: "%>" (location: (1:53)-(1:55))
+        │       │       └── statements: (1 item)
+        │       │           └── @ HTMLTextNode (location: (1:55)-(1:58))
+        │       │               └── content: "App"
+        │       │
+        │       │
+        │       └── end_node:
+        │           └── @ ERBEndNode (location: (1:58)-(1:67))
+        │               ├── tag_opening: "<%" (location: (1:58)-(1:60))
+        │               ├── content: " end " (location: (1:60)-(1:65))
+        │               └── tag_closing: "%>" (location: (1:65)-(1:67))
+        │
+        │
+        ├── close_tag:
+        │   └── @ HTMLCloseTagNode (location: (1:67)-(1:75))
+        │       ├── tag_opening: "</" (location: (1:67)-(1:69))
+        │       ├── tag_name: "title" (location: (1:69)-(1:74))
+        │       ├── children: []
+        │       └── tag_closing: ">" (location: (1:74)-(1:75))
+        │
+        ├── is_void: false
+        └── element_source: "HTML"

--- a/test/snapshots/parser/title_test/test_0005_title_with_an_uppercase_closing_tag_463f85410b9601bf1cc756ff53b7b751.txt
+++ b/test/snapshots/parser/title_test/test_0005_title_with_an_uppercase_closing_tag_463f85410b9601bf1cc756ff53b7b751.txt
@@ -1,0 +1,29 @@
+---
+source: "Parser::TitleTest#test_0005_title with an uppercase closing tag"
+input: "<title>text</TITLE>"
+---
+@ DocumentNode (location: (1:0)-(1:19))
+└── children: (1 item)
+    └── @ HTMLElementNode (location: (1:0)-(1:19))
+        ├── open_tag:
+        │   └── @ HTMLOpenTagNode (location: (1:0)-(1:7))
+        │       ├── tag_opening: "<" (location: (1:0)-(1:1))
+        │       ├── tag_name: "title" (location: (1:1)-(1:6))
+        │       ├── tag_closing: ">" (location: (1:6)-(1:7))
+        │       ├── children: []
+        │       └── is_void: false
+        │
+        ├── tag_name: "title" (location: (1:1)-(1:6))
+        ├── body: (1 item)
+        │   └── @ HTMLTextNode (location: (1:7)-(1:11))
+        │       └── content: "text"
+        │
+        ├── close_tag:
+        │   └── @ HTMLCloseTagNode (location: (1:11)-(1:19))
+        │       ├── tag_opening: "</" (location: (1:11)-(1:13))
+        │       ├── tag_name: "TITLE" (location: (1:13)-(1:18))
+        │       ├── children: []
+        │       └── tag_closing: ">" (location: (1:18)-(1:19))
+        │
+        ├── is_void: false
+        └── element_source: "HTML"

--- a/test/snapshots/parser/title_test/test_0006_unclosed_title_c7a6929069d8fd7d7793364abfa3237a.txt
+++ b/test/snapshots/parser/title_test/test_0006_unclosed_title_c7a6929069d8fd7d7793364abfa3237a.txt
@@ -1,0 +1,28 @@
+---
+source: "Parser::TitleTest#test_0006_unclosed title"
+input: "<title>never closed<div>"
+---
+@ DocumentNode (location: (1:0)-(1:24))
+└── children: (1 item)
+    └── @ HTMLElementNode (location: (1:0)-(1:7))
+        ├── errors: (1 error)
+        │   └── @ MissingClosingTagError (location: (1:1)-(1:6))
+        │       ├── message: "Opening tag `<title>` at (1:1) doesn't have a matching closing tag `</title>` in the same scope."
+        │       └── opening_tag: "title" (location: (1:1)-(1:6))
+        │
+        ├── open_tag:
+        │   └── @ HTMLOpenTagNode (location: (1:0)-(1:7))
+        │       ├── tag_opening: "<" (location: (1:0)-(1:1))
+        │       ├── tag_name: "title" (location: (1:1)-(1:6))
+        │       ├── tag_closing: ">" (location: (1:6)-(1:7))
+        │       ├── children: []
+        │       └── is_void: false
+        │
+        ├── tag_name: "title" (location: (1:1)-(1:6))
+        ├── body: (1 item)
+        │   └── @ HTMLTextNode (location: (1:7)-(1:24))
+        │       └── content: "never closed<div>"
+        │
+        ├── close_tag: ∅
+        ├── is_void: false
+        └── element_source: "HTML"

--- a/test/snapshots/parser/title_test/test_0007_svg_title_keeps_its_elements_a62f34a7f7a6fdfbb5d18d80f5922f4f.txt
+++ b/test/snapshots/parser/title_test/test_0007_svg_title_keeps_its_elements_a62f34a7f7a6fdfbb5d18d80f5922f4f.txt
@@ -1,0 +1,109 @@
+---
+source: "Parser::TitleTest#test_0007_svg title keeps its elements"
+input: "<svg><title>Icon <tspan>x</tspan></title><path d=\"M0 0\"/></svg>"
+---
+@ DocumentNode (location: (1:0)-(1:63))
+└── children: (1 item)
+    └── @ HTMLElementNode (location: (1:0)-(1:63))
+        ├── open_tag:
+        │   └── @ HTMLOpenTagNode (location: (1:0)-(1:5))
+        │       ├── tag_opening: "<" (location: (1:0)-(1:1))
+        │       ├── tag_name: "svg" (location: (1:1)-(1:4))
+        │       ├── tag_closing: ">" (location: (1:4)-(1:5))
+        │       ├── children: []
+        │       └── is_void: false
+        │
+        ├── tag_name: "svg" (location: (1:1)-(1:4))
+        ├── body: (2 items)
+        │   ├── @ HTMLElementNode (location: (1:5)-(1:41))
+        │   │   ├── open_tag:
+        │   │   │   └── @ HTMLOpenTagNode (location: (1:5)-(1:12))
+        │   │   │       ├── tag_opening: "<" (location: (1:5)-(1:6))
+        │   │   │       ├── tag_name: "title" (location: (1:6)-(1:11))
+        │   │   │       ├── tag_closing: ">" (location: (1:11)-(1:12))
+        │   │   │       ├── children: []
+        │   │   │       └── is_void: false
+        │   │   │
+        │   │   ├── tag_name: "title" (location: (1:6)-(1:11))
+        │   │   ├── body: (2 items)
+        │   │   │   ├── @ HTMLTextNode (location: (1:12)-(1:17))
+        │   │   │   │   └── content: "Icon "
+        │   │   │   │
+        │   │   │   └── @ HTMLElementNode (location: (1:17)-(1:33))
+        │   │   │       ├── open_tag:
+        │   │   │       │   └── @ HTMLOpenTagNode (location: (1:17)-(1:24))
+        │   │   │       │       ├── tag_opening: "<" (location: (1:17)-(1:18))
+        │   │   │       │       ├── tag_name: "tspan" (location: (1:18)-(1:23))
+        │   │   │       │       ├── tag_closing: ">" (location: (1:23)-(1:24))
+        │   │   │       │       ├── children: []
+        │   │   │       │       └── is_void: false
+        │   │   │       │
+        │   │   │       ├── tag_name: "tspan" (location: (1:18)-(1:23))
+        │   │   │       ├── body: (1 item)
+        │   │   │       │   └── @ HTMLTextNode (location: (1:24)-(1:25))
+        │   │   │       │       └── content: "x"
+        │   │   │       │
+        │   │   │       ├── close_tag:
+        │   │   │       │   └── @ HTMLCloseTagNode (location: (1:25)-(1:33))
+        │   │   │       │       ├── tag_opening: "</" (location: (1:25)-(1:27))
+        │   │   │       │       ├── tag_name: "tspan" (location: (1:27)-(1:32))
+        │   │   │       │       ├── children: []
+        │   │   │       │       └── tag_closing: ">" (location: (1:32)-(1:33))
+        │   │   │       │
+        │   │   │       ├── is_void: false
+        │   │   │       └── element_source: "HTML"
+        │   │   │
+        │   │   ├── close_tag:
+        │   │   │   └── @ HTMLCloseTagNode (location: (1:33)-(1:41))
+        │   │   │       ├── tag_opening: "</" (location: (1:33)-(1:35))
+        │   │   │       ├── tag_name: "title" (location: (1:35)-(1:40))
+        │   │   │       ├── children: []
+        │   │   │       └── tag_closing: ">" (location: (1:40)-(1:41))
+        │   │   │
+        │   │   ├── is_void: false
+        │   │   └── element_source: "HTML"
+        │   │
+        │   └── @ HTMLElementNode (location: (1:41)-(1:57))
+        │       ├── open_tag:
+        │       │   └── @ HTMLOpenTagNode (location: (1:41)-(1:57))
+        │       │       ├── tag_opening: "<" (location: (1:41)-(1:42))
+        │       │       ├── tag_name: "path" (location: (1:42)-(1:46))
+        │       │       ├── tag_closing: "/>" (location: (1:55)-(1:57))
+        │       │       ├── children: (1 item)
+        │       │       │   └── @ HTMLAttributeNode (location: (1:47)-(1:55))
+        │       │       │       ├── name:
+        │       │       │       │   └── @ HTMLAttributeNameNode (location: (1:47)-(1:48))
+        │       │       │       │       └── children: (1 item)
+        │       │       │       │           └── @ LiteralNode (location: (1:47)-(1:48))
+        │       │       │       │               └── content: "d"
+        │       │       │       │
+        │       │       │       │
+        │       │       │       ├── equals: "=" (location: (1:48)-(1:49))
+        │       │       │       └── value:
+        │       │       │           └── @ HTMLAttributeValueNode (location: (1:49)-(1:55))
+        │       │       │               ├── open_quote: """ (location: (1:49)-(1:50))
+        │       │       │               ├── children: (1 item)
+        │       │       │               │   └── @ LiteralNode (location: (1:50)-(1:54))
+        │       │       │               │       └── content: "M0 0"
+        │       │       │               │
+        │       │       │               ├── close_quote: """ (location: (1:54)-(1:55))
+        │       │       │               └── quoted: true
+        │       │       │
+        │       │       │
+        │       │       └── is_void: true
+        │       │
+        │       ├── tag_name: "path" (location: (1:42)-(1:46))
+        │       ├── body: []
+        │       ├── close_tag: ∅
+        │       ├── is_void: true
+        │       └── element_source: "HTML"
+        │
+        ├── close_tag:
+        │   └── @ HTMLCloseTagNode (location: (1:57)-(1:63))
+        │       ├── tag_opening: "</" (location: (1:57)-(1:59))
+        │       ├── tag_name: "svg" (location: (1:59)-(1:62))
+        │       ├── children: []
+        │       └── tag_closing: ">" (location: (1:62)-(1:63))
+        │
+        ├── is_void: false
+        └── element_source: "HTML"

--- a/test/snapshots/parser/title_test/test_0008_html_title_after_an_svg_is_text_again_b8207c78573f36f1129389da952aad76.txt
+++ b/test/snapshots/parser/title_test/test_0008_html_title_after_an_svg_is_text_again_b8207c78573f36f1129389da952aad76.txt
@@ -1,0 +1,74 @@
+---
+source: "Parser::TitleTest#test_0008_html title after an svg is text again"
+input: "<svg><title>Icon</title></svg><title>a <b>bold</b></title>"
+---
+@ DocumentNode (location: (1:0)-(1:58))
+└── children: (2 items)
+    ├── @ HTMLElementNode (location: (1:0)-(1:30))
+    │   ├── open_tag:
+    │   │   └── @ HTMLOpenTagNode (location: (1:0)-(1:5))
+    │   │       ├── tag_opening: "<" (location: (1:0)-(1:1))
+    │   │       ├── tag_name: "svg" (location: (1:1)-(1:4))
+    │   │       ├── tag_closing: ">" (location: (1:4)-(1:5))
+    │   │       ├── children: []
+    │   │       └── is_void: false
+    │   │
+    │   ├── tag_name: "svg" (location: (1:1)-(1:4))
+    │   ├── body: (1 item)
+    │   │   └── @ HTMLElementNode (location: (1:5)-(1:24))
+    │   │       ├── open_tag:
+    │   │       │   └── @ HTMLOpenTagNode (location: (1:5)-(1:12))
+    │   │       │       ├── tag_opening: "<" (location: (1:5)-(1:6))
+    │   │       │       ├── tag_name: "title" (location: (1:6)-(1:11))
+    │   │       │       ├── tag_closing: ">" (location: (1:11)-(1:12))
+    │   │       │       ├── children: []
+    │   │       │       └── is_void: false
+    │   │       │
+    │   │       ├── tag_name: "title" (location: (1:6)-(1:11))
+    │   │       ├── body: (1 item)
+    │   │       │   └── @ HTMLTextNode (location: (1:12)-(1:16))
+    │   │       │       └── content: "Icon"
+    │   │       │
+    │   │       ├── close_tag:
+    │   │       │   └── @ HTMLCloseTagNode (location: (1:16)-(1:24))
+    │   │       │       ├── tag_opening: "</" (location: (1:16)-(1:18))
+    │   │       │       ├── tag_name: "title" (location: (1:18)-(1:23))
+    │   │       │       ├── children: []
+    │   │       │       └── tag_closing: ">" (location: (1:23)-(1:24))
+    │   │       │
+    │   │       ├── is_void: false
+    │   │       └── element_source: "HTML"
+    │   │
+    │   ├── close_tag:
+    │   │   └── @ HTMLCloseTagNode (location: (1:24)-(1:30))
+    │   │       ├── tag_opening: "</" (location: (1:24)-(1:26))
+    │   │       ├── tag_name: "svg" (location: (1:26)-(1:29))
+    │   │       ├── children: []
+    │   │       └── tag_closing: ">" (location: (1:29)-(1:30))
+    │   │
+    │   ├── is_void: false
+    │   └── element_source: "HTML"
+    │
+    └── @ HTMLElementNode (location: (1:30)-(1:58))
+        ├── open_tag:
+        │   └── @ HTMLOpenTagNode (location: (1:30)-(1:37))
+        │       ├── tag_opening: "<" (location: (1:30)-(1:31))
+        │       ├── tag_name: "title" (location: (1:31)-(1:36))
+        │       ├── tag_closing: ">" (location: (1:36)-(1:37))
+        │       ├── children: []
+        │       └── is_void: false
+        │
+        ├── tag_name: "title" (location: (1:31)-(1:36))
+        ├── body: (1 item)
+        │   └── @ HTMLTextNode (location: (1:37)-(1:50))
+        │       └── content: "a <b>bold</b>"
+        │
+        ├── close_tag:
+        │   └── @ HTMLCloseTagNode (location: (1:50)-(1:58))
+        │       ├── tag_opening: "</" (location: (1:50)-(1:52))
+        │       ├── tag_name: "title" (location: (1:52)-(1:57))
+        │       ├── children: []
+        │       └── tag_closing: ">" (location: (1:57)-(1:58))
+        │
+        ├── is_void: false
+        └── element_source: "HTML"

--- a/test/snapshots/parser/title_test/test_0009_title_in_an_xml_document_keeps_its_elements_55588b693dc4b2ebd549c5a81068e8ff.txt
+++ b/test/snapshots/parser/title_test/test_0009_title_in_an_xml_document_keeps_its_elements_55588b693dc4b2ebd549c5a81068e8ff.txt
@@ -1,0 +1,200 @@
+---
+source: "Parser::TitleTest#test_0009_title in an xml document keeps its elements"
+input: |2-
+<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0">
+  <channel>
+    <title><%= @feed.title %></title>
+    <item><title>Post <b>one</b></title></item>
+  </channel>
+</rss>
+---
+@ DocumentNode (location: (1:0)-(8:0))
+└── children: (4 items)
+    ├── @ XMLDeclarationNode (location: (1:0)-(1:38))
+    │   ├── tag_opening: "<?xml" (location: (1:0)-(1:5))
+    │   ├── children: (1 item)
+    │   │   └── @ LiteralNode (location: (1:5)-(1:36))
+    │   │       └── content: " version=\"1.0\" encoding=\"UTF-8\""
+    │   │
+    │   └── tag_closing: "?>" (location: (1:36)-(1:38))
+    │
+    ├── @ HTMLTextNode (location: (1:38)-(2:0))
+    │   └── content: "\n"
+    │
+    ├── @ HTMLElementNode (location: (2:0)-(7:6))
+    │   ├── open_tag:
+    │   │   └── @ HTMLOpenTagNode (location: (2:0)-(2:19))
+    │   │       ├── tag_opening: "<" (location: (2:0)-(2:1))
+    │   │       ├── tag_name: "rss" (location: (2:1)-(2:4))
+    │   │       ├── tag_closing: ">" (location: (2:18)-(2:19))
+    │   │       ├── children: (1 item)
+    │   │       │   └── @ HTMLAttributeNode (location: (2:5)-(2:18))
+    │   │       │       ├── name:
+    │   │       │       │   └── @ HTMLAttributeNameNode (location: (2:5)-(2:12))
+    │   │       │       │       └── children: (1 item)
+    │   │       │       │           └── @ LiteralNode (location: (2:5)-(2:12))
+    │   │       │       │               └── content: "version"
+    │   │       │       │
+    │   │       │       │
+    │   │       │       ├── equals: "=" (location: (2:12)-(2:13))
+    │   │       │       └── value:
+    │   │       │           └── @ HTMLAttributeValueNode (location: (2:13)-(2:18))
+    │   │       │               ├── open_quote: """ (location: (2:13)-(2:14))
+    │   │       │               ├── children: (1 item)
+    │   │       │               │   └── @ LiteralNode (location: (2:14)-(2:17))
+    │   │       │               │       └── content: "2.0"
+    │   │       │               │
+    │   │       │               ├── close_quote: """ (location: (2:17)-(2:18))
+    │   │       │               └── quoted: true
+    │   │       │
+    │   │       │
+    │   │       └── is_void: false
+    │   │
+    │   ├── tag_name: "rss" (location: (2:1)-(2:4))
+    │   ├── body: (3 items)
+    │   │   ├── @ HTMLTextNode (location: (2:19)-(3:2))
+    │   │   │   └── content: "\n  "
+    │   │   │
+    │   │   ├── @ HTMLElementNode (location: (3:2)-(6:12))
+    │   │   │   ├── open_tag:
+    │   │   │   │   └── @ HTMLOpenTagNode (location: (3:2)-(3:11))
+    │   │   │   │       ├── tag_opening: "<" (location: (3:2)-(3:3))
+    │   │   │   │       ├── tag_name: "channel" (location: (3:3)-(3:10))
+    │   │   │   │       ├── tag_closing: ">" (location: (3:10)-(3:11))
+    │   │   │   │       ├── children: []
+    │   │   │   │       └── is_void: false
+    │   │   │   │
+    │   │   │   ├── tag_name: "channel" (location: (3:3)-(3:10))
+    │   │   │   ├── body: (5 items)
+    │   │   │   │   ├── @ HTMLTextNode (location: (3:11)-(4:4))
+    │   │   │   │   │   └── content: "\n    "
+    │   │   │   │   │
+    │   │   │   │   ├── @ HTMLElementNode (location: (4:4)-(4:37))
+    │   │   │   │   │   ├── open_tag:
+    │   │   │   │   │   │   └── @ HTMLOpenTagNode (location: (4:4)-(4:11))
+    │   │   │   │   │   │       ├── tag_opening: "<" (location: (4:4)-(4:5))
+    │   │   │   │   │   │       ├── tag_name: "title" (location: (4:5)-(4:10))
+    │   │   │   │   │   │       ├── tag_closing: ">" (location: (4:10)-(4:11))
+    │   │   │   │   │   │       ├── children: []
+    │   │   │   │   │   │       └── is_void: false
+    │   │   │   │   │   │
+    │   │   │   │   │   ├── tag_name: "title" (location: (4:5)-(4:10))
+    │   │   │   │   │   ├── body: (1 item)
+    │   │   │   │   │   │   └── @ ERBContentNode (location: (4:11)-(4:29))
+    │   │   │   │   │   │       ├── tag_opening: "<%=" (location: (4:11)-(4:14))
+    │   │   │   │   │   │       ├── content: " @feed.title " (location: (4:14)-(4:27))
+    │   │   │   │   │   │       ├── tag_closing: "%>" (location: (4:27)-(4:29))
+    │   │   │   │   │   │       ├── parsed: true
+    │   │   │   │   │   │       └── valid: true
+    │   │   │   │   │   │
+    │   │   │   │   │   ├── close_tag:
+    │   │   │   │   │   │   └── @ HTMLCloseTagNode (location: (4:29)-(4:37))
+    │   │   │   │   │   │       ├── tag_opening: "</" (location: (4:29)-(4:31))
+    │   │   │   │   │   │       ├── tag_name: "title" (location: (4:31)-(4:36))
+    │   │   │   │   │   │       ├── children: []
+    │   │   │   │   │   │       └── tag_closing: ">" (location: (4:36)-(4:37))
+    │   │   │   │   │   │
+    │   │   │   │   │   ├── is_void: false
+    │   │   │   │   │   └── element_source: "HTML"
+    │   │   │   │   │
+    │   │   │   │   ├── @ HTMLTextNode (location: (4:37)-(5:4))
+    │   │   │   │   │   └── content: "\n    "
+    │   │   │   │   │
+    │   │   │   │   ├── @ HTMLElementNode (location: (5:4)-(5:47))
+    │   │   │   │   │   ├── open_tag:
+    │   │   │   │   │   │   └── @ HTMLOpenTagNode (location: (5:4)-(5:10))
+    │   │   │   │   │   │       ├── tag_opening: "<" (location: (5:4)-(5:5))
+    │   │   │   │   │   │       ├── tag_name: "item" (location: (5:5)-(5:9))
+    │   │   │   │   │   │       ├── tag_closing: ">" (location: (5:9)-(5:10))
+    │   │   │   │   │   │       ├── children: []
+    │   │   │   │   │   │       └── is_void: false
+    │   │   │   │   │   │
+    │   │   │   │   │   ├── tag_name: "item" (location: (5:5)-(5:9))
+    │   │   │   │   │   ├── body: (1 item)
+    │   │   │   │   │   │   └── @ HTMLElementNode (location: (5:10)-(5:40))
+    │   │   │   │   │   │       ├── open_tag:
+    │   │   │   │   │   │       │   └── @ HTMLOpenTagNode (location: (5:10)-(5:17))
+    │   │   │   │   │   │       │       ├── tag_opening: "<" (location: (5:10)-(5:11))
+    │   │   │   │   │   │       │       ├── tag_name: "title" (location: (5:11)-(5:16))
+    │   │   │   │   │   │       │       ├── tag_closing: ">" (location: (5:16)-(5:17))
+    │   │   │   │   │   │       │       ├── children: []
+    │   │   │   │   │   │       │       └── is_void: false
+    │   │   │   │   │   │       │
+    │   │   │   │   │   │       ├── tag_name: "title" (location: (5:11)-(5:16))
+    │   │   │   │   │   │       ├── body: (2 items)
+    │   │   │   │   │   │       │   ├── @ HTMLTextNode (location: (5:17)-(5:22))
+    │   │   │   │   │   │       │   │   └── content: "Post "
+    │   │   │   │   │   │       │   │
+    │   │   │   │   │   │       │   └── @ HTMLElementNode (location: (5:22)-(5:32))
+    │   │   │   │   │   │       │       ├── open_tag:
+    │   │   │   │   │   │       │       │   └── @ HTMLOpenTagNode (location: (5:22)-(5:25))
+    │   │   │   │   │   │       │       │       ├── tag_opening: "<" (location: (5:22)-(5:23))
+    │   │   │   │   │   │       │       │       ├── tag_name: "b" (location: (5:23)-(5:24))
+    │   │   │   │   │   │       │       │       ├── tag_closing: ">" (location: (5:24)-(5:25))
+    │   │   │   │   │   │       │       │       ├── children: []
+    │   │   │   │   │   │       │       │       └── is_void: false
+    │   │   │   │   │   │       │       │
+    │   │   │   │   │   │       │       ├── tag_name: "b" (location: (5:23)-(5:24))
+    │   │   │   │   │   │       │       ├── body: (1 item)
+    │   │   │   │   │   │       │       │   └── @ HTMLTextNode (location: (5:25)-(5:28))
+    │   │   │   │   │   │       │       │       └── content: "one"
+    │   │   │   │   │   │       │       │
+    │   │   │   │   │   │       │       ├── close_tag:
+    │   │   │   │   │   │       │       │   └── @ HTMLCloseTagNode (location: (5:28)-(5:32))
+    │   │   │   │   │   │       │       │       ├── tag_opening: "</" (location: (5:28)-(5:30))
+    │   │   │   │   │   │       │       │       ├── tag_name: "b" (location: (5:30)-(5:31))
+    │   │   │   │   │   │       │       │       ├── children: []
+    │   │   │   │   │   │       │       │       └── tag_closing: ">" (location: (5:31)-(5:32))
+    │   │   │   │   │   │       │       │
+    │   │   │   │   │   │       │       ├── is_void: false
+    │   │   │   │   │   │       │       └── element_source: "HTML"
+    │   │   │   │   │   │       │
+    │   │   │   │   │   │       ├── close_tag:
+    │   │   │   │   │   │       │   └── @ HTMLCloseTagNode (location: (5:32)-(5:40))
+    │   │   │   │   │   │       │       ├── tag_opening: "</" (location: (5:32)-(5:34))
+    │   │   │   │   │   │       │       ├── tag_name: "title" (location: (5:34)-(5:39))
+    │   │   │   │   │   │       │       ├── children: []
+    │   │   │   │   │   │       │       └── tag_closing: ">" (location: (5:39)-(5:40))
+    │   │   │   │   │   │       │
+    │   │   │   │   │   │       ├── is_void: false
+    │   │   │   │   │   │       └── element_source: "HTML"
+    │   │   │   │   │   │
+    │   │   │   │   │   ├── close_tag:
+    │   │   │   │   │   │   └── @ HTMLCloseTagNode (location: (5:40)-(5:47))
+    │   │   │   │   │   │       ├── tag_opening: "</" (location: (5:40)-(5:42))
+    │   │   │   │   │   │       ├── tag_name: "item" (location: (5:42)-(5:46))
+    │   │   │   │   │   │       ├── children: []
+    │   │   │   │   │   │       └── tag_closing: ">" (location: (5:46)-(5:47))
+    │   │   │   │   │   │
+    │   │   │   │   │   ├── is_void: false
+    │   │   │   │   │   └── element_source: "HTML"
+    │   │   │   │   │
+    │   │   │   │   └── @ HTMLTextNode (location: (5:47)-(6:2))
+    │   │   │   │       └── content: "\n  "
+    │   │   │   │
+    │   │   │   ├── close_tag:
+    │   │   │   │   └── @ HTMLCloseTagNode (location: (6:2)-(6:12))
+    │   │   │   │       ├── tag_opening: "</" (location: (6:2)-(6:4))
+    │   │   │   │       ├── tag_name: "channel" (location: (6:4)-(6:11))
+    │   │   │   │       ├── children: []
+    │   │   │   │       └── tag_closing: ">" (location: (6:11)-(6:12))
+    │   │   │   │
+    │   │   │   ├── is_void: false
+    │   │   │   └── element_source: "HTML"
+    │   │   │
+    │   │   └── @ HTMLTextNode (location: (6:12)-(7:0))
+    │   │       └── content: "\n"
+    │   │
+    │   ├── close_tag:
+    │   │   └── @ HTMLCloseTagNode (location: (7:0)-(7:6))
+    │   │       ├── tag_opening: "</" (location: (7:0)-(7:2))
+    │   │       ├── tag_name: "rss" (location: (7:2)-(7:5))
+    │   │       ├── children: []
+    │   │       └── tag_closing: ">" (location: (7:5)-(7:6))
+    │   │
+    │   ├── is_void: false
+    │   └── element_source: "HTML"
+    │
+    └── @ HTMLTextNode (location: (7:6)-(8:0))
+        └── content: "\n"


### PR DESCRIPTION
Follow up on #2596.

This pull request makes the parser read the content of `<title>` as text, the way the HTML5 tokenizer does for its second RCDATA element, and switches the content of both RCDATA elements to `HTMLTextNode` children. `<title>` follows the same rule as `<textarea>`. 

After the start tag the tokenizer is in the RCDATA state, so `<title>a <b>bold</b></title>` is a title whose text is `a <b>bold</b>`, not a title with a `<b>` inside. Herb parsed the `<b>` as an element. It now adds `title` as a fourth foreign content type, with two places where the rule does not apply. Inside `<svg>`, `<title>` is an ordinary element that can hold `<tspan>` and friends, which the `svg` depth counter from #2596 already knows how to detect. In a document that opens with an `<?xml` declaration, `<title>` is an ordinary XML element, as in an RSS or Atom feed, so the parser remembers having seen the declaration and skips the rule for the rest of the file.

```erb
<title><%= page_title %> | App</title>
```

```js
@ HTMLElementNode title
└── body:
    ├── @ ERBContentNode <%= page_title %>
    └── @ HTMLTextNode " | App"
```
