### PR TITLE
Engine: Anchor a slot on an element opened across a conditional

### DIFF
--- a/lib/herb/ast/helpers.rb
+++ b/lib/herb/ast/helpers.rb
@@ -79,6 +79,27 @@ module Herb
         !omitted_close_tag(node).nil?
       end
 
+      #: (Herb::AST::Node?) -> Array[untyped]
+      def open_tags_for(open_tag)
+        case open_tag
+        when Herb::AST::HTMLConditionalOpenTagNode
+          branch_open_tags(open_tag.conditional)
+        when Herb::AST::HTMLOpenTagNode, Herb::AST::ERBOpenTagNode
+          [open_tag]
+        else
+          []
+        end
+      end
+
+      #: (Herb::AST::Node?) -> Array[untyped]
+      def branch_open_tags(node)
+        return [] unless node
+        return [] if node.is_a?(Herb::AST::HTMLElementNode)
+        return [node] if node.is_a?(Herb::AST::HTMLOpenTagNode)
+
+        node.compact_child_nodes.flat_map { |child| branch_open_tags(child) }
+      end
+
       #: (Herb::AST::ERBContentNode) -> bool
       def inline_ruby_comment?(node)
         return false unless node.is_a?(Herb::AST::ERBContentNode)

--- a/lib/herb/engine/slots/visitor.rb
+++ b/lib/herb/engine/slots/visitor.rb
@@ -1879,7 +1879,9 @@ module Herb
           return unless node.is_a?(Herb::AST::HTMLElementNode)
 
           open_tag = node.open_tag
-          return unless open_tag.is_a?(Herb::AST::HTMLOpenTagNode) || open_tag.is_a?(Herb::AST::ERBOpenTagNode)
+          targets = open_tags_for(open_tag)
+
+          return if targets.empty?
 
           anchors = (@element_anchored[open_tag] || []).map { |annotation|
             slot = @slots.fetch(annotation.survivor.index)
@@ -1891,7 +1893,9 @@ module Herb
 
           return if anchors.empty?
 
-          open_tag.children << attribute_node("data-herb-slot", @markers.element_anchors(anchors))
+          value = @markers.element_anchors(anchors)
+
+          targets.each { |target| target.children << attribute_node("data-herb-slot", value) }
         end
 
         #: (Slot) -> String?

--- a/lib/herb/engine/visitors/source_attribution_visitor.rb
+++ b/lib/herb/engine/visitors/source_attribution_visitor.rb
@@ -106,22 +106,7 @@ module Herb
 
       #: (Herb::AST::Node?) -> void
       def stamp_open_tag(open_tag)
-        if open_tag.is_a?(Herb::AST::HTMLConditionalOpenTagNode)
-          branch_open_tags(open_tag.conditional).each { |branch| stamp(branch) }
-
-          return
-        end
-
-        stamp(open_tag)
-      end
-
-      #: (Herb::AST::Node?) -> Array[Herb::AST::HTMLOpenTagNode]
-      def branch_open_tags(node)
-        return [] unless node
-        return [] if node.is_a?(Herb::AST::HTMLElementNode)
-        return [node] if node.is_a?(Herb::AST::HTMLOpenTagNode)
-
-        node.compact_child_nodes.flat_map { |child| branch_open_tags(child) }
+        open_tags_for(open_tag).each { |tag| stamp(tag) }
       end
 
       #: (Herb::AST::Node?) -> void

--- a/sig/herb/ast/helpers.rbs
+++ b/sig/herb/ast/helpers.rbs
@@ -36,6 +36,12 @@ module Herb
       # : (Herb::AST::Node?) -> bool
       def omitted_close_tag?: (Herb::AST::Node?) -> bool
 
+      # : (Herb::AST::Node?) -> Array[untyped]
+      def open_tags_for: (Herb::AST::Node?) -> Array[untyped]
+
+      # : (Herb::AST::Node?) -> Array[untyped]
+      def branch_open_tags: (Herb::AST::Node?) -> Array[untyped]
+
       # : (Herb::AST::ERBContentNode) -> bool
       def inline_ruby_comment?: (Herb::AST::ERBContentNode) -> bool
     end

--- a/sig/herb/engine/visitors/source_attribution_visitor.rbs
+++ b/sig/herb/engine/visitors/source_attribution_visitor.rbs
@@ -71,9 +71,6 @@ module Herb
       # : (Herb::AST::Node?) -> void
       def stamp_open_tag: (Herb::AST::Node?) -> void
 
-      # : (Herb::AST::Node?) -> Array[Herb::AST::HTMLOpenTagNode]
-      def branch_open_tags: (Herb::AST::Node?) -> Array[Herb::AST::HTMLOpenTagNode]
-
       # : (Herb::AST::Node?) -> void
       def stamp: (Herb::AST::Node?) -> void
 

--- a/test/engine/slots/markers_test.rb
+++ b/test/engine/slots/markers_test.rb
@@ -548,6 +548,13 @@ module Engine
           options
         )
       end
