### PR TITLE
Engine: Stamp `data-herb-source` on elements opened across conditionals

### DIFF
--- a/lib/herb/engine/visitors/source_attribution_visitor.rb
+++ b/lib/herb/engine/visitors/source_attribution_visitor.rb
@@ -71,7 +71,7 @@ module Herb
 
       #: (Herb::AST::HTMLElementNode) -> void
       def visit_html_element_node(node)
-        stamp(node.open_tag)
+        stamp_open_tag(node.open_tag)
 
         super
       end
@@ -102,6 +102,26 @@ module Herb
       #: () -> String
       def current_file
         @file || context.relative_file_path
+      end
+
+      #: (Herb::AST::Node?) -> void
+      def stamp_open_tag(open_tag)
+        if open_tag.is_a?(Herb::AST::HTMLConditionalOpenTagNode)
+          branch_open_tags(open_tag.conditional).each { |branch| stamp(branch) }
+
+          return
+        end
+
+        stamp(open_tag)
+      end
+
+      #: (Herb::AST::Node?) -> Array[Herb::AST::HTMLOpenTagNode]
+      def branch_open_tags(node)
+        return [] unless node
+        return [] if node.is_a?(Herb::AST::HTMLElementNode)
+        return [node] if node.is_a?(Herb::AST::HTMLOpenTagNode)
+
+        node.compact_child_nodes.flat_map { |child| branch_open_tags(child) }
       end
 
       #: (Herb::AST::Node?) -> void

--- a/sig/herb/engine/visitors/source_attribution_visitor.rbs
+++ b/sig/herb/engine/visitors/source_attribution_visitor.rbs
@@ -69,6 +69,12 @@ module Herb
       def current_file: () -> String
 
       # : (Herb::AST::Node?) -> void
+      def stamp_open_tag: (Herb::AST::Node?) -> void
+
+      # : (Herb::AST::Node?) -> Array[Herb::AST::HTMLOpenTagNode]
+      def branch_open_tags: (Herb::AST::Node?) -> Array[Herb::AST::HTMLOpenTagNode]
+
+      # : (Herb::AST::Node?) -> void
       def stamp: (Herb::AST::Node?) -> void
 
       # : ((Herb::AST::HTMLOpenTagNode | Herb::AST::ERBOpenTagNode)) -> Herb::serialized_position?

--- a/test/engine/visitors/source_attribution_test.rb
+++ b/test/engine/visitors/source_attribution_test.rb
@@ -212,6 +212,21 @@ module Engine
       test "escapes a value that would close it" do
         assert_evaluated_snapshot("<div>x</div>", {}, attribution_options, filename: %(a"b.html.erb))
       end
+
+      test "an element whose open tag is written across a conditional is stamped in each branch" do
+        template = <<~ERB
+          <% if condition %>
+            <div class="a">
+          <% else %>
+            <div class="b">
+          <% end %>
+            Content
+          </div>
+        ERB
+
+        assert_evaluated_snapshot(template, { condition: true }, attribution_options, filename: FILENAME)
+        assert_evaluated_snapshot(template, { condition: false }, attribution_options, filename: FILENAME)
+      end
     end
 
     describe "inspect" do

--- a/test/snapshots/engine/source_attribution_test/the_attribute/test_0003_an_element_whose_open_tag_is_written_across_a_conditional_is_stamped_in_each_branch_1b16ecbc5f8000768a78dece8f573680.txt
+++ b/test/snapshots/engine/source_attribution_test/the_attribute/test_0003_an_element_whose_open_tag_is_written_across_a_conditional_is_stamped_in_each_branch_1b16ecbc5f8000768a78dece8f573680.txt
@@ -1,0 +1,7 @@
+---
+source: "Engine::SourceAttributionTest::the attribute#test_0003_an element whose open tag is written across a conditional is stamped in each branch"
+input: "{source: \"<% if condition %>\\n  <div class=\\\"a\\\">\\n<% else %>\\n  <div class=\\\"b\\\">\\n<% end %>\\n  Content\\n</div>\\n\", locals: {condition: false}, options: {escape: false, visitors: [#<Herb::Engine::SourceAttributionVisitor>], filename: \"app/views/posts/_card.html.erb\"}}"
+---
+  <div class="b" data-herb-source="app/views/posts/_card.html.erb:4:3">
+  Content
+</div>

--- a/test/snapshots/engine/source_attribution_test/the_attribute/test_0003_an_element_whose_open_tag_is_written_across_a_conditional_is_stamped_in_each_branch_31b4cfe6f2a977fae6ba1649dc6dafbc.txt
+++ b/test/snapshots/engine/source_attribution_test/the_attribute/test_0003_an_element_whose_open_tag_is_written_across_a_conditional_is_stamped_in_each_branch_31b4cfe6f2a977fae6ba1649dc6dafbc.txt
@@ -1,0 +1,7 @@
+---
+source: "Engine::SourceAttributionTest::the attribute#test_0003_an element whose open tag is written across a conditional is stamped in each branch"
+input: "{source: \"<% if condition %>\\n  <div class=\\\"a\\\">\\n<% else %>\\n  <div class=\\\"b\\\">\\n<% end %>\\n  Content\\n</div>\\n\", locals: {condition: true}, options: {escape: false, visitors: [#<Herb::Engine::SourceAttributionVisitor>], filename: \"app/views/posts/_card.html.erb\"}}"
+---
+  <div class="a" data-herb-source="app/views/posts/_card.html.erb:2:3">
+  Content
+</div>


### PR DESCRIPTION
An element can be opened across an `if` and an `else`. Those rendered without a `data-herb-source` attribute, so rendered page lint could not attribute them back to the template they came from.

```erb
<% if condition %>
  <div class="a">
<% else %>
  <div class="b">
<% end %>
  Content
</div>
```
