### PR TITLE
Parser: Key foreign content on a kind and the element name

### DIFF
--- a/src/include/parser/parser.h
+++ b/src/include/parser/parser.h
@@ -10,14 +10,10 @@
 #include <stdint.h>
 
 typedef enum {
-  FOREIGN_CONTENT_UNKNOWN = 0,
-  FOREIGN_CONTENT_SCRIPT,
-  FOREIGN_CONTENT_STYLE,
-  FOREIGN_CONTENT_TEXTAREA,
-  FOREIGN_CONTENT_TITLE,
-  // FOREIGN_CONTENT_RUBY,
-  // FOREIGN_CONTENT_TEMPLATE
-} foreign_content_type_T;
+  FOREIGN_CONTENT_NONE = 0,
+  FOREIGN_CONTENT_RAW_TEXT,
+  FOREIGN_CONTENT_RCDATA,
+} foreign_content_kind_T;
 
 typedef enum { PARSER_STATE_DATA, PARSER_STATE_FOREIGN_CONTENT } parser_state_T;
 
@@ -90,7 +86,8 @@ typedef struct PARSER_STRUCT {
   token_T* current_token;
   hb_array_T* open_tags_stack;
   parser_state_T state;
-  foreign_content_type_T foreign_content_type;
+  foreign_content_kind_T foreign_content_kind;
+  hb_string_T foreign_content_tag_name;
   size_t svg_depth;
   bool xml_document;
   parser_options_T options;

--- a/src/include/parser/parser_helpers.h
+++ b/src/include/parser/parser_helpers.h
@@ -40,14 +40,13 @@ void parser_append_literal_node_from_buffer(
 
 bool parser_in_svg_context(const parser_T* parser);
 
-foreign_content_type_T parser_get_foreign_content_type(hb_string_T tag_name);
+foreign_content_kind_T parser_get_foreign_content_kind(hb_string_T tag_name);
 bool parser_is_foreign_content_tag(hb_string_T tag_name);
-hb_string_T parser_get_foreign_content_closing_tag(foreign_content_type_T type);
 
-void parser_enter_foreign_content(parser_T* parser, foreign_content_type_T type);
+void parser_enter_foreign_content(parser_T* parser, foreign_content_kind_T kind, hb_string_T tag_name);
 void parser_exit_foreign_content(parser_T* parser);
 
-bool parser_is_expected_closing_tag_name(hb_string_T tag_name, foreign_content_type_T expected_type);
+bool parser_is_foreign_content_closing_tag_name(const parser_T* parser, hb_string_T tag_name);
 
 token_T* parser_advance(parser_T* parser);
 token_T* parser_consume_if_present(parser_T* parser, token_type_T type);

--- a/src/parser.c
+++ b/src/parser.c
@@ -69,7 +69,8 @@ void herb_parser_init(parser_T* parser, lexer_T* lexer, parser_options_T options
   parser->current_token = lexer_next_token(lexer);
   parser->open_tags_stack = hb_array_init(16, parser->allocator);
   parser->state = PARSER_STATE_DATA;
-  parser->foreign_content_type = FOREIGN_CONTENT_UNKNOWN;
+  parser->foreign_content_kind = FOREIGN_CONTENT_NONE;
+  parser->foreign_content_tag_name = HB_STRING_NULL;
   parser->svg_depth = 0;
   parser->xml_document = false;
   parser->options = options;
@@ -1409,8 +1410,8 @@ static AST_HTML_ELEMENT_NODE_T* parser_parse_html_regular_element(
   parser_push_open_tag(parser, open_tag->tag_name);
 
   if (parser_element_has_foreign_content(parser, open_tag->tag_name->value)) {
-    foreign_content_type_T content_type = parser_get_foreign_content_type(open_tag->tag_name->value);
-    parser_enter_foreign_content(parser, content_type);
+    foreign_content_kind_T kind = parser_get_foreign_content_kind(open_tag->tag_name->value);
+    parser_enter_foreign_content(parser, kind, open_tag->tag_name->value);
     parser_parse_foreign_content(parser, body, &errors);
   } else {
     parser_parse_in_data_state(parser, body, &errors);
@@ -1568,10 +1569,10 @@ static AST_ERB_CONTENT_NODE_T* parser_parse_erb_tag(parser_T* parser) {
 static bool parser_element_has_foreign_content(const parser_T* parser, hb_string_T tag_name) {
   if (hb_string_is_empty(tag_name)) { return false; }
 
-  foreign_content_type_T content_type = parser_get_foreign_content_type(tag_name);
+  if (parser_get_foreign_content_kind(tag_name) == FOREIGN_CONTENT_NONE) { return false; }
 
-  if (content_type == FOREIGN_CONTENT_UNKNOWN) { return false; }
-  if (content_type == FOREIGN_CONTENT_TITLE && (parser_in_svg_context(parser) || parser->xml_document)) {
+  if (hb_string_equals_case_insensitive(tag_name, hb_string("title"))
+      && (parser_in_svg_context(parser) || parser->xml_document)) {
     return false;
   }
 
@@ -1585,8 +1586,7 @@ static void parser_append_foreign_content_from_buffer(
   hb_array_T* children,
   position_T start
 ) {
-  bool is_text =
-    parser->foreign_content_type == FOREIGN_CONTENT_TEXTAREA || parser->foreign_content_type == FOREIGN_CONTENT_TITLE;
+  bool is_text = parser->foreign_content_kind == FOREIGN_CONTENT_RCDATA;
 
   if (!is_text || buffer->length == 0) {
     parser_append_literal_node_from_buffer(parser, buffer, children, start);
@@ -1608,8 +1608,7 @@ static void parser_parse_foreign_content(parser_T* parser, hb_array_T* children,
   hb_buffer_T content;
   hb_buffer_init(&content, 1024, parser->allocator);
   position_T start = parser->current_token->location.start;
-  hb_string_T expected_closing_tag = parser_get_foreign_content_closing_tag(parser->foreign_content_type);
-  bool has_closing_tag = !hb_string_is_empty(expected_closing_tag);
+  bool has_closing_tag = !hb_string_is_empty(parser->foreign_content_tag_name);
 
   while (!token_is(parser, TOKEN_EOF)) {
     if (token_is(parser, TOKEN_ERB_START)) {
@@ -1630,7 +1629,7 @@ static void parser_parse_foreign_content(parser_T* parser, hb_array_T* children,
       bool is_potential_match = false;
 
       if (next_token && next_token->type == TOKEN_IDENTIFIER && !hb_string_is_empty(next_token->value)) {
-        is_potential_match = parser_is_expected_closing_tag_name(next_token->value, parser->foreign_content_type);
+        is_potential_match = parser_is_foreign_content_closing_tag_name(parser, next_token->value);
       }
 
       lexer_restore_state(parser->lexer, saved_state);

--- a/src/parser/parser_helpers.c
+++ b/src/parser/parser_helpers.c
@@ -56,43 +56,48 @@ bool parser_in_svg_context(const parser_T* parser) {
 
 // ===== Foreign Content Handling =====
 
-foreign_content_type_T parser_get_foreign_content_type(hb_string_T tag_name) {
-  if (hb_string_is_empty(tag_name)) { return FOREIGN_CONTENT_UNKNOWN; }
+typedef struct {
+  const char* name;
+  foreign_content_kind_T kind;
+} foreign_content_element_T;
 
-  if (hb_string_equals_case_insensitive(tag_name, hb_string("script"))) { return FOREIGN_CONTENT_SCRIPT; }
-  if (hb_string_equals_case_insensitive(tag_name, hb_string("style"))) { return FOREIGN_CONTENT_STYLE; }
-  if (hb_string_equals_case_insensitive(tag_name, hb_string("textarea"))) { return FOREIGN_CONTENT_TEXTAREA; }
-  if (hb_string_equals_case_insensitive(tag_name, hb_string("title"))) { return FOREIGN_CONTENT_TITLE; }
+static const foreign_content_element_T FOREIGN_CONTENT_ELEMENTS[] = {
+  { "script", FOREIGN_CONTENT_RAW_TEXT },
+  { "style", FOREIGN_CONTENT_RAW_TEXT },
+  { "textarea", FOREIGN_CONTENT_RCDATA },
+  { "title", FOREIGN_CONTENT_RCDATA },
+};
 
-  return FOREIGN_CONTENT_UNKNOWN;
+foreign_content_kind_T parser_get_foreign_content_kind(hb_string_T tag_name) {
+  if (hb_string_is_empty(tag_name)) { return FOREIGN_CONTENT_NONE; }
+
+  for (size_t i = 0; i < sizeof(FOREIGN_CONTENT_ELEMENTS) / sizeof(FOREIGN_CONTENT_ELEMENTS[0]); i++) {
+    if (hb_string_equals_case_insensitive(tag_name, hb_string(FOREIGN_CONTENT_ELEMENTS[i].name))) {
+      return FOREIGN_CONTENT_ELEMENTS[i].kind;
+    }
+  }
+
+  return FOREIGN_CONTENT_NONE;
 }
 
 bool parser_is_foreign_content_tag(hb_string_T tag_name) {
-  return parser_get_foreign_content_type(tag_name) != FOREIGN_CONTENT_UNKNOWN;
+  return parser_get_foreign_content_kind(tag_name) != FOREIGN_CONTENT_NONE;
 }
 
-hb_string_T parser_get_foreign_content_closing_tag(foreign_content_type_T type) {
-  switch (type) {
-    case FOREIGN_CONTENT_SCRIPT: return hb_string("script");
-    case FOREIGN_CONTENT_STYLE: return hb_string("style");
-    case FOREIGN_CONTENT_TEXTAREA: return hb_string("textarea");
-    case FOREIGN_CONTENT_TITLE: return hb_string("title");
-    default: return HB_STRING_EMPTY;
-  }
-}
-
-void parser_enter_foreign_content(parser_T* parser, foreign_content_type_T type) {
+void parser_enter_foreign_content(parser_T* parser, foreign_content_kind_T kind, hb_string_T tag_name) {
   if (parser == NULL) { return; }
 
   parser->state = PARSER_STATE_FOREIGN_CONTENT;
-  parser->foreign_content_type = type;
+  parser->foreign_content_kind = kind;
+  parser->foreign_content_tag_name = tag_name;
 }
 
 void parser_exit_foreign_content(parser_T* parser) {
   if (parser == NULL) { return; }
 
   parser->state = PARSER_STATE_DATA;
-  parser->foreign_content_type = FOREIGN_CONTENT_UNKNOWN;
+  parser->foreign_content_kind = FOREIGN_CONTENT_NONE;
+  parser->foreign_content_tag_name = HB_STRING_NULL;
 }
 
 void parser_append_unexpected_error_impl(
@@ -267,12 +272,10 @@ void parser_handle_mismatched_tags(
   }
 }
 
-bool parser_is_expected_closing_tag_name(hb_string_T tag_name, foreign_content_type_T expected_type) {
-  hb_string_T expected_tag_name = parser_get_foreign_content_closing_tag(expected_type);
+bool parser_is_foreign_content_closing_tag_name(const parser_T* parser, hb_string_T tag_name) {
+  if (hb_string_is_empty(tag_name) || hb_string_is_empty(parser->foreign_content_tag_name)) { return false; }
 
-  if (hb_string_is_empty(tag_name) || hb_string_is_empty(expected_tag_name)) { return false; }
-
-  return hb_string_equals_case_insensitive(expected_tag_name, tag_name);
+  return hb_string_equals_case_insensitive(parser->foreign_content_tag_name, tag_name);
 }
 
 void parser_synchronize(parser_T* parser, hb_array_T** errors) {


### PR DESCRIPTION
This pull request replaces the per-element foreign content enum with a two-value kind and the element's own name.

The parser now keeps `foreign_content_kind_T`, which is `FOREIGN_CONTENT_RAW_TEXT` or `FOREIGN_CONTENT_RCDATA`, together with `foreign_content_tag_name`, the name of the element it entered. 

Follow up on #2596 and #2597

