### PR TITLE
Linter: Add `defaultEnabledIn` so version gate sees re-enabled rules

### DIFF
--- a/javascript/packages/linter/package.json
+++ b/javascript/packages/linter/package.json
@@ -22,7 +22,7 @@
     "watch": "tsc --emitDeclarationOnly -w",
     "test": "vitest run",
     "test:watch": "vitest --watch",
-    "check:rule-versions": "! grep -rl 'static introducedIn = \"unreleased\"' src/rules/ 2>/dev/null || (echo '\\n\u2717 Found linter rules with introducedIn = \"unreleased\". Update them to a release version before publishing.\\n' && exit 1)",
+    "check:rule-versions": "! grep -rlE '(introducedIn|defaultEnabledIn) = (this\\.version\\()?\"unreleased\"' src/rules/ 2>/dev/null || (echo '\\n\u2717 Found linter rules with a version of \"unreleased\". Update them to a release version before publishing.\\n' && exit 1)",
     "typecheck": "tsc -p tsconfig.test.json && tsc -p tsconfig.browser-test.json",
     "prepublishOnly": "yarn check:rule-versions && yarn clean && yarn build && yarn test"
   },

--- a/javascript/packages/linter/src/cli/summary-reporter.ts
+++ b/javascript/packages/linter/src/cli/summary-reporter.ts
@@ -271,10 +271,14 @@ export class SummaryReporter {
 
     const ruleCount = skippedRules.length
     const suggestedVersion = toolVersion || configVersion || "latest"
+    const wasReEnabled = (rule: VersionSkippedRule) => rule.defaultEnabledIn !== undefined && compareSemver(rule.defaultEnabledIn, rule.introducedIn) > 0
+    const hasNewlyEnabled = skippedRules.every(wasReEnabled)
+    const heading = hasNewlyEnabled ? "Rules available" : "New rules available"
+    const noun = hasNewlyEnabled ? this.pluralize(ruleCount, "rule") : `new ${this.pluralize(ruleCount, "rule")}`
 
     console.log("")
-    console.log(` ${colorize(`New rules available:`, "bold")}`)
-    console.log(`  Your ${colorize(".herb.yml", "cyan")} version is ${colorize(configVersion!, "cyan")}. ${colorize(String(ruleCount), "bold")} new ${this.pluralize(ruleCount, "rule")} ${ruleCount === 1 ? "is" : "are"} disabled to ease upgrades:`)
+    console.log(` ${colorize(`${heading}:`, "bold")}`)
+    console.log(`  Your ${colorize(".herb.yml", "cyan")} version is ${colorize(configVersion!, "cyan")}. ${colorize(String(ruleCount), "bold")} ${noun} ${ruleCount === 1 ? "is" : "are"} disabled to ease upgrades:`)
 
     if (configPath) {
       console.log(`  ${colorize("from Herb config:", "gray")} ${colorize(configPath, "cyan")}`)
@@ -283,11 +287,15 @@ export class SummaryReporter {
     console.log("")
 
     const grouped = new Map<string, string[]>()
+    const labels = new Map<string, string>()
 
     for (const rule of skippedRules) {
-      const existing = grouped.get(rule.introducedIn) || []
+      const version = rule.defaultEnabledIn ?? rule.introducedIn
+      const existing = grouped.get(version) || []
+
       existing.push(rule.ruleName)
-      grouped.set(rule.introducedIn, existing)
+      grouped.set(version, existing)
+      labels.set(rule.ruleName, wasReEnabled(rule) ? "enabled by default in" : "introduced in")
     }
 
     const sortedVersions = Array.from(grouped.keys()).sort((a, b) => compareSemver(a, b))
@@ -299,7 +307,7 @@ export class SummaryReporter {
       for (const ruleName of ruleNames) {
         const ruleText = colorize(ruleName, "white")
         const ruleLink = hyperlink(ruleText, ruleDocumentationUrl(ruleName))
-        console.log(`  ${ruleLink}${colorize(` (introduced in ${versionLabel})`, "gray")}`)
+        console.log(`  ${ruleLink}${colorize(` (${labels.get(ruleName)} ${versionLabel})`, "gray")}`)
       }
     }
 

--- a/javascript/packages/linter/src/linter.ts
+++ b/javascript/packages/linter/src/linter.ts
@@ -57,6 +57,7 @@ export interface LinterOptions {
 export interface VersionSkippedRule {
   ruleName: string
   introducedIn: RuleVersion
+  defaultEnabledIn?: RuleVersion
 }
 
 export interface FilterRulesResult {
@@ -204,12 +205,15 @@ export class Linter {
         continue
       }
 
-      if (allRulesDefault !== true && configVersion && ruleClass.introducedIn) {
-        if (semverGreaterThan(ruleClass.introducedIn, configVersion)) {
+      const gateVersion = ruleClass.defaultEnabledIn ?? ruleClass.introducedIn
+
+      if (allRulesDefault !== true && configVersion && gateVersion) {
+        if (semverGreaterThan(gateVersion, configVersion)) {
           if (defaultEnabled) {
             skippedByVersion.push({
               ruleName: ruleClass.ruleName,
               introducedIn: ruleClass.introducedIn,
+              defaultEnabledIn: ruleClass.defaultEnabledIn,
             })
           } else {
             notEnabledByDefault++

--- a/javascript/packages/linter/src/rules/actionview-no-content-argument-with-block.ts
+++ b/javascript/packages/linter/src/rules/actionview-no-content-argument-with-block.ts
@@ -83,6 +83,7 @@ class ContentArgumentWithBlockCollector extends PrismVisitor {
 export class ActionViewNoContentArgumentWithBlockRule extends ParserRule {
   static ruleName = "actionview-no-content-argument-with-block"
   static introducedIn = this.version("unreleased")
+  static defaultEnabledIn = this.version("unreleased")
 
   get defaultConfig(): FullRuleConfig {
     return {

--- a/javascript/packages/linter/src/rules/actionview-no-dynamic-partial-path.ts
+++ b/javascript/packages/linter/src/rules/actionview-no-dynamic-partial-path.ts
@@ -49,6 +49,7 @@ class ActionViewNoDynamicPartialPathVisitor extends BaseRuleVisitor {
 export class ActionViewNoDynamicPartialPathRule extends ParserRule {
   static ruleName = "actionview-no-dynamic-partial-path"
   static introducedIn = this.version("unreleased")
+  static defaultEnabledIn = this.version("unreleased")
 
   get defaultConfig(): FullRuleConfig {
     return {

--- a/javascript/packages/linter/src/rules/actionview-no-helper-shadowing.ts
+++ b/javascript/packages/linter/src/rules/actionview-no-helper-shadowing.ts
@@ -126,6 +126,7 @@ class NoHelperShadowingVisitor extends BaseRuleVisitor {
 export class ActionViewNoHelperShadowingRule extends ParserRule {
   static ruleName = "actionview-no-helper-shadowing"
   static introducedIn = this.version("unreleased")
+  static defaultEnabledIn = this.version("unreleased")
 
   get defaultConfig(): FullRuleConfig {
     return {

--- a/javascript/packages/linter/src/rules/actionview-no-implicit-partial.ts
+++ b/javascript/packages/linter/src/rules/actionview-no-implicit-partial.ts
@@ -50,6 +50,7 @@ class ActionViewNoImplicitPartialVisitor extends BaseRuleVisitor {
 export class ActionViewNoImplicitPartialRule extends ParserRule {
   static ruleName = "actionview-no-implicit-partial"
   static introducedIn = this.version("unreleased")
+  static defaultEnabledIn = this.version("unreleased")
 
   get defaultConfig(): FullRuleConfig {
     return {

--- a/javascript/packages/linter/src/rules/actionview-no-implicit-polymorphic-url.ts
+++ b/javascript/packages/linter/src/rules/actionview-no-implicit-polymorphic-url.ts
@@ -175,6 +175,7 @@ class ImplicitPolymorphicURLCollector extends PrismVisitor {
 export class ActionViewNoImplicitPolymorphicURLRule extends ParserRule {
   static ruleName = "actionview-no-implicit-polymorphic-url"
   static introducedIn = this.version("unreleased")
+  static defaultEnabledIn = this.version("unreleased")
 
   get defaultConfig(): FullRuleConfig {
     return {

--- a/javascript/packages/linter/src/rules/actionview-no-mistyped-locals.ts
+++ b/javascript/packages/linter/src/rules/actionview-no-mistyped-locals.ts
@@ -78,6 +78,7 @@ class ActionViewNoMistypedLocalsVisitor extends BaseRuleVisitor {
 export class ActionViewNoMistypedLocalsRule extends ParserRule {
   static ruleName = "actionview-no-mistyped-locals"
   static introducedIn = this.version("unreleased")
+  static defaultEnabledIn = this.version("unreleased")
 
   get parserOptions(): Partial<ParserOptions> {
     return {

--- a/javascript/packages/linter/src/rules/actionview-no-redundant-local-assigns.ts
+++ b/javascript/packages/linter/src/rules/actionview-no-redundant-local-assigns.ts
@@ -98,6 +98,7 @@ class LocalAssignsLookupCollector extends PrismVisitor {
 export class ActionViewNoRedundantLocalAssignsRule extends ParserRule {
   static ruleName = "actionview-no-redundant-local-assigns"
   static introducedIn = this.version("unreleased")
+  static defaultEnabledIn = this.version("unreleased")
 
   get defaultConfig(): FullRuleConfig {
     return {

--- a/javascript/packages/linter/src/rules/actionview-no-render-option-shadowing.ts
+++ b/javascript/packages/linter/src/rules/actionview-no-render-option-shadowing.ts
@@ -65,6 +65,7 @@ class ActionViewNoRenderOptionShadowingVisitor extends BaseRuleVisitor {
 export class ActionViewNoRenderOptionShadowingRule extends ParserRule {
   static ruleName = "actionview-no-render-option-shadowing"
   static introducedIn = this.version("unreleased")
+  static defaultEnabledIn = this.version("unreleased")
 
   get defaultConfig(): FullRuleConfig {
     return {

--- a/javascript/packages/linter/src/rules/actionview-no-silent-helper.ts
+++ b/javascript/packages/linter/src/rules/actionview-no-silent-helper.ts
@@ -98,6 +98,7 @@ export class ActionViewNoSilentHelperRule extends ParserRule<ActionViewNoSilentH
   static autofixRequiresContext = true
   static ruleName = "actionview-no-silent-helper"
   static introducedIn = this.version("0.9.0")
+  static defaultEnabledIn = this.version("0.9.0")
 
   get defaultConfig(): FullRuleConfig {
     return {

--- a/javascript/packages/linter/src/rules/actionview-no-silent-render.ts
+++ b/javascript/packages/linter/src/rules/actionview-no-silent-render.ts
@@ -21,6 +21,7 @@ class ActionViewNoSilentRenderVisitor extends BaseRuleVisitor {
 export class ActionViewNoSilentRenderRule extends ParserRule {
   static ruleName = "actionview-no-silent-render"
   static introducedIn = this.version("0.9.1")
+  static defaultEnabledIn = this.version("0.9.1")
 
   get defaultConfig(): FullRuleConfig {
     return {

--- a/javascript/packages/linter/src/rules/actionview-no-strict-locals-error.ts
+++ b/javascript/packages/linter/src/rules/actionview-no-strict-locals-error.ts
@@ -136,6 +136,7 @@ class ActionViewNoStrictLocalsErrorVisitor extends BaseRuleVisitor {
 export class ActionViewNoStrictLocalsErrorRule extends ParserRule {
   static ruleName = "actionview-no-strict-locals-error"
   static introducedIn = this.version("unreleased")
+  static defaultEnabledIn = this.version("unreleased")
 
   get defaultConfig(): FullRuleConfig {
     return {

--- a/javascript/packages/linter/src/rules/actionview-no-unnecessary-html-safe.ts
+++ b/javascript/packages/linter/src/rules/actionview-no-unnecessary-html-safe.ts
@@ -93,6 +93,7 @@ class ActionViewNoUnnecessaryHTMLSafeVisitor extends BaseRuleVisitor<Unnecessary
 export class ActionViewNoUnnecessaryHTMLSafeRule extends ParserRule<UnnecessaryHTMLSafeAutofixContext> {
   static ruleName = "actionview-no-unnecessary-html-safe"
   static introducedIn = this.version("unreleased")
+  static defaultEnabledIn = this.version("unreleased")
   static autocorrectable = true
 
   get defaultConfig(): FullRuleConfig {

--- a/javascript/packages/linter/src/rules/actionview-no-unnecessary-tag-attributes.ts
+++ b/javascript/packages/linter/src/rules/actionview-no-unnecessary-tag-attributes.ts
@@ -76,6 +76,7 @@ export class ActionViewNoUnnecessaryTagAttributesRule extends ParserRule<Unneces
   static autocorrectable = true
   static ruleName = "actionview-no-unnecessary-tag-attributes"
   static introducedIn = this.version("0.9.3")
+  static defaultEnabledIn = this.version("0.9.3")
 
   get defaultConfig(): FullRuleConfig {
     return {

--- a/javascript/packages/linter/src/rules/actionview-no-unused-strict-locals.ts
+++ b/javascript/packages/linter/src/rules/actionview-no-unused-strict-locals.ts
@@ -160,6 +160,7 @@ class ActionViewNoUnusedStrictLocalsVisitor extends BaseRuleVisitor {
 export class ActionViewNoUnusedStrictLocalsRule extends ParserRule {
   static ruleName = "actionview-no-unused-strict-locals"
   static introducedIn = this.version("unreleased")
+  static defaultEnabledIn = this.version("unreleased")
 
   get defaultConfig(): FullRuleConfig {
     return {

--- a/javascript/packages/linter/src/rules/actionview-no-void-element-content.ts
+++ b/javascript/packages/linter/src/rules/actionview-no-void-element-content.ts
@@ -6,6 +6,7 @@ import type { ParseResult, ParserOptions } from "@herb-tools/core"
 export class ActionViewNoVoidElementContentRule extends ParserRule {
   static ruleName = "actionview-no-void-element-content"
   static introducedIn = this.version("0.9.3")
+  static defaultEnabledIn = this.version("0.9.3")
   static consumesParserErrors = true
 
   get defaultConfig(): FullRuleConfig {

--- a/javascript/packages/linter/src/rules/actionview-prefer-collection-render.ts
+++ b/javascript/packages/linter/src/rules/actionview-prefer-collection-render.ts
@@ -94,6 +94,7 @@ class PreferCollectionRenderVisitor extends BaseRuleVisitor {
 export class ActionViewPreferCollectionRenderRule extends ParserRule {
   static ruleName = "actionview-prefer-collection-render"
   static introducedIn = this.version("unreleased")
+  static defaultEnabledIn = this.version("unreleased")
 
   get defaultConfig(): FullRuleConfig {
     return {

--- a/javascript/packages/linter/src/rules/actionview-prefer-link-to-helper.ts
+++ b/javascript/packages/linter/src/rules/actionview-prefer-link-to-helper.ts
@@ -140,6 +140,7 @@ class ActionViewPreferLinkToHelperVisitor extends BaseRuleVisitor<PreferLinkToHe
 export class ActionViewPreferLinkToHelperRule extends ParserRule<PreferLinkToHelperAutofixContext> {
   static ruleName = "actionview-prefer-link-to-helper"
   static introducedIn = this.version("unreleased")
+  static defaultEnabledIn = this.version("unreleased")
   static autocorrectable = true
   static autofixRequiresContext = true
 

--- a/javascript/packages/linter/src/rules/actionview-prefer-pluralize-helper.ts
+++ b/javascript/packages/linter/src/rules/actionview-prefer-pluralize-helper.ts
@@ -203,6 +203,7 @@ class ActionViewPreferPluralizeHelperVisitor extends BaseRuleVisitor {
 export class ActionViewPreferPluralizeHelperRule extends ParserRule {
   static ruleName = "actionview-prefer-pluralize-helper"
   static introducedIn = this.version("unreleased")
+  static defaultEnabledIn = this.version("unreleased")
 
   get defaultConfig(): FullRuleConfig {
     return {

--- a/javascript/packages/linter/src/rules/actionview-prefer-qualified-partial-path.ts
+++ b/javascript/packages/linter/src/rules/actionview-prefer-qualified-partial-path.ts
@@ -120,6 +120,7 @@ class ActionViewPreferQualifiedPartialPathVisitor extends BaseRuleVisitor<Prefer
 export class ActionViewPreferQualifiedPartialPathRule extends ParserRule<PreferQualifiedPartialPathAutofixContext> {
   static ruleName = "actionview-prefer-qualified-partial-path"
   static introducedIn = this.version("unreleased")
+  static defaultEnabledIn = this.version("unreleased")
   static unsafeAutocorrectable = true
   static autofixRequiresContext = true
 

--- a/javascript/packages/linter/src/rules/actionview-strict-locals-partial-only.ts
+++ b/javascript/packages/linter/src/rules/actionview-strict-locals-partial-only.ts
@@ -20,6 +20,7 @@ export class ActionViewStrictLocalsPartialOnlyRule extends ParserRule {
   static unsafeAutocorrectable = true
   static ruleName = "actionview-strict-locals-partial-only"
   static introducedIn = this.version("0.9.3")
+  static defaultEnabledIn = this.version("0.9.3")
 
   get parserOptions() {
     return { strict_locals: true }

--- a/javascript/packages/linter/src/rules/erb-comment-syntax.ts
+++ b/javascript/packages/linter/src/rules/erb-comment-syntax.ts
@@ -42,6 +42,7 @@ export class ERBCommentSyntax extends ParserRule<ERBCommentSyntaxAutofixContext>
   static autocorrectable = true
   static ruleName = "erb-comment-syntax"
   static introducedIn = this.version("0.7.5")
+  static defaultEnabledIn = this.version("0.7.5")
 
   get defaultConfig(): FullRuleConfig {
     return {

--- a/javascript/packages/linter/src/rules/erb-no-byte-order-mark.ts
+++ b/javascript/packages/linter/src/rules/erb-no-byte-order-mark.ts
@@ -23,6 +23,7 @@ export class ERBNoByteOrderMarkRule extends SourceRule {
   static autocorrectable = true
   static ruleName = "erb-no-byte-order-mark"
   static introducedIn = this.version("unreleased")
+  static defaultEnabledIn = this.version("unreleased")
 
   get defaultConfig(): FullRuleConfig {
     return {

--- a/javascript/packages/linter/src/rules/erb-no-case-node-children.ts
+++ b/javascript/packages/linter/src/rules/erb-no-case-node-children.ts
@@ -53,6 +53,7 @@ class ERBNoCaseNodeChildrenVisitor extends BaseRuleVisitor {
 export class ERBNoCaseNodeChildrenRule extends ParserRule {
   static ruleName = "erb-no-case-node-children"
   static introducedIn = this.version("0.8.0")
+  static defaultEnabledIn = this.version("0.8.0")
 
   get defaultConfig(): FullRuleConfig {
     return {

--- a/javascript/packages/linter/src/rules/erb-no-class-definitions.ts
+++ b/javascript/packages/linter/src/rules/erb-no-class-definitions.ts
@@ -24,6 +24,7 @@ class ClassDefinitionCollector extends PrismVisitor {
 export class ERBNoClassDefinitionsRule extends ParserRule {
   static ruleName = "erb-no-class-definitions"
   static introducedIn = this.version("unreleased")
+  static defaultEnabledIn = this.version("unreleased")
 
   get defaultConfig(): FullRuleConfig {
     return {

--- a/javascript/packages/linter/src/rules/erb-no-commented-out-output-tags.ts
+++ b/javascript/packages/linter/src/rules/erb-no-commented-out-output-tags.ts
@@ -35,6 +35,7 @@ class ERBNoCommentedOutOutputTagsVisitor extends BaseRuleVisitor {
 export class ERBNoCommentedOutOutputTagsRule extends ParserRule {
   static ruleName = "erb-no-commented-out-output-tags"
   static introducedIn = this.version("0.10.3")
+  static defaultEnabledIn = this.version("0.10.3")
 
   get defaultConfig(): FullRuleConfig {
     return {

--- a/javascript/packages/linter/src/rules/erb-no-conditional-html-element.ts
+++ b/javascript/packages/linter/src/rules/erb-no-conditional-html-element.ts
@@ -36,6 +36,7 @@ class ERBNoConditionalHTMLElementRuleVisitor extends BaseRuleVisitor {
 export class ERBNoConditionalHTMLElementRule extends ParserRule {
   static ruleName = "erb-no-conditional-html-element"
   static introducedIn = this.version("0.9.0")
+  static defaultEnabledIn = this.version("0.9.0")
 
   get defaultConfig(): FullRuleConfig {
     return {

--- a/javascript/packages/linter/src/rules/erb-no-conditional-open-tag.ts
+++ b/javascript/packages/linter/src/rules/erb-no-conditional-open-tag.ts
@@ -20,6 +20,7 @@ class ERBNoConditionalOpenTagRuleVisitor extends BaseRuleVisitor {
 export class ERBNoConditionalOpenTagRule extends ParserRule {
   static ruleName = "erb-no-conditional-open-tag"
   static introducedIn = this.version("0.9.0")
+  static defaultEnabledIn = this.version("0.9.0")
 
   get defaultConfig(): FullRuleConfig {
     return {

--- a/javascript/packages/linter/src/rules/erb-no-debug-output.ts
+++ b/javascript/packages/linter/src/rules/erb-no-debug-output.ts
@@ -21,6 +21,7 @@ class DebugOutputCallCollector extends PrismVisitor {
 export class ERBNoDebugOutputRule extends ParserRule {
   static ruleName = "erb-no-debug-output"
   static introducedIn = this.version("0.9.3")
+  static defaultEnabledIn = this.version("0.9.3")
 
   get defaultConfig(): FullRuleConfig {
     return {

--- a/javascript/packages/linter/src/rules/erb-no-duplicate-branch-elements.ts
+++ b/javascript/packages/linter/src/rules/erb-no-duplicate-branch-elements.ts
@@ -300,6 +300,7 @@ class ERBNoDuplicateBranchElementsVisitor extends BaseRuleVisitor<DuplicateBranc
 export class ERBNoDuplicateBranchElementsRule extends ParserRule<DuplicateBranchAutofixContext> {
   static ruleName = "erb-no-duplicate-branch-elements"
   static introducedIn = this.version("0.9.0")
+  static defaultEnabledIn = this.version("0.9.0")
   static autocorrectable = true
   static autofixRequiresContext = true
   static reindentAfterAutofix = true

--- a/javascript/packages/linter/src/rules/erb-no-empty-control-flow.ts
+++ b/javascript/packages/linter/src/rules/erb-no-empty-control-flow.ts
@@ -238,6 +238,7 @@ class ERBNoEmptyControlFlowVisitor extends BaseRuleVisitor {
 export class ERBNoEmptyControlFlowRule extends ParserRule {
   static ruleName = "erb-no-empty-control-flow"
   static introducedIn = this.version("0.9.1")
+  static defaultEnabledIn = this.version("0.9.1")
 
   get defaultConfig(): FullRuleConfig {
     return {

--- a/javascript/packages/linter/src/rules/erb-no-empty-tags.ts
+++ b/javascript/packages/linter/src/rules/erb-no-empty-tags.ts
@@ -35,6 +35,7 @@ class ERBNoEmptyTagsVisitor extends BaseRuleVisitor {
 export class ERBNoEmptyTagsRule extends ParserRule {
   static ruleName = "erb-no-empty-tags"
   static introducedIn = this.version("0.4.0")
+  static defaultEnabledIn = this.version("0.4.0")
 
   get defaultConfig(): FullRuleConfig {
     return {

--- a/javascript/packages/linter/src/rules/erb-no-extra-newline.ts
+++ b/javascript/packages/linter/src/rules/erb-no-extra-newline.ts
@@ -44,6 +44,7 @@ export class ERBNoExtraNewLineRule extends SourceRule {
   static autocorrectable = true
   static ruleName = "erb-no-extra-newline"
   static introducedIn = this.version("0.8.0")
+  static defaultEnabledIn = this.version("0.8.0")
 
   get defaultConfig(): FullRuleConfig {
     return {

--- a/javascript/packages/linter/src/rules/erb-no-extra-whitespace-inside-tags.ts
+++ b/javascript/packages/linter/src/rules/erb-no-extra-whitespace-inside-tags.ts
@@ -100,6 +100,7 @@ export class ERBNoExtraWhitespaceRule extends ParserRule<CommentedERBTagAutofixC
   static autocorrectable = true
   static ruleName = "erb-no-extra-whitespace-inside-tags"
   static introducedIn = this.version("0.8.0")
+  static defaultEnabledIn = this.version("0.8.0")
 
   get defaultConfig(): FullRuleConfig {
     return {

--- a/javascript/packages/linter/src/rules/erb-no-inline-case-conditions.ts
+++ b/javascript/packages/linter/src/rules/erb-no-inline-case-conditions.ts
@@ -33,6 +33,7 @@ class ERBNoInlineCaseConditionsVisitor extends BaseRuleVisitor {
 export class ERBNoInlineCaseConditionsRule extends ParserRule {
   static ruleName = "erb-no-inline-case-conditions"
   static introducedIn = this.version("0.9.0")
+  static defaultEnabledIn = this.version("0.9.0")
 
   get defaultConfig(): FullRuleConfig {
     return {

--- a/javascript/packages/linter/src/rules/erb-no-instance-variables-in-partials.ts
+++ b/javascript/packages/linter/src/rules/erb-no-instance-variables-in-partials.ts
@@ -60,6 +60,7 @@ class InstanceVariableCollector extends PrismVisitor {
 export class ERBNoInstanceVariablesInPartialsRule extends ParserRule {
   static ruleName = "erb-no-instance-variables-in-partials"
   static introducedIn = this.version("0.9.0")
+  static defaultEnabledIn = this.version("0.9.0")
 
   get defaultConfig(): FullRuleConfig {
     return {

--- a/javascript/packages/linter/src/rules/erb-no-interpolated-class-names.ts
+++ b/javascript/packages/linter/src/rules/erb-no-interpolated-class-names.ts
@@ -48,6 +48,7 @@ class ERBNoInterpolatedClassNamesVisitor extends AttributeVisitorMixin {
 export class ERBNoInterpolatedClassNamesRule extends ParserRule {
   static ruleName = "erb-no-interpolated-class-names"
   static introducedIn = this.version("0.9.0")
+  static defaultEnabledIn = this.version("0.9.0")
 
   get defaultConfig(): FullRuleConfig {
     return {

--- a/javascript/packages/linter/src/rules/erb-no-javascript-tag-helper.ts
+++ b/javascript/packages/linter/src/rules/erb-no-javascript-tag-helper.ts
@@ -31,6 +31,7 @@ class ERBNoJavascriptTagHelperVisitor extends BaseRuleVisitor {
 export class ERBNoJavascriptTagHelperRule extends ParserRule {
   static ruleName = "erb-no-javascript-tag-helper"
   static introducedIn = this.version("0.9.0")
+  static defaultEnabledIn = this.version("0.9.0")
 
   get defaultConfig(): FullRuleConfig {
     return {

--- a/javascript/packages/linter/src/rules/erb-no-method-definitions.ts
+++ b/javascript/packages/linter/src/rules/erb-no-method-definitions.ts
@@ -49,6 +49,7 @@ class MethodDefinitionCollector extends PrismVisitor {
 export class ERBNoMethodDefinitionsRule extends ParserRule {
   static ruleName = "erb-no-method-definitions"
   static introducedIn = this.version("unreleased")
+  static defaultEnabledIn = this.version("unreleased")
   static consumesParserErrors = true
 
   get defaultConfig(): FullRuleConfig {

--- a/javascript/packages/linter/src/rules/erb-no-module-definitions.ts
+++ b/javascript/packages/linter/src/rules/erb-no-module-definitions.ts
@@ -44,6 +44,7 @@ class ModuleDefinitionCollector extends PrismVisitor {
 export class ERBNoModuleDefinitionsRule extends ParserRule {
   static ruleName = "erb-no-module-definitions"
   static introducedIn = this.version("unreleased")
+  static defaultEnabledIn = this.version("unreleased")
 
   get defaultConfig(): FullRuleConfig {
     return {

--- a/javascript/packages/linter/src/rules/erb-no-output-control-flow.ts
+++ b/javascript/packages/linter/src/rules/erb-no-output-control-flow.ts
@@ -92,6 +92,7 @@ class ERBNoOutputControlFlowRuleVisitor extends BaseRuleVisitor<ERBNoOutputContr
 export class ERBNoOutputControlFlowRule extends ParserRule<ERBNoOutputControlFlowAutofixContext> {
   static ruleName = "erb-no-output-control-flow"
   static introducedIn = this.version("0.4.0")
+  static defaultEnabledIn = this.version("0.4.0")
   static autocorrectable = true
 
   get defaultConfig(): FullRuleConfig {

--- a/javascript/packages/linter/src/rules/erb-no-output-in-attribute-name.ts
+++ b/javascript/packages/linter/src/rules/erb-no-output-in-attribute-name.ts
@@ -24,6 +24,7 @@ class ERBNoOutputInAttributeNameVisitor extends BaseRuleVisitor {
 export class ERBNoOutputInAttributeNameRule extends ParserRule {
   static ruleName = "erb-no-output-in-attribute-name"
   static introducedIn = this.version("0.9.0")
+  static defaultEnabledIn = this.version("0.9.0")
 
   get defaultConfig(): FullRuleConfig {
     return {

--- a/javascript/packages/linter/src/rules/erb-no-output-in-attribute-position.ts
+++ b/javascript/packages/linter/src/rules/erb-no-output-in-attribute-position.ts
@@ -38,6 +38,7 @@ class ERBNoOutputInAttributePositionVisitor extends BaseRuleVisitor {
 export class ERBNoOutputInAttributePositionRule extends ParserRule {
   static ruleName = "erb-no-output-in-attribute-position"
   static introducedIn = this.version("0.9.0")
+  static defaultEnabledIn = this.version("0.9.0")
 
   get defaultConfig(): FullRuleConfig {
     return {

--- a/javascript/packages/linter/src/rules/erb-no-raw-output-in-attribute-value.ts
+++ b/javascript/packages/linter/src/rules/erb-no-raw-output-in-attribute-value.ts
@@ -32,6 +32,7 @@ class ERBNoRawOutputInAttributeValueVisitor extends AttributeVisitorMixin {
 export class ERBNoRawOutputInAttributeValueRule extends ParserRule {
   static ruleName = "erb-no-raw-output-in-attribute-value"
   static introducedIn = this.version("0.9.0")
+  static defaultEnabledIn = this.version("0.9.0")
 
   get defaultConfig(): FullRuleConfig {
     return {

--- a/javascript/packages/linter/src/rules/erb-no-return.ts
+++ b/javascript/packages/linter/src/rules/erb-no-return.ts
@@ -24,6 +24,7 @@ class ReturnCollector extends PrismVisitor {
 export class ERBNoReturnRule extends ParserRule {
   static ruleName = "erb-no-return"
   static introducedIn = this.version("unreleased")
+  static defaultEnabledIn = this.version("unreleased")
 
   get defaultConfig(): FullRuleConfig {
     return {

--- a/javascript/packages/linter/src/rules/erb-no-shadowed-block-argument.ts
+++ b/javascript/packages/linter/src/rules/erb-no-shadowed-block-argument.ts
@@ -77,6 +77,7 @@ class NoShadowedBlockArgumentVisitor extends BaseRuleVisitor {
 export class ERBNoShadowedBlockArgumentRule extends ParserRule {
   static ruleName = "erb-no-shadowed-block-argument"
   static introducedIn = this.version("unreleased")
+  static defaultEnabledIn = this.version("unreleased")
 
   get defaultConfig(): FullRuleConfig {
     return {

--- a/javascript/packages/linter/src/rules/erb-no-silent-tag-in-attribute-name.ts
+++ b/javascript/packages/linter/src/rules/erb-no-silent-tag-in-attribute-name.ts
@@ -29,6 +29,7 @@ class ERBNoSilentTagInAttributeNameVisitor extends BaseRuleVisitor {
 export class ERBNoSilentTagInAttributeNameRule extends ParserRule {
   static ruleName = "erb-no-silent-tag-in-attribute-name"
   static introducedIn = this.version("0.6.0")
+  static defaultEnabledIn = this.version("0.6.0")
 
   get defaultConfig(): FullRuleConfig {
     return {

--- a/javascript/packages/linter/src/rules/erb-no-sleep.ts
+++ b/javascript/packages/linter/src/rules/erb-no-sleep.ts
@@ -21,6 +21,7 @@ class SleepCallCollector extends PrismVisitor {
 export class ERBNoSleepRule extends ParserRule {
   static ruleName = "erb-no-sleep"
   static introducedIn = this.version("unreleased")
+  static defaultEnabledIn = this.version("unreleased")
 
   get defaultConfig(): FullRuleConfig {
     return {

--- a/javascript/packages/linter/src/rules/erb-no-statement-in-script.ts
+++ b/javascript/packages/linter/src/rules/erb-no-statement-in-script.ts
@@ -68,6 +68,7 @@ class ERBNoStatementInScriptVisitor extends BaseRuleVisitor {
 export class ERBNoStatementInScriptRule extends ParserRule {
   static ruleName = "erb-no-statement-in-script"
   static introducedIn = this.version("0.9.0")
+  static defaultEnabledIn = this.version("0.9.0")
 
   get defaultConfig(): FullRuleConfig {
     return {

--- a/javascript/packages/linter/src/rules/erb-no-then-in-control-flow.ts
+++ b/javascript/packages/linter/src/rules/erb-no-then-in-control-flow.ts
@@ -41,6 +41,7 @@ class ERBNoThenInControlFlowVisitor extends BaseRuleVisitor {
 export class ERBNoThenInControlFlowRule extends ParserRule {
   static ruleName = "erb-no-then-in-control-flow"
   static introducedIn = this.version("0.9.0")
+  static defaultEnabledIn = this.version("0.9.0")
 
   get defaultConfig(): FullRuleConfig {
     return {

--- a/javascript/packages/linter/src/rules/erb-no-trailing-whitespace.ts
+++ b/javascript/packages/linter/src/rules/erb-no-trailing-whitespace.ts
@@ -97,6 +97,7 @@ export class ERBNoTrailingWhitespaceRule extends ParserRule<ERBNoTrailingWhitesp
   static autocorrectable = true
   static ruleName = "erb-no-trailing-whitespace"
   static introducedIn = this.version("0.9.0")
+  static defaultEnabledIn = this.version("0.9.0")
 
   get defaultConfig(): FullRuleConfig {
     return {

--- a/javascript/packages/linter/src/rules/erb-no-unsafe-js-attribute.ts
+++ b/javascript/packages/linter/src/rules/erb-no-unsafe-js-attribute.ts
@@ -32,6 +32,7 @@ class ERBNoUnsafeJSAttributeVisitor extends AttributeVisitorMixin {
 export class ERBNoUnsafeJSAttributeRule extends ParserRule {
   static ruleName = "erb-no-unsafe-js-attribute"
   static introducedIn = this.version("0.9.0")
+  static defaultEnabledIn = this.version("0.9.0")
 
   get defaultConfig(): FullRuleConfig {
     return {

--- a/javascript/packages/linter/src/rules/erb-no-unsafe-raw.ts
+++ b/javascript/packages/linter/src/rules/erb-no-unsafe-raw.ts
@@ -101,6 +101,7 @@ class ERBNoUnsafeRawVisitor extends ElementStackVisitor {
 export class ERBNoUnsafeRawRule extends ParserRule {
   static ruleName = "erb-no-unsafe-raw"
   static introducedIn = this.version("0.9.0")
+  static defaultEnabledIn = this.version("0.9.0")
 
   get defaultConfig(): FullRuleConfig {
     return {

--- a/javascript/packages/linter/src/rules/erb-no-unsafe-script-interpolation.ts
+++ b/javascript/packages/linter/src/rules/erb-no-unsafe-script-interpolation.ts
@@ -99,6 +99,7 @@ class ERBNoUnsafeScriptInterpolationVisitor extends BaseRuleVisitor {
 export class ERBNoUnsafeScriptInterpolationRule extends ParserRule {
   static ruleName = "erb-no-unsafe-script-interpolation"
   static introducedIn = this.version("0.9.0")
+  static defaultEnabledIn = this.version("0.9.0")
 
   get defaultConfig(): FullRuleConfig {
     return {

--- a/javascript/packages/linter/src/rules/erb-no-unused-block-argument.ts
+++ b/javascript/packages/linter/src/rules/erb-no-unused-block-argument.ts
@@ -235,6 +235,7 @@ class NoUnusedBlockArgumentVisitor extends BaseRuleVisitor {
 export class ERBNoUnusedBlockArgumentRule extends ParserRule {
   static ruleName = "erb-no-unused-block-argument"
   static introducedIn = this.version("unreleased")
+  static defaultEnabledIn = this.version("unreleased")
 
   get defaultConfig(): FullRuleConfig {
     return {

--- a/javascript/packages/linter/src/rules/erb-no-unused-expressions.ts
+++ b/javascript/packages/linter/src/rules/erb-no-unused-expressions.ts
@@ -224,6 +224,7 @@ class ERBNoUnusedExpressionsVisitor extends BaseRuleVisitor {
 export class ERBNoUnusedExpressionsRule extends ParserRule {
   static ruleName = "erb-no-unused-expressions"
   static introducedIn = this.version("0.9.3")
+  static defaultEnabledIn = this.version("0.9.3")
 
   get defaultConfig(): FullRuleConfig {
     return {

--- a/javascript/packages/linter/src/rules/erb-no-unused-literals.ts
+++ b/javascript/packages/linter/src/rules/erb-no-unused-literals.ts
@@ -168,6 +168,7 @@ class ERBNoUnusedLiteralsVisitor extends BaseRuleVisitor {
 export class ERBNoUnusedLiteralsRule extends ParserRule {
   static ruleName = "erb-no-unused-literals"
   static introducedIn = this.version("0.9.3")
+  static defaultEnabledIn = this.version("0.9.3")
 
   get defaultConfig(): FullRuleConfig {
     return {

--- a/javascript/packages/linter/src/rules/erb-no-unused-local-variable.ts
+++ b/javascript/packages/linter/src/rules/erb-no-unused-local-variable.ts
@@ -113,6 +113,7 @@ class LocalVariableCollector extends PrismVisitor {
 export class ERBNoUnusedLocalVariableRule extends ParserRule {
   static ruleName = "erb-no-unused-local-variable"
   static introducedIn = this.version("unreleased")
+  static defaultEnabledIn = this.version("unreleased")
 
   get defaultConfig(): FullRuleConfig {
     return {

--- a/javascript/packages/linter/src/rules/erb-prefer-direct-output.ts
+++ b/javascript/packages/linter/src/rules/erb-prefer-direct-output.ts
@@ -122,6 +122,7 @@ class PreferDirectOutputVisitor extends BaseRuleVisitor<PreferDirectOutputAutofi
 export class ERBPreferDirectOutputRule extends ParserRule<PreferDirectOutputAutofixContext> {
   static ruleName = "erb-prefer-direct-output"
   static introducedIn = this.version("0.9.4")
+  static defaultEnabledIn = this.version("0.9.4")
   static autocorrectable = true
 
   get defaultConfig(): FullRuleConfig {

--- a/javascript/packages/linter/src/rules/erb-prefer-do-end-blocks.ts
+++ b/javascript/packages/linter/src/rules/erb-prefer-do-end-blocks.ts
@@ -66,6 +66,7 @@ class PreferDoEndBlocksVisitor extends BaseRuleVisitor<PreferDoEndBlocksAutofixC
 export class ERBPreferDoEndBlocksRule extends ParserRule<PreferDoEndBlocksAutofixContext> {
   static ruleName = "erb-prefer-do-end-blocks"
   static introducedIn = this.version("unreleased")
+  static defaultEnabledIn = this.version("unreleased")
   static autocorrectable = true
 
   get defaultConfig(): FullRuleConfig {

--- a/javascript/packages/linter/src/rules/erb-prefer-each-over-map.ts
+++ b/javascript/packages/linter/src/rules/erb-prefer-each-over-map.ts
@@ -32,6 +32,7 @@ class PreferEachOverMapVisitor extends BaseRuleVisitor {
 export class ERBPreferEachOverMapRule extends ParserRule {
   static ruleName = "erb-prefer-each-over-map"
   static introducedIn = this.version("unreleased")
+  static defaultEnabledIn = this.version("unreleased")
 
   get defaultConfig(): FullRuleConfig {
     return {

--- a/javascript/packages/linter/src/rules/erb-prefer-image-tag-helper.ts
+++ b/javascript/packages/linter/src/rules/erb-prefer-image-tag-helper.ts
@@ -94,6 +94,7 @@ class ERBPreferImageTagHelperVisitor extends BaseRuleVisitor {
 export class ERBPreferImageTagHelperRule extends ParserRule {
   static ruleName = "erb-prefer-image-tag-helper"
   static introducedIn = this.version("0.4.3")
+  static defaultEnabledIn = this.version("0.4.3")
 
   get defaultConfig(): FullRuleConfig {
     return {

--- a/javascript/packages/linter/src/rules/erb-require-trailing-newline.ts
+++ b/javascript/packages/linter/src/rules/erb-require-trailing-newline.ts
@@ -26,6 +26,7 @@ export class ERBRequireTrailingNewlineRule extends SourceRule {
   static autocorrectable = true
   static ruleName = "erb-require-trailing-newline"
   static introducedIn = this.version("0.8.0")
+  static defaultEnabledIn = this.version("0.8.0")
 
   get defaultConfig(): FullRuleConfig {
     return {

--- a/javascript/packages/linter/src/rules/erb-require-whitespace-inside-tags.ts
+++ b/javascript/packages/linter/src/rules/erb-require-whitespace-inside-tags.ts
@@ -120,6 +120,7 @@ export class ERBRequireWhitespaceRule extends ParserRule<CommentedERBTagAutofixC
   static autocorrectable = true
   static ruleName = "erb-require-whitespace-inside-tags"
   static introducedIn = this.version("0.4.0")
+  static defaultEnabledIn = this.version("0.4.0")
 
   get defaultConfig(): FullRuleConfig {
     return {

--- a/javascript/packages/linter/src/rules/erb-right-trim.ts
+++ b/javascript/packages/linter/src/rules/erb-right-trim.ts
@@ -28,6 +28,7 @@ export class ERBRightTrimRule extends ParserRule<ERBRightTrimAutofixContext> {
   static autocorrectable = true
   static ruleName = "erb-right-trim"
   static introducedIn = this.version("0.7.5")
+  static defaultEnabledIn = this.version("0.7.5")
 
   get defaultConfig(): FullRuleConfig {
     return {

--- a/javascript/packages/linter/src/rules/erb-strict-locals-comment-syntax.ts
+++ b/javascript/packages/linter/src/rules/erb-strict-locals-comment-syntax.ts
@@ -498,6 +498,7 @@ export class ERBStrictLocalsCommentSyntaxRule extends ParserRule<ERBStrictLocals
   static consumesParserErrors = true
   static ruleName = "erb-strict-locals-comment-syntax"
   static introducedIn = this.version("0.8.8")
+  static defaultEnabledIn = this.version("0.8.8")
 
   get parserOptions() {
     return {

--- a/javascript/packages/linter/src/rules/herb-component-requires-slots.ts
+++ b/javascript/packages/linter/src/rules/herb-component-requires-slots.ts
@@ -46,6 +46,7 @@ class ComponentRequiresSlotsVisitor extends BaseRuleVisitor {
 export class HerbComponentRequiresSlotsRule extends ParserRule {
   static ruleName = "herb-component-requires-slots"
   static introducedIn = this.version("unreleased")
+  static defaultEnabledIn = this.version("unreleased")
 
   get defaultConfig(): FullRuleConfig {
     return {

--- a/javascript/packages/linter/src/rules/herb-config-framework-option.ts
+++ b/javascript/packages/linter/src/rules/herb-config-framework-option.ts
@@ -82,6 +82,7 @@ class StrictLocalsCollector extends BaseRuleVisitor {
 export class HerbConfigFrameworkOptionRule extends ParserRule {
   static ruleName = "herb-config-framework-option"
   static introducedIn = this.version("unreleased")
+  static defaultEnabledIn = this.version("unreleased")
   static reportsOncePerRun = true
 
   get defaultConfig(): FullRuleConfig {

--- a/javascript/packages/linter/src/rules/herb-disable-comment-malformed.ts
+++ b/javascript/packages/linter/src/rules/herb-disable-comment-malformed.ts
@@ -49,6 +49,7 @@ class HerbDisableCommentMalformedVisitor extends HerbDisableCommentBaseVisitor {
 export class HerbDisableCommentMalformedRule extends ParserRule {
   static ruleName = "herb-disable-comment-malformed"
   static introducedIn = this.version("0.8.0")
+  static defaultEnabledIn = this.version("0.8.0")
 
   get defaultConfig(): FullRuleConfig {
     return {

--- a/javascript/packages/linter/src/rules/herb-disable-comment-missing-rules.ts
+++ b/javascript/packages/linter/src/rules/herb-disable-comment-missing-rules.ts
@@ -24,6 +24,7 @@ class HerbDisableCommentMissingRulesVisitor extends HerbDisableCommentBaseVisito
 export class HerbDisableCommentMissingRulesRule extends ParserRule {
   static ruleName = "herb-disable-comment-missing-rules"
   static introducedIn = this.version("0.8.0")
+  static defaultEnabledIn = this.version("0.8.0")
 
   get defaultConfig(): FullRuleConfig {
     return {

--- a/javascript/packages/linter/src/rules/herb-disable-comment-no-duplicate-rules.ts
+++ b/javascript/packages/linter/src/rules/herb-disable-comment-no-duplicate-rules.ts
@@ -29,6 +29,7 @@ class HerbDisableCommentNoDuplicateRulesVisitor extends HerbDisableCommentParsed
 export class HerbDisableCommentNoDuplicateRulesRule extends ParserRule {
   static ruleName = "herb-disable-comment-no-duplicate-rules"
   static introducedIn = this.version("0.8.0")
+  static defaultEnabledIn = this.version("0.8.0")
 
   get defaultConfig(): FullRuleConfig {
     return {

--- a/javascript/packages/linter/src/rules/herb-disable-comment-no-redundant-all.ts
+++ b/javascript/packages/linter/src/rules/herb-disable-comment-no-redundant-all.ts
@@ -23,6 +23,7 @@ class HerbDisableCommentNoRedundantAllVisitor extends HerbDisableCommentParsedVi
 export class HerbDisableCommentNoRedundantAllRule extends ParserRule {
   static ruleName = "herb-disable-comment-no-redundant-all"
   static introducedIn = this.version("0.8.0")
+  static defaultEnabledIn = this.version("0.8.0")
 
   get defaultConfig(): FullRuleConfig {
     return {

--- a/javascript/packages/linter/src/rules/herb-disable-comment-unnecessary.ts
+++ b/javascript/packages/linter/src/rules/herb-disable-comment-unnecessary.ts
@@ -74,6 +74,7 @@ class HerbDisableCommentUnnecessaryVisitor extends HerbDisableCommentParsedVisit
 export class HerbDisableCommentUnnecessaryRule extends ParserRule {
   static ruleName = "herb-disable-comment-unnecessary"
   static introducedIn = this.version("0.8.0")
+  static defaultEnabledIn = this.version("0.8.0")
 
   get defaultConfig(): FullRuleConfig {
     return {

--- a/javascript/packages/linter/src/rules/herb-disable-comment-valid-rule-name.ts
+++ b/javascript/packages/linter/src/rules/herb-disable-comment-valid-rule-name.ts
@@ -36,6 +36,7 @@ class HerbDisableCommentValidRuleNameVisitor extends HerbDisableCommentParsedVis
 export class HerbDisableCommentValidRuleNameRule extends ParserRule {
   static ruleName = "herb-disable-comment-valid-rule-name"
   static introducedIn = this.version("0.8.0")
+  static defaultEnabledIn = this.version("0.8.0")
 
   get defaultConfig(): FullRuleConfig {
     return {

--- a/javascript/packages/linter/src/rules/herb-into-requires-collection.ts
+++ b/javascript/packages/linter/src/rules/herb-into-requires-collection.ts
@@ -121,6 +121,7 @@ function keysItems(node: Node): boolean {
 export class HerbIntoRequiresCollectionRule extends ParserRule {
   static ruleName = "herb-into-requires-collection"
   static introducedIn = this.version("unreleased")
+  static defaultEnabledIn = this.version("unreleased")
 
   get defaultConfig(): FullRuleConfig {
     return {

--- a/javascript/packages/linter/src/rules/herb-scoped-style-no-unused-selector.ts
+++ b/javascript/packages/linter/src/rules/herb-scoped-style-no-unused-selector.ts
@@ -379,6 +379,7 @@ class ScopedStyleNoUnusedSelectorVisitor extends ElementStackVisitor {
 export class HerbScopedStyleNoUnusedSelectorRule extends ParserRule {
   static ruleName = "herb-scoped-style-no-unused-selector"
   static introducedIn = this.version("unreleased")
+  static defaultEnabledIn = this.version("unreleased")
 
   get defaultConfig(): FullRuleConfig {
     return {

--- a/javascript/packages/linter/src/rules/herb-scoped-style-require-top-level.ts
+++ b/javascript/packages/linter/src/rules/herb-scoped-style-require-top-level.ts
@@ -32,6 +32,7 @@ class ScopedStyleRequireTopLevelVisitor extends BaseRuleVisitor {
 export class HerbScopedStyleRequireTopLevelRule extends ParserRule {
   static ruleName = "herb-scoped-style-require-top-level"
   static introducedIn = this.version("unreleased")
+  static defaultEnabledIn = this.version("unreleased")
 
   get defaultConfig(): FullRuleConfig {
     return {

--- a/javascript/packages/linter/src/rules/herb-scoped-style-single-declaration.ts
+++ b/javascript/packages/linter/src/rules/herb-scoped-style-single-declaration.ts
@@ -28,6 +28,7 @@ class ScopedStyleSingleDeclarationVisitor extends BaseRuleVisitor {
 export class HerbScopedStyleSingleDeclarationRule extends ParserRule {
   static ruleName = "herb-scoped-style-single-declaration"
   static introducedIn = this.version("unreleased")
+  static defaultEnabledIn = this.version("unreleased")
 
   get defaultConfig(): FullRuleConfig {
     return {

--- a/javascript/packages/linter/src/rules/herb-slots-single-directive.ts
+++ b/javascript/packages/linter/src/rules/herb-slots-single-directive.ts
@@ -38,6 +38,7 @@ class SlotsSingleDirectiveVisitor extends BaseRuleVisitor {
 export class HerbSlotsSingleDirectiveRule extends ParserRule {
   static ruleName = "herb-slots-single-directive"
   static introducedIn = this.version("unreleased")
+  static defaultEnabledIn = this.version("unreleased")
 
   get defaultConfig(): FullRuleConfig {
     return {

--- a/javascript/packages/linter/src/rules/herb-slots-valid-components.ts
+++ b/javascript/packages/linter/src/rules/herb-slots-valid-components.ts
@@ -182,6 +182,7 @@ class SlotsValidComponentsVisitor extends BaseRuleVisitor {
 export class HerbSlotsValidComponentsRule extends ParserRule {
   static ruleName = "herb-slots-valid-components"
   static introducedIn = this.version("unreleased")
+  static defaultEnabledIn = this.version("unreleased")
 
   get parserOptions(): Partial<ParserOptions> {
     return {

--- a/javascript/packages/linter/src/rules/herb-slots-valid-mode.ts
+++ b/javascript/packages/linter/src/rules/herb-slots-valid-mode.ts
@@ -55,6 +55,7 @@ class SlotsValidModeVisitor extends BaseRuleVisitor {
 export class HerbSlotsValidModeRule extends ParserRule {
   static ruleName = "herb-slots-valid-mode"
   static introducedIn = this.version("unreleased")
+  static defaultEnabledIn = this.version("unreleased")
 
   get defaultConfig(): FullRuleConfig {
     return {

--- a/javascript/packages/linter/src/rules/herb-state-directive-syntax.ts
+++ b/javascript/packages/linter/src/rules/herb-state-directive-syntax.ts
@@ -77,6 +77,7 @@ export class HerbStateDirectiveSyntaxRule extends ParserRule<HerbStateDirectiveS
   static consumesParserErrors = true
   static ruleName = "herb-state-directive-syntax"
   static introducedIn = this.version("unreleased")
+  static defaultEnabledIn = this.version("unreleased")
 
   get parserOptions() {
     return {

--- a/javascript/packages/linter/src/rules/herb-state-no-server-writes.ts
+++ b/javascript/packages/linter/src/rules/herb-state-no-server-writes.ts
@@ -254,6 +254,7 @@ class StateNoServerWritesVisitor extends BaseRuleVisitor {
 export class HerbStateNoServerWritesRule extends ParserRule {
   static ruleName = "herb-state-no-server-writes"
   static introducedIn = this.version("unreleased")
+  static defaultEnabledIn = this.version("unreleased")
 
   get parserOptions(): Partial<ParserOptions> {
     return {

--- a/javascript/packages/linter/src/rules/herb-state-no-shadowed-states.ts
+++ b/javascript/packages/linter/src/rules/herb-state-no-shadowed-states.ts
@@ -100,6 +100,7 @@ class NoShadowedStatesVisitor extends BaseRuleVisitor {
 export class HerbStateNoShadowedStatesRule extends ParserRule {
   static ruleName = "herb-state-no-shadowed-states"
   static introducedIn = this.version("unreleased")
+  static defaultEnabledIn = this.version("unreleased")
 
   get defaultConfig(): FullRuleConfig {
     return {

--- a/javascript/packages/linter/src/rules/herb-state-no-silent-reads.ts
+++ b/javascript/packages/linter/src/rules/herb-state-no-silent-reads.ts
@@ -49,6 +49,7 @@ class StateNoSilentReadsVisitor extends BaseRuleVisitor {
 export class HerbStateNoSilentReadsRule extends ParserRule {
   static ruleName = "herb-state-no-silent-reads"
   static introducedIn = this.version("unreleased")
+  static defaultEnabledIn = this.version("unreleased")
 
   get defaultConfig(): FullRuleConfig {
     return {

--- a/javascript/packages/linter/src/rules/herb-state-no-unused-states.ts
+++ b/javascript/packages/linter/src/rules/herb-state-no-unused-states.ts
@@ -124,6 +124,7 @@ class UnusedStatesVisitor extends BaseRuleVisitor {
 export class HerbStateNoUnusedStatesRule extends ParserRule {
   static ruleName = "herb-state-no-unused-states"
   static introducedIn = this.version("unreleased")
+  static defaultEnabledIn = this.version("unreleased")
 
   get parserOptions(): Partial<ParserOptions> {
     return {

--- a/javascript/packages/linter/src/rules/herb-state-requires-slots.ts
+++ b/javascript/packages/linter/src/rules/herb-state-requires-slots.ts
@@ -32,6 +32,7 @@ class StateRequiresSlotsVisitor extends BaseRuleVisitor {
 export class HerbStateRequiresSlotsRule extends ParserRule {
   static ruleName = "herb-state-requires-slots"
   static introducedIn = this.version("unreleased")
+  static defaultEnabledIn = this.version("unreleased")
 
   get defaultConfig(): FullRuleConfig {
     return {

--- a/javascript/packages/linter/src/rules/herb-state-single-declaration.ts
+++ b/javascript/packages/linter/src/rules/herb-state-single-declaration.ts
@@ -39,6 +39,7 @@ class StateSingleDeclarationVisitor extends BaseRuleVisitor {
 export class HerbStateSingleDeclarationRule extends ParserRule {
   static ruleName = "herb-state-single-declaration"
   static introducedIn = this.version("unreleased")
+  static defaultEnabledIn = this.version("unreleased")
 
   get defaultConfig(): FullRuleConfig {
     return {

--- a/javascript/packages/linter/src/rules/herb-state-valid-actions.ts
+++ b/javascript/packages/linter/src/rules/herb-state-valid-actions.ts
@@ -242,6 +242,7 @@ class StateValidActionsVisitor extends BaseRuleVisitor {
 export class HerbStateValidActionsRule extends ParserRule {
   static ruleName = "herb-state-valid-actions"
   static introducedIn = this.version("unreleased")
+  static defaultEnabledIn = this.version("unreleased")
 
   get parserOptions(): Partial<ParserOptions> {
     return {

--- a/javascript/packages/linter/src/rules/herb-state-valid-bindings.ts
+++ b/javascript/packages/linter/src/rules/herb-state-valid-bindings.ts
@@ -170,6 +170,7 @@ function capitalize(word: string): string {
 export class HerbStateValidBindingsRule extends ParserRule {
   static ruleName = "herb-state-valid-bindings"
   static introducedIn = this.version("unreleased")
+  static defaultEnabledIn = this.version("unreleased")
 
   get parserOptions(): Partial<ParserOptions> {
     return {

--- a/javascript/packages/linter/src/rules/herb-state-valid-declaration.ts
+++ b/javascript/packages/linter/src/rules/herb-state-valid-declaration.ts
@@ -199,6 +199,7 @@ class StateValidDeclarationVisitor extends BaseRuleVisitor {
 export class HerbStateValidDeclarationRule extends ParserRule {
   static ruleName = "herb-state-valid-declaration"
   static introducedIn = this.version("unreleased")
+  static defaultEnabledIn = this.version("unreleased")
 
   get parserOptions(): Partial<ParserOptions> {
     return {

--- a/javascript/packages/linter/src/rules/herb-state-valid-reads.ts
+++ b/javascript/packages/linter/src/rules/herb-state-valid-reads.ts
@@ -739,6 +739,7 @@ function capitalize(word: string): string {
 export class HerbStateValidReadsRule extends ParserRule {
   static ruleName = "herb-state-valid-reads"
   static introducedIn = this.version("unreleased")
+  static defaultEnabledIn = this.version("unreleased")
 
   get parserOptions(): Partial<ParserOptions> {
     return {

--- a/javascript/packages/linter/src/rules/herb-valid-slot-names.ts
+++ b/javascript/packages/linter/src/rules/herb-valid-slot-names.ts
@@ -193,6 +193,7 @@ function containsERB(node: Node): boolean {
 export class HerbValidSlotNamesRule extends ParserRule {
   static ruleName = "herb-valid-slot-names"
   static introducedIn = this.version("unreleased")
+  static defaultEnabledIn = this.version("unreleased")
 
   get defaultConfig(): FullRuleConfig {
     return {

--- a/javascript/packages/linter/src/rules/html-allowed-script-type.ts
+++ b/javascript/packages/linter/src/rules/html-allowed-script-type.ts
@@ -67,6 +67,7 @@ class AllowedScriptTypeVisitor extends BaseRuleVisitor {
 export class HTMLAllowedScriptTypeRule extends ParserRule {
   static ruleName = "html-allowed-script-type"
   static introducedIn = this.version("0.9.0")
+  static defaultEnabledIn = this.version("0.9.0")
 
   get defaultConfig(): FullRuleConfig {
     return {

--- a/javascript/packages/linter/src/rules/html-anchor-require-href.ts
+++ b/javascript/packages/linter/src/rules/html-anchor-require-href.ts
@@ -85,6 +85,7 @@ class AnchorRequireHrefVisitor extends BaseRuleVisitor {
 export class HTMLAnchorRequireHrefRule extends ParserRule {
   static ruleName = "html-anchor-require-href"
   static introducedIn = this.version("0.4.0")
+  static defaultEnabledIn = this.version("0.4.0")
 
   get defaultConfig(): FullRuleConfig {
     return {

--- a/javascript/packages/linter/src/rules/html-aria-attribute-must-be-valid.ts
+++ b/javascript/packages/linter/src/rules/html-aria-attribute-must-be-valid.ts
@@ -27,6 +27,7 @@ class AriaAttributeMustBeValid extends AttributeVisitorMixin {
 export class HTMLAriaAttributeMustBeValid extends ParserRule {
   static ruleName = "html-aria-attribute-must-be-valid"
   static introducedIn = this.version("0.4.1")
+  static defaultEnabledIn = this.version("0.4.1")
 
   get defaultConfig(): FullRuleConfig {
     return {

--- a/javascript/packages/linter/src/rules/html-aria-label-is-well-formatted.ts
+++ b/javascript/packages/linter/src/rules/html-aria-label-is-well-formatted.ts
@@ -46,6 +46,7 @@ class AriaLabelIsWellFormattedVisitor extends AttributeVisitorMixin {
 export class HTMLAriaLabelIsWellFormattedRule extends ParserRule {
   static ruleName = "html-aria-label-is-well-formatted"
   static introducedIn = this.version("0.6.0")
+  static defaultEnabledIn = this.version("0.6.0")
 
   get defaultConfig(): FullRuleConfig {
     return {

--- a/javascript/packages/linter/src/rules/html-aria-level-must-be-valid.ts
+++ b/javascript/packages/linter/src/rules/html-aria-level-must-be-valid.ts
@@ -65,6 +65,7 @@ class HTMLAriaLevelMustBeValidVisitor extends AttributeVisitorMixin {
 export class HTMLAriaLevelMustBeValidRule extends ParserRule {
   static ruleName = "html-aria-level-must-be-valid"
   static introducedIn = this.version("0.4.3")
+  static defaultEnabledIn = this.version("0.4.3")
 
   get defaultConfig(): FullRuleConfig {
     return {

--- a/javascript/packages/linter/src/rules/html-aria-role-heading-requires-level.ts
+++ b/javascript/packages/linter/src/rules/html-aria-role-heading-requires-level.ts
@@ -23,6 +23,7 @@ class AriaRoleHeadingRequiresLevel extends AttributeVisitorMixin {
 export class HTMLAriaRoleHeadingRequiresLevelRule extends ParserRule {
   static ruleName = "html-aria-role-heading-requires-level"
   static introducedIn = this.version("0.4.0")
+  static defaultEnabledIn = this.version("0.4.0")
 
   get defaultConfig(): FullRuleConfig {
     return {

--- a/javascript/packages/linter/src/rules/html-aria-role-must-be-valid.ts
+++ b/javascript/packages/linter/src/rules/html-aria-role-must-be-valid.ts
@@ -20,6 +20,7 @@ class AriaRoleMustBeValid extends AttributeVisitorMixin {
 export class HTMLAriaRoleMustBeValidRule extends ParserRule {
   static ruleName = "html-aria-role-must-be-valid"
   static introducedIn = this.version("0.4.1")
+  static defaultEnabledIn = this.version("0.4.1")
 
   get defaultConfig(): FullRuleConfig {
     return {

--- a/javascript/packages/linter/src/rules/html-attribute-double-quotes.ts
+++ b/javascript/packages/linter/src/rules/html-attribute-double-quotes.ts
@@ -46,6 +46,7 @@ export class HTMLAttributeDoubleQuotesRule extends ParserRule<AttributeDoubleQuo
   static autocorrectable = true
   static ruleName = "html-attribute-double-quotes"
   static introducedIn = this.version("0.4.0")
+  static defaultEnabledIn = this.version("0.4.0")
 
   get defaultConfig(): FullRuleConfig {
     return {

--- a/javascript/packages/linter/src/rules/html-attribute-equals-spacing.ts
+++ b/javascript/packages/linter/src/rules/html-attribute-equals-spacing.ts
@@ -36,6 +36,7 @@ export class HTMLAttributeEqualsSpacingRule extends ParserRule<AttributeEqualsSp
   static autocorrectable = true
   static ruleName = "html-attribute-equals-spacing"
   static introducedIn = this.version("0.6.0")
+  static defaultEnabledIn = this.version("0.6.0")
 
   get defaultConfig(): FullRuleConfig {
     return {

--- a/javascript/packages/linter/src/rules/html-attribute-name-valid-characters.ts
+++ b/javascript/packages/linter/src/rules/html-attribute-name-valid-characters.ts
@@ -113,6 +113,7 @@ class HTMLAttributeNameValidCharactersVisitor extends AttributeVisitorMixin {
 export class HTMLAttributeNameValidCharactersRule extends ParserRule {
   static ruleName = "html-attribute-name-valid-characters"
   static introducedIn = this.version("unreleased")
+  static defaultEnabledIn = this.version("unreleased")
 
   get defaultConfig(): FullRuleConfig {
     return {

--- a/javascript/packages/linter/src/rules/html-attribute-values-require-quotes.ts
+++ b/javascript/packages/linter/src/rules/html-attribute-values-require-quotes.ts
@@ -54,6 +54,7 @@ export class HTMLAttributeValuesRequireQuotesRule extends ParserRule<AttributeVa
   static autocorrectable = true
   static ruleName = "html-attribute-values-require-quotes"
   static introducedIn = this.version("0.4.0")
+  static defaultEnabledIn = this.version("0.4.0")
 
   get defaultConfig(): FullRuleConfig {
     return {

--- a/javascript/packages/linter/src/rules/html-avoid-both-disabled-and-aria-disabled.ts
+++ b/javascript/packages/linter/src/rules/html-avoid-both-disabled-and-aria-disabled.ts
@@ -54,6 +54,7 @@ class AvoidBothDisabledAndAriaDisabledVisitor extends BaseRuleVisitor {
 export class HTMLAvoidBothDisabledAndAriaDisabledRule extends ParserRule {
   static ruleName = "html-avoid-both-disabled-and-aria-disabled"
   static introducedIn = this.version("0.6.0")
+  static defaultEnabledIn = this.version("0.6.0")
 
   get defaultConfig(): FullRuleConfig {
     return {

--- a/javascript/packages/linter/src/rules/html-body-only-elements.ts
+++ b/javascript/packages/linter/src/rules/html-body-only-elements.ts
@@ -30,6 +30,7 @@ export class HTMLBodyOnlyElementsRule extends ParserRule {
   static autocorrectable = false
   static ruleName = "html-body-only-elements"
   static introducedIn = this.version("0.8.0")
+  static defaultEnabledIn = this.version("0.8.0")
 
   get defaultConfig(): FullRuleConfig {
     return {

--- a/javascript/packages/linter/src/rules/html-boolean-attributes-no-value.ts
+++ b/javascript/packages/linter/src/rules/html-boolean-attributes-no-value.ts
@@ -84,6 +84,7 @@ export class HTMLBooleanAttributesNoValueRule extends ParserRule<BooleanAttribut
   static autocorrectable = true
   static ruleName = "html-boolean-attributes-no-value"
   static introducedIn = this.version("0.4.0")
+  static defaultEnabledIn = this.version("0.4.0")
 
   get defaultConfig(): FullRuleConfig {
     return {

--- a/javascript/packages/linter/src/rules/html-details-has-summary.ts
+++ b/javascript/packages/linter/src/rules/html-details-has-summary.ts
@@ -48,6 +48,7 @@ class DetailsHasSummaryVisitor extends BaseRuleVisitor {
 export class HTMLDetailsHasSummaryRule extends ParserRule {
   static ruleName = "html-details-has-summary"
   static introducedIn = this.version("0.9.0")
+  static defaultEnabledIn = this.version("0.9.0")
 
   get defaultConfig(): FullRuleConfig {
     return {

--- a/javascript/packages/linter/src/rules/html-head-only-elements.ts
+++ b/javascript/packages/linter/src/rules/html-head-only-elements.ts
@@ -94,6 +94,7 @@ export class HTMLHeadOnlyElementsRule extends ParserRule {
   static autocorrectable = false
   static ruleName = "html-head-only-elements"
   static introducedIn = this.version("0.8.0")
+  static defaultEnabledIn = this.version("0.8.0")
 
   get defaultConfig(): FullRuleConfig {
     return {

--- a/javascript/packages/linter/src/rules/html-iframe-has-title.ts
+++ b/javascript/packages/linter/src/rules/html-iframe-has-title.ts
@@ -47,6 +47,7 @@ class IframeHasTitleVisitor extends BaseRuleVisitor {
 export class HTMLIframeHasTitleRule extends ParserRule {
   static ruleName = "html-iframe-has-title"
   static introducedIn = this.version("0.6.0")
+  static defaultEnabledIn = this.version("0.6.0")
 
   get defaultConfig(): FullRuleConfig {
     return {

--- a/javascript/packages/linter/src/rules/html-img-require-alt.ts
+++ b/javascript/packages/linter/src/rules/html-img-require-alt.ts
@@ -54,6 +54,7 @@ class ImgRequireAltVisitor extends BaseRuleVisitor {
 export class HTMLImgRequireAltRule extends ParserRule {
   static ruleName = "html-img-require-alt"
   static introducedIn = this.version("0.4.0")
+  static defaultEnabledIn = this.version("0.4.0")
 
   get defaultConfig(): FullRuleConfig {
     return {

--- a/javascript/packages/linter/src/rules/html-input-require-autocomplete.ts
+++ b/javascript/packages/linter/src/rules/html-input-require-autocomplete.ts
@@ -67,6 +67,7 @@ class HTMLInputRequireAutocompleteVisitor extends BaseRuleVisitor {
 export class HTMLInputRequireAutocompleteRule extends ParserRule {
   static ruleName = "html-input-require-autocomplete"
   static introducedIn = this.version("0.8.0")
+  static defaultEnabledIn = this.version("0.8.0")
 
   get defaultConfig(): FullRuleConfig {
     return {

--- a/javascript/packages/linter/src/rules/html-no-abstract-roles.ts
+++ b/javascript/packages/linter/src/rules/html-no-abstract-roles.ts
@@ -23,6 +23,7 @@ class NoAbstractRolesVisitor extends AttributeVisitorMixin {
 export class HTMLNoAbstractRolesRule extends ParserRule {
   static ruleName = "html-no-abstract-roles"
   static introducedIn = this.version("0.9.0")
+  static defaultEnabledIn = this.version("0.9.0")
 
   get defaultConfig(): FullRuleConfig {
     return {

--- a/javascript/packages/linter/src/rules/html-no-aria-hidden-on-body.ts
+++ b/javascript/packages/linter/src/rules/html-no-aria-hidden-on-body.ts
@@ -41,6 +41,7 @@ class NoAriaHiddenBodyVisitor extends BaseRuleVisitor {
 export class HTMLNoAriaHiddenOnBodyRule extends ParserRule {
   static ruleName = "html-no-aria-hidden-on-body"
   static introducedIn = this.version("0.9.0")
+  static defaultEnabledIn = this.version("0.9.0")
 
   get defaultConfig(): FullRuleConfig {
     return {

--- a/javascript/packages/linter/src/rules/html-no-aria-hidden-on-focusable.ts
+++ b/javascript/packages/linter/src/rules/html-no-aria-hidden-on-focusable.ts
@@ -38,6 +38,7 @@ class NoAriaHiddenOnFocusableVisitor extends BaseRuleVisitor {
 export class HTMLNoAriaHiddenOnFocusableRule extends ParserRule {
   static ruleName = "html-no-aria-hidden-on-focusable"
   static introducedIn = this.version("0.6.0")
+  static defaultEnabledIn = this.version("0.6.0")
 
   get defaultConfig(): FullRuleConfig {
     return {

--- a/javascript/packages/linter/src/rules/html-no-duplicate-attributes.ts
+++ b/javascript/packages/linter/src/rules/html-no-duplicate-attributes.ts
@@ -174,6 +174,7 @@ class NoDuplicateAttributesVisitor extends ControlFlowTrackingVisitor<
 export class HTMLNoDuplicateAttributesRule extends ParserRule {
   static ruleName = "html-no-duplicate-attributes"
   static introducedIn = this.version("0.4.0")
+  static defaultEnabledIn = this.version("0.4.0")
 
   get defaultConfig(): FullRuleConfig {
     return {

--- a/javascript/packages/linter/src/rules/html-no-duplicate-ids.ts
+++ b/javascript/packages/linter/src/rules/html-no-duplicate-ids.ts
@@ -343,6 +343,7 @@ class NoDuplicateIdsVisitor extends ControlFlowTrackingVisitor<BaseAutofixContex
 export class HTMLNoDuplicateIdsRule extends ParserRule {
   static ruleName = "html-no-duplicate-ids"
   static introducedIn = this.version("0.4.1")
+  static defaultEnabledIn = this.version("0.4.1")
 
   get defaultConfig(): FullRuleConfig {
     return {

--- a/javascript/packages/linter/src/rules/html-no-duplicate-meta-names.ts
+++ b/javascript/packages/linter/src/rules/html-no-duplicate-meta-names.ts
@@ -185,6 +185,7 @@ export class HTMLNoDuplicateMetaNamesRule extends ParserRule {
   static autocorrectable = false
   static ruleName = "html-no-duplicate-meta-names"
   static introducedIn = this.version("0.8.0")
+  static defaultEnabledIn = this.version("0.8.0")
 
   get defaultConfig(): FullRuleConfig {
     return {

--- a/javascript/packages/linter/src/rules/html-no-empty-attributes.ts
+++ b/javascript/packages/linter/src/rules/html-no-empty-attributes.ts
@@ -124,6 +124,7 @@ class NoEmptyAttributesVisitor extends AttributeVisitorMixin {
 export class HTMLNoEmptyAttributesRule extends ParserRule {
   static ruleName = "html-no-empty-attributes"
   static introducedIn = this.version("0.7.0")
+  static defaultEnabledIn = this.version("0.7.0")
 
   get defaultConfig(): FullRuleConfig {
     return {

--- a/javascript/packages/linter/src/rules/html-no-empty-css-rule.ts
+++ b/javascript/packages/linter/src/rules/html-no-empty-css-rule.ts
@@ -86,6 +86,7 @@ class NoEmptyCSSRuleVisitor extends BaseRuleVisitor {
 export class HTMLNoEmptyCSSRuleRule extends ParserRule {
   static ruleName = "html-no-empty-css-rule"
   static introducedIn = this.version("unreleased")
+  static defaultEnabledIn = this.version("unreleased")
 
   get defaultConfig(): FullRuleConfig {
     return {

--- a/javascript/packages/linter/src/rules/html-no-empty-headings.ts
+++ b/javascript/packages/linter/src/rules/html-no-empty-headings.ts
@@ -107,6 +107,7 @@ class NoEmptyHeadingsVisitor extends BaseRuleVisitor {
 export class HTMLNoEmptyHeadingsRule extends ParserRule {
   static ruleName = "html-no-empty-headings"
   static introducedIn = this.version("0.4.0")
+  static defaultEnabledIn = this.version("0.4.0")
 
   get defaultConfig(): FullRuleConfig {
     return {

--- a/javascript/packages/linter/src/rules/html-no-literal-nbsp.ts
+++ b/javascript/packages/linter/src/rules/html-no-literal-nbsp.ts
@@ -80,6 +80,7 @@ export class HTMLNoLiteralNBSPRule extends ParserRule<LiteralNbspAutofixContext>
   static autocorrectable = true
   static ruleName = "html-no-literal-nbsp"
   static introducedIn = this.version("unreleased")
+  static defaultEnabledIn = this.version("unreleased")
 
   get defaultConfig(): FullRuleConfig {
     return {

--- a/javascript/packages/linter/src/rules/html-no-nested-forms.ts
+++ b/javascript/packages/linter/src/rules/html-no-nested-forms.ts
@@ -135,6 +135,7 @@ class NestedFormVisitor extends ElementStackVisitor {
 export class HTMLNoNestedFormsRule extends ParserRule {
   static ruleName = "html-no-nested-forms"
   static introducedIn = this.version("unreleased")
+  static defaultEnabledIn = this.version("unreleased")
 
   get defaultConfig(): FullRuleConfig {
     return {

--- a/javascript/packages/linter/src/rules/html-no-nested-links.ts
+++ b/javascript/packages/linter/src/rules/html-no-nested-links.ts
@@ -78,6 +78,7 @@ class NestedLinkVisitor extends ElementStackVisitor {
 export class HTMLNoNestedLinksRule extends ParserRule {
   static ruleName = "html-no-nested-links"
   static introducedIn = this.version("0.4.0")
+  static defaultEnabledIn = this.version("0.4.0")
 
   get defaultConfig(): FullRuleConfig {
     return {

--- a/javascript/packages/linter/src/rules/html-no-positive-tab-index.ts
+++ b/javascript/packages/linter/src/rules/html-no-positive-tab-index.ts
@@ -22,6 +22,7 @@ class NoPositiveTabIndexVisitor extends AttributeVisitorMixin {
 export class HTMLNoPositiveTabIndexRule extends ParserRule {
   static ruleName = "html-no-positive-tab-index"
   static introducedIn = this.version("0.6.0")
+  static defaultEnabledIn = this.version("0.6.0")
 
   get defaultConfig(): FullRuleConfig {
     return {

--- a/javascript/packages/linter/src/rules/html-no-self-closing.ts
+++ b/javascript/packages/linter/src/rules/html-no-self-closing.ts
@@ -42,6 +42,7 @@ export class HTMLNoSelfClosingRule extends ParserRule<NoSelfClosingAutofixContex
   static autocorrectable = true
   static ruleName = "html-no-self-closing"
   static introducedIn = this.version("0.6.0")
+  static defaultEnabledIn = this.version("0.6.0")
 
   get defaultConfig(): FullRuleConfig {
     return {

--- a/javascript/packages/linter/src/rules/html-no-space-in-tag.ts
+++ b/javascript/packages/linter/src/rules/html-no-space-in-tag.ts
@@ -188,8 +188,8 @@ class HTMLNoSpaceInTagVisitor extends BaseRuleVisitor<HTMLNoSpaceInTagAutofixCon
 export class HTMLNoSpaceInTagRule extends ParserRule<HTMLNoSpaceInTagAutofixContext> {
   static autocorrectable = true
   static ruleName = "html-no-space-in-tag"
-  // Initially introduced in 0.8.0 (#559)
-  static introducedIn = this.version("0.10.3")
+  static introducedIn = this.version("0.8.0")
+  static defaultEnabledIn = this.version("0.10.3")
 
   get defaultConfig(): FullRuleConfig {
     return {

--- a/javascript/packages/linter/src/rules/html-no-underscores-in-attribute-names.ts
+++ b/javascript/packages/linter/src/rules/html-no-underscores-in-attribute-names.ts
@@ -49,6 +49,7 @@ class HTMLNoUnderscoresInAttributeNamesVisitor extends AttributeVisitorMixin {
 export class HTMLNoUnderscoresInAttributeNamesRule extends ParserRule {
   static ruleName = "html-no-underscores-in-attribute-names"
   static introducedIn = this.version("0.7.0")
+  static defaultEnabledIn = this.version("0.7.0")
 
   get defaultConfig(): FullRuleConfig {
     return {

--- a/javascript/packages/linter/src/rules/html-no-unescaped-entities.ts
+++ b/javascript/packages/linter/src/rules/html-no-unescaped-entities.ts
@@ -124,6 +124,7 @@ class HTMLNoUnescapedEntitiesVisitor extends BaseRuleVisitor<UnescapedEntitiesAu
 export class HTMLNoUnescapedEntitiesRule extends ParserRule<UnescapedEntitiesAutofixContext> {
   static ruleName = "html-no-unescaped-entities"
   static introducedIn = this.version("0.9.3")
+  static defaultEnabledIn = this.version("0.9.3")
   static unsafeAutocorrectable = true
 
   get defaultConfig(): FullRuleConfig {

--- a/javascript/packages/linter/src/rules/html-no-unknown-tag.ts
+++ b/javascript/packages/linter/src/rules/html-no-unknown-tag.ts
@@ -55,6 +55,7 @@ class NoUnknownTagVisitor extends BaseRuleVisitor {
 export class HTMLNoUnknownTagRule extends ParserRule {
   static ruleName = "html-no-unknown-tag"
   static introducedIn = this.version("0.9.3")
+  static defaultEnabledIn = this.version("0.9.3")
 
   get defaultConfig(): FullRuleConfig {
     return {

--- a/javascript/packages/linter/src/rules/html-require-closing-tags.ts
+++ b/javascript/packages/linter/src/rules/html-require-closing-tags.ts
@@ -20,6 +20,7 @@ export class HTMLRequireClosingTagsRule extends ParserRule {
   static autocorrectable = false
   static ruleName = "html-require-closing-tags"
   static introducedIn = this.version("0.9.0")
+  static defaultEnabledIn = this.version("0.9.0")
 
   get defaultConfig(): FullRuleConfig {
     return {

--- a/javascript/packages/linter/src/rules/html-require-script-nonce.ts
+++ b/javascript/packages/linter/src/rules/html-require-script-nonce.ts
@@ -76,6 +76,7 @@ class RequireScriptNonceVisitor extends BaseRuleVisitor {
 export class HTMLRequireScriptNonceRule extends ParserRule {
   static ruleName = "html-require-script-nonce"
   static introducedIn = this.version("0.9.3")
+  static defaultEnabledIn = this.version("0.9.3")
 
   get defaultConfig(): FullRuleConfig {
     return {

--- a/javascript/packages/linter/src/rules/html-tag-name-lowercase.ts
+++ b/javascript/packages/linter/src/rules/html-tag-name-lowercase.ts
@@ -88,6 +88,7 @@ export class HTMLTagNameLowercaseRule extends ParserRule<TagNameAutofixContext> 
   static autocorrectable = true
   static ruleName = "html-tag-name-lowercase"
   static introducedIn = this.version("0.4.0")
+  static defaultEnabledIn = this.version("0.4.0")
 
   get defaultConfig(): FullRuleConfig {
     return {

--- a/javascript/packages/linter/src/rules/parser-no-errors.ts
+++ b/javascript/packages/linter/src/rules/parser-no-errors.ts
@@ -6,6 +6,7 @@ import type { ParseResult, HerbError } from "@herb-tools/core"
 export class ParserNoErrorsRule extends ParserRule {
   static ruleName = "parser-no-errors"
   static introducedIn = this.version("0.5.0")
+  static defaultEnabledIn = this.version("0.5.0")
 
   get defaultConfig(): FullRuleConfig {
     return {

--- a/javascript/packages/linter/src/rules/source-indentation.ts
+++ b/javascript/packages/linter/src/rules/source-indentation.ts
@@ -36,6 +36,7 @@ export class SourceIndentationRule extends SourceRule {
   static autocorrectable = true
   static ruleName = "source-indentation"
   static introducedIn = this.version("0.9.3")
+  static defaultEnabledIn = this.version("0.9.3")
 
   get defaultConfig(): FullRuleConfig {
     return {

--- a/javascript/packages/linter/src/rules/svg-no-deprecated-tags.ts
+++ b/javascript/packages/linter/src/rules/svg-no-deprecated-tags.ts
@@ -71,6 +71,7 @@ class SVGNoDeprecatedTagsVisitor extends ElementStackVisitor {
 export class SVGNoDeprecatedTagsRule extends ParserRule {
   static ruleName = "svg-no-deprecated-tags"
   static introducedIn = this.version("unreleased")
+  static defaultEnabledIn = this.version("unreleased")
 
   get defaultConfig(): FullRuleConfig {
     return {

--- a/javascript/packages/linter/src/rules/svg-tag-name-capitalization.ts
+++ b/javascript/packages/linter/src/rules/svg-tag-name-capitalization.ts
@@ -51,6 +51,7 @@ export class SVGTagNameCapitalizationRule extends ParserRule<SVGTagNameCapitaliz
   static autocorrectable = true
   static ruleName = "svg-tag-name-capitalization"
   static introducedIn = this.version("0.4.2")
+  static defaultEnabledIn = this.version("0.4.2")
 
   get defaultConfig(): FullRuleConfig {
     return {

--- a/javascript/packages/linter/src/rules/turbo-permanent-no-misleading-value.ts
+++ b/javascript/packages/linter/src/rules/turbo-permanent-no-misleading-value.ts
@@ -46,6 +46,7 @@ export class TurboPermanentNoMisleadingValueRule extends ParserRule<TurboPermane
   static autocorrectable = true
   static ruleName = "turbo-permanent-no-misleading-value"
   static introducedIn = this.version("unreleased")
+  static defaultEnabledIn = this.version("unreleased")
 
   get defaultConfig(): FullRuleConfig {
     return {

--- a/javascript/packages/linter/src/rules/turbo-permanent-require-id.ts
+++ b/javascript/packages/linter/src/rules/turbo-permanent-require-id.ts
@@ -37,6 +37,7 @@ class TurboPermanentRequireIdVisitor extends BaseRuleVisitor {
 export class TurboPermanentRequireIdRule extends ParserRule {
   static ruleName = "turbo-permanent-require-id"
   static introducedIn = this.version("0.9.0")
+  static defaultEnabledIn = this.version("0.9.0")
 
   get defaultConfig(): FullRuleConfig {
     return {

--- a/javascript/packages/linter/src/rules/ujs-no-remote-attribute.ts
+++ b/javascript/packages/linter/src/rules/ujs-no-remote-attribute.ts
@@ -19,6 +19,7 @@ const DESCRIPTOR: UJSAttributeDescriptor = {
 export class UJSNoRemoteAttributeRule extends ParserRule {
   static ruleName = "ujs-no-remote-attribute"
   static introducedIn = this.version("unreleased")
+  static defaultEnabledIn = this.version("unreleased")
 
   get defaultConfig(): FullRuleConfig {
     return {

--- a/javascript/packages/linter/src/rules/ujs-prefer-turbo-confirm.ts
+++ b/javascript/packages/linter/src/rules/ujs-prefer-turbo-confirm.ts
@@ -14,6 +14,7 @@ const DESCRIPTOR: UJSAttributeDescriptor = {
 export class UJSPreferTurboConfirmRule extends ParserRule {
   static ruleName = "ujs-prefer-turbo-confirm"
   static introducedIn = this.version("unreleased")
+  static defaultEnabledIn = this.version("unreleased")
 
   get defaultConfig(): FullRuleConfig {
     return {

--- a/javascript/packages/linter/src/rules/ujs-prefer-turbo-method.ts
+++ b/javascript/packages/linter/src/rules/ujs-prefer-turbo-method.ts
@@ -19,6 +19,7 @@ const DESCRIPTOR: UJSAttributeDescriptor = {
 export class UJSPreferTurboMethodRule extends ParserRule {
   static ruleName = "ujs-prefer-turbo-method"
   static introducedIn = this.version("unreleased")
+  static defaultEnabledIn = this.version("unreleased")
 
   get defaultConfig(): FullRuleConfig {
     return {

--- a/javascript/packages/linter/src/rules/ujs-prefer-turbo-submits-with.ts
+++ b/javascript/packages/linter/src/rules/ujs-prefer-turbo-submits-with.ts
@@ -14,6 +14,7 @@ const DESCRIPTOR: UJSAttributeDescriptor = {
 export class UJSPreferTurboSubmitsWithRule extends ParserRule {
   static ruleName = "ujs-prefer-turbo-submits-with"
   static introducedIn = this.version("unreleased")
+  static defaultEnabledIn = this.version("unreleased")
 
   get defaultConfig(): FullRuleConfig {
     return {

--- a/javascript/packages/linter/src/types.ts
+++ b/javascript/packages/linter/src/types.ts
@@ -119,6 +119,8 @@ export abstract class ParserRule<TAutofixContext extends BaseAutofixContext = Ba
   static ruleName: string
   /** The version in which this rule was introduced. Used for version-gated rule filtering. */
   static introducedIn: RuleVersion
+  /** The version in which this rule started being enabled by default. Falls back to `introducedIn`. */
+  static defaultEnabledIn?: RuleVersion
 
   static version(version: RuleVersion): RuleVersion { return version }
   /** Indicates whether this rule supports autofix. Defaults to false. */
@@ -200,6 +202,8 @@ export abstract class LexerRule<TAutofixContext extends BaseAutofixContext = Bas
   static ruleName: string
   /** The version in which this rule was introduced. Used for version-gated rule filtering. */
   static introducedIn: RuleVersion
+  /** The version in which this rule started being enabled by default. Falls back to `introducedIn`. */
+  static defaultEnabledIn?: RuleVersion
 
   static version(version: RuleVersion): RuleVersion { return version }
 
@@ -258,6 +262,7 @@ export interface LexerRuleConstructor {
   new (): LexerRule
   ruleName: string
   introducedIn: RuleVersion
+  defaultEnabledIn?: RuleVersion
   autocorrectable?: boolean
   unsafeAutocorrectable?: boolean
   autofixRequiresContext?: boolean
@@ -312,6 +317,8 @@ export abstract class SourceRule<TAutofixContext extends BaseAutofixContext = Ba
   static ruleName: string
   /** The version in which this rule was introduced. Used for version-gated rule filtering. */
   static introducedIn: RuleVersion
+  /** The version in which this rule started being enabled by default. Falls back to `introducedIn`. */
+  static defaultEnabledIn?: RuleVersion
 
   static version(version: RuleVersion): RuleVersion { return version }
 
@@ -370,6 +377,7 @@ export interface SourceRuleConstructor {
   new (): SourceRule
   ruleName: string
   introducedIn: RuleVersion
+  defaultEnabledIn?: RuleVersion
   autocorrectable?: boolean
   unsafeAutocorrectable?: boolean
   autofixRequiresContext?: boolean
@@ -385,6 +393,7 @@ export type ParserRuleClass = (new () => ParserRule) & {
   type?: "parser"
   ruleName: string
   introducedIn: RuleVersion
+  defaultEnabledIn?: RuleVersion
   autocorrectable?: boolean
   unsafeAutocorrectable?: boolean
   autofixRequiresContext?: boolean

--- a/javascript/packages/linter/test/rule-default-enabled-in.test.ts
+++ b/javascript/packages/linter/test/rule-default-enabled-in.test.ts
@@ -1,0 +1,112 @@
+import { describe, test, expect } from "vitest"
+
+import { rules } from "../src/rules.js"
+import { Linter } from "../src/linter.js"
+import { ParserRule } from "../src/types.js"
+import { compareSemver, UNRELEASED_VERSION } from "@herb-tools/core"
+
+import type { FullRuleConfig } from "../src/types.js"
+
+const enabledByDefault = rules.filter(rule => new rule().defaultConfig?.enabled !== false)
+const disabledByDefault = rules.filter(rule => new rule().defaultConfig?.enabled === false)
+
+describe("defaultEnabledIn metadata", () => {
+  test.each(enabledByDefault.map(rule => [rule.ruleName, rule] as const))(
+    "%s declares defaultEnabledIn",
+    (_ruleName, rule) => {
+      expect(
+        rule.defaultEnabledIn,
+        `${rule.ruleName} is enabled by default, so it must declare 'static defaultEnabledIn' saying which version switched it on.`
+      ).toBeDefined()
+    }
+  )
+
+  test.each(disabledByDefault.map(rule => [rule.ruleName, rule] as const))(
+    "%s does not declare defaultEnabledIn",
+    (_ruleName, rule) => {
+      expect(
+        rule.defaultEnabledIn,
+        `${rule.ruleName} is disabled by default, so it must not declare 'defaultEnabledIn'. Set it in the same change that switches the rule on.`
+      ).toBeUndefined()
+    }
+  )
+
+  test.each(enabledByDefault.map(rule => [rule.ruleName, rule] as const))(
+    "%s was not enabled before it was introduced",
+    (_ruleName, rule) => {
+      if (rule.introducedIn === UNRELEASED_VERSION) return
+
+      expect(
+        compareSemver(rule.defaultEnabledIn!, rule.introducedIn) >= 0,
+        `${rule.ruleName} claims defaultEnabledIn ${rule.defaultEnabledIn}, which is older than introducedIn ${rule.introducedIn}.`
+      ).toBe(true)
+    }
+  )
+
+  test("html-no-space-in-tag records both its real age and its re-enable", () => {
+    const rule = rules.find(rule => rule.ruleName === "html-no-space-in-tag")!
+
+    expect(rule.introducedIn).toBe("0.8.0")
+    expect(rule.defaultEnabledIn).toBe("0.10.3")
+  })
+})
+
+describe("version gating on defaultEnabledIn", () => {
+  class ReEnabledRule extends ParserRule {
+    static ruleName = "test-re-enabled"
+    static introducedIn = this.version("0.8.0")
+    static defaultEnabledIn = this.version("0.10.3")
+
+    get defaultConfig(): FullRuleConfig {
+      return { enabled: true, severity: "error" }
+    }
+
+    check() { return [] }
+  }
+
+  class OldRule extends ParserRule {
+    static ruleName = "test-old"
+    static introducedIn = this.version("0.8.0")
+    static defaultEnabledIn = this.version("0.8.0")
+
+    get defaultConfig(): FullRuleConfig {
+      return { enabled: true, severity: "error" }
+    }
+
+    check() { return [] }
+  }
+
+  test("gates a rule whose default was switched on after the config version", () => {
+    const { enabled, skippedByVersion } = Linter.filterRulesByConfig([ReEnabledRule as any], undefined, "0.10.2")
+
+    expect(enabled).toHaveLength(0)
+    expect(skippedByVersion).toEqual([
+      { ruleName: "test-re-enabled", introducedIn: "0.8.0", defaultEnabledIn: "0.10.3" }
+    ])
+  })
+
+  test("enables it once the config version catches up", () => {
+    const { enabled, skippedByVersion } = Linter.filterRulesByConfig([ReEnabledRule as any], undefined, "0.10.3")
+
+    expect(enabled).toHaveLength(1)
+    expect(skippedByVersion).toHaveLength(0)
+  })
+
+  test("does not gate a rule that has been enabled since it was introduced", () => {
+    const { enabled, skippedByVersion } = Linter.filterRulesByConfig([OldRule as any], undefined, "0.10.2")
+
+    expect(enabled).toHaveLength(1)
+    expect(skippedByVersion).toHaveLength(0)
+  })
+
+  test("an explicit user setting still wins over the gate", () => {
+    const { enabled, skippedByVersion } = Linter.filterRulesByConfig(
+      [ReEnabledRule as any],
+      { "test-re-enabled": { enabled: true } },
+      "0.10.2"
+    )
+
+    expect(enabled).toHaveLength(1)
+    expect(skippedByVersion).toHaveLength(0)
+  })
+})


### PR DESCRIPTION
This pull request introduces a `defaultEnabledIn` field on every rule class, so the version gate can tell when a rule *started being enabled by default*, which until now it had no way to express.

`filterRulesByConfig` gated on `introducedIn` alone, which answers "was this rule added after your config version". A rule that shipped disabled and was switched on later slipped straight past it, because its `introducedIn` was already older than the user's config version. It went from silent to reporting on a routine version bump, with no `--upgrade` triage and no grace period, which is the one thing the gate exists to prevent.

That has already happened once. `html-no-space-in-tag` was introduced in `0.8.0`, disabled in #697 for false positives, and re-enabled in #1907 for `v0.10.3`. To make the gate fire, its `introducedIn` was rewritten from `0.8.0` to `0.10.3`, so the rule has been claiming to be two minor versions younger than it is. This pull request restores `0.8.0` and records the re-enable properly:

```ts
static introducedIn = this.version("0.8.0")
static defaultEnabledIn = this.version("0.10.3")
```