### PR TITLE
Engine: Raise `CompilationError` as a `SyntaxError`

### DIFF
--- a/lib/herb/engine.rb
+++ b/lib/herb/engine.rb
@@ -39,7 +39,7 @@ module Herb
       "'" => "&#39;",
     }.freeze
 
-    class CompilationError < StandardError
+    class CompilationError < SyntaxError
     end
 
     class GeneratorTemplateError < CompilationError

--- a/lib/herb/project.rb
+++ b/lib/herb/project.rb
@@ -334,7 +334,7 @@ module Herb
         puts "```ruby"
         puts engine.src
         puts "```"
-      rescue StandardError
+      rescue Herb::Engine::CompilationError, StandardError
         # Skip if compilation fails entirely
       end
     end
@@ -507,7 +507,7 @@ module Herb
                  compilation_error: compilation_error,
                  diagnostics: [{ name: error_name, message: e.message }],
                  log: "⚠️ Compilation failed for #{file_path} (validation error)" }
-      rescue StandardError
+      rescue Herb::Engine::CompilationError, StandardError
         # Not a validator-caused error, continue with other checks
       end
 
@@ -518,7 +518,7 @@ module Herb
                  compilation_error: compilation_error,
                  diagnostics: [{ name: "CompilationError", message: "#{e.message} (strict mode)" }],
                  log: "🔒 Compilation failed for #{file_path} (strict mode error)" }
-      rescue StandardError
+      rescue Herb::Engine::CompilationError, StandardError
         # Fall through
       end
 

--- a/sig/herb/engine.rbs
+++ b/sig/herb/engine.rbs
@@ -30,7 +30,7 @@ module Herb
 
     ESCAPE_TABLE: untyped
 
-    class CompilationError < StandardError
+    class CompilationError < SyntaxError
     end
 
     class GeneratorTemplateError < CompilationError

--- a/test/engine/error_handling_test.rb
+++ b/test/engine/error_handling_test.rb
@@ -447,5 +447,14 @@ module Engine
       assert_instance_of Herb::Engine, engine
       assert_instance_of String, engine.src
     end
+
+    test "compile errors are syntax errors" do
+      error = assert_raises(Herb::Engine::CompilationError) do
+        Herb::Engine.new("check <% [ %>\n")
+      end
+
+      assert_kind_of SyntaxError, error
+      refute_kind_of StandardError, error
+    end
   end
 end


### PR DESCRIPTION
This pull request changes `Herb::Engine::CompilationError` to inherit from `SyntaxError` instead of `StandardError`, so a template that fails to compile raises the class of error Ruby uses for code that does not parse. 

`ParseError`, `GeneratorTemplateError`, `InvalidRubyError`, and `SubtreeCompiler::TargetNotFound` inherit the new ancestry through `CompilationError`. `SecurityError` stays a `StandardError`, since a validator finding is a policy problem and not a syntax problem.

The motivation is the Rails integration. Action View wraps a `SyntaxError` raised during template compilation in `ActionView::SyntaxErrorInTemplate` and renders its standard error page with the template source. 

Erubi compiles broken Ruby into broken compiled Ruby, so the error surfaces as a `SyntaxError` from `module_eval`. Herb raises at engine construction instead, and with `CompilationError < StandardError` the existing rescue in `ActionView::Template#compile` did not match, which broke the error page for templates that fail to compile. With this change the rescue matches without any adapter code in Rails.

Since `SyntaxError` lives under `ScriptError`, a plain `rescue => e` no longer catches compile errors. The rescues in `Herb::Project` that guard engine compiles now name `Herb::Engine::CompilationError` explicitly, and a new test pins the ancestry in both directions so the change stays deliberate.

#2608 ships the same change for `v0.11.0` on the `main` branch.
