### PR TITLE
JavaScript: Order every build before the tasks that read its output

### DIFF
--- a/javascript/packages/client/project.json
+++ b/javascript/packages/client/project.json
@@ -5,6 +5,7 @@
   "projectType": "library",
   "targets": {
     "build": {
+      "outputs": ["{projectRoot}/dist"],
       "executor": "nx:run-script",
       "options": {
         "script": "build"

--- a/javascript/packages/formatter/project.json
+++ b/javascript/packages/formatter/project.json
@@ -23,7 +23,8 @@
       "executor": "nx:run-script",
       "options": {
         "script": "test"
-      }
+      },
+      "dependsOn": ["build"]
     },
     "clean": {
       "executor": "nx:run-script",

--- a/javascript/packages/highlighter/project.json
+++ b/javascript/packages/highlighter/project.json
@@ -19,7 +19,8 @@
       "executor": "nx:run-script",
       "options": {
         "script": "test"
-      }
+      },
+      "dependsOn": ["build"]
     },
     "clean": {
       "executor": "nx:run-script",

--- a/javascript/packages/linter/project.json
+++ b/javascript/packages/linter/project.json
@@ -25,7 +25,8 @@
       "executor": "nx:run-script",
       "options": {
         "script": "test"
-      }
+      },
+      "dependsOn": ["build"]
     },
     "clean": {
       "executor": "nx:run-script",

--- a/javascript/packages/node/project.json
+++ b/javascript/packages/node/project.json
@@ -10,13 +10,14 @@
       "options": {
         "script": "build"
       },
-      "dependsOn": ["@herb-tools/core:build"]
+      "dependsOn": ["templates:generate", "prism:build", "@herb-tools/core:build"]
     },
     "test": {
       "executor": "nx:run-script",
       "options": {
         "script": "test"
-      }
+      },
+      "dependsOn": ["build"]
     },
     "clean": {
       "executor": "nx:run-script",

--- a/src/project.json
+++ b/src/project.json
@@ -10,7 +10,7 @@
         "commands": [
           "bundle install",
           "make templates prism build/libherb.a"
-        ],
+        ]
       },
       "inputs": ["{projectRoot}/**/*"],
       "outputs": ["{workspaceRoot}/build/libherb.a", "{workspaceRoot}/build/obj"],


### PR DESCRIPTION
This pull request declares the nx task dependencies that were missing wherever one task reads a directory another task writes.