### PR TITLE
Parser: Only report `NestedCommentError` in strict mode

### DIFF
--- a/.github/corpus-expectations.yml
+++ b/.github/corpus-expectations.yml
@@ -1,0 +1,29 @@
+---
+expected:
+  - file: helpy/app/views/admin/reports/team.html.erb
+    reason: "`<div class\"row\">` is a missing `=` that the old parser swallowed"
+    pull_request: 2593
+
+  - file: politwoops/app/views/admin/politicians/admin_user.html.erb
+    reason: "`width\"73\"` is a missing `=` that the old parser swallowed"
+    pull_request: 2593
+
+  - file: politwoops/app/views/politicians/all.html.erb
+    reason: "`width\"73\"` is a missing `=` that the old parser swallowed"
+    pull_request: 2593
+
+  - file: refinerycms/core/app/views/refinery/_html_tag.html.erb
+    reason: "`<!-->` now closes the conditional comment, revealing an `<html>` the partial never closes"
+    pull_request: 2601
+
+  - file: RescueRails/app/views/adopt_app_mailer/approved_to_adopt.html.erb
+    reason: "NestedCommentError in strict mode for `<!--[if !mso]><!-- -->`"
+    pull_request: 2601
+
+  - file: RescueRails/app/views/donation_mailer/donation_accounting_notification.html.erb
+    reason: "NestedCommentError in strict mode for `<!--[if !mso]><!-- -->`"
+    pull_request: 2601
+
+  - file: RescueRails/app/views/training_mailer/free_training_notice.html.erb
+    reason: "NestedCommentError in strict mode for `<!--[if !mso]><!-- -->`"
+    pull_request: 2601

--- a/.github/workflows/corpus.yml
+++ b/.github/workflows/corpus.yml
@@ -152,6 +152,7 @@ jobs:
           corpus/bin/diff-runs \
             corpus/runs/baseline.json \
             corpus/runs/branch.json \
+            --expected .github/corpus-expectations.yml \
             "${flags[@]}" | tee comparison.txt
 
       - name: Comment on the pull request

--- a/src/parser.c
+++ b/src/parser.c
@@ -193,7 +193,7 @@ static AST_HTML_COMMENT_NODE_T* parser_parse_html_comment(parser_T* parser) {
       }
 
       // <!-- outer <!-- inner -->