+
+      test "anchors a slot on an element opened across a conditional" do
+        template = %(<% if @c %><div class="a"><% else %><div class="b"><% end %><%= @value %></div>)
+
+        assert_evaluated_snapshot(template, { "@c" => true, "@value" => "v" }, options)
+        assert_evaluated_snapshot(template, { "@c" => false, "@value" => "v" }, options)
+      end
     end
   end
 end

--- a/test/snapshots/engine/slots/markers_test/test_0069_anchors_a_slot_on_an_element_opened_across_a_conditional_4d2a49ff005f5af39a9acb70c867b819.txt
+++ b/test/snapshots/engine/slots/markers_test/test_0069_anchors_a_slot_on_an_element_opened_across_a_conditional_4d2a49ff005f5af39a9acb70c867b819.txt
@@ -1,0 +1,5 @@
+---
+source: "Engine::Slots::MarkersTest#test_0069_anchors a slot on an element opened across a conditional"
+input: "{source: \"<% if @c %><div class=\\\"a\\\"><% else %><div class=\\\"b\\\"><% end %><%= @value %></div>\", locals: {\"@c\" => true, \"@value\" => \"v\"}, options: {visitors: [#<Herb::Engine::Slots::Visitor server>], filename: \"app/views/test.html.erb\"}}"
+---
+<!--herb-region:app/views/test.html.erb:83ab2bfd:0--><div class="a" data-herb-slot="1:child">v</div><!--/herb-region:app/views/test.html.erb-->

--- a/test/snapshots/engine/slots/markers_test/test_0069_anchors_a_slot_on_an_element_opened_across_a_conditional_dd799cc1bdb242ada0526fdf9d746204.txt
+++ b/test/snapshots/engine/slots/markers_test/test_0069_anchors_a_slot_on_an_element_opened_across_a_conditional_dd799cc1bdb242ada0526fdf9d746204.txt
@@ -1,0 +1,5 @@
+---
+source: "Engine::Slots::MarkersTest#test_0069_anchors a slot on an element opened across a conditional"
+input: "{source: \"<% if @c %><div class=\\\"a\\\"><% else %><div class=\\\"b\\\"><% end %><%= @value %></div>\", locals: {\"@c\" => false, \"@value\" => \"v\"}, options: {visitors: [#<Herb::Engine::Slots::Visitor server>], filename: \"app/views/test.html.erb\"}}"
+---
+<!--herb-region:app/views/test.html.erb:83ab2bfd:0--><div class="b" data-herb-slot="1:child">v</div><!--/herb-region:app/views/test.html.erb-->


### PR DESCRIPTION
Follow up on #2611, which fixed the same bug in `SourceAttributionVisitor`. `Slots::Visitor` has it too.

An element can be opened across an `if` and an `else`:

```erb
<% if @c %><div class="a"><% else %><div class="b"><% end %><%= @value %></div>
```

`anchor_attributes` writes `data-herb-slot` into that element's open tag, guarded the same way as before:

```ruby
open_tag = node.open_tag
return unless open_tag.is_a?(Herb::AST::HTMLOpenTagNode) || open_tag.is_a?(Herb::AST::ERBOpenTagNode)
```
