### PR TITLE
Herb: Derive the ERB node group from the tag tokens

### DIFF
--- a/javascript/packages/core/test/node-type-guards.test.ts
+++ b/javascript/packages/core/test/node-type-guards.test.ts
@@ -6,6 +6,7 @@ import {
   LiteralNode,
   HTMLTextNode,
   ERBContentNode,
+  HerbDirectiveNode,
 
 } from '../src/nodes.js'
 
@@ -18,6 +19,7 @@ import {
   isERBContentNode,
   isHTMLNode,
   isERBNode,
+  isHerbDirectiveNode,
   isAnyOf,
   isNoneOf,
   isNode,
@@ -49,6 +51,17 @@ describe('Node Type Guards', () => {
     location: Location.zero,
     errors: [],
     content: 'text'
+  })
+
+  const herbDirectiveNode = new HerbDirectiveNode({
+    type: 'AST_HERB_DIRECTIVE_NODE',
+    location: Location.zero,
+    errors: [],
+    tag_opening: null,
+    content: null,
+    tag_closing: null,
+    key: null,
+    arguments: null,
   })
 
   const erbContentNode = new ERBContentNode({
@@ -112,6 +125,15 @@ describe('Node Type Guards', () => {
       expect(isERBNode(erbContentNode)).toBe(true)
       expect(isERBNode(documentNode)).toBe(false)
       expect(isERBNode(literalNode)).toBe(false)
+      expect(isERBNode(htmlTextNode)).toBe(false)
+    })
+
+    it('counts a directive as an ERB node, since it is written as an ERB tag', () => {
+      expect(isHerbDirectiveNode(herbDirectiveNode)).toBe(true)
+      expect(isERBNode(herbDirectiveNode)).toBe(true)
+    })
+
+    it('leaves a node without ERB tag tokens out of the group', () => {
       expect(isERBNode(htmlTextNode)).toBe(false)
     })
   })

--- a/javascript/packages/printer/src/identity-printer.ts
+++ b/javascript/packages/printer/src/identity-printer.ts
@@ -529,7 +529,7 @@ export class IdentityPrinter extends Printer {
   /**
    * Print ERB node tags and content
    */
-  protected printERBNode(node: Nodes.ERBNode | Nodes.HerbDirectiveNode | Nodes.HerbStateDirectiveNode): void {
+  protected printERBNode(node: Nodes.ERBNode): void {
     if (node.tag_opening) {
       this.write(node.tag_opening.value)
     }

--- a/templates/javascript/packages/core/src/node-type-guards.ts.erb
+++ b/templates/javascript/packages/core/src/node-type-guards.ts.erb
@@ -43,7 +43,7 @@ export function isHTMLNode(node: Node): boolean {
  * Checks if a node is any ERB node type
  */
 export function isERBNode(node: Node): node is ERBNode {
-<%- erb_nodes = nodes.select { |n| n.name.start_with?("ERB") } -%>
+<%- erb_nodes = nodes.select(&:erb_tag?) -%>
   return <%= erb_nodes.map { |n| "is#{n.name}(node)" }.join(" ||\n         ") %>
 }
 

--- a/templates/javascript/packages/core/src/nodes.ts.erb
+++ b/templates/javascript/packages/core/src/nodes.ts.erb
@@ -533,17 +533,21 @@ export type NodeType =
   | "<%= node.type %>"
   <%- end -%>
 
-export type ERBNodeType = Extract<NodeType, `AST_ERB_${string}`>;
+export type ERBNodeType =
+  <%- nodes.each do |node| -%>
+    <%- next unless node.erb_tag? -%>
+  | "<%= node.type %>"
+  <%- end -%>
 
 export type ERBNode =
   <%- nodes.each_with_index.map do |node, index| -%>
-    <%- next unless node.name.start_with?("ERB") -%>
+    <%- next unless node.erb_tag? -%>
   | <%= node.name %>
   <%- end -%>
 
 export const ERBNodeClasses = [
   <%- nodes.each_with_index.map do |node, index| -%>
-  <%- next unless node.name.start_with?("ERB") -%>
+  <%- next unless node.erb_tag? -%>
   <%= node.name %>,
   <%- end -%>
 ]

--- a/templates/javascript/packages/core/src/visitor.ts.erb
+++ b/templates/javascript/packages/core/src/visitor.ts.erb
@@ -47,7 +47,7 @@ export class Visitor implements IVisitor {
   <%- nodes.each do |node| -%>
   visit<%= node.name %>(node: <%= node.name %>): void {
     this.visitNode(node)
-    <%- if node.name.start_with?("ERB") -%>
+    <%- if node.erb_tag? -%>
     this.visitERBNode(node)
     <%- end -%>
     this.visitChildNodes(node)

--- a/templates/lib/herb/visitor.rb.erb
+++ b/templates/lib/herb/visitor.rb.erb
@@ -37,7 +37,7 @@ module Herb
     #: (Herb::AST::<%= node.name %>) -> void
     def visit_<%= node.human %>(node)
       visit_node(node)
-      <%- if node.name.start_with?("ERB") -%>
+      <%- if node.erb_tag? -%>
       visit_erb_node(node)
       <%- end -%>
       visit_child_nodes(node)

--- a/templates/rust/src/nodes.rs.erb
+++ b/templates/rust/src/nodes.rs.erb
@@ -539,7 +539,7 @@ impl Node for <%= node.name %> {
   }
 }
 
-<%- if node.name.start_with?("ERB") -%>
+<%- if node.erb_tag? -%>
 impl ERBNode for <%= node.name %> {
   fn tag_opening(&self) -> &Option<Token> {
     &self.tag_opening

--- a/templates/rust/src/visitor.rs.erb
+++ b/templates/rust/src/visitor.rs.erb
@@ -30,7 +30,7 @@ pub trait Visitor {
 
   <%- nodes.each do |node| -%>
   fn visit_<%= node.human %>(&mut self, node: &<%= node.name %>) {
-    <%- if node.name.start_with?("ERB") -%>
+    <%- if node.erb_tag? -%>
     self.visit_erb_node(node);
     <%- end -%>
     self.walk_<%= node.human %>(node);

--- a/templates/src/diff/herb_diff_nodes.c.erb
+++ b/templates/src/diff/herb_diff_nodes.c.erb
@@ -219,7 +219,7 @@ void herb_diff_node(
     <%- node_fields = all_fields.select { |field| field.is_a?(Herb::Template::NodeField) || field.is_a?(Herb::Template::BorrowedNodeField) } -%>
     <%- content_tokens = token_fields.select { |field| %w[content tag_opening].include?(field.name) } -%>
     <%- has_comparisons = content_tokens.any? || string_fields.any? || array_fields.any? || node_fields.any? -%>
-    <%- is_erb_node = node.name.start_with?("ERB") || node.name.start_with?("Ruby") -%>
+    <%- is_erb_node = node.erb_tag? || node.name.start_with?("Ruby") -%>
     <%- if !has_comparisons -%>
     case <%= node.type %>: {
       herb_diff_emit_operation(result, HERB_DIFF_NODE_REPLACED, path, old_node, new_node, 0, 0);

--- a/templates/template.rb
+++ b/templates/template.rb
@@ -443,6 +443,8 @@ module Herb
     class NodeType
       include ConfigType
 
+      ERB_TAG_FIELDS = ["tag_opening", "content", "tag_closing"].freeze
+
       attr_reader :name, :type, :struct_type, :struct_name, :human, :fields
 
       def initialize(config)
@@ -460,6 +462,12 @@ module Herb
 
           type.new(name: field_name, kind: kind, writable: field.fetch("writable", false))
         end
+      end
+
+      def erb_tag?
+        names = fields.map(&:name)
+
+        ERB_TAG_FIELDS.all? { |field| names.include?(field) }
       end
 
       def c_type

--- a/test/visitor_test.rb
+++ b/test/visitor_test.rb
@@ -226,4 +226,25 @@ class VisitorTest < Minitest::Spec
     assert_equal({ prism_program: true, strict: false }, Herb::Visitor.parser_options_for([visitor]))
     assert_equal({ prism_program: true, strict: false }, klass.parser_options_for([visitor]))
   end
+
+  class ERBNodeCollector < Herb::Visitor
+    attr_reader :erb_nodes
+
+    def initialize
+      super
+      @erb_nodes = []
+    end
+
+    def visit_erb_node(node)
+      @erb_nodes << node.class.to_s.split("::").last
+    end
+  end
+
+  test "visit_erb_node fires for every node written as an ERB tag" do
+    visitor = ERBNodeCollector.new
+
+    Herb.parse(%(<%# herb:slots %><%# a comment %><%= value %><% code %>), herb_directives: true).visit(visitor)
+
+    assert_equal ["HerbDirectiveNode", "ERBCommentNode", "ERBContentNode", "ERBContentNode"], visitor.erb_nodes
+  end
 end


### PR DESCRIPTION
Follow up on #2605.

Every binding decided what counts as an ERB node by testing whether the class name starts with `ERB`:

```erb
<%- if node.name.start_with?("ERB") -%>
```

`HerbDirectiveNode` and `HerbStateDirectiveNode` are written as `<%# ... %>` and carry the same three tokens as any other ERB tag, but they are spelled `Herb`, so they fell out of the group on a spelling.

Three things followed from that.

`isERBNode` returned false for a directive, so `IdentityPrinter` had to name by hand the two nodes the union had dropped:

```diff
-  protected printERBNode(node: Nodes.ERBNode | Nodes.HerbDirectiveNode | Nodes.HerbStateDirectiveNode): void {
+  protected printERBNode(node: Nodes.ERBNode): void {
```

`visitERBNode` never fired for a directive, in Ruby, Rust or JavaScript. That hook is what a detector overrides when it wants every ERB tag in a document without naming each node type, which `linter-ignore` and `format-ignore` both do.

And the diff engine reported a changed directive as `HERB_DIFF_TEXT_CHANGED` instead of `HERB_DIFF_ERB_CONTENT_CHANGED`, so the playground labelled a directive edit as a text change.