-      if (next_type != TOKEN_EOF) {
+      if (next_type != TOKEN_EOF && parser->options.strict) {
         append_nested_comment_error(
           comment_start,
           parser->current_token,

--- a/test/parser/comments_test.rb
+++ b/test/parser/comments_test.rb
@@ -56,11 +56,17 @@ module Parser
     end
 
     test "nested HTML comment opener" do
-      assert_parsed_snapshot(%(<!-- a <!-- b --> c -->))
+      template = %(<!-- a <!-- b --> c -->)
+
+      assert_parsed_snapshot(template, strict: true)
+      assert_parsed_snapshot(template, strict: false)
     end
 
     test "nested HTML comment opener in an unclosed comment" do
-      assert_parsed_snapshot(%(<!-- outer <!-- inner))
+      template = %(<!-- outer <!-- inner)
+
+      assert_parsed_snapshot(template, strict: true)
+      assert_parsed_snapshot(template, strict: false)
     end
 
     test "conditional comment closed by an abrupt opener" do
@@ -69,6 +75,13 @@ module Parser
 
     test "nested HTML comment opener at end of file" do
       assert_parsed_snapshot(%(<!-- a <!--))
+    end
+
+    test "conditional comment with a nested opener" do
+      template = %(<!--[if !mso]><!-- -->)
+
+      assert_parsed_snapshot(template, strict: true)
+      assert_parsed_snapshot(template, strict: false)
     end
   end
 end

--- a/test/snapshots/parser/comments_test/test_0011_nested_HTML_comment_opener_1fa7d7e18493c321ce25c032c81938ca-08996694f7ff1e6e34277dc32f646630.txt
+++ b/test/snapshots/parser/comments_test/test_0011_nested_HTML_comment_opener_1fa7d7e18493c321ce25c032c81938ca-08996694f7ff1e6e34277dc32f646630.txt
@@ -1,6 +1,7 @@
 ---
 source: "Parser::CommentsTest#test_0011_nested HTML comment opener"
 input: "<!-- a <!-- b --> c -->"
+options: {strict: true}
 ---
 @ DocumentNode (location: (1:0)-(1:23))
 └── children: (2 items)

--- a/test/snapshots/parser/comments_test/test_0011_nested_HTML_comment_opener_1fa7d7e18493c321ce25c032c81938ca-2ffd01e26b8c99a6c7a6dad67c9489dc.txt
+++ b/test/snapshots/parser/comments_test/test_0011_nested_HTML_comment_opener_1fa7d7e18493c321ce25c032c81938ca-2ffd01e26b8c99a6c7a6dad67c9489dc.txt
@@ -1,0 +1,17 @@
+---
+source: "Parser::CommentsTest#test_0011_nested HTML comment opener"
+input: "<!-- a <!-- b --> c -->"
+options: {strict: false}
+---
+@ DocumentNode (location: (1:0)-(1:23))
+└── children: (2 items)
+    ├── @ HTMLCommentNode (location: (1:0)-(1:17))
+    │   ├── comment_start: "<!--" (location: (1:0)-(1:4))
+    │   ├── children: (1 item)
+    │   │   └── @ LiteralNode (location: (1:4)-(1:14))
+    │   │       └── content: " a <!-- b "
+    │   │
+    │   └── comment_end: "-->" (location: (1:14)-(1:17))
+    │
+    └── @ HTMLTextNode (location: (1:17)-(1:23))
+        └── content: " c -->"

--- a/test/snapshots/parser/comments_test/test_0012_nested_HTML_comment_opener_in_an_unclosed_comment_269b4844a88465fe76b669bc988c82b6-08996694f7ff1e6e34277dc32f646630.txt
+++ b/test/snapshots/parser/comments_test/test_0012_nested_HTML_comment_opener_in_an_unclosed_comment_269b4844a88465fe76b669bc988c82b6-08996694f7ff1e6e34277dc32f646630.txt
@@ -1,0 +1,24 @@
+---
+source: "Parser::CommentsTest#test_0012_nested HTML comment opener in an unclosed comment"
+input: "<!-- outer <!-- inner"
+options: {strict: true}
+---
+@ DocumentNode (location: (1:0)-(1:21))
+└── children: (1 item)
+    └── @ HTMLCommentNode (location: (1:0)-(1:21))
+        ├── errors: (2 errors)
+        │   ├── @ NestedCommentError (location: (1:11)-(1:15))
+        │   │   ├── message: "Comment opened at (1:0) contains another `<!--` at (1:11)."
+        │   │   ├── comment_start: "<!--" (location: (1:0)-(1:4))
+        │   │   └── nested_start: "<!--" (location: (1:11)-(1:15))
+        │   │
+        │   └── @ UnclosedCommentError (location: (1:0)-(1:21))
+        │       ├── message: "Comment opened at (1:0) is missing its closing `-->`."
+        │       └── comment_start: "<!--" (location: (1:0)-(1:4))
+        │
+        ├── comment_start: "<!--" (location: (1:0)-(1:4))
+        ├── children: (1 item)
+        │   └── @ LiteralNode (location: (1:4)-(1:21))
+        │       └── content: " outer <!-- inner"
+        │
+        └── comment_end: "" (location: (1:21)-(1:21))

--- a/test/snapshots/parser/comments_test/test_0012_nested_HTML_comment_opener_in_an_unclosed_comment_269b4844a88465fe76b669bc988c82b6-2ffd01e26b8c99a6c7a6dad67c9489dc.txt
+++ b/test/snapshots/parser/comments_test/test_0012_nested_HTML_comment_opener_in_an_unclosed_comment_269b4844a88465fe76b669bc988c82b6-2ffd01e26b8c99a6c7a6dad67c9489dc.txt
@@ -1,16 +1,12 @@
 ---
 source: "Parser::CommentsTest#test_0012_nested HTML comment opener in an unclosed comment"
 input: "<!-- outer <!-- inner"
+options: {strict: false}
 ---
 @ DocumentNode (location: (1:0)-(1:21))
 └── children: (1 item)
     └── @ HTMLCommentNode (location: (1:0)-(1:21))
-        ├── errors: (2 errors)
-        │   ├── @ NestedCommentError (location: (1:11)-(1:15))
-        │   │   ├── message: "Comment opened at (1:0) contains another `<!--` at (1:11)."
-        │   │   ├── comment_start: "<!--" (location: (1:0)-(1:4))
-        │   │   └── nested_start: "<!--" (location: (1:11)-(1:15))
-        │   │
+        ├── errors: (1 error)
         │   └── @ UnclosedCommentError (location: (1:0)-(1:21))
         │       ├── message: "Comment opened at (1:0) is missing its closing `-->`."
         │       └── comment_start: "<!--" (location: (1:0)-(1:4))

--- a/test/snapshots/parser/comments_test/test_0015_conditional_comment_with_a_nested_opener_9504f696921ebe9d00eca8262c9736c2-08996694f7ff1e6e34277dc32f646630.txt
+++ b/test/snapshots/parser/comments_test/test_0015_conditional_comment_with_a_nested_opener_9504f696921ebe9d00eca8262c9736c2-08996694f7ff1e6e34277dc32f646630.txt
@@ -1,0 +1,20 @@
+---
+source: "Parser::CommentsTest#test_0015_conditional comment with a nested opener"
+input: "<!--[if !mso]><!-- -->"
+options: {strict: true}
+---
+@ DocumentNode (location: (1:0)-(1:22))
+└── children: (1 item)
+    └── @ HTMLCommentNode (location: (1:0)-(1:22))
+        ├── errors: (1 error)
+        │   └── @ NestedCommentError (location: (1:14)-(1:18))
+        │       ├── message: "Comment opened at (1:0) contains another `<!--` at (1:14)."
+        │       ├── comment_start: "<!--" (location: (1:0)-(1:4))
+        │       └── nested_start: "<!--" (location: (1:14)-(1:18))
+        │
+        ├── comment_start: "<!--" (location: (1:0)-(1:4))
+        ├── children: (1 item)
+        │   └── @ LiteralNode (location: (1:4)-(1:19))
+        │       └── content: "[if !mso]><!-- "
+        │
+        └── comment_end: "-->" (location: (1:19)-(1:22))

--- a/test/snapshots/parser/comments_test/test_0015_conditional_comment_with_a_nested_opener_9504f696921ebe9d00eca8262c9736c2-2ffd01e26b8c99a6c7a6dad67c9489dc.txt
+++ b/test/snapshots/parser/comments_test/test_0015_conditional_comment_with_a_nested_opener_9504f696921ebe9d00eca8262c9736c2-2ffd01e26b8c99a6c7a6dad67c9489dc.txt
@@ -1,0 +1,14 @@
+---
+source: "Parser::CommentsTest#test_0015_conditional comment with a nested opener"
+input: "<!--[if !mso]><!-- -->"
+options: {strict: false}
+---
+@ DocumentNode (location: (1:0)-(1:22))
+└── children: (1 item)
+    └── @ HTMLCommentNode (location: (1:0)-(1:22))
+        ├── comment_start: "<!--" (location: (1:0)-(1:4))
+        ├── children: (1 item)
+        │   └── @ LiteralNode (location: (1:4)-(1:19))
+        │       └── content: "[if !mso]><!-- "
+        │
+        └── comment_end: "-->" (location: (1:19)-(1:22))


### PR DESCRIPTION
Follow up on #2601.

This pull request moves `NestedCommentError` behind the `strict` option, and adds `.github/corpus-expectations.yml` so the corpus job can be told which outcome changes a branch intends.

`NestedCommentError` reports a `<!--` inside a comment, which the HTML5 tokenizer calls a `nested-comment` parse error. That is worth catching as you type, because the author usually expects the rest of the line to be commented out and the comment actually ends at the first `-->`. It is also how HTML email opens a downlevel-revealed block:

```html
<!--[if !mso]><!-- -->
<link href="https://fonts.googleapis.com/css?family=Lato" rel="stylesheet">
<!--<![endif]-->
```