### PR TITLE
Core: Give `isHTMLNode` the same shape as `isERBNode`

### DIFF
--- a/javascript/packages/core/test/node-type-guards.test.ts
+++ b/javascript/packages/core/test/node-type-guards.test.ts
@@ -128,6 +128,16 @@ describe('Node Type Guards', () => {
       expect(isERBNode(htmlTextNode)).toBe(false)
     })
 
+    it('narrows to HTMLNode so a caller can reach a shared field', () => {
+      const node: Node = htmlTextNode
+
+      expect(isHTMLNode(node)).toBe(true)
+
+      if (isHTMLNode(node)) {
+        expect(node.type).toBe('AST_HTML_TEXT_NODE')
+      }
+    })
+
     it('counts a directive as an ERB node, since it is written as an ERB tag', () => {
       expect(isHerbDirectiveNode(herbDirectiveNode)).toBe(true)
       expect(isERBNode(herbDirectiveNode)).toBe(true)

--- a/templates/javascript/packages/core/src/node-type-guards.ts.erb
+++ b/templates/javascript/packages/core/src/node-type-guards.ts.erb
@@ -1,4 +1,4 @@
-import type { Node, NodeType, ERBNode } from "./nodes.js"
+import type { Node, NodeType, ERBNode, HTMLNode } from "./nodes.js"
 
 import { Token } from "./token.js"
 import { ParseResult } from "./parse-result.js"
@@ -34,8 +34,8 @@ export function is<%= node.name %>(node: Node | null | undefined): node is <%= 
 /**
  * Checks if a node is any HTML node type
  */
-export function isHTMLNode(node: Node): boolean {
-<%- html_nodes = nodes.select { |n| n.name.start_with?("HTML") } -%>
+export function isHTMLNode(node: Node): node is HTMLNode {
+<%- html_nodes = nodes.select(&:html?) -%>
   return <%= html_nodes.map { |n| "is#{n.name}(node)" }.join(" ||\n         ") %>
 }
 

--- a/templates/javascript/packages/core/src/nodes.ts.erb
+++ b/templates/javascript/packages/core/src/nodes.ts.erb
@@ -533,6 +533,25 @@ export type NodeType =
   | "<%= node.type %>"
   <%- end -%>
 
+export type HTMLNodeType =
+  <%- nodes.each do |node| -%>
+    <%- next unless node.html? -%>
+  | "<%= node.type %>"
+  <%- end -%>
+
+export type HTMLNode =
+  <%- nodes.each do |node| -%>
+    <%- next unless node.html? -%>
+  | <%= node.name %>
+  <%- end -%>
+
+export const HTMLNodeClasses = [
+  <%- nodes.each do |node| -%>
+  <%- next unless node.html? -%>
+  <%= node.name %>,
+  <%- end -%>
+]
+
 export type ERBNodeType =
   <%- nodes.each do |node| -%>
     <%- next unless node.erb_tag? -%>

--- a/templates/template.rb
+++ b/templates/template.rb
@@ -470,6 +470,10 @@ module Herb
         ERB_TAG_FIELDS.all? { |field| names.include?(field) }
       end
 
+      def html?
+        name.start_with?("HTML")
+      end
+
       def c_type
         @struct_type
       end


### PR DESCRIPTION
Follow up on #2606.

`isHTMLNode` returned a plain boolean:

```ts
export function isHTMLNode(node: Node): boolean
export function isERBNode(node: Node): node is ERBNode
```

So it told a caller that a node is one of the thirteen HTML types without letting them reach anything the group has in common, and TypeScript learned nothing from the check. There was no `HTMLNode` union and no `HTMLNodeClasses` either, where the ERB group has had both since it was generated.

It narrows now, and the union and the classes array join it:

```ts
export type HTMLNodeType =
  | "AST_HTML_OPEN_TAG_NODE"
  | "AST_HTML_CONDITIONAL_OPEN_TAG_NODE"
  ...

export type HTMLNode =
  | HTMLOpenTagNode
  | HTMLConditionalOpenTagNode
  ...

export const HTMLNodeClasses = [...]

export function isHTMLNode(node: Node): node is HTMLNode
```