### PR TITLE
Linter: Cover Component slot setters in `actionview-no-silent-helper`

### DIFF
--- a/javascript/packages/linter/docs/rules/actionview-no-silent-helper.md
+++ b/javascript/packages/linter/docs/rules/actionview-no-silent-helper.md
@@ -48,6 +48,14 @@ A silent tag is fine when the helper's return value is used instead of being dis
 <% end %>
 ```
 
+A helper that is the return value of a block is consumed by whatever method takes the block, so a silent tag is fine there too. ViewComponent slot setters are the common case:
+
+```erb
+<%= render CardComponent.new do |card| %>
+  <% card.with_header { tag.h3("Title") } %>
+<% end %>
+```
+
 ### 🚫 Bad
 
 ```erb

--- a/javascript/packages/linter/test/rules/actionview-no-silent-helper.test.ts
+++ b/javascript/packages/linter/test/rules/actionview-no-silent-helper.test.ts
@@ -309,6 +309,40 @@ describe("ActionViewNoSilentHelperRule", () => {
     `)
   })
 
+  test("silent tag with slot setter taking a helper in a brace block is allowed", () => {
+    expectNoOffenses(dedent`
+      <%= render CardComponent.new do |card| %>
+        <% card.with_header { tag.h3("Title") } %>
+      <% end %>
+    `)
+  })
+
+  test("silent tag with slot setter taking a helper in a do/end block is allowed", () => {
+    expectNoOffenses(dedent`
+      <%= render CardComponent.new do |card| %>
+        <% card.with_header do %>
+          <%= tag.h3("Title") %>
+        <% end %>
+      <% end %>
+    `)
+  })
+
+  test("silent tag with slot setter taking a helper as an argument is allowed", () => {
+    expectNoOffenses(dedent`
+      <%= render CardComponent.new do |card| %>
+        <% card.with_footer(link_to("Home", root_path)) %>
+      <% end %>
+    `)
+  })
+
+  test("silent tag with slot setter on a helper block local is allowed", () => {
+    expectNoOffenses(dedent`
+      <%= card_component do |card| %>
+        <% card.with_header { tag.h3("Title") } %>
+      <% end %>
+    `)
+  })
+
   test("silent tag with helper inside a conditional else branch is not allowed", () => {
     expectError("Avoid using `<% %>` with `link_to`. Use `<%= %>` to ensure the helper's output is rendered.")
 

--- a/javascript/packages/linter/test/rules/erb-no-unused-expressions.test.ts
+++ b/javascript/packages/linter/test/rules/erb-no-unused-expressions.test.ts
@@ -196,6 +196,14 @@ describe("ERBNoUnusedExpressionsRule", () => {
       `)
     })
 
+    test("passes for slot setter taking a helper in a brace block", () => {
+      expectNoOffenses(dedent`
+        <%= render CardComponent.new do |card| %>
+          <% card.with_header { tag.h3("Title") } %>
+        <% end %>
+      `)
+    })
+
     test("passes for multiple block locals in render", () => {
       expectNoOffenses(dedent`
         <%= render TableComponent.new do |table, index| %>


### PR DESCRIPTION
#1971 replaced the recursive collector in `actionview-no-silent-helper` with `collectDiscardedHelperCalls`, which walks only statements, conditionals, logical operators, `begin` and parentheses. A call's block body is not walked, because a helper that is the return value of a block is consumed by the method taking that block.

That also settled the false positive reported in https://github.com/marcoroth/herb/issues/2340, where the brace form of a ViewComponent slot setter was reported as a discarded helper:

```erb
<%= render CardComponent.new do |card| %>
  <% card.with_header { tag.h3("Title") } %>
<% end %>
```

Following the suggestion there produces wrong output, since `tag.h3(...)` is the block's return value and `with_header` consumes it, so `<%= c.with_header { ... } %>` renders the component's `to_s` at that position instead.

Resolves https://github.com/marcoroth/herb/issues/2340
