### PR TITLE
Linter: Allow slot setters on block local in `erb-no-unused-expressions`

### DIFF
--- a/javascript/packages/linter/docs/rules/erb-no-unused-expressions.md
+++ b/javascript/packages/linter/docs/rules/erb-no-unused-expressions.md
@@ -56,6 +56,14 @@ ViewComponent slot setters are intentional side effects and are not flagged, inc
 <% end %>
 ```
 
+A `with_*` call on an object yielded by any ERB block is treated the same way, so component libraries that wrap `render` in a helper are not flagged:
+
+```erb
+<%= card_component do |card| %>
+  <% card.with_title("Title") %>
+<% end %>
+```
+
 ### 🚫 Bad
 
 ```erb

--- a/javascript/packages/linter/src/rules/erb-no-unused-expressions.ts
+++ b/javascript/packages/linter/src/rules/erb-no-unused-expressions.ts
@@ -29,12 +29,14 @@ const MUTATION_METHODS = new Set([
 class UnusedExpressionCollector extends PrismVisitor {
   public readonly expressions: PrismNode[] = []
   private readonly blockLocalNames: Set<string>
+  private readonly slotBuilderNames: Set<string>
   private readonly stateNames: Set<string>
 
-  constructor(blockLocalNames: Set<string> = new Set(), stateNames: Set<string> = new Set()) {
+  constructor(blockLocalNames: Set<string> = new Set(), slotBuilderNames: Set<string> = new Set(), stateNames: Set<string> = new Set()) {
     super()
 
     this.blockLocalNames = blockLocalNames
+    this.slotBuilderNames = slotBuilderNames
     this.stateNames = stateNames
   }
 
@@ -66,6 +68,14 @@ class UnusedExpressionCollector extends PrismVisitor {
     return SIDE_EFFECT_METHODS.has(node.name)
   }
 
+  private isSlotSetterOnBlockLocal(node: PrismNode): boolean {
+    if (this.slotBuilderNames.size === 0) return false
+    if (!node.receiver) return false
+    if (!node.name.startsWith("with_")) return false
+
+    return isCallOnLocal(node, this.slotBuilderNames)
+  }
+
   private isStateRead(node: PrismNode): boolean {
     if (this.stateNames.size === 0) return false
     if (node.receiver || node.block) return false
@@ -86,6 +96,7 @@ class UnusedExpressionCollector extends PrismVisitor {
       if (isSleepCall(node)) return false
       if (this.isStateRead(node)) return false
       if (this.blockLocalNames.size > 0 && isCallOnLocal(node, this.blockLocalNames)) return false
+      if (this.isSlotSetterOnBlockLocal(node)) return false
 
       return true
     }
@@ -103,6 +114,7 @@ class UnusedExpressionCollector extends PrismVisitor {
 
 class ERBNoUnusedExpressionsVisitor extends BaseRuleVisitor {
   private exemptLocalNames: Set<string> = new Set()
+  private blockLocalNames: Set<string> = new Set()
   private states: StateScopeMap
   private scopeStack: (ERBBlockNode | null)[] = [null]
 
@@ -124,7 +136,7 @@ class ERBNoUnusedExpressionsVisitor extends BaseRuleVisitor {
     if (prismNode && this.isSlotSetterCall(prismNode)) {
       this.visitExemptingBlockArguments(node)
     } else {
-      this.visitChildNodes(node)
+      this.visitTrackingBlockArguments(node)
     }
 
     this.scopeStack.pop()
@@ -134,23 +146,44 @@ class ERBNoUnusedExpressionsVisitor extends BaseRuleVisitor {
     return isPrismNodeType(node, "CallNode") && Boolean(node.receiver) && node.name.startsWith("with_")
   }
 
-  private visitExemptingBlockArguments(node: ERBRenderNode | ERBBlockNode): void {
-    const previousLocalNames = this.exemptLocalNames
-    const localNames = new Set(previousLocalNames)
+  private blockArgumentNames(node: ERBRenderNode | ERBBlockNode): string[] {
+    const names: string[] = []
 
     for (const argument of node.block_arguments) {
       if (isRubyParameterNode(argument)) {
         const name = argument.name?.value
 
         if (name) {
-          localNames.add(name)
+          names.push(name)
         }
       }
     }
 
-    this.exemptLocalNames = localNames
+    return names
+  }
+
+  private visitExemptingBlockArguments(node: ERBRenderNode | ERBBlockNode): void {
+    const previousExemptNames = this.exemptLocalNames
+    const previousBlockNames = this.blockLocalNames
+    const names = this.blockArgumentNames(node)
+
+    this.exemptLocalNames = new Set([...previousExemptNames, ...names])
+    this.blockLocalNames = new Set([...previousBlockNames, ...names])
+
     this.visitChildNodes(node)
-    this.exemptLocalNames = previousLocalNames
+
+    this.exemptLocalNames = previousExemptNames
+    this.blockLocalNames = previousBlockNames
+  }
+
+  private visitTrackingBlockArguments(node: ERBBlockNode): void {
+    const previousBlockNames = this.blockLocalNames
+
+    this.blockLocalNames = new Set([...previousBlockNames, ...this.blockArgumentNames(node)])
+
+    this.visitChildNodes(node)
+
+    this.blockLocalNames = previousBlockNames
   }
 
   visitERBContentNode(node: ERBContentNode): void {
@@ -162,7 +195,7 @@ class ERBNoUnusedExpressionsVisitor extends BaseRuleVisitor {
     const source = node.source
     if (!source) return
 
-    const collector = new UnusedExpressionCollector(this.exemptLocalNames, new Set(this.states.namesIn(this.scopeStack)))
+    const collector = new UnusedExpressionCollector(this.exemptLocalNames, this.blockLocalNames, new Set(this.states.namesIn(this.scopeStack)))
     collector.visit(prismNode)
 
     const tagOpening = node.tag_opening?.value ?? "<%"

--- a/javascript/packages/linter/test/rules/erb-no-unused-expressions.test.ts
+++ b/javascript/packages/linter/test/rules/erb-no-unused-expressions.test.ts
@@ -261,6 +261,44 @@ describe("ERBNoUnusedExpressionsRule", () => {
       `)
     })
 
+    test("passes for slot setters on a builder yielded by a wrapper helper block", () => {
+      expectNoOffenses(dedent`
+        <%= card_component do |card| %>
+          <% card.with_title("Title") %>
+        <% end %>
+      `)
+    })
+
+    test("passes for chained slot setters on a builder yielded by a wrapper helper block", () => {
+      expectNoOffenses(dedent`
+        <%= card_component(variant: :compact) do |card| %>
+          <% card.with_header(classes: "title").with_body("Body") %>
+        <% end %>
+      `)
+    })
+
+    test("passes for slot setters on a builder yielded by a nested wrapper helper block", () => {
+      expectNoOffenses(dedent`
+        <%= render LayoutComponent.new do |layout| %>
+          <%= card_component do |card| %>
+            <% card.with_title("Title") %>
+          <% end %>
+
+          <% layout.with_sidebar %>
+        <% end %>
+      `)
+    })
+
+    test("passes for slot setters on a slot builder nested inside a wrapper helper block", () => {
+      expectNoOffenses(dedent`
+        <%= card_component do |card| %>
+          <% card.with_header do |header| %>
+            <% header.with_title("Title") %>
+          <% end %>
+        <% end %>
+      `)
+    })
+
     test("passes for shovel operator", () => {
       expectNoOffenses(dedent`
         <% @items << item %>
@@ -478,6 +516,44 @@ describe("ERBNoUnusedExpressionsRule", () => {
         <% plain_method do |x| %>
           <% x.slot_setter("d") %>
         <% end %>
+      `)
+    })
+
+    test("still fails for a bare block local read inside a wrapper helper block", () => {
+      expectError(
+        "Avoid unused expressions in silent ERB tags. `<% card %>` is evaluated but its return value is discarded. Use `<%= card %>` to output the value or remove the expression.",
+      )
+
+      assertOffenses(dedent`
+        <%= card_component do |card| %>
+          <% card %>
+        <% end %>
+      `)
+    })
+
+    test("still fails for slot setters on a receiver that is not a block local inside a wrapper helper block", () => {
+      expectError(
+        "Avoid unused expressions in silent ERB tags. `<% @card.with_title(\"Title\") %>` is evaluated but its return value is discarded. Use `<%= @card.with_title(\"Title\") %>` to output the value or remove the expression.",
+      )
+
+      assertOffenses(dedent`
+        <%= card_component do |card| %>
+          <% @card.with_title("Title") %>
+        <% end %>
+      `)
+    })
+
+    test("still fails for slot setters on a block local outside its block", () => {
+      expectError(
+        "Avoid unused expressions in silent ERB tags. `<% card.with_title(\"Title\") %>` is evaluated but its return value is discarded. Use `<%= card.with_title(\"Title\") %>` to output the value or remove the expression.",
+      )
+
+      assertOffenses(dedent`
+        <%= card_component do |card| %>
+          <% card.with_header %>
+        <% end %>
+
+        <% card.with_title("Title") %>
       `)
     })
 


### PR DESCRIPTION
This pull request updates `erb-no-unused-expressions` to exempt `with_*` slot setters on the block local of any ERB block, not only of `render` blocks and slot setter blocks.

Component libraries usually expose a component by wrapping `render Component.new(...)` in a helper, so the template yields the instance from the helper. The rule reported an offense on the setter, and following the suggestion renders the slot's `to_s` at that position.

```erb
<%= card_component do |card| %>
  <% card.with_title("Title") %>
<% end %>
```

The exemption from #1580 and #1822 collects block arguments on every `ERBRenderNode`, but on an `ERBBlockNode` only when the block's own call is a `with_*` setter.  Every `ERBBlockNode` now records its block arguments in a second set, and a call is skipped when its name starts with `with_`, it has a receiver.

Resolves https://github.com/marcoroth/herb/issues/2426